### PR TITLE
Refactor recommenders to properly inherit from BaseRecommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.12] - 2026-01-03
+
+### Changed
+- **Recommenders now inherit from BaseRecommender** — Major refactoring to reduce code duplication
+  - PlexMovieRecommender and PlexTVRecommender now properly inherit from BaseRecommender
+  - Moved common initialization logic (config, plex, display options, weights) to base class
+  - Implemented abstract methods: `_load_weights()`, `_get_watched_data()`, `_get_watched_count()`, `_save_watched_cache()`
+  - Renamed `watched_movie_ids`/`watched_show_ids` to `watched_ids` for consistency
+  - Removed duplicate `_refresh_watched_data()` (now uses base class version)
+  - Uses `_get_user_context()` from base class instead of duplicating logic
+  - Updated tests to mock at `recommenders.base.*` instead of media-specific modules
+
 ## [1.6.11] - 2026-01-03
 
 ### Fixed

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -102,17 +102,17 @@ class TestPlexMovieRecommenderInit:
     """Tests for PlexMovieRecommender initialization."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_init_creates_movie_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that PlexMovieRecommender creates a MovieCache."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
-            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'tmdb_keywords': 0.2}
+            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2}
         }
         mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
         mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
@@ -127,10 +127,10 @@ class TestPlexMovieRecommenderWeights:
     """Tests for PlexMovieRecommender weight loading."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_loads_weights_from_config(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that weights are loaded from config."""
@@ -157,10 +157,10 @@ class TestPlexMovieRecommenderWeights:
         assert recommender.weights['actor'] == 0.20
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_uses_default_weights_when_missing(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that default weights are used when not in config."""
@@ -186,10 +186,10 @@ class TestPlexMovieRecommenderLibraryMethods:
     """Tests for PlexMovieRecommender library methods."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_library_movies_set(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_library_movies_set returns movie IDs."""
@@ -220,10 +220,10 @@ class TestPlexMovieRecommenderSimilarity:
 
     @patch('recommenders.movie.calculate_similarity_score')
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_calculate_similarity_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_calc):
         """Test _calculate_similarity_from_cache uses cached data."""
@@ -267,10 +267,10 @@ class TestPlexMovieRecommenderWatchedCache:
 
     @patch('recommenders.movie.save_watched_cache')
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_save_watched_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_save):
         """Test _save_watched_cache saves data correctly."""
@@ -379,10 +379,10 @@ class TestPlexMovieRecommenderWatchedCount:
 
     @patch('recommenders.movie.get_watched_movie_count')
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_watched_count_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_count):
         """Test that _get_watched_count uses utility function."""
@@ -407,10 +407,10 @@ class TestPlexMovieRecommenderTmdbMethods:
     """Tests for PlexMovieRecommender TMDB-related methods."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_plex_movie_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_plex_movie_tmdb_id returns from cache."""
@@ -435,10 +435,10 @@ class TestPlexMovieRecommenderTmdbMethods:
         assert result == 456
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_plex_movie_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_plex_movie_imdb_id extracts from guids."""
@@ -468,17 +468,17 @@ class TestPlexMovieRecommenderRefreshWatchedData:
     """Tests for PlexMovieRecommender._refresh_watched_data method."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_refresh_clears_data(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _refresh_watched_data clears existing data."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
-            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'tmdb_keywords': 0.2}
+            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2}
         }
         mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
         mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
@@ -486,26 +486,26 @@ class TestPlexMovieRecommenderRefreshWatchedData:
         mock_cache.return_value = Mock(cache={'movies': {}})
 
         recommender = PlexMovieRecommender('/path/to/config.yml')
-        recommender.watched_movie_ids = {1, 2, 3}
+        recommender.watched_ids = {1, 2, 3}
         recommender.watched_data_counters = {'genres': Counter({'action': 5})}
 
-        # Mock the methods called during refresh
-        recommender._get_plex_watched_data = Mock(return_value={'genres': Counter()})
+        # Mock the methods called during refresh (base class calls _get_watched_data)
+        recommender._get_watched_data = Mock(return_value={'genres': Counter()})
         recommender._save_watched_cache = Mock()
 
         recommender._refresh_watched_data()
 
-        assert len(recommender.watched_movie_ids) == 0
+        assert len(recommender.watched_ids) == 0
 
 
 class TestPlexMovieRecommenderGetRecommendations:
     """Tests for PlexMovieRecommender.get_recommendations method."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_recommendations_returns_dict(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test get_recommendations returns a dict with plex_recommendations."""
@@ -537,17 +537,17 @@ class TestPlexMovieRecommenderGetRecommendations:
         assert 'plex_recommendations' in result
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_recommendations_excludes_watched(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test get_recommendations excludes watched movies."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {'limit_plex_results': 10},
-            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'tmdb_keywords': 0.2}
+            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2}
         }
         mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
         mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
@@ -568,7 +568,7 @@ class TestPlexMovieRecommenderGetRecommendations:
         mock_cache.return_value = mock_cache_inst
 
         recommender = PlexMovieRecommender('/path/to/config.yml')
-        recommender.watched_movie_ids = {1}
+        recommender.watched_ids = {1}
         recommender.cached_watched_count = 1
         recommender.watched_data = {
             'genres': Counter(), 'directors': Counter(), 'actors': Counter(),
@@ -587,10 +587,10 @@ class TestPlexMovieRecommenderCollectionBonus:
 
     @patch('recommenders.movie.calculate_similarity_score')
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_collection_bonus_applied(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_calc):
         """Test that collection bonus is applied for movies in watched collections."""
@@ -707,10 +707,10 @@ class TestPlexMovieRecommenderExcludedGenres:
     """Tests for genre exclusion in recommendations."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_excludes_configured_genres(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that configured excluded genres are filtered."""
@@ -795,10 +795,10 @@ class TestPlexMovieRecommenderManageLabels:
     """Tests for PlexMovieRecommender.manage_plex_labels method."""
 
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_manage_labels_skips_when_disabled(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test manage_plex_labels does nothing when disabled."""
@@ -871,10 +871,10 @@ class TestPlexMovieRecommenderLibraryImdbIds:
 
     @patch('recommenders.movie.get_library_imdb_ids')
     @patch('recommenders.movie.MovieCache')
-    @patch('recommenders.movie.init_plex')
-    @patch('recommenders.movie.get_configured_users')
-    @patch('recommenders.movie.get_tmdb_config')
-    @patch('recommenders.movie.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_library_imdb_ids_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_get_ids):
         """Test that _get_library_imdb_ids uses utility function."""

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -139,10 +139,10 @@ class TestPlexTVRecommenderInit:
     """Tests for PlexTVRecommender initialization."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_init_creates_show_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that PlexTVRecommender creates a ShowCache."""
@@ -165,10 +165,10 @@ class TestPlexTVRecommenderInit:
         mock_cache.assert_called_once()
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_init_sets_library_title(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that PlexTVRecommender sets library title from config."""
@@ -195,10 +195,10 @@ class TestPlexTVRecommenderWeights:
     """Tests for PlexTVRecommender weight loading."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_loads_weights_from_config(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that weights are loaded from config."""
@@ -229,10 +229,10 @@ class TestPlexTVRecommenderWeights:
         assert recommender.weights['actor'] == 0.15
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_uses_default_weights_when_missing(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that default weights are used when not in config."""
@@ -262,10 +262,10 @@ class TestPlexTVRecommenderLibraryMethods:
     """Tests for PlexTVRecommender library methods."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_library_shows_set(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_library_shows_set returns show tuples."""
@@ -294,10 +294,10 @@ class TestPlexTVRecommenderLibraryMethods:
         assert ('breaking bad', 2008) in result
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_library_shows_set_handles_embedded_year(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_library_shows_set handles embedded year in title."""
@@ -333,10 +333,10 @@ class TestPlexTVRecommenderSimilarity:
 
     @patch('recommenders.tv.calculate_similarity_score')
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_calculate_similarity_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_calc):
         """Test _calculate_similarity_from_cache uses cached data."""
@@ -384,10 +384,10 @@ class TestPlexTVRecommenderWatchedCache:
 
     @patch('recommenders.tv.save_watched_cache')
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_save_watched_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_save):
         """Test _save_watched_cache saves data correctly."""
@@ -407,7 +407,7 @@ class TestPlexTVRecommenderWatchedCache:
 
         recommender = PlexTVRecommender('/path/to/config.yml')
         recommender.watched_data_counters = {'genres': Counter({'drama': 5})}
-        recommender.watched_show_ids = {1, 2, 3}
+        recommender.watched_ids = {1, 2, 3}
         recommender.cached_watched_count = 10
 
         recommender._save_watched_cache()
@@ -420,10 +420,10 @@ class TestPlexTVRecommenderWatchedCount:
 
     @patch('recommenders.tv.get_watched_show_count')
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_watched_count_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_count):
         """Test that _get_watched_count uses utility function."""
@@ -452,10 +452,10 @@ class TestPlexTVRecommenderTmdbMethods:
     """Tests for PlexTVRecommender TMDB-related methods."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_plex_show_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_plex_show_tmdb_id returns from cache."""
@@ -484,10 +484,10 @@ class TestPlexTVRecommenderTmdbMethods:
         assert result == 456
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_plex_show_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_plex_show_imdb_id extracts from guids."""
@@ -518,10 +518,10 @@ class TestPlexTVRecommenderTmdbMethods:
 
     @patch('recommenders.tv.get_tmdb_keywords')
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_tmdb_keywords_for_id(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_keywords):
         """Test _get_tmdb_keywords_for_id returns keywords."""
@@ -553,10 +553,10 @@ class TestPlexTVRecommenderRefreshWatchedData:
     """Tests for PlexTVRecommender._refresh_watched_data method."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_refresh_clears_data(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _refresh_watched_data clears existing data."""
@@ -575,7 +575,7 @@ class TestPlexTVRecommenderRefreshWatchedData:
         mock_cache.return_value = Mock(cache={'shows': {}})
 
         recommender = PlexTVRecommender('/path/to/config.yml')
-        recommender.watched_show_ids = {1, 2, 3}
+        recommender.watched_ids = {1, 2, 3}
         recommender.watched_data_counters = {'genres': Counter({'drama': 5})}
 
         # Mock the methods called during refresh
@@ -584,17 +584,17 @@ class TestPlexTVRecommenderRefreshWatchedData:
 
         recommender._refresh_watched_data()
 
-        assert len(recommender.watched_show_ids) == 0
+        assert len(recommender.watched_ids) == 0
 
 
 class TestPlexTVRecommenderGetRecommendations:
     """Tests for PlexTVRecommender.get_recommendations method."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_recommendations_returns_dict(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test get_recommendations returns a dict with plex_recommendations."""
@@ -613,7 +613,7 @@ class TestPlexTVRecommenderGetRecommendations:
         mock_cache.return_value = Mock(cache={'shows': {}})
 
         recommender = PlexTVRecommender('/path/to/config.yml')
-        recommender.watched_show_ids = set()
+        recommender.watched_ids = set()
         recommender.cached_watched_count = 0
         recommender.watched_data = {'genres': Counter(), 'studio': Counter(), 'actors': Counter(), 'languages': Counter(), 'tmdb_keywords': Counter()}
 
@@ -623,10 +623,10 @@ class TestPlexTVRecommenderGetRecommendations:
         assert 'plex_recommendations' in result
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_recommendations_excludes_watched(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test get_recommendations excludes watched shows."""
@@ -655,7 +655,7 @@ class TestPlexTVRecommenderGetRecommendations:
         mock_cache.return_value = mock_cache_inst
 
         recommender = PlexTVRecommender('/path/to/config.yml')
-        recommender.watched_show_ids = {1}  # Show 1 is watched
+        recommender.watched_ids = {1}  # Show 1 is watched
         recommender.cached_watched_count = 1
         recommender.watched_data = {'genres': Counter(), 'studio': Counter(), 'actors': Counter(), 'languages': Counter(), 'tmdb_keywords': Counter()}
         recommender._calculate_similarity_from_cache = Mock(return_value=(0.5, {}))
@@ -763,10 +763,10 @@ class TestPlexTVRecommenderShowDetails:
     """Tests for PlexTVRecommender.get_show_details method."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_show_details_returns_dict(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test get_show_details returns a dict with show info."""
@@ -808,10 +808,10 @@ class TestPlexTVRecommenderPlexAccountIds:
 
     @patch('recommenders.tv.get_plex_account_ids')
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_get_plex_account_ids_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_get_ids):
         """Test that _get_plex_account_ids uses utility function."""
@@ -841,10 +841,10 @@ class TestPlexTVRecommenderManageLabels:
     """Tests for PlexTVRecommender.manage_plex_labels method."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_manage_labels_skips_when_disabled(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test manage_plex_labels does nothing when disabled."""
@@ -873,10 +873,10 @@ class TestPlexTVRecommenderExcludedGenres:
     """Tests for genre exclusion in recommendations."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_excludes_configured_genres(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that configured excluded genres are filtered."""
@@ -904,7 +904,7 @@ class TestPlexTVRecommenderExcludedGenres:
         mock_cache.return_value = mock_cache_inst
 
         recommender = PlexTVRecommender('/path/to/config.yml')
-        recommender.watched_show_ids = set()
+        recommender.watched_ids = set()
         recommender.cached_watched_count = 0
         recommender.watched_data = {'genres': Counter(), 'studio': Counter(), 'actors': Counter(), 'languages': Counter(), 'tmdb_keywords': Counter()}
         recommender._calculate_similarity_from_cache = Mock(return_value=(0.5, {}))
@@ -920,10 +920,10 @@ class TestPlexTVRecommenderExtractGenres:
     """Tests for PlexTVRecommender._extract_genres method."""
 
     @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.tv.init_plex')
-    @patch('recommenders.tv.get_configured_users')
-    @patch('recommenders.tv.get_tmdb_config')
-    @patch('recommenders.tv.load_config')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
     @patch('os.makedirs')
     def test_extract_genres_from_show(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _extract_genres returns list of genres."""


### PR DESCRIPTION
## Summary
- PlexMovieRecommender and PlexTVRecommender now properly inherit from BaseRecommender
- Moved common initialization logic to base class, reducing code duplication by ~100 lines
- Implemented abstract methods: `_load_weights()`, `_get_watched_data()`
- Renamed `watched_movie_ids`/`watched_show_ids` to `watched_ids` for consistency

## Test plan
- [x] All 564 tests passing
- [x] Movie recommender tests updated for new mocking paths
- [x] TV recommender tests updated for new mocking paths
- [x] Syntax verified with py_compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)