### PR TITLE
Add popularity dampening for very popular content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.6] - 2026-01-03
+
+### Added
+- **Popularity dampening** — Slight penalty for very popular content (50k+ votes)
+  - Prevents blockbusters from dominating due to more complete metadata
+  - ~3% penalty per order of magnitude above threshold (capped at 10%)
+  - Configurable via `use_popularity_dampening` and `popularity_threshold` parameters
+
 ## [1.6.5] - 2026-01-03
 
 ### Added

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -49,7 +49,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"
 
 # Import base class
 from recommenders.base import BaseCache
@@ -754,7 +754,8 @@ class PlexMovieRecommender:
             'directors': movie_info.get('directors', []),
             'cast': movie_info.get('cast', []),
             'language': movie_info.get('language', 'N/A'),
-            'keywords': movie_info.get('tmdb_keywords', [])
+            'keywords': movie_info.get('tmdb_keywords', []),
+            'vote_count': movie_info.get('vote_count', 0)
         }
 
         # Use shared scoring function

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -51,7 +51,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"
 
 # Import base class
 from recommenders.base import BaseCache
@@ -691,7 +691,8 @@ class PlexTVRecommender:
             'studio': show_info.get('studio', 'N/A'),
             'cast': show_info.get('cast', []),
             'language': show_info.get('language', 'N/A'),
-            'keywords': show_info.get('tmdb_keywords', [])
+            'keywords': show_info.get('tmdb_keywords', []),
+            'vote_count': show_info.get('vote_count', 0)
         }
 
         # Use shared scoring function


### PR DESCRIPTION
## Summary
- Slight penalty for content with 50k+ TMDB votes
- ~3% penalty per order of magnitude above threshold (capped at 10%)
- Prevents blockbusters from dominating due to more complete metadata

## Test plan
- [x] All 501 tests passing (5 new tests for popularity dampening)