### PR TITLE
Fix backfill infinite retry for movies not in TMDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.11] - 2026-01-03
+
+### Fixed
+- **Backfill handles API failures** — Collection backfill now marks movies as processed even when TMDB API returns 404
+  - Prevents infinite retry loop for movies removed from TMDB
+
 ## [1.6.10] - 2026-01-03
 
 ### Removed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -191,11 +191,16 @@ class BaseCache(ABC):
                         info['collection_name'] = collection.get('name')
                         updated += 1
                     else:
-                        # Mark as checked (no collection)
                         info['collection_id'] = None
                         info['collection_name'] = None
+                else:
+                    # API failed (404, etc) - mark as processed to avoid infinite retries
+                    info['collection_id'] = None
+                    info['collection_name'] = None
             except Exception:
-                pass  # Skip failures, will retry next run
+                # Mark as processed even on exception
+                info['collection_id'] = None
+                info['collection_name'] = None
 
         print(f"\n{GREEN}Added collection data for {updated} movies{RESET}")
         return True

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -47,7 +47,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.10"
+__version__ = "1.6.11"
 
 # Import base class
 from recommenders.base import BaseCache

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -49,7 +49,7 @@ from utils import (
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger('plex_recommender')
 
-__version__ = "1.6.10"
+__version__ = "1.6.11"
 
 # Import base class
 from recommenders.base import BaseCache


### PR DESCRIPTION
## Summary
- Collection backfill now marks movies as processed even when TMDB API returns 404
- Fixes infinite retry loop for movies that were removed from TMDB (e.g., Kennedy Center specials)

## Root cause
When `fetch_tmdb_with_retry` returns None (404), the code never set `collection_id`, so the movie stayed in the "needs backfill" list forever.

## Test plan
- [x] All 564 tests pass
- [x] Verified the 2 affected movies (Dave Chappelle and Kevin Hart Kennedy Center specials) return 404 from TMDB