### PR TITLE
Add collection bonus for sequels/franchise movies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.8] - 2026-01-03
+
+### Added
+- **Collection bonus for sequels** — Movies in franchises get a score bonus
+  - Tracks TMDB collection data (e.g., "Harry Potter Collection")
+  - Applies 5-15% bonus for unwatched movies in collections user has watched
+  - Logarithmic scaling: more watched movies = higher bonus (capped at 15%)
+
 ## [1.6.7] - 2026-01-03
 
 ### Added

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -52,7 +52,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"
 
 # Import base class
 from recommenders.base import BaseCache

--- a/utils/counters.py
+++ b/utils/counters.py
@@ -28,9 +28,10 @@ def create_empty_counters(media_type: str = 'movie') -> Dict:
         'tmdb_keywords': Counter(),
         'tmdb_ids': set()
     }
-    # Movies use directors, TV uses studio
+    # Movies use directors and collections, TV uses studio
     if media_type == 'movie':
         counters['directors'] = Counter()
+        counters['collections'] = Counter()  # Track TMDB collection IDs for sequel bonus
     else:
         counters['studio'] = Counter()
     return counters
@@ -160,6 +161,11 @@ def process_counters_from_cache(
             for director in directors:
                 if director:
                     _apply_capped_weight(counters['directors'], director, total_weight, cap_penalty)
+
+            # Track movie collections (for sequel bonus)
+            collection_id = media_info.get('collection_id')
+            if collection_id and 'collections' in counters:
+                _apply_capped_weight(counters['collections'], collection_id, total_weight, cap_penalty)
         else:
             studio = media_info.get('studio', '')
             if studio:


### PR DESCRIPTION
## Summary
- Adds 5-15% score bonus for movies in TMDB collections the user has watched
- Tracks collection_id and collection_name in movie cache
- Auto-backfills collection data for existing cached movies (one-time migration)
- Bonus scales logarithmically based on how many movies watched in collection

## Changes
- `recommenders/base.py`: Added `_backfill_collection_data` method, collection fields in `_get_tmdb_data`
- `recommenders/movie.py`: Added collection bonus calculation in similarity scoring
- `utils/counters.py`: Added collections counter tracking

## Test plan
- [x] All 506 tests passing
- [x] Verified backfill completes successfully (1945 movies processed)
- [x] Verified collection bonus shows in recommendation output