### PR TITLE
v2.8.18: Fix run.ps1 crash when Python emits stderr

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -83,7 +83,11 @@ function Check-ForUpdates {
     param($pythonCmd)
 
     if (Test-Path "config/config.yml") {
-        $autoUpdate = & $pythonCmd -c "import yaml; c=yaml.safe_load(open('config/config.yml')); print(c.get('general', {}).get('auto_update', False))" 2>$null
+        try {
+            $autoUpdate = & $pythonCmd -c "import yaml; c=yaml.safe_load(open('config/config.yml')); print(c.get('general', {}).get('auto_update', False))" 2>$null
+        } catch {
+            $autoUpdate = "False"
+        }
 
         if ($autoUpdate -eq "True") {
             Write-Cyan "Checking for updates..."

--- a/utils/config.py
+++ b/utils/config.py
@@ -9,7 +9,7 @@ import yaml
 from typing import Dict
 
 # Project version - single source of truth
-__version__ = "2.8.17"
+__version__ = "2.8.18"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Fix NativeCommandError crash on Windows when auto-update config check emits stderr
- Wrapped Python native command call in try/catch so it fails gracefully

Fixes #143