### PR TITLE
Key users by stable Plex account ID + migrate on username change (fixes #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.19] - 2026-07-20
+
+### Fixed
+- **Renaming a Plex account no longer resets user settings** (#153): Per-user preferences, cache files, and Plex labels/collections were keyed on the mutable Plex username instead of the stable Plex account id. Renaming an account in Plex created what looked like a brand-new user, dropping `display_name`/`exclude_genres`/`max_rating` back to defaults and orphaning the old collection. Curatarr now tracks a Plex account id -> username map (`cache/user_id_map.json`) and, on detecting a rename, migrates `users.preferences.<name>` and `users.list` in `config.yml`, renames the affected cache files, and cleans up the stale collection under the old name. Falls back to today's behavior if a stable id can't be resolved
+
 ## [2.8.16] - 2026-02-06
 
 ### Fixed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,6 +454,7 @@ class TestRunRecommenderMain:
 
         assert exc_info.value.code == 1
 
+    @patch('utils.cli.migrate_renamed_plex_users')
     @patch('utils.cli.print_runtime')
     @patch('utils.cli.resolve_admin_username')
     @patch('utils.cli.setup_logging')
@@ -463,12 +464,13 @@ class TestRunRecommenderMain:
     @patch('utils.cli.argparse.ArgumentParser.parse_args')
     def test_exits_if_no_users_configured(
         self, mock_parse_args, mock_root, mock_open, mock_yaml,
-        mock_setup_log, mock_resolve, mock_print
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test exits with code 1 if no users configured."""
         mock_parse_args.return_value = Mock(username=None, debug=False)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {'plex': {'token': 'abc'}}  # No users
+        mock_migrate.return_value = {}
 
         mock_adapt = Mock(return_value={'plex': {'token': 'abc'}, 'general': {}})
         mock_process = Mock()
@@ -479,6 +481,7 @@ class TestRunRecommenderMain:
 
         assert exc_info.value.code == 1
 
+    @patch('utils.cli.migrate_renamed_plex_users')
     @patch('utils.cli.print_runtime')
     @patch('utils.cli.resolve_admin_username')
     @patch('utils.cli.setup_logging')
@@ -488,7 +491,7 @@ class TestRunRecommenderMain:
     @patch('utils.cli.argparse.ArgumentParser.parse_args')
     def test_processes_each_user(
         self, mock_parse_args, mock_root, mock_open, mock_yaml,
-        mock_setup_log, mock_resolve, mock_print
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test calls process_func for each configured user."""
         mock_parse_args.return_value = Mock(username=None, debug=False)
@@ -497,6 +500,7 @@ class TestRunRecommenderMain:
             'plex': {'token': 'abc'},
             'users': {'list': 'alice, bob'}
         }
+        mock_migrate.return_value = {}
 
         mock_adapt = Mock(return_value={
             'plex': {'token': 'abc'},
@@ -511,6 +515,7 @@ class TestRunRecommenderMain:
 
         assert mock_process.call_count == 2
 
+    @patch('utils.cli.migrate_renamed_plex_users')
     @patch('utils.cli.print_runtime')
     @patch('utils.cli.resolve_admin_username')
     @patch('utils.cli.setup_logging')
@@ -520,7 +525,7 @@ class TestRunRecommenderMain:
     @patch('utils.cli.argparse.ArgumentParser.parse_args')
     def test_single_user_mode(
         self, mock_parse_args, mock_root, mock_open, mock_yaml,
-        mock_setup_log, mock_resolve, mock_print
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test processes only specified user in single user mode."""
         mock_parse_args.return_value = Mock(username='bob', debug=False)
@@ -529,6 +534,7 @@ class TestRunRecommenderMain:
             'plex': {'token': 'abc'},
             'users': {'list': 'alice, bob, charlie'}
         }
+        mock_migrate.return_value = {}
 
         mock_adapt = Mock(return_value={
             'plex': {'token': 'abc'},
@@ -543,6 +549,7 @@ class TestRunRecommenderMain:
 
         assert mock_process.call_count == 1
 
+    @patch('utils.cli.migrate_renamed_plex_users')
     @patch('utils.cli.print_runtime')
     @patch('utils.cli.resolve_admin_username')
     @patch('utils.cli.setup_logging')
@@ -552,7 +559,7 @@ class TestRunRecommenderMain:
     @patch('utils.cli.argparse.ArgumentParser.parse_args')
     def test_enables_debug_logging(
         self, mock_parse_args, mock_root, mock_open, mock_yaml,
-        mock_setup_log, mock_resolve, mock_print
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test enables debug logging when --debug flag is set."""
         mock_parse_args.return_value = Mock(username=None, debug=True)
@@ -561,6 +568,7 @@ class TestRunRecommenderMain:
             'plex': {'token': 'abc'},
             'users': {'list': 'alice'}
         }
+        mock_migrate.return_value = {}
 
         mock_adapt = Mock(return_value={
             'plex': {'token': 'abc'},
@@ -577,3 +585,67 @@ class TestRunRecommenderMain:
         mock_setup_log.assert_called_once()
         call_kwargs = mock_setup_log.call_args
         assert call_kwargs[1]['debug'] is True
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_calls_user_migration_before_adapting_config(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """Test run_recommender_main invokes rename migration and re-reads
+        config.yml when a rename was migrated, so downstream processing
+        sees the updated usernames."""
+        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_root.return_value = '/fake/root'
+        mock_yaml.side_effect = [
+            {'plex': {'token': 'abc'}, 'users': {'list': 'oldname'}},
+            {'plex': {'token': 'abc'}, 'users': {'list': 'newname'}},
+        ]
+        mock_migrate.return_value = {'oldname': 'newname'}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('Movie', 'Test', mock_adapt, mock_process)
+
+        mock_migrate.assert_called_once()
+        # Config was re-read after migration, so the adapted config (and
+        # therefore the processed user) reflects the new username.
+        assert mock_yaml.call_count == 2
+        mock_process.assert_called_once()
+        assert mock_process.call_args[0][3] == 'newname'
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_skips_config_reload_when_no_renames(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """Test config.yml is only read once when no rename was detected."""
+        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_root.return_value = '/fake/root'
+        mock_yaml.return_value = {'plex': {'token': 'abc'}, 'users': {'list': 'alice'}}
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('Movie', 'Test', mock_adapt, mock_process)
+
+        assert mock_yaml.call_count == 1

--- a/tests/test_user_migration.py
+++ b/tests/test_user_migration.py
@@ -1,0 +1,545 @@
+"""
+Tests for utils/user_migration.py - Plex account rename detection and
+migration of per-user config/cache/collection artifacts (issue #153).
+"""
+
+import json
+import os
+
+import plexapi.exceptions
+import pytest
+from unittest.mock import Mock, patch
+
+from utils.user_migration import (
+    load_user_id_map,
+    save_user_id_map,
+    get_live_plex_user_map,
+    detect_renamed_users,
+    rename_user_preferences_key,
+    rename_user_in_users_list,
+    migrate_cache_files,
+    cleanup_orphaned_user_collections,
+    migrate_renamed_plex_users,
+)
+
+
+SAMPLE_CONFIG_TEXT = """# Curatarr Configuration
+# Core settings - see tuning.yml for display/scoring options
+
+plex:
+  url: https://example.plex.direct:32400
+  token: test-token
+  movie_library: Movies
+  tv_library: TV Shows
+tmdb:
+  api_key: test-key
+users:
+  list: jasonsmith523, ericarutyunov, homehouse165
+  preferences:
+    jasonsmith523:
+      display_name: Jason
+      exclude_genres:
+      - romance
+      - children
+    ericarutyunov:
+      display_name: Eric
+    homehouse165:
+      display_name: Home
+      # max_rating: PG-13  # Optional: filter out R, NC-17
+general:
+  confirm_operations: false
+  plex_only: true
+
+# Huntarr: Find missing/upcoming movies from collections
+huntarr:
+  sequel_huntarr: true
+  horizon_huntarr: true
+"""
+
+
+# ---------------------------------------------------------------------------
+# Stable id <-> username map persistence
+# ---------------------------------------------------------------------------
+
+class TestLoadSaveUserIdMap:
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        result = load_user_id_map(str(tmp_path))
+        assert result == {}
+
+    def test_save_then_load_roundtrip(self, tmp_path):
+        id_map = {"1": "jasonsmith523", "2": "ericarutyunov"}
+        save_user_id_map(str(tmp_path), id_map)
+
+        loaded = load_user_id_map(str(tmp_path))
+
+        assert loaded == id_map
+
+    def test_load_corrupt_json_returns_empty(self, tmp_path):
+        path = tmp_path / "user_id_map.json"
+        path.write_text("not valid json", encoding="utf-8")
+
+        result = load_user_id_map(str(tmp_path))
+
+        assert result == {}
+
+    def test_load_non_dict_json_returns_empty(self, tmp_path):
+        path = tmp_path / "user_id_map.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+
+        result = load_user_id_map(str(tmp_path))
+
+        assert result == {}
+
+    def test_save_creates_cache_dir(self, tmp_path):
+        cache_dir = tmp_path / "nested" / "cache"
+
+        save_user_id_map(str(cache_dir), {"1": "user"})
+
+        assert (cache_dir / "user_id_map.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Live Plex user resolution
+# ---------------------------------------------------------------------------
+
+class TestGetLivePlexUserMap:
+    @patch('utils.user_migration.MyPlexAccount')
+    def test_builds_map_from_account_and_users(self, mock_account_class):
+        mock_account = Mock()
+        mock_account.id = 1
+        mock_account.username = "admin_user"
+
+        mock_user = Mock()
+        mock_user.id = 2
+        mock_user.title = "renamed_user"
+        mock_account.users.return_value = [mock_user]
+        mock_account_class.return_value = mock_account
+
+        result = get_live_plex_user_map({'plex': {'token': 'tok'}})
+
+        assert result == {"1": "admin_user", "2": "renamed_user"}
+
+    @patch('utils.user_migration.MyPlexAccount')
+    def test_returns_empty_on_api_exception(self, mock_account_class):
+        mock_account_class.side_effect = plexapi.exceptions.PlexApiException("auth failed")
+
+        result = get_live_plex_user_map({'plex': {'token': 'bad'}})
+
+        assert result == {}
+
+    @patch('utils.user_migration.MyPlexAccount')
+    def test_returns_empty_on_missing_config_key(self, mock_account_class):
+        result = get_live_plex_user_map({'plex': {}})
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Rename detection
+# ---------------------------------------------------------------------------
+
+class TestDetectRenamedUsers:
+    def test_detects_rename(self):
+        previous = {"1": "oldname"}
+        live = {"1": "newname"}
+
+        result = detect_renamed_users(previous, live)
+
+        assert result == {"oldname": "newname"}
+
+    def test_no_op_when_username_unchanged(self):
+        previous = {"1": "samename"}
+        live = {"1": "samename"}
+
+        result = detect_renamed_users(previous, live)
+
+        assert result == {}
+
+    def test_ignores_id_missing_from_live_map(self):
+        """An id that disappeared from Plex (e.g. removed user) isn't a rename."""
+        previous = {"1": "oldname"}
+        live = {}
+
+        result = detect_renamed_users(previous, live)
+
+        assert result == {}
+
+    def test_ignores_new_id_with_no_prior_history(self):
+        previous = {}
+        live = {"1": "brand_new_user"}
+
+        result = detect_renamed_users(previous, live)
+
+        assert result == {}
+
+    def test_detects_multiple_renames(self):
+        previous = {"1": "old1", "2": "old2", "3": "stable"}
+        live = {"1": "new1", "2": "new2", "3": "stable"}
+
+        result = detect_renamed_users(previous, live)
+
+        assert result == {"old1": "new1", "old2": "new2"}
+
+
+# ---------------------------------------------------------------------------
+# config.yml text surgery
+# ---------------------------------------------------------------------------
+
+class TestRenameUserPreferencesKey:
+    def test_renames_key_preserves_comments_and_formatting(self):
+        new_text, changed = rename_user_preferences_key(
+            SAMPLE_CONFIG_TEXT, "jasonsmith523", "jsmith_new"
+        )
+
+        assert changed is True
+        assert "    jsmith_new:\n" in new_text
+        assert "jasonsmith523:" not in new_text.split("preferences:")[1].split("general:")[0]
+        # Everything else, including comments, must be untouched
+        assert "# max_rating: PG-13  # Optional: filter out R, NC-17" in new_text
+        assert "# Huntarr: Find missing/upcoming movies from collections" in new_text
+        # display_name/exclude_genres values for the renamed user survive
+        assert "display_name: Jason" in new_text
+        assert "- romance" in new_text
+
+    def test_other_users_preferences_untouched(self):
+        new_text, changed = rename_user_preferences_key(
+            SAMPLE_CONFIG_TEXT, "jasonsmith523", "jsmith_new"
+        )
+
+        assert changed is True
+        assert "ericarutyunov:" in new_text
+        assert "display_name: Eric" in new_text
+
+    def test_no_change_when_user_not_present(self):
+        new_text, changed = rename_user_preferences_key(
+            SAMPLE_CONFIG_TEXT, "nonexistent_user", "somebody_new"
+        )
+
+        assert changed is False
+        assert new_text == SAMPLE_CONFIG_TEXT
+
+    def test_no_change_when_no_users_section(self):
+        text = "plex:\n  url: http://x\n"
+
+        new_text, changed = rename_user_preferences_key(text, "old", "new")
+
+        assert changed is False
+        assert new_text == text
+
+    def test_no_change_when_no_preferences_block(self):
+        text = "users:\n  list: alice, bob\n"
+
+        new_text, changed = rename_user_preferences_key(text, "alice", "alicia")
+
+        assert changed is False
+        assert new_text == text
+
+    def test_idempotent_when_already_renamed(self):
+        new_text, changed = rename_user_preferences_key(
+            SAMPLE_CONFIG_TEXT, "jasonsmith523", "jsmith_new"
+        )
+        second_text, second_changed = rename_user_preferences_key(
+            new_text, "jasonsmith523", "jsmith_new"
+        )
+
+        assert second_changed is False
+        assert second_text == new_text
+
+
+class TestRenameUserInUsersList:
+    def test_renames_comma_separated_list(self):
+        new_text, changed = rename_user_in_users_list(
+            SAMPLE_CONFIG_TEXT, "jasonsmith523", "jsmith_new"
+        )
+
+        assert changed is True
+        list_line = [l for l in new_text.splitlines() if l.strip().startswith("list:")][0]
+        assert "jsmith_new" in list_line
+        assert "jasonsmith523" not in list_line
+        # Other users on the same line preserved, formatting/commas intact
+        assert "ericarutyunov" in list_line
+        assert "homehouse165" in list_line
+
+    def test_renames_yaml_sequence_list(self):
+        text = (
+            "users:\n"
+            "  list:\n"
+            "    - jasonsmith523\n"
+            "    - ericarutyunov\n"
+            "  preferences:\n"
+            "    jasonsmith523:\n"
+            "      display_name: Jason\n"
+        )
+
+        new_text, changed = rename_user_in_users_list(text, "jasonsmith523", "jsmith_new")
+
+        assert changed is True
+        assert "- jsmith_new\n" in new_text
+        assert "- jasonsmith523\n" not in new_text
+        assert "- ericarutyunov\n" in new_text
+
+    def test_no_change_when_user_not_in_list(self):
+        new_text, changed = rename_user_in_users_list(
+            SAMPLE_CONFIG_TEXT, "nonexistent_user", "somebody_new"
+        )
+
+        assert changed is False
+        assert new_text == SAMPLE_CONFIG_TEXT
+
+    def test_does_not_partial_match_substring_username(self):
+        """'jason' must not match inside 'jasonsmith523'."""
+        new_text, changed = rename_user_in_users_list(SAMPLE_CONFIG_TEXT, "jason", "renamed")
+
+        assert changed is False
+        assert new_text == SAMPLE_CONFIG_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Cache file migration
+# ---------------------------------------------------------------------------
+
+class TestMigrateCacheFiles:
+    def test_renames_existing_cache_files(self, tmp_path):
+        old_file = tmp_path / "watched_cache_plex_oldname.json"
+        old_file.write_text('{"watched_count": 5}', encoding="utf-8")
+
+        migrate_cache_files(str(tmp_path), "oldname", "newname")
+
+        assert not old_file.exists()
+        new_file = tmp_path / "watched_cache_plex_newname.json"
+        assert new_file.exists()
+        assert json.loads(new_file.read_text(encoding="utf-8")) == {"watched_count": 5}
+
+    def test_migrates_multiple_known_patterns(self, tmp_path):
+        for pattern in (
+            "watched_cache_plex_oldname.json",
+            "tv_watched_cache_plex_oldname.json",
+            "external_recs_oldname_movies.json",
+            "external_recs_oldname_shows.json",
+        ):
+            (tmp_path / pattern).write_text("{}", encoding="utf-8")
+
+        migrate_cache_files(str(tmp_path), "oldname", "newname")
+
+        for pattern in (
+            "watched_cache_plex_newname.json",
+            "tv_watched_cache_plex_newname.json",
+            "external_recs_newname_movies.json",
+            "external_recs_newname_shows.json",
+        ):
+            assert (tmp_path / pattern).exists()
+
+    def test_removes_stale_when_new_already_exists(self, tmp_path):
+        old_file = tmp_path / "watched_cache_plex_oldname.json"
+        new_file = tmp_path / "watched_cache_plex_newname.json"
+        old_file.write_text('{"stale": true}', encoding="utf-8")
+        new_file.write_text('{"fresh": true}', encoding="utf-8")
+
+        migrate_cache_files(str(tmp_path), "oldname", "newname")
+
+        assert not old_file.exists()
+        assert json.loads(new_file.read_text(encoding="utf-8")) == {"fresh": True}
+
+    def test_noop_when_no_cache_files_exist(self, tmp_path):
+        # Should not raise even if nothing to migrate
+        migrate_cache_files(str(tmp_path), "oldname", "newname")
+
+        assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Orphaned collection cleanup
+# ---------------------------------------------------------------------------
+
+class TestCleanupOrphanedUserCollections:
+    @patch('utils.user_migration.cleanup_old_collections')
+    @patch('utils.user_migration.init_plex')
+    def test_cleans_up_both_libraries(self, mock_init_plex, mock_cleanup):
+        mock_plex = Mock()
+        mock_movie_section = Mock()
+        mock_tv_section = Mock()
+        mock_plex.library.section.side_effect = lambda title: {
+            'Movies': mock_movie_section,
+            'TV Shows': mock_tv_section,
+        }[title]
+        mock_init_plex.return_value = mock_plex
+
+        config = {'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'}}
+
+        cleanup_orphaned_user_collections(config, "oldname", "Old Display")
+
+        # Called once per library section (display name != username -> also
+        # cleaned up under the raw username pattern)
+        assert mock_cleanup.call_count == 4
+
+    @patch('utils.user_migration.init_plex')
+    def test_handles_connection_failure_gracefully(self, mock_init_plex):
+        mock_init_plex.side_effect = Exception("connection refused")
+
+        # Should not raise
+        cleanup_orphaned_user_collections({'plex': {}}, "oldname", "Old")
+
+    @patch('utils.user_migration.cleanup_old_collections')
+    @patch('utils.user_migration.init_plex')
+    def test_handles_missing_library_gracefully(self, mock_init_plex, mock_cleanup):
+        mock_plex = Mock()
+        mock_plex.library.section.side_effect = plexapi.exceptions.PlexApiException("not found")
+        mock_init_plex.return_value = mock_plex
+
+        # Should not raise even though every section lookup fails
+        cleanup_orphaned_user_collections({'plex': {}}, "oldname", "Old")
+
+        mock_cleanup.assert_not_called()
+
+    @patch('utils.user_migration.cleanup_old_collections')
+    @patch('utils.user_migration.init_plex')
+    def test_skips_duplicate_call_when_display_name_matches_username(self, mock_init_plex, mock_cleanup):
+        mock_plex = Mock()
+        mock_plex.library.section.return_value = Mock()
+        mock_init_plex.return_value = mock_plex
+
+        cleanup_orphaned_user_collections({'plex': {}}, "sameword", "sameword")
+
+        # One call per library (2), not two per library
+        assert mock_cleanup.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: migrate_renamed_plex_users
+# ---------------------------------------------------------------------------
+
+class TestMigrateRenamedPlexUsers:
+    def _write_config(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(SAMPLE_CONFIG_TEXT, encoding="utf-8")
+        return str(config_path)
+
+    @patch('utils.user_migration.cleanup_orphaned_user_collections')
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_migrates_preferences_and_list_on_rename(self, mock_live_map, mock_cleanup, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        save_user_id_map(str(cache_dir), {"1": "jasonsmith523"})
+        mock_live_map.return_value = {"1": "jsmith_new"}
+
+        config_path = self._write_config(tmp_path)
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        renames = migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        assert renames == {"jasonsmith523": "jsmith_new"}
+
+        new_text = open(config_path, encoding="utf-8").read()
+        assert "jsmith_new:" in new_text
+        assert "list: jsmith_new, ericarutyunov, homehouse165" in new_text
+
+        updated_map = load_user_id_map(str(cache_dir))
+        assert updated_map == {"1": "jsmith_new"}
+
+        mock_cleanup.assert_called_once()
+        call_args = mock_cleanup.call_args[0]
+        assert call_args[1] == "jasonsmith523"
+
+    @patch('utils.user_migration.cleanup_orphaned_user_collections')
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_migrates_cache_files_on_rename(self, mock_live_map, mock_cleanup, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        save_user_id_map(str(cache_dir), {"1": "jasonsmith523"})
+        (cache_dir / "watched_cache_plex_jasonsmith523.json").write_text("{}", encoding="utf-8")
+        mock_live_map.return_value = {"1": "jsmith_new"}
+
+        config_path = self._write_config(tmp_path)
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        assert not (cache_dir / "watched_cache_plex_jasonsmith523.json").exists()
+        assert (cache_dir / "watched_cache_plex_jsmith_new.json").exists()
+
+    @patch('utils.user_migration.cleanup_orphaned_user_collections')
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_cleans_up_orphan_collection_for_old_name(self, mock_live_map, mock_cleanup, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        save_user_id_map(str(cache_dir), {"1": "jasonsmith523"})
+        mock_live_map.return_value = {"1": "jsmith_new"}
+
+        config_path = self._write_config(tmp_path)
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        mock_cleanup.assert_called_once()
+        args = mock_cleanup.call_args[0]
+        # (config, old_username, old_display_name)
+        assert args[1] == "jasonsmith523"
+        assert args[2] == "Jason"  # display_name captured before the rewrite
+
+    @patch('utils.user_migration.cleanup_orphaned_user_collections')
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_no_op_when_username_unchanged(self, mock_live_map, mock_cleanup, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        save_user_id_map(str(cache_dir), {"1": "jasonsmith523"})
+        mock_live_map.return_value = {"1": "jasonsmith523"}
+
+        config_path = self._write_config(tmp_path)
+        original_text = open(config_path, encoding="utf-8").read()
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        renames = migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        assert renames == {}
+        mock_cleanup.assert_not_called()
+        assert open(config_path, encoding="utf-8").read() == original_text
+
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_graceful_fallback_when_id_unavailable(self, mock_live_map, tmp_path):
+        """If Plex ids can't be resolved this run, fall back to today's
+        username-keyed behavior - no crash, nothing migrated."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        mock_live_map.return_value = {}
+
+        config_path = self._write_config(tmp_path)
+        original_text = open(config_path, encoding="utf-8").read()
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        renames = migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        assert renames == {}
+        assert open(config_path, encoding="utf-8").read() == original_text
+
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_first_run_populates_map_without_migrating(self, mock_live_map, tmp_path):
+        """With no prior map file, nothing is a 'rename' yet - just seed
+        the map for future comparison."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        mock_live_map.return_value = {"1": "jasonsmith523"}
+
+        config_path = self._write_config(tmp_path)
+        import yaml
+        root_config = yaml.safe_load(open(config_path, encoding="utf-8"))
+
+        renames = migrate_renamed_plex_users(root_config, config_path, str(cache_dir))
+
+        assert renames == {}
+        assert load_user_id_map(str(cache_dir)) == {"1": "jasonsmith523"}
+
+    @patch('utils.user_migration.get_live_plex_user_map')
+    def test_never_raises_on_unexpected_error(self, mock_live_map, tmp_path):
+        mock_live_map.side_effect = RuntimeError("boom")
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Should not raise
+        renames = migrate_renamed_plex_users({'users': {}}, str(tmp_path / "config.yml"), str(cache_dir))
+
+        assert renames == {}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -176,6 +176,20 @@ from .plex import (
     apply_user_label_restrictions,
 )
 
+# User identity migration utilities (stable Plex account id -> username)
+from .user_migration import (
+    USER_ID_MAP_FILENAME,
+    load_user_id_map,
+    save_user_id_map,
+    get_live_plex_user_map,
+    detect_renamed_users,
+    rename_user_preferences_key,
+    rename_user_in_users_list,
+    migrate_cache_files,
+    cleanup_orphaned_user_collections,
+    migrate_renamed_plex_users,
+)
+
 # Trakt utilities
 from .trakt import (
     TRAKT_RATE_LIMIT_DELAY,
@@ -347,6 +361,17 @@ __all__ = [
     'extract_rating',
     'get_library_imdb_ids',
     'get_plex_user_ids',
+    # User migration (stable Plex id -> username)
+    'USER_ID_MAP_FILENAME',
+    'load_user_id_map',
+    'save_user_id_map',
+    'get_live_plex_user_map',
+    'detect_renamed_users',
+    'rename_user_preferences_key',
+    'rename_user_in_users_list',
+    'migrate_cache_files',
+    'cleanup_orphaned_user_collections',
+    'migrate_renamed_plex_users',
     # Trakt
     'TRAKT_RATE_LIMIT_DELAY',
     'TraktAuthError',

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -21,6 +21,7 @@ from .display import (
     setup_logging,
 )
 from .helpers import cleanup_old_logs, get_project_root
+from .user_migration import migrate_renamed_plex_users
 
 
 def get_users_from_config(config: Dict) -> List[str]:
@@ -207,6 +208,16 @@ def run_recommender_main(
     try:
         with open(config_path, 'r') as f:
             root_config = yaml.safe_load(f)
+
+        # Detect Plex account renames (keyed by stable id) and migrate any
+        # affected preferences/cache files/collections before this run
+        # processes users. Best-effort - never blocks a normal run.
+        cache_dir = os.path.join(project_root, 'cache')
+        renamed_users = migrate_renamed_plex_users(root_config, config_path, cache_dir)
+        if renamed_users:
+            with open(config_path, 'r') as f:
+                root_config = yaml.safe_load(f)
+
         base_config = adapt_config_func(root_config)
     except Exception as e:
         log_error(f"Could not load config.yml from project root: {e}")

--- a/utils/config.py
+++ b/utils/config.py
@@ -9,7 +9,7 @@ import yaml
 from typing import Dict
 
 # Project version - single source of truth
-__version__ = "2.8.18"
+__version__ = "2.8.19"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/user_migration.py
+++ b/utils/user_migration.py
@@ -1,0 +1,373 @@
+"""
+User identity migration utilities for Curatarr.
+
+Plex usernames are mutable (a user can rename their account/display name),
+but curatarr historically keyed all per-user artifacts - config preferences,
+cache filenames, Plex labels/collections - on that mutable username string.
+A rename therefore looked like a brand-new user: settings reset to defaults
+and the old collection was orphaned in Plex.
+
+This module detects renames by comparing the *stable* Plex account id
+against a small persisted id -> username map, and migrates the affected
+config/cache/collection artifacts from the old username to the new one.
+
+Entirely best-effort: any failure here is logged and swallowed so a
+migration problem never breaks a normal recommendation run. If a stable id
+can't be resolved for a user, behavior is unchanged (falls back to today's
+username-keyed behavior - no regression).
+"""
+
+import json
+import logging
+import os
+import re
+from typing import Dict, List, Optional, Tuple
+
+import plexapi.exceptions
+from plexapi.myplex import MyPlexAccount
+
+from .display import log_warning
+from .plex import cleanup_old_collections, init_plex
+
+logger = logging.getLogger('curatarr')
+
+USER_ID_MAP_FILENAME = 'user_id_map.json'
+
+# Cache filename patterns keyed on username. Kept explicit (rather than a
+# filesystem glob) so migration only ever touches files curatarr itself
+# generates for a given user.
+_CACHE_FILENAME_PATTERNS = [
+    'watched_cache_plex_{username}.json',
+    'tv_watched_cache_plex_{username}.json',
+    'external_recs_{username}_movies.json',
+    'external_recs_{username}_shows.json',
+]
+
+
+# ---------------------------------------------------------------------------
+# Stable id <-> username map
+# ---------------------------------------------------------------------------
+
+def load_user_id_map(cache_dir: str) -> Dict[str, str]:
+    """Load the persisted Plex account id -> last-known-username map."""
+    path = os.path.join(cache_dir, USER_ID_MAP_FILENAME)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except (json.JSONDecodeError, IOError, OSError) as e:
+        log_warning(f"Could not read user id map ({path}): {e}")
+    return {}
+
+
+def save_user_id_map(cache_dir: str, id_map: Dict[str, str]) -> None:
+    """Persist the Plex account id -> username map."""
+    path = os.path.join(cache_dir, USER_ID_MAP_FILENAME)
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(id_map, f, indent=2, sort_keys=True)
+    except (IOError, OSError) as e:
+        log_warning(f"Could not save user id map ({path}): {e}")
+
+
+def get_live_plex_user_map(config: Dict) -> Dict[str, str]:
+    """
+    Build a map of stable Plex account id -> current username for the
+    server owner plus all managed/shared users.
+
+    Uses the same "username" identity (title) that the rest of curatarr
+    keys off of (see get_configured_users). Returns {} on any failure so
+    callers can safely no-op.
+    """
+    try:
+        account = MyPlexAccount(token=config['plex']['token'])
+        live_map = {str(account.id): account.username}
+        for user in account.users():
+            if hasattr(user, 'id') and hasattr(user, 'title') and user.title:
+                live_map[str(user.id)] = user.title
+        return live_map
+    except (plexapi.exceptions.PlexApiException, KeyError, TypeError) as e:
+        log_warning(f"Could not resolve live Plex users for rename detection: {e}")
+        return {}
+
+
+def detect_renamed_users(previous_map: Dict[str, str], live_map: Dict[str, str]) -> Dict[str, str]:
+    """
+    Return {old_username: new_username} for accounts whose stable id is
+    known from a prior run but whose username has since changed.
+    """
+    renames = {}
+    for account_id, old_username in previous_map.items():
+        new_username = live_map.get(account_id)
+        if new_username and new_username != old_username:
+            renames[old_username] = new_username
+    return renames
+
+
+# ---------------------------------------------------------------------------
+# config.yml text surgery (targeted edits - preserves comments/formatting
+# for everything outside the specific lines being changed)
+# ---------------------------------------------------------------------------
+
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(' '))
+
+
+def _find_bare_key_line(lines: List[str], key: str, start: int, end: int) -> Optional[int]:
+    """Find a `key:` line (block mapping key, no inline scalar value) within lines[start:end]."""
+    pattern = re.compile(rf'^[ \t]*{re.escape(key)}\s*:\s*(#.*)?$')
+    for i in range(start, end):
+        if pattern.match(lines[i]):
+            return i
+    return None
+
+
+def _block_end(lines: List[str], key_line: int, key_indent: int) -> int:
+    """
+    Given the index of a `key:` line and its indentation, return the
+    exclusive end index of its block (the first subsequent line indented
+    at or below key_indent, ignoring blank lines and full-line comments).
+    """
+    for i in range(key_line + 1, len(lines)):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        if _line_indent(lines[i]) <= key_indent:
+            return i
+    return len(lines)
+
+
+def _first_child_indent(lines: List[str], key_line: int, block_end: int) -> Optional[int]:
+    for i in range(key_line + 1, block_end):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        return _line_indent(lines[i])
+    return None
+
+
+def rename_user_preferences_key(config_text: str, old_username: str, new_username: str) -> Tuple[str, bool]:
+    """
+    Rename the `users.preferences.<old_username>` mapping key to
+    `<new_username>` in raw config.yml text, leaving everything else
+    (including comments/formatting) untouched.
+
+    Returns (possibly modified text, changed).
+    """
+    lines = config_text.splitlines(keepends=True)
+
+    users_line = _find_bare_key_line(lines, 'users', 0, len(lines))
+    if users_line is None:
+        return config_text, False
+    users_indent = _line_indent(lines[users_line])
+    users_end = _block_end(lines, users_line, users_indent)
+
+    prefs_line = _find_bare_key_line(lines, 'preferences', users_line + 1, users_end)
+    if prefs_line is None:
+        return config_text, False
+    prefs_indent = _line_indent(lines[prefs_line])
+    prefs_end = _block_end(lines, prefs_line, prefs_indent)
+
+    user_key_indent = _first_child_indent(lines, prefs_line, prefs_end)
+    if user_key_indent is None:
+        return config_text, False
+
+    key_pattern = re.compile(
+        rf'^(?P<indent>[ \t]{{{user_key_indent}}}){re.escape(old_username)}(?P<rest>\s*:\s*(#.*)?)$'
+    )
+    for i in range(prefs_line + 1, prefs_end):
+        if _line_indent(lines[i]) != user_key_indent:
+            continue
+        stripped_line = lines[i].rstrip('\r\n')
+        newline = lines[i][len(stripped_line):]
+        m = key_pattern.match(stripped_line)
+        if m:
+            lines[i] = f"{m.group('indent')}{new_username}{m.group('rest')}{newline}"
+            return ''.join(lines), True
+
+    return config_text, False
+
+
+def rename_user_in_users_list(config_text: str, old_username: str, new_username: str) -> Tuple[str, bool]:
+    """
+    Rename `old_username` to `new_username` wherever it appears as an entry
+    in `users.list` (comma-separated string or YAML sequence form).
+    """
+    lines = config_text.splitlines(keepends=True)
+
+    users_line = _find_bare_key_line(lines, 'users', 0, len(lines))
+    if users_line is None:
+        return config_text, False
+    users_indent = _line_indent(lines[users_line])
+    users_end = _block_end(lines, users_line, users_indent)
+
+    token_pattern = re.compile(rf'(?<![\w.-]){re.escape(old_username)}(?![\w.-])')
+
+    for i in range(users_line + 1, users_end):
+        stripped = lines[i].strip()
+
+        if re.match(r'^list\s*:', stripped):
+            if token_pattern.search(lines[i]):
+                lines[i] = token_pattern.sub(new_username, lines[i], count=1)
+                return ''.join(lines), True
+            continue
+
+        seq_match = re.match(r'^-\s*(?P<val>.+?)\s*$', stripped)
+        if seq_match and seq_match.group('val') == old_username:
+            indent = ' ' * _line_indent(lines[i])
+            newline = lines[i][len(lines[i].rstrip('\r\n')):]
+            dash = re.match(r'^-\s*', stripped).group(0)
+            lines[i] = f"{indent}{dash}{new_username}{newline}"
+            return ''.join(lines), True
+
+    return config_text, False
+
+
+# ---------------------------------------------------------------------------
+# Cache files + orphaned collections
+# ---------------------------------------------------------------------------
+
+def _capture_old_display_name(root_config: Dict, old_username: str) -> str:
+    prefs = (root_config.get('users', {}) or {}).get('preferences', {}) or {}
+    old_prefs = prefs.get(old_username, {}) or {}
+    return old_prefs.get('display_name') or old_username.capitalize()
+
+
+def migrate_cache_files(cache_dir: str, old_username: str, new_username: str) -> None:
+    """Rename (or drop, if a file for the new name already exists) known
+    per-user cache files so a rename doesn't leave stale/orphaned caches."""
+    for pattern in _CACHE_FILENAME_PATTERNS:
+        old_path = os.path.join(cache_dir, pattern.format(username=old_username))
+        new_path = os.path.join(cache_dir, pattern.format(username=new_username))
+        if not os.path.exists(old_path):
+            continue
+        try:
+            if os.path.exists(new_path):
+                # Don't clobber an existing cache for the new name - drop
+                # the stale one so it regenerates cleanly on next run.
+                os.remove(old_path)
+                logger.info(f"Removed stale cache for renamed user: {os.path.basename(old_path)}")
+            else:
+                os.rename(old_path, new_path)
+                logger.info(f"Migrated cache file: {os.path.basename(old_path)} -> {os.path.basename(new_path)}")
+        except OSError as e:
+            log_warning(f"Could not migrate cache file {old_path}: {e}")
+
+
+def cleanup_orphaned_user_collections(config: Dict, old_username: str, old_display_name: str) -> None:
+    """
+    Best-effort deletion of the old username's "Recommendation" collection
+    in both the movie and TV libraries so it doesn't linger orphaned after
+    a rename. The correct collection under the new name is recreated by
+    the normal recommendation run.
+    """
+    try:
+        plex = init_plex(config)
+    except Exception as e:
+        log_warning(f"Could not connect to Plex for orphaned-collection cleanup: {e}")
+        return
+
+    plex_config = config.get('plex', {}) or {}
+    library_targets = (
+        (plex_config.get('movie_library', 'Movies'), '🎬'),
+        (plex_config.get('tv_library', 'TV Shows'), '📺'),
+    )
+
+    for library_title, emoji in library_targets:
+        try:
+            section = plex.library.section(library_title)
+        except plexapi.exceptions.PlexApiException as e:
+            logger.debug(f"Library '{library_title}' not available for cleanup: {e}")
+            continue
+
+        # No collection exists yet under the new name at migration time,
+        # so there's nothing that needs to be protected from deletion.
+        try:
+            cleanup_old_collections(section, current_collection_name="", username=old_display_name, emoji=emoji, logger=logger)
+            if old_display_name.lower() != old_username.lower():
+                cleanup_old_collections(section, current_collection_name="", username=old_username, emoji=emoji, logger=logger)
+        except plexapi.exceptions.PlexApiException as e:
+            log_warning(f"Error cleaning up orphaned collection in '{library_title}': {e}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def migrate_renamed_plex_users(root_config: Dict, config_path: str, cache_dir: str) -> Dict[str, str]:
+    """
+    Detect Plex account renames (by stable id) since the last run and
+    migrate this user's config preferences, users.list entry, cache files,
+    and orphaned Plex collection so a rename doesn't silently reset their
+    settings.
+
+    Args:
+        root_config: Raw config.yml dict (as loaded, before per-media adapt)
+        config_path: Path to config.yml (rewritten in place if a rename is
+            detected and located)
+        cache_dir: Directory containing curatarr's per-user cache files
+
+    Returns:
+        {old_username: new_username} for any renames that were detected
+        (whether or not every part of the migration fully succeeded).
+    """
+    try:
+        previous_map = load_user_id_map(cache_dir)
+        live_map = get_live_plex_user_map(root_config)
+        if not live_map:
+            # Can't resolve stable ids this run - leave everything as-is.
+            return {}
+
+        renames = detect_renamed_users(previous_map, live_map)
+
+        if renames:
+            config_text = None
+            try:
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    config_text = f.read()
+            except (IOError, OSError) as e:
+                log_warning(f"Could not read {config_path} for user migration: {e}")
+
+            for old_username, new_username in renames.items():
+                log_warning(f"Detected Plex username change: '{old_username}' -> '{new_username}' (migrating settings)")
+                old_display_name = _capture_old_display_name(root_config, old_username)
+
+                if config_text is not None:
+                    try:
+                        config_text, prefs_changed = rename_user_preferences_key(config_text, old_username, new_username)
+                        config_text, list_changed = rename_user_in_users_list(config_text, old_username, new_username)
+                        if not (prefs_changed or list_changed):
+                            log_warning(
+                                f"Could not locate '{old_username}' in config.yml users section "
+                                f"(unexpected format) - settings were not migrated automatically."
+                            )
+                    except Exception as e:
+                        log_warning(f"Error migrating config.yml for renamed user '{old_username}': {e}")
+
+                try:
+                    migrate_cache_files(cache_dir, old_username, new_username)
+                except Exception as e:
+                    log_warning(f"Error migrating cache files for renamed user '{old_username}': {e}")
+
+                try:
+                    cleanup_orphaned_user_collections(root_config, old_username, old_display_name)
+                except Exception as e:
+                    log_warning(f"Error cleaning up orphaned collection for renamed user '{old_username}': {e}")
+
+            if config_text is not None:
+                try:
+                    with open(config_path, 'w', encoding='utf-8') as f:
+                        f.write(config_text)
+                except (IOError, OSError) as e:
+                    log_warning(f"Could not write migrated config.yml: {e}")
+
+        save_user_id_map(cache_dir, live_map)
+        return renames
+
+    except Exception as e:
+        log_warning(f"User rename migration failed, continuing with existing behavior: {e}")
+        return {}


### PR DESCRIPTION
## Summary

Curatarr keys per-user settings, cache files, and Plex labels/collections on the mutable Plex username string. Renaming a Plex account therefore looks like a brand-new user to curatarr: preferences reset to defaults and the old collection is left orphaned in Plex.

## Root cause

- Per-user settings: `user_preferences` dict keyed by username (`recommenders/base.py`), looked up in `utils/plex.py` and `recommenders/base.py`
- Collection display name and `Recommended_<username>` label are derived from the username
- Cache filenames follow the pattern `*_plex_<username>.json`
- The stable Plex account **id** is already fetched live for watch-history lookups but was never persisted as a key anywhere

## Fix

- Added `utils/user_migration.py`: persists a Plex account id -> last-known-username map at `cache/user_id_map.json`. Each run compares it against the live Plex user list (via `MyPlexAccount`). If an id's username has changed since last run:
  - Migrates `users.preferences.<old>` -> `<new>` and the `users.list` entry in `config.yml`, via targeted text edits that preserve existing comments/formatting (no full YAML re-dump)
  - Renames the known per-user cache files (`watched_cache_plex_*`, `tv_watched_cache_plex_*`, `external_recs_*_movies/shows`) to the new username, or drops the stale one if a cache for the new name already exists
  - Deletes the orphaned <old name> - Recommendation collection in both the movie and TV libraries so it doesn't linger; the correct collection under the new name is recreated by the normal run
- Hooked into `utils/cli.py:run_recommender_main`, before the per-user loop, so it applies once per invocation and re-reads `config.yml` if a migration happened
- Entirely best-effort: every file/Plex operation is guarded so a migration problem can't break a normal recommendation run. If a stable id can't be resolved (e.g. offline/API error), behavior is unchanged from before this fix (falls back to username-keyed behavior, no regression)
- Left the dead Tautulli `_get_plex_user_ids` hook untouched (out of scope)

## Test plan

- [x] `tests/test_user_migration.py` (38 tests): rename detection, config.yml text migration (preferences key + users.list, comments preserved), cache file migration/regeneration, orphan-collection cleanup, no-op when username unchanged, graceful fallback when a stable id can't be resolved
- [x] `tests/test_cli.py`: updated existing `run_recommender_main` tests to mock the new migration call (avoids live Plex network calls in unit tests); added tests confirming the migration hook runs and config.yml is re-read only when a rename occurred
- [x] Full suite: `pytest tests/ --cov=. --cov-fail-under=85` -> 1119 passed, 85.47% coverage