### PR TITLE
Consolidate TMDB helper methods to BaseRecommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Plex Recommender will be documented in this file.
 
+## [1.6.14] - 2026-01-03
+
+### Changed
+- **Consolidated TMDB helper methods to BaseRecommender** — Removed ~130 lines of duplicated code
+  - Moved `_get_plex_item_tmdb_id()` to BaseRecommender (was `_get_plex_movie_tmdb_id`/`_get_plex_show_tmdb_id`)
+  - Moved `_get_plex_item_imdb_id()` to BaseRecommender (was `_get_plex_movie_imdb_id`/`_get_plex_show_imdb_id`)
+  - Moved `_get_tmdb_id_via_imdb()` to BaseRecommender (identical logic, different result key)
+  - Moved `_get_tmdb_keywords_for_id()` to BaseRecommender (100% identical between movie/tv)
+  - Moved `_get_library_imdb_ids()` to BaseRecommender (100% identical one-liner)
+  - Removed unnecessary delegate methods `_extract_genres()` and `_get_*_language()` - now call utilities directly
+  - Uses `self.media_type` to handle movie vs tv differences in base class methods
+  - Cleaned up unused imports from movie.py and tv.py
+
 ## [1.6.13] - 2026-01-03
 
 ### Changed

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -412,8 +412,8 @@ class TestPlexMovieRecommenderTmdbMethods:
     @patch('recommenders.base.get_tmdb_config')
     @patch('recommenders.base.load_config')
     @patch('os.makedirs')
-    def test_get_plex_movie_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
-        """Test _get_plex_movie_tmdb_id returns from cache."""
+    def test_get_plex_item_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test _get_plex_item_tmdb_id returns from cache."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
@@ -430,7 +430,7 @@ class TestPlexMovieRecommenderTmdbMethods:
         mock_movie = Mock()
         mock_movie.ratingKey = 123
 
-        result = recommender._get_plex_movie_tmdb_id(mock_movie)
+        result = recommender._get_plex_item_tmdb_id(mock_movie)
 
         assert result == 456
 
@@ -440,8 +440,8 @@ class TestPlexMovieRecommenderTmdbMethods:
     @patch('recommenders.base.get_tmdb_config')
     @patch('recommenders.base.load_config')
     @patch('os.makedirs')
-    def test_get_plex_movie_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
-        """Test _get_plex_movie_imdb_id extracts from guids."""
+    def test_get_plex_item_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test _get_plex_item_imdb_id extracts from guids."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
@@ -459,7 +459,7 @@ class TestPlexMovieRecommenderTmdbMethods:
         mock_movie = Mock()
         mock_movie.guids = [mock_guid]
 
-        result = recommender._get_plex_movie_imdb_id(mock_movie)
+        result = recommender._get_plex_item_imdb_id(mock_movie)
 
         assert result == 'tt1234567'
 
@@ -867,9 +867,9 @@ class TestFormatMovieOutputExtended:
 
 
 class TestPlexMovieRecommenderLibraryImdbIds:
-    """Tests for PlexMovieRecommender._get_library_imdb_ids method."""
+    """Tests for PlexMovieRecommender._get_library_imdb_ids method (inherited from BaseRecommender)."""
 
-    @patch('recommenders.movie.get_library_imdb_ids')
+    @patch('recommenders.base.get_library_imdb_ids')
     @patch('recommenders.movie.MovieCache')
     @patch('recommenders.base.init_plex')
     @patch('recommenders.base.get_configured_users')

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -457,8 +457,8 @@ class TestPlexTVRecommenderTmdbMethods:
     @patch('recommenders.base.get_tmdb_config')
     @patch('recommenders.base.load_config')
     @patch('os.makedirs')
-    def test_get_plex_show_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
-        """Test _get_plex_show_tmdb_id returns from cache."""
+    def test_get_plex_item_tmdb_id_from_cache(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test _get_plex_item_tmdb_id returns from cache."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
@@ -479,7 +479,7 @@ class TestPlexTVRecommenderTmdbMethods:
         mock_show = Mock()
         mock_show.ratingKey = 123
 
-        result = recommender._get_plex_show_tmdb_id(mock_show)
+        result = recommender._get_plex_item_tmdb_id(mock_show)
 
         assert result == 456
 
@@ -489,8 +489,8 @@ class TestPlexTVRecommenderTmdbMethods:
     @patch('recommenders.base.get_tmdb_config')
     @patch('recommenders.base.load_config')
     @patch('os.makedirs')
-    def test_get_plex_show_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
-        """Test _get_plex_show_imdb_id extracts from guids."""
+    def test_get_plex_item_imdb_id_from_guids(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test _get_plex_item_imdb_id extracts from guids."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
             'general': {},
@@ -512,11 +512,11 @@ class TestPlexTVRecommenderTmdbMethods:
         mock_show = Mock()
         mock_show.guids = [mock_guid]
 
-        result = recommender._get_plex_show_imdb_id(mock_show)
+        result = recommender._get_plex_item_imdb_id(mock_show)
 
         assert result == 'tt0903747'
 
-    @patch('recommenders.tv.get_tmdb_keywords')
+    @patch('recommenders.base.get_tmdb_keywords')
     @patch('recommenders.tv.ShowCache')
     @patch('recommenders.base.init_plex')
     @patch('recommenders.base.get_configured_users')
@@ -916,32 +916,12 @@ class TestPlexTVRecommenderExcludedGenres:
         assert 'Drama Show' in rec_titles
 
 
-class TestPlexTVRecommenderExtractGenres:
-    """Tests for PlexTVRecommender._extract_genres method."""
+class TestExtractGenresFromShow:
+    """Tests for extract_genres utility with TV shows."""
 
-    @patch('recommenders.tv.ShowCache')
-    @patch('recommenders.base.init_plex')
-    @patch('recommenders.base.get_configured_users')
-    @patch('recommenders.base.get_tmdb_config')
-    @patch('recommenders.base.load_config')
-    @patch('os.makedirs')
-    def test_extract_genres_from_show(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
-        """Test _extract_genres returns list of genres."""
-        mock_load.return_value = {
-            'plex': {'url': 'http://localhost', 'token': 'abc'},
-            'general': {},
-            'weights': {}
-        }
-        mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
-        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
-        mock_section = Mock()
-        mock_section.all.return_value = []
-        mock_plex_inst = Mock()
-        mock_plex_inst.library.section.return_value = mock_section
-        mock_plex.return_value = mock_plex_inst
-        mock_cache.return_value = Mock(cache={'shows': {}})
-
-        recommender = PlexTVRecommender('/path/to/config.yml')
+    def test_extract_genres_from_show(self):
+        """Test extract_genres returns list of genres from show."""
+        from utils import extract_genres
 
         mock_genre1 = Mock()
         mock_genre1.tag = 'Drama'
@@ -950,7 +930,7 @@ class TestPlexTVRecommenderExtractGenres:
         mock_show = Mock()
         mock_show.genres = [mock_genre1, mock_genre2]
 
-        result = recommender._extract_genres(mock_show)
+        result = extract_genres(mock_show)
 
         assert 'drama' in result
         assert 'thriller' in result


### PR DESCRIPTION
## Summary
- Consolidates 5 TMDB-related methods from movie/tv recommenders into BaseRecommender
- Removes unnecessary delegate methods that just called utilities directly
- Cleans up unused imports
- Eliminates ~130 lines of duplicated code

## Changes
- `_get_plex_item_tmdb_id()` - consolidated from `_get_plex_movie_tmdb_id`/`_get_plex_show_tmdb_id`
- `_get_plex_item_imdb_id()` - consolidated from `_get_plex_movie_imdb_id`/`_get_plex_show_imdb_id`
- `_get_tmdb_id_via_imdb()` - uses `self.media_type` for movie/tv differences
- `_get_tmdb_keywords_for_id()` - was 100% identical in both
- `_get_library_imdb_ids()` - was 100% identical one-liner

## Test plan
- [x] All 564 tests pass
- [x] Syntax validation passes