### PR TITLE
Remove dead code and unused imports from recommenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.10] - 2026-01-03
+
+### Removed
+- **Dead code cleanup** — Removed unused code from recommenders
+  - Removed unused `import random` from movie.py and tv.py
+  - Removed unused utility imports (RATING_MULTIPLIERS, DEFAULT_NEGATIVE_MULTIPLIERS, DEFAULT_RATING, TOP_POOL_PERCENTAGE)
+  - Removed dead `find_similar_content()` function from external.py
+  - Removed duplicate `get_tmdb_keywords()` from external.py (now uses utils version)
+  - Removed unused `self.plex_only` attribute from tv.py
+
 ## [1.6.9] - 2026-01-03
 
 ### Changed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -28,7 +28,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 from utils import (
     RED, GREEN, YELLOW, CYAN, RESET,
     RATING_MULTIPLIERS, GENRE_NORMALIZATION,
-    get_plex_account_ids, get_tmdb_config,
+    get_plex_account_ids, get_tmdb_config, get_tmdb_keywords,
     fetch_watch_history_with_tmdb,
     print_user_header, print_user_footer, print_status,
     log_warning, log_error, load_config,
@@ -380,22 +380,6 @@ def build_user_profile(plex, config, username, media_type='movie'):
     print(f"  Top genres: {dict(counters['genres'].most_common(5))}")
 
     return counters
-
-
-def get_tmdb_keywords(tmdb_api_key, tmdb_id, media_type='movie'):
-    """Fetch keywords from TMDB for a given item."""
-    try:
-        media = 'movie' if media_type == 'movie' else 'tv'
-        url = f"https://api.themoviedb.org/3/{media}/{tmdb_id}/keywords"
-        response = requests.get(url, params={'api_key': tmdb_api_key}, timeout=10)
-        if response.status_code == 200:
-            data = response.json()
-            # Movies use 'keywords', TV uses 'results'
-            keywords_list = data.get('keywords', data.get('results', []))
-            return [kw['name'] for kw in keywords_list[:10]]  # Top 10 keywords
-    except (requests.RequestException, KeyError):
-        pass
-    return []
 
 
 def get_tmdb_details(tmdb_api_key, tmdb_id, media_type='movie'):
@@ -824,14 +808,6 @@ def find_similar_content_with_profile(tmdb_api_key, user_profile, library_data, 
 
     return final_recs
 
-
-# Keep old function name for compatibility but redirect to new one
-def find_similar_content(tmdb_api_key, watched_items, library_data, media_type='movie', limit=50, genre_distribution=None, exclude_genres=None, min_relevance_score=0.25):
-    """Legacy wrapper - redirects to profile-based scoring in process_user()"""
-    # This function is kept for compatibility but the actual work
-    # is now done in process_user() using find_similar_content_with_profile()
-    print_status("Warning: Using legacy find_similar_content", "warning")
-    return []
 
 def load_cache(display_name, media_type):
     """Load existing recommendations cache"""

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -11,7 +11,6 @@ import yaml
 import requests
 from typing import Dict, List, Set, Optional, Tuple
 import time
-import random
 import json
 import re
 from datetime import datetime
@@ -20,12 +19,12 @@ import copy
 # Import shared utilities
 from utils import (
     RED, GREEN, YELLOW, CYAN, RESET,
-    RATING_MULTIPLIERS, CACHE_VERSION, check_cache_version,
-    TOP_CAST_COUNT, TMDB_RATE_LIMIT_DELAY, DEFAULT_RATING,
-    WEIGHT_SUM_TOLERANCE, DEFAULT_LIMIT_PLEX_RESULTS, TOP_POOL_PERCENTAGE,
+    CACHE_VERSION, check_cache_version,
+    TOP_CAST_COUNT, TMDB_RATE_LIMIT_DELAY,
+    WEIGHT_SUM_TOLERANCE, DEFAULT_LIMIT_PLEX_RESULTS,
     TIER_SAFE_PERCENT, TIER_DIVERSE_PERCENT, TIER_WILDCARD_PERCENT,
     select_tiered_recommendations,
-    DEFAULT_NEGATIVE_MULTIPLIERS, DEFAULT_NEGATIVE_THRESHOLD,
+    DEFAULT_NEGATIVE_THRESHOLD,
     get_full_language_name, cleanup_old_logs, setup_logging, get_tmdb_config,
     get_plex_account_ids, fetch_plex_watch_history_movies, get_watched_movie_count,
     log_warning, log_error, update_plex_collection, cleanup_old_collections,
@@ -35,10 +34,8 @@ from utils import (
     calculate_recency_multiplier, calculate_rewatch_multiplier,
     calculate_similarity_score, find_plex_movie,
     show_progress, TeeLogger,
-    # Consolidated utilities
     extract_genres, extract_ids_from_guids, fetch_tmdb_with_retry,
     get_tmdb_id_for_item, get_tmdb_keywords, adapt_config_for_media_type,
-    # Additional consolidated utilities
     user_select_recommendations, format_media_output,
     build_label_name, categorize_labeled_items, remove_labels_from_items, add_labels_to_items,
     get_library_imdb_ids, print_similarity_breakdown,
@@ -50,7 +47,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.9"
+__version__ = "1.6.10"
 
 # Import base class
 from recommenders.base import BaseCache

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -11,7 +11,6 @@ import yaml
 import requests
 from typing import Dict, List, Set, Optional, Tuple
 import time
-import random
 import json
 import re
 from datetime import datetime
@@ -20,12 +19,12 @@ import copy
 # Import shared utilities
 from utils import (
     RED, GREEN, YELLOW, CYAN, RESET,
-    RATING_MULTIPLIERS, CACHE_VERSION, check_cache_version,
-    TOP_CAST_COUNT, TMDB_RATE_LIMIT_DELAY, DEFAULT_RATING,
-    WEIGHT_SUM_TOLERANCE, DEFAULT_LIMIT_PLEX_RESULTS, TOP_POOL_PERCENTAGE,
+    CACHE_VERSION, check_cache_version,
+    TOP_CAST_COUNT, TMDB_RATE_LIMIT_DELAY,
+    WEIGHT_SUM_TOLERANCE, DEFAULT_LIMIT_PLEX_RESULTS,
     TIER_SAFE_PERCENT, TIER_DIVERSE_PERCENT, TIER_WILDCARD_PERCENT,
     select_tiered_recommendations,
-    DEFAULT_NEGATIVE_MULTIPLIERS, DEFAULT_NEGATIVE_THRESHOLD,
+    DEFAULT_NEGATIVE_THRESHOLD,
     get_full_language_name, cleanup_old_logs, setup_logging, get_tmdb_config,
     get_plex_account_ids, get_watched_show_count,
     fetch_plex_watch_history_shows,
@@ -37,10 +36,8 @@ from utils import (
     calculate_recency_multiplier, calculate_rewatch_multiplier,
     calculate_similarity_score,
     show_progress, TeeLogger,
-    # Consolidated utilities
     extract_genres, extract_ids_from_guids, fetch_tmdb_with_retry,
     get_tmdb_id_for_item, get_tmdb_keywords, adapt_config_for_media_type,
-    # Additional consolidated utilities
     user_select_recommendations, format_media_output,
     build_label_name, categorize_labeled_items, remove_labels_from_items, add_labels_to_items,
     get_library_imdb_ids, print_similarity_breakdown,
@@ -52,7 +49,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.8"
+__version__ = "1.6.10"
 
 # Import base class
 from recommenders.base import BaseCache
@@ -146,7 +143,6 @@ class PlexTVRecommender:
         self.randomize_recommendations = general_config.get('randomize_recommendations', True)
         self.normalize_counters = general_config.get('normalize_counters', True)
         self.show_summary = general_config.get('show_summary', False)
-        self.plex_only = general_config.get('plex_only', False)
         self.show_cast = general_config.get('show_cast', False)
         self.show_language = general_config.get('show_language', False)
         self.show_rating = general_config.get('show_rating', False)


### PR DESCRIPTION
## Summary
- Remove unused `import random` from movie.py and tv.py
- Remove unused utility imports (RATING_MULTIPLIERS, DEFAULT_NEGATIVE_MULTIPLIERS, DEFAULT_RATING, TOP_POOL_PERCENTAGE)
- Remove dead `find_similar_content()` from external.py
- Remove duplicate `get_tmdb_keywords()` from external.py (now uses utils version)
- Remove unused `self.plex_only` attribute from tv.py
- Bump version to 1.6.10

## Test plan
- [x] All 564 tests pass
- [x] Syntax validation passes