### PR TITLE
Add workflow to auto-close external PRs

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -1,0 +1,27 @@
+name: Auto-close external PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'OrchestratedChaos'
+    steps:
+      - name: Close PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Thanks for the interest, but this project is not accepting external contributions. Feel free to fork it for your own use.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
Auto-closes PRs from non-owners with a polite message.