### PR TITLE
Refactor recommenders to use full inheritance from BaseRecommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.13] - 2026-01-03
+
+### Changed
+- **Deep inheritance refactor** — Eliminated ~650 lines of duplicated code between movie/tv recommenders
+  - Moved `get_recommendations()` to BaseRecommender (was duplicated in both)
+  - Moved `manage_plex_labels()` to BaseRecommender (was duplicated in both)
+  - Moved `_get_plex_user_ids()` to BaseRecommender (was identical in both)
+  - Moved `_get_managed_users_watched_data()` to BaseRecommender (was near-identical)
+  - Moved `_load_watched_cache()` to BaseRecommender (cache init block was duplicated)
+  - Added `_do_save_watched_cache()` helper to BaseRecommender
+  - Added abstract methods: `_get_media_cache()`, `_find_plex_item()`, `_calculate_similarity_from_cache()`, `_print_similarity_breakdown()`
+  - Added `media_key` class attribute to recommenders for generic cache access
+
 ## [1.6.12] - 2026-01-03
 
 ### Changed

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -346,8 +346,17 @@ class ConcreteRecommender(BaseRecommender):
     def _save_watched_cache(self):
         pass
 
-    def get_recommendations(self, username=None):
-        return []
+    def _get_media_cache(self):
+        return Mock()
+
+    def _find_plex_item(self, section, rec):
+        return None
+
+    def _calculate_similarity_from_cache(self, item_info):
+        return (0.5, {})
+
+    def _print_similarity_breakdown(self, item_info, score, breakdown):
+        pass
 
 
 class TestBaseRecommenderInit:

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -265,7 +265,7 @@ class TestPlexMovieRecommenderSimilarity:
 class TestPlexMovieRecommenderWatchedCache:
     """Tests for PlexMovieRecommender watched cache methods."""
 
-    @patch('recommenders.movie.save_watched_cache')
+    @patch('recommenders.base.save_watched_cache')
     @patch('recommenders.movie.MovieCache')
     @patch('recommenders.base.init_plex')
     @patch('recommenders.base.get_configured_users')

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -382,7 +382,7 @@ class TestPlexTVRecommenderSimilarity:
 class TestPlexTVRecommenderWatchedCache:
     """Tests for PlexTVRecommender watched cache methods."""
 
-    @patch('recommenders.tv.save_watched_cache')
+    @patch('recommenders.base.save_watched_cache')
     @patch('recommenders.tv.ShowCache')
     @patch('recommenders.base.init_plex')
     @patch('recommenders.base.get_configured_users')


### PR DESCRIPTION
## Summary
- Eliminates ~650 lines of duplicated code between movie and TV recommenders
- Moves core methods (get_recommendations, manage_plex_labels, etc.) to BaseRecommender
- Adds abstract methods for media-specific behavior

## Test plan
- [x] All 564 tests pass
- [x] Live test with real Plex data successful