### PR TITLE
v1.4.0: HTML watchlist with Radarr/Sonarr export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.4.0] - 2026-01-03
+
+### Added
+- **HTML watchlist with export buttons** — Interactive HTML view of external recommendations
+  - Single page with tabs for each user
+  - Selectable items with checkboxes (unchecked by default)
+  - "Export to Radarr" button downloads IMDB IDs for selected movies
+  - "Export to Sonarr" button downloads IMDB IDs for selected shows
+  - Movie theater themed dark design with gold accents
+  - Auto-open in browser after run (configurable via `auto_open_html`)
+
 ## [1.3.0] - 2026-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,23 +109,20 @@ Collections automatically appear:
 Pin them to your home screen. They update daily.
 
 ### External Watchlists
-Markdown files showing what to acquire:
+Interactive HTML files with export buttons:
+```
+recommendations/external/john_watchlist.html
+
+- Select which movies/shows to export
+- Click "Export to Radarr" → downloads IMDB IDs for import
+- Click "Export to Sonarr" → downloads IMDB IDs for import
+- Grouped by streaming service availability
+- Auto-opens in browser after run (configurable)
+```
+
+Also generates markdown for reference:
 ```
 recommendations/external/john_watchlist.md
-
-## Movies to Watch
-
-### Available on Your Services
-#### Netflix (4 movies)
-- The Power of the Dog (2021) - Drama
-- Glass Onion (2022) - Mystery
-
-#### Disney+ (2 movies)
-- ...
-
-### Need to Acquire (15 movies)
-- Oppenheimer (2023) - Drama, History
-- ...
 ```
 
 ---
@@ -193,6 +190,7 @@ collections:
 
 external_recommendations:
   min_relevance_score: 0.25   # See note below
+  auto_open_html: false       # Open HTML watchlist in browser after run
 ```
 
 ### External Recommendations: Relevance Score

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -6,6 +6,7 @@ Creates per-user markdown watchlists that update daily and auto-remove acquired 
 
 import os
 import sys
+import webbrowser
 
 # Add project root to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -503,6 +504,20 @@ def get_library_items(plex, library_name, media_type='movie'):
         log_warning(f"Warning: Could not fetch {library_name} library: {e}")
         return {'tmdb_ids': set(), 'tvdb_ids': set(), 'titles': set()}
 
+def get_imdb_id(tmdb_api_key, tmdb_id, media_type='movie'):
+    """Fetch IMDB ID from TMDB external IDs endpoint."""
+    try:
+        media = 'movie' if media_type == 'movie' else 'tv'
+        url = f"https://api.themoviedb.org/3/{media}/{tmdb_id}/external_ids"
+        response = requests.get(url, params={'api_key': tmdb_api_key}, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            return data.get('imdb_id')
+    except (requests.RequestException, KeyError):
+        pass
+    return None
+
+
 def get_watch_providers(tmdb_api_key, tmdb_id, media_type='movie'):
     """
     Get streaming providers for a TMDB item (US region)
@@ -966,6 +981,481 @@ def generate_markdown(username, display_name, movies_categorized, shows_categori
 
     return output_file
 
+
+def generate_combined_html(all_users_data, output_dir, tmdb_api_key):
+    """
+    Generate single HTML watchlist with tabs for all users.
+    Users can switch between tabs, select items, and export.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, 'watchlist.html')
+
+    now = datetime.now()
+
+    # Collect all IMDB IDs across all users (to avoid duplicate API calls)
+    print("  Fetching IMDB IDs for export...")
+    all_imdb_ids = {}  # tmdb_id -> imdb_id
+
+    for user_data in all_users_data:
+        movies_cat = user_data['movies_categorized']
+        shows_cat = user_data['shows_categorized']
+
+        # Gather all movie tmdb_ids
+        for items in movies_cat['user_services'].values():
+            for item in items:
+                tmdb_id = item.get('tmdb_id')
+                if tmdb_id and tmdb_id not in all_imdb_ids:
+                    imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'movie')
+                    if imdb_id:
+                        all_imdb_ids[tmdb_id] = imdb_id
+        for items in movies_cat['other_services'].values():
+            for item in items:
+                tmdb_id = item.get('tmdb_id')
+                if tmdb_id and tmdb_id not in all_imdb_ids:
+                    imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'movie')
+                    if imdb_id:
+                        all_imdb_ids[tmdb_id] = imdb_id
+        for item in movies_cat['acquire']:
+            tmdb_id = item.get('tmdb_id')
+            if tmdb_id and tmdb_id not in all_imdb_ids:
+                imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'movie')
+                if imdb_id:
+                    all_imdb_ids[tmdb_id] = imdb_id
+
+        # Gather all show tmdb_ids
+        for items in shows_cat['user_services'].values():
+            for item in items:
+                tmdb_id = item.get('tmdb_id')
+                if tmdb_id and tmdb_id not in all_imdb_ids:
+                    imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'tv')
+                    if imdb_id:
+                        all_imdb_ids[tmdb_id] = imdb_id
+        for items in shows_cat['other_services'].values():
+            for item in items:
+                tmdb_id = item.get('tmdb_id')
+                if tmdb_id and tmdb_id not in all_imdb_ids:
+                    imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'tv')
+                    if imdb_id:
+                        all_imdb_ids[tmdb_id] = imdb_id
+        for item in shows_cat['acquire']:
+            tmdb_id = item.get('tmdb_id')
+            if tmdb_id and tmdb_id not in all_imdb_ids:
+                imdb_id = get_imdb_id(tmdb_api_key, tmdb_id, 'tv')
+                if imdb_id:
+                    all_imdb_ids[tmdb_id] = imdb_id
+
+    def render_table(items, media_type, user_id):
+        """Render HTML table for items with checkboxes (unchecked by default)"""
+        rows = []
+        for item in items:
+            tmdb_id = item.get('tmdb_id', '')
+            imdb_id = all_imdb_ids.get(tmdb_id, '')
+            days_listed = (now - datetime.fromisoformat(item['added_date'])).days
+            rows.append(f'''
+                <tr data-tmdb="{tmdb_id}" data-imdb="{imdb_id}" data-type="{media_type}" data-user="{user_id}">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>{item['title']}</td>
+                    <td>{item['year']}</td>
+                    <td>{item['rating']:.1f}</td>
+                    <td>{item['score']:.0%}</td>
+                    <td>{days_listed}</td>
+                </tr>''')
+        return '\n'.join(rows)
+
+    def render_service_section(service, items, media_type, user_id):
+        """Render a service section with table"""
+        service_display = SERVICE_DISPLAY_NAMES.get(service, service.title())
+        return f'''
+            <h4>{service_display} ({len(items)} {media_type}s)</h4>
+            <table>
+                <thead>
+                    <tr><th><input type="checkbox" class="select-all-table"></th><th>Title</th><th>Year</th><th>Rating</th><th>Score</th><th>Days</th></tr>
+                </thead>
+                <tbody>
+                    {render_table(items, media_type, user_id)}
+                </tbody>
+            </table>'''
+
+    # Build tabs HTML
+    tabs_html = ""
+    panels_html = ""
+
+    for i, user_data in enumerate(all_users_data):
+        display_name = user_data['display_name']
+        user_id = user_data['username'].lower().replace(' ', '_')
+        movies_cat = user_data['movies_categorized']
+        shows_cat = user_data['shows_categorized']
+        is_active = "active" if i == 0 else ""
+
+        # Tab button
+        tabs_html += f'<button class="tab-btn {is_active}" data-user="{user_id}">{display_name}</button>\n'
+
+        # Panel content
+        panel_content = ""
+
+        # Movies section
+        if any([movies_cat['user_services'], movies_cat['other_services'], movies_cat['acquire']]):
+            panel_content += "<h2>Movies to Watch</h2>"
+
+            if movies_cat['user_services']:
+                panel_content += "<h3>Available on Your Services</h3>"
+                for service, items in sorted(movies_cat['user_services'].items(), key=lambda x: -len(x[1])):
+                    panel_content += render_service_section(service, items, 'movie', user_id)
+
+            if movies_cat['other_services']:
+                panel_content += "<h3>Available on Other Services</h3>"
+                for service, items in sorted(movies_cat['other_services'].items(), key=lambda x: -len(x[1])):
+                    panel_content += render_service_section(service, items, 'movie', user_id)
+
+            if movies_cat['acquire']:
+                panel_content += f"<h3>Need to Acquire ({len(movies_cat['acquire'])} movies)</h3>"
+                panel_content += f'''
+                    <table>
+                        <thead>
+                            <tr><th><input type="checkbox" class="select-all-table"></th><th>Title</th><th>Year</th><th>Rating</th><th>Score</th><th>Days</th></tr>
+                        </thead>
+                        <tbody>
+                            {render_table(movies_cat['acquire'], 'movie', user_id)}
+                        </tbody>
+                    </table>'''
+
+        # Shows section
+        if any([shows_cat['user_services'], shows_cat['other_services'], shows_cat['acquire']]):
+            panel_content += "<h2>TV Shows to Watch</h2>"
+
+            if shows_cat['user_services']:
+                panel_content += "<h3>Available on Your Services</h3>"
+                for service, items in sorted(shows_cat['user_services'].items(), key=lambda x: -len(x[1])):
+                    panel_content += render_service_section(service, items, 'show', user_id)
+
+            if shows_cat['other_services']:
+                panel_content += "<h3>Available on Other Services</h3>"
+                for service, items in sorted(shows_cat['other_services'].items(), key=lambda x: -len(x[1])):
+                    panel_content += render_service_section(service, items, 'show', user_id)
+
+            if shows_cat['acquire']:
+                panel_content += f"<h3>Need to Acquire ({len(shows_cat['acquire'])} shows)</h3>"
+                panel_content += f'''
+                    <table>
+                        <thead>
+                            <tr><th><input type="checkbox" class="select-all-table"></th><th>Title</th><th>Year</th><th>Rating</th><th>Score</th><th>Days</th></tr>
+                        </thead>
+                        <tbody>
+                            {render_table(shows_cat['acquire'], 'show', user_id)}
+                        </tbody>
+                    </table>'''
+
+        if not panel_content:
+            panel_content = "<p>No recommendations available for this user.</p>"
+
+        panels_html += f'<div class="tab-panel {is_active}" data-user="{user_id}">{panel_content}</div>\n'
+
+    html_content = f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Plex Watchlist</title>
+    <style>
+        * {{ box-sizing: border-box; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: linear-gradient(135deg, #0d0d0d 0%, #1a1a1a 50%, #0d0d0d 100%);
+            color: #e8e8e8;
+            min-height: 100vh;
+        }}
+        h1 {{
+            color: #d4af37;
+            margin-bottom: 5px;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
+            font-size: 2em;
+        }}
+        h2 {{
+            background: linear-gradient(90deg, #8b0000 0%, #660000 100%);
+            color: #d4af37;
+            padding: 12px 15px;
+            border-radius: 3px;
+            margin-top: 30px;
+            border-left: 4px solid #d4af37;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 1.1em;
+        }}
+        h3 {{
+            background: #1c1c1c;
+            color: #c0c0c0;
+            padding: 10px 12px;
+            border-radius: 3px;
+            border-left: 3px solid #8b0000;
+            font-size: 0.95em;
+        }}
+        h4 {{
+            color: #d4af37;
+            margin: 15px 0 8px 0;
+            font-size: 0.9em;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }}
+        .header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 15px;
+            margin-bottom: 25px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #333;
+        }}
+        .export-buttons {{
+            display: flex;
+            gap: 10px;
+        }}
+        .export-btn {{
+            background: linear-gradient(180deg, #8b0000 0%, #5c0000 100%);
+            color: #d4af37;
+            border: 1px solid #d4af37;
+            padding: 12px 24px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            transition: all 0.2s ease;
+        }}
+        .export-btn:hover {{
+            background: linear-gradient(180deg, #a00000 0%, #700000 100%);
+            box-shadow: 0 0 10px rgba(212, 175, 55, 0.3);
+        }}
+        .export-btn.sonarr {{
+            background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 100%);
+        }}
+        .export-btn.sonarr:hover {{
+            background: linear-gradient(180deg, #3a3a3a 0%, #2a2a2a 100%);
+        }}
+        .tabs {{
+            display: flex;
+            gap: 3px;
+            margin-bottom: 25px;
+            flex-wrap: wrap;
+            background: #111;
+            padding: 5px;
+            border-radius: 5px;
+        }}
+        .tab-btn {{
+            background: #1a1a1a;
+            color: #888;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            transition: all 0.2s ease;
+        }}
+        .tab-btn:hover {{
+            background: #2a2a2a;
+            color: #c0c0c0;
+        }}
+        .tab-btn.active {{
+            background: linear-gradient(180deg, #8b0000 0%, #5c0000 100%);
+            color: #d4af37;
+        }}
+        .tab-panel {{ display: none; }}
+        .tab-panel.active {{ display: block; }}
+        table {{
+            width: 100%;
+            border-collapse: collapse;
+            margin: 10px 0 25px 0;
+            background: #141414;
+            border-radius: 3px;
+            overflow: hidden;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+        }}
+        th, td {{
+            padding: 12px 10px;
+            text-align: left;
+            border-bottom: 1px solid #2a2a2a;
+        }}
+        th {{
+            background: #1c1c1c;
+            color: #d4af37;
+            font-size: 0.8em;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }}
+        tr:hover {{ background: #1f1f1f; }}
+        td:first-child, th:first-child {{ width: 40px; text-align: center; }}
+        input[type="checkbox"] {{
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            accent-color: #8b0000;
+        }}
+        .timestamp {{ color: #666; font-size: 12px; }}
+        .instructions {{
+            background: #141414;
+            padding: 20px;
+            border-radius: 3px;
+            margin-top: 40px;
+            border: 1px solid #2a2a2a;
+        }}
+        .instructions h3 {{
+            background: none;
+            border: none;
+            padding: 0;
+            color: #d4af37;
+            margin-bottom: 15px;
+        }}
+        .instructions ul {{
+            margin: 0;
+            padding-left: 20px;
+            color: #999;
+        }}
+        .instructions li {{ margin-bottom: 8px; }}
+        .instructions strong {{ color: #c0c0c0; }}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div>
+            <h1>Plex Watchlist</h1>
+            <p class="timestamp">Last updated: {now.strftime('%Y-%m-%d %H:%M')}</p>
+        </div>
+        <div class="export-buttons">
+            <button class="export-btn" onclick="exportRadarr()">Export to Radarr (<span id="movie-count">0</span>)</button>
+            <button class="export-btn sonarr" onclick="exportSonarr()">Export to Sonarr (<span id="show-count">0</span>)</button>
+        </div>
+    </div>
+
+    <div class="tabs">
+        {tabs_html}
+    </div>
+
+    {panels_html}
+
+    <div class="instructions">
+        <h3>How to Use</h3>
+        <ul>
+            <li>Click a user tab to view their recommendations</li>
+            <li>Check the items you want to export</li>
+            <li><strong>Radarr:</strong> Click "Export to Radarr" to download IMDB IDs for selected movies</li>
+            <li><strong>Sonarr:</strong> Click "Export to Sonarr" to download IMDB IDs for selected shows</li>
+            <li>Exports include selections from ALL users, not just the active tab</li>
+        </ul>
+    </div>
+
+    <script>
+        // Tab switching
+        document.querySelectorAll('.tab-btn').forEach(btn => {{
+            btn.addEventListener('click', function() {{
+                const userId = this.getAttribute('data-user');
+
+                // Update active tab
+                document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+                this.classList.add('active');
+
+                // Show corresponding panel
+                document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+                document.querySelector(`.tab-panel[data-user="${{userId}}"]`).classList.add('active');
+            }});
+        }});
+
+        // Select-all checkbox functionality (per table)
+        document.querySelectorAll('.select-all-table').forEach(selectAll => {{
+            selectAll.addEventListener('change', function() {{
+                const table = this.closest('table');
+                table.querySelectorAll('.select-item').forEach(cb => {{
+                    cb.checked = this.checked;
+                }});
+                updateCounts();
+            }});
+        }});
+
+        // Update counts when individual items are checked
+        document.querySelectorAll('.select-item').forEach(cb => {{
+            cb.addEventListener('change', updateCounts);
+        }});
+
+        function updateCounts() {{
+            // Count ALL selected items across ALL users
+            const movieCount = document.querySelectorAll('tr[data-type="movie"] .select-item:checked').length;
+            const showCount = document.querySelectorAll('tr[data-type="show"] .select-item:checked').length;
+            document.getElementById('movie-count').textContent = movieCount;
+            document.getElementById('show-count').textContent = showCount;
+        }}
+
+        function exportRadarr() {{
+            // Export from ALL users
+            const rows = document.querySelectorAll('tr[data-type="movie"]');
+            const imdbIds = [];
+            rows.forEach(row => {{
+                const checkbox = row.querySelector('.select-item');
+                if (checkbox && checkbox.checked) {{
+                    const imdb = row.getAttribute('data-imdb');
+                    if (imdb && imdb.startsWith('tt')) {{
+                        imdbIds.push(imdb);
+                    }}
+                }}
+            }});
+            if (imdbIds.length === 0) {{
+                alert('No selected movies with IMDB IDs to export. Select items first.');
+                return;
+            }}
+            downloadFile('radarr_import.txt', [...new Set(imdbIds)].join('\\n'));
+            alert('Exported ' + imdbIds.length + ' movies for Radarr import.');
+        }}
+
+        function exportSonarr() {{
+            // Export from ALL users
+            const rows = document.querySelectorAll('tr[data-type="show"]');
+            const imdbIds = [];
+            rows.forEach(row => {{
+                const checkbox = row.querySelector('.select-item');
+                if (checkbox && checkbox.checked) {{
+                    const imdb = row.getAttribute('data-imdb');
+                    if (imdb && imdb.startsWith('tt')) {{
+                        imdbIds.push(imdb);
+                    }}
+                }}
+            }});
+            if (imdbIds.length === 0) {{
+                alert('No selected TV shows with IMDB IDs to export. Select items first.');
+                return;
+            }}
+            downloadFile('sonarr_import.txt', [...new Set(imdbIds)].join('\\n'));
+            alert('Exported ' + imdbIds.length + ' shows for Sonarr import.');
+        }}
+
+        function downloadFile(filename, content) {{
+            const blob = new Blob([content], {{ type: 'text/plain' }});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }}
+
+        // Initialize counts on load
+        updateCounts();
+    </script>
+</body>
+</html>'''
+
+    with open(output_file, 'w') as f:
+        f.write(html_content)
+
+    return output_file
+
+
 def process_user(config, plex, username):
     """Process external recommendations for a single user"""
     user_prefs = config['users']['preferences'].get(username, {})
@@ -1149,10 +1639,10 @@ def process_user(config, plex, username):
         'tv'
     )
 
-    # Generate markdown
+    # Generate markdown per user
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     output_dir = os.path.join(project_root, 'recommendations', 'external')
-    output_file = generate_markdown(username, display_name, movies_categorized, shows_categorized, output_dir)
+    generate_markdown(username, display_name, movies_categorized, shows_categorized, output_dir)
 
     # Count totals
     total_movies = sum(len(items) for items in movies_categorized['user_services'].values()) + \
@@ -1162,8 +1652,16 @@ def process_user(config, plex, username):
                   sum(len(items) for items in shows_categorized['other_services'].values()) + \
                   len(shows_categorized['acquire'])
 
-    print_status(f"Watchlist generated: {total_movies} movies, {total_shows} shows", "success")
+    print_status(f"Processed: {total_movies} movies, {total_shows} shows", "success")
     print_user_footer(f"{display_name} (external recommendations)")
+
+    # Return data for combined HTML generation
+    return {
+        'username': username,
+        'display_name': display_name,
+        'movies_categorized': movies_categorized,
+        'shows_categorized': shows_categorized
+    }
 
 def main():
     print(f"\n{CYAN}External Recommendations Generator{RESET}")
@@ -1185,18 +1683,36 @@ def main():
     # Get users
     users = [u.strip() for u in config['users']['list'].split(',')]
 
-    # Process each user
+    # Process each user and collect data for combined HTML
+    all_users_data = []
     for username in users:
         try:
-            process_user(config, plex, username)
+            user_data = process_user(config, plex, username)
+            if user_data:
+                all_users_data.append(user_data)
         except Exception as e:
             print_status(f"Error processing {username}: {e}", "error")
             import traceback
             traceback.print_exc()
 
-    print_status("All watchlists generated!", "success")
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    print(f"Watchlists saved to: {os.path.join(project_root, 'recommendations', 'external')}")
+    # Generate combined HTML with all users
+    output_dir = os.path.join(project_root, 'recommendations', 'external')
+    tmdb_api_key = get_tmdb_config(config)['api_key']
+
+    if all_users_data:
+        html_file = generate_combined_html(all_users_data, output_dir, tmdb_api_key)
+        print_status("Combined watchlist generated!", "success")
+    else:
+        html_file = None
+        print_status("No user data to generate watchlist", "warning")
+
+    print(f"Watchlists saved to: {output_dir}")
+
+    # Auto-open HTML if enabled
+    external_config = config.get('external_recommendations', {})
+    if external_config.get('auto_open_html', False) and html_file:
+        print_status("Opening watchlist in browser...", "info")
+        webbrowser.open(f'file://{html_file}')
 
 if __name__ == "__main__":
     main()

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,0 +1,393 @@
+"""Tests for recommenders/external.py - HTML watchlist and export functionality"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime
+import os
+import tempfile
+import json
+
+# Import the functions to test
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from recommenders.external import (
+    get_imdb_id,
+    generate_combined_html,
+    generate_markdown,
+    get_watch_providers,
+    categorize_by_streaming_service,
+    is_in_library,
+    load_cache,
+    save_cache,
+    SERVICE_DISPLAY_NAMES,
+    TMDB_PROVIDERS,
+)
+
+
+class TestGetImdbId:
+    """Tests for get_imdb_id function"""
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_imdb_id_for_movie(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'imdb_id': 'tt1234567'}
+        mock_get.return_value = mock_response
+
+        result = get_imdb_id('api_key', 12345, 'movie')
+
+        assert result == 'tt1234567'
+        mock_get.assert_called_once()
+        assert 'movie/12345/external_ids' in mock_get.call_args[0][0]
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_imdb_id_for_tv(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'imdb_id': 'tt9876543'}
+        mock_get.return_value = mock_response
+
+        result = get_imdb_id('api_key', 54321, 'tv')
+
+        assert result == 'tt9876543'
+        assert 'tv/54321/external_ids' in mock_get.call_args[0][0]
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_none_on_api_error(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        result = get_imdb_id('api_key', 12345, 'movie')
+
+        assert result is None
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_none_on_missing_imdb_id(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'tvdb_id': 123}  # No imdb_id
+        mock_get.return_value = mock_response
+
+        result = get_imdb_id('api_key', 12345, 'movie')
+
+        assert result is None
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_none_on_exception(self, mock_get):
+        import requests
+        mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
+
+        result = get_imdb_id('api_key', 12345, 'movie')
+
+        assert result is None
+
+
+class TestGetWatchProviders:
+    """Tests for get_watch_providers function"""
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_providers_list(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'results': {
+                'US': {
+                    'flatrate': [
+                        {'provider_id': 8, 'provider_name': 'Netflix'},
+                        {'provider_id': 337, 'provider_name': 'Disney Plus'}
+                    ]
+                }
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = get_watch_providers('api_key', 12345, 'movie')
+
+        assert 'netflix' in result
+        assert 'disney_plus' in result
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_empty_on_no_us_providers(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'results': {
+                'GB': {'flatrate': [{'provider_id': 8}]}
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = get_watch_providers('api_key', 12345, 'movie')
+
+        assert result == []
+
+    @patch('recommenders.external.requests.get')
+    def test_returns_empty_on_error(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        result = get_watch_providers('api_key', 12345, 'movie')
+
+        assert result == []
+
+
+class TestCategorizeByStreamingService:
+    """Tests for categorize_by_streaming_service function"""
+
+    @patch('recommenders.external.get_watch_providers')
+    def test_categorizes_by_user_services(self, mock_providers):
+        mock_providers.return_value = ['netflix']
+
+        recommendations = [
+            {'tmdb_id': 1, 'title': 'Movie 1', 'year': '2023', 'rating': 7.5, 'score': 0.8, 'added_date': datetime.now().isoformat()}
+        ]
+        user_services = ['netflix', 'hulu']
+
+        result = categorize_by_streaming_service(recommendations, 'api_key', user_services, 'movie')
+
+        assert 'netflix' in result['user_services']
+        assert len(result['user_services']['netflix']) == 1
+
+    @patch('recommenders.external.get_watch_providers')
+    def test_categorizes_to_acquire(self, mock_providers):
+        mock_providers.return_value = []  # Not on any service
+
+        recommendations = [
+            {'tmdb_id': 1, 'title': 'Movie 1', 'year': '2023', 'rating': 7.5, 'score': 0.8, 'added_date': datetime.now().isoformat()}
+        ]
+
+        result = categorize_by_streaming_service(recommendations, 'api_key', ['netflix'], 'movie')
+
+        assert len(result['acquire']) == 1
+
+    @patch('recommenders.external.get_watch_providers')
+    def test_categorizes_other_services(self, mock_providers):
+        mock_providers.return_value = ['disney_plus']
+
+        recommendations = [
+            {'tmdb_id': 1, 'title': 'Movie 1', 'year': '2023', 'rating': 7.5, 'score': 0.8, 'added_date': datetime.now().isoformat()}
+        ]
+
+        result = categorize_by_streaming_service(recommendations, 'api_key', ['netflix'], 'movie')
+
+        assert 'disney_plus' in result['other_services']
+
+
+class TestIsInLibrary:
+    """Tests for is_in_library function"""
+
+    def test_finds_by_tmdb_id(self):
+        library_data = {'tmdb_ids': {12345}, 'titles': set()}
+
+        result = is_in_library(12345, 'Some Movie', '2023', library_data)
+
+        assert result is True
+
+    def test_finds_by_title_and_year(self):
+        library_data = {'tmdb_ids': set(), 'titles': {('some movie', 2023)}}
+
+        result = is_in_library(None, 'Some Movie', '2023', library_data)
+
+        assert result is True
+
+    def test_finds_by_title_only(self):
+        library_data = {'tmdb_ids': set(), 'titles': {('some movie', 2023)}}
+
+        result = is_in_library(None, 'Some Movie', None, library_data)
+
+        assert result is True
+
+    def test_returns_false_when_not_found(self):
+        library_data = {'tmdb_ids': set(), 'titles': set()}
+
+        result = is_in_library(None, 'Unknown Movie', '2023', library_data)
+
+        assert result is False
+
+
+class TestGenerateCombinedHtml:
+    """Tests for generate_combined_html function"""
+
+    @patch('recommenders.external.get_imdb_id')
+    def test_generates_html_file(self, mock_get_imdb):
+        mock_get_imdb.return_value = 'tt1234567'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            all_users_data = [
+                {
+                    'username': 'testuser',
+                    'display_name': 'Test User',
+                    'movies_categorized': {
+                        'user_services': {},
+                        'other_services': {},
+                        'acquire': [
+                            {'tmdb_id': 1, 'title': 'Test Movie', 'year': '2023', 'rating': 7.5, 'score': 0.8, 'added_date': datetime.now().isoformat()}
+                        ]
+                    },
+                    'shows_categorized': {
+                        'user_services': {},
+                        'other_services': {},
+                        'acquire': []
+                    }
+                }
+            ]
+
+            result = generate_combined_html(all_users_data, tmpdir, 'api_key')
+
+            assert os.path.exists(result)
+            assert result.endswith('watchlist.html')
+
+            with open(result) as f:
+                content = f.read()
+                assert 'Test User' in content
+                assert 'Test Movie' in content
+                assert 'Plex Watchlist' in content
+
+    @patch('recommenders.external.get_imdb_id')
+    def test_html_contains_tabs_for_multiple_users(self, mock_get_imdb):
+        mock_get_imdb.return_value = 'tt1234567'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            all_users_data = [
+                {
+                    'username': 'user1',
+                    'display_name': 'User One',
+                    'movies_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []},
+                    'shows_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []}
+                },
+                {
+                    'username': 'user2',
+                    'display_name': 'User Two',
+                    'movies_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []},
+                    'shows_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []}
+                }
+            ]
+
+            result = generate_combined_html(all_users_data, tmpdir, 'api_key')
+
+            with open(result) as f:
+                content = f.read()
+                assert 'User One' in content
+                assert 'User Two' in content
+                assert 'tab-btn' in content
+
+    @patch('recommenders.external.get_imdb_id')
+    def test_html_contains_export_buttons(self, mock_get_imdb):
+        mock_get_imdb.return_value = 'tt1234567'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            all_users_data = [
+                {
+                    'username': 'testuser',
+                    'display_name': 'Test',
+                    'movies_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []},
+                    'shows_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []}
+                }
+            ]
+
+            result = generate_combined_html(all_users_data, tmpdir, 'api_key')
+
+            with open(result) as f:
+                content = f.read()
+                assert 'Export to Radarr' in content
+                assert 'Export to Sonarr' in content
+                assert 'exportRadarr()' in content
+                assert 'exportSonarr()' in content
+
+    @patch('recommenders.external.get_imdb_id')
+    def test_html_checkboxes_unchecked_by_default(self, mock_get_imdb):
+        mock_get_imdb.return_value = 'tt1234567'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            all_users_data = [
+                {
+                    'username': 'testuser',
+                    'display_name': 'Test',
+                    'movies_categorized': {
+                        'user_services': {},
+                        'other_services': {},
+                        'acquire': [
+                            {'tmdb_id': 1, 'title': 'Movie', 'year': '2023', 'rating': 7.0, 'score': 0.5, 'added_date': datetime.now().isoformat()}
+                        ]
+                    },
+                    'shows_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []}
+                }
+            ]
+
+            result = generate_combined_html(all_users_data, tmpdir, 'api_key')
+
+            with open(result) as f:
+                content = f.read()
+                # Should have unchecked checkboxes (no 'checked' attribute on select-item)
+                assert 'class="select-item">' in content or 'class="select-item"' in content
+                assert 'class="select-item" checked' not in content
+
+
+class TestCacheOperations:
+    """Tests for cache load/save operations"""
+
+    def test_save_and_load_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Patch the cache directory
+            with patch('recommenders.external.os.path.dirname') as mock_dirname:
+                mock_dirname.return_value = tmpdir
+
+                cache_data = {
+                    '12345': {
+                        'tmdb_id': 12345,
+                        'title': 'Test Movie',
+                        'year': '2023',
+                        'rating': 7.5,
+                        'score': 0.8,
+                        'added_date': '2023-01-01T00:00:00'
+                    }
+                }
+
+                # Create cache dir
+                os.makedirs(os.path.join(tmpdir, 'cache'), exist_ok=True)
+
+                save_cache('TestUser', 'movies', cache_data)
+
+                loaded = load_cache('TestUser', 'movies')
+
+                assert '12345' in loaded
+                assert loaded['12345']['title'] == 'Test Movie'
+
+    def test_load_empty_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('recommenders.external.os.path.dirname') as mock_dirname:
+                mock_dirname.return_value = tmpdir
+
+                loaded = load_cache('NonExistent', 'movies')
+
+                assert loaded == {}
+
+
+class TestServiceDisplayNames:
+    """Tests for SERVICE_DISPLAY_NAMES constant"""
+
+    def test_contains_major_services(self):
+        assert 'netflix' in SERVICE_DISPLAY_NAMES
+        assert 'hulu' in SERVICE_DISPLAY_NAMES
+        assert 'disney_plus' in SERVICE_DISPLAY_NAMES
+        assert 'amazon_prime' in SERVICE_DISPLAY_NAMES
+
+    def test_display_names_are_readable(self):
+        assert SERVICE_DISPLAY_NAMES['netflix'] == 'Netflix'
+        assert SERVICE_DISPLAY_NAMES['disney_plus'] == 'Disney+'
+        assert SERVICE_DISPLAY_NAMES['amazon_prime'] == 'Amazon Prime Video'
+
+
+class TestTmdbProviders:
+    """Tests for TMDB_PROVIDERS mapping"""
+
+    def test_contains_netflix(self):
+        assert 8 in TMDB_PROVIDERS
+        assert TMDB_PROVIDERS[8] == 'netflix'
+
+    def test_contains_disney_plus(self):
+        assert 337 in TMDB_PROVIDERS
+        assert TMDB_PROVIDERS[337] == 'disney_plus'


### PR DESCRIPTION
## Summary
- Interactive HTML watchlist with tabs for each user
- Export buttons for Radarr (movies) and Sonarr (shows) - downloads IMDB IDs
- Movie theater themed dark design with gold accents
- Auto-open in browser after run (configurable via `auto_open_html`)
- 25 new unit tests for external.py functions

## Test plan
- [x] Unit tests pass (pytest tests/test_external.py)
- [x] HTML generates correctly with multiple users
- [x] Export buttons produce valid IMDB ID lists
- [x] Checkboxes unchecked by default
- [x] Tabs switch between users correctly