### PR TITLE
Fix config key names for library settings

### DIFF
--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -119,7 +119,7 @@ class PlexMovieRecommender(BaseRecommender):
     # Required class attributes for BaseRecommender
     media_type = 'movie'
     media_key = 'movies'
-    library_config_key = 'movie_library_title'
+    library_config_key = 'movie_library'
     default_library_name = 'Movies'
 
     def _load_weights(self, weights_config: Dict) -> Dict:

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -88,7 +88,7 @@ class PlexTVRecommender(BaseRecommender):
     # Required class attributes for BaseRecommender
     media_type = 'tv'
     media_key = 'shows'
-    library_config_key = 'TV_library_title'
+    library_config_key = 'tv_library'
     default_library_name = 'TV Shows'
 
     def _load_weights(self, weights_config: Dict) -> Dict:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -331,7 +331,7 @@ class TestBaseCacheGetTmdbData:
 class ConcreteRecommender(BaseRecommender):
     """Concrete implementation of BaseRecommender for testing."""
     media_type = 'movie'
-    library_config_key = 'movie_library_title'
+    library_config_key = 'movie_library'
     default_library_name = 'Movies'
 
     def _load_weights(self, weights_config):

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -194,7 +194,7 @@ class TestPlexMovieRecommenderLibraryMethods:
     def test_get_library_movies_set(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test _get_library_movies_set returns movie IDs."""
         mock_load.return_value = {
-            'plex': {'url': 'http://localhost', 'token': 'abc', 'movie_library_title': 'Movies'},
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'movie_library': 'Movies'},
             'general': {},
             'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'tmdb_keywords': 0.2}
         }

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -173,7 +173,7 @@ class TestPlexTVRecommenderInit:
     def test_init_sets_library_title(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
         """Test that PlexTVRecommender sets library title from config."""
         mock_load.return_value = {
-            'plex': {'url': 'http://localhost', 'token': 'abc', 'TV_library_title': 'My TV Shows'},
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'tv_library': 'My TV Shows'},
             'general': {},
             'weights': {}
         }


### PR DESCRIPTION
Changed library_config_key from 'TV_library_title' to 'tv_library' and 'movie_library_title' to 'movie_library' to match what users actually configure and what external.py already uses.

Fixes #57