### PR TITLE
Fix user_preferences config path for consolidated config

### DIFF
--- a/scripts/Movie-Recommendations-for-Plex/MRFP.py
+++ b/scripts/Movie-Recommendations-for-Plex/MRFP.py
@@ -369,7 +369,7 @@ class PlexMovieRecommender:
         self.exclude_genres = [g.strip().lower() for g in exclude_genre_str.split(',') if g.strip()] if exclude_genre_str else []
 
         # Load user preferences for per-user customization
-        self.user_preferences = self.config.get('user_preferences', {})
+        self.user_preferences = self.config.get('users', {}).get('preferences', {})
 
         weights_config = self.config.get('weights', {})
         self.weights = {

--- a/scripts/TV-Show-Recommendations-for-Plex/TRFP.py
+++ b/scripts/TV-Show-Recommendations-for-Plex/TRFP.py
@@ -344,7 +344,7 @@ class PlexTVRecommender:
         self.sonarr_config = self.config.get('sonarr', {})
 
         # Load user preferences for per-user customization
-        self.user_preferences = self.config.get('user_preferences', {})
+        self.user_preferences = self.config.get('users', {}).get('preferences', {})
 
         # Get user context for cache files
         if single_user:


### PR DESCRIPTION
Updated MRFP.py and TRFP.py to read user preferences from the new config structure:
- Changed from config['user_preferences'] to config['users']['preferences']
- Fixes exclude_genres not being applied per-user