### PR TITLE
Optional Tautulli watch-history integration (closes #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.20] - 2026-07-20
+
+### Added
+- **Optional Tautulli watch-history integration** (#150): When `tautulli.enabled` is set, Curatarr supplements each user's Plex watch history with history pulled from a Tautulli instance, weighted the same way as Plex history (recency decay, ratings, rewatch). Mainly useful for shared/external Plex users whose Plex-native history retention is thin. Users are matched to Plex accounts by email, falling back to username. Disabled by default; if Tautulli is unreachable or a user can't be mapped, Curatarr silently falls back to Plex-only history (no regression). Configure via the new `tautulli` block in `config.yml` (`enabled`, `url`, `api_key`)
+
+### Removed
+- Dead `_get_plex_user_ids` scaffolding in `recommenders/base.py` (unused, 0 callers) - superseded by `utils/tautulli.py`'s user-mapping logic
+
 ## [2.8.19] - 2026-07-20
 
 ### Fixed

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -50,6 +50,17 @@ huntarr:
 logging:
   level: INFO  # DEBUG, INFO, WARNING, ERROR
 
+# Optional: Tautulli watch-history integration
+# Supplements Plex's own watch history with history from Tautulli, weighted
+# the same way. Mainly useful for shared/external users whose Plex-native
+# history retention is thin. Users are matched to Plex accounts by email
+# (falls back to username). Disabled by default; if unreachable or a user
+# can't be matched, Curatarr silently falls back to Plex-only history.
+tautulli:
+  enabled: false
+  url: http://YOUR_TAUTULLI_URL:8181  # e.g. http://192.168.1.10:8181
+  api_key: YOUR_TAUTULLI_API_KEY  # Settings -> Web Interface -> API Key
+
 # =============================================================================
 # OPTIONAL MODULE FILES (in this directory)
 # =============================================================================

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -27,7 +27,6 @@ from utils import (
     TMDB_RATE_LIMIT_DELAY,
     DEFAULT_LIMIT_PLEX_RESULTS,
     WEIGHT_SUM_TOLERANCE,
-    PLEX_REQUEST_TIMEOUT,
     TIER_SAFE_PERCENT, TIER_DIVERSE_PERCENT, TIER_WILDCARD_PERCENT,
     GREEN, YELLOW, CYAN, RED, RESET,
     load_config,
@@ -485,39 +484,6 @@ class BaseRecommender(ABC):
         self.watched_ids = set()
         self.watched_data_counters = self._get_watched_data()
         self._save_watched_cache()
-
-    def _get_plex_user_ids(self) -> List[str]:
-        """Resolve configured Plex usernames to their user IDs."""
-        user_ids = []
-        try:
-            users_response = requests.get(
-                f"{self.config['plex_users']['url']}/api/v2",
-                params={
-                    'apikey': self.config['plex_users']['api_key'],
-                    'cmd': 'get_users'
-                },
-                timeout=PLEX_REQUEST_TIMEOUT
-            )
-            users_response.raise_for_status()
-            plex_users = users_response.json()['response']['data']
-
-            users_to_match = [self.single_user] if self.single_user else self.users['plex_users']
-
-            for username in users_to_match:
-                user = next(
-                    (u for u in plex_users
-                     if u['username'].lower() == username.lower()),
-                    None
-                )
-                if user:
-                    user_ids.append(str(user['user_id']))
-                else:
-                    log_error(f"User '{username}' not found in Plex accounts!")
-
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log_error(f"Error resolving Plex users: {e}")
-
-        return user_ids
 
     def _get_managed_users_watched_data(self) -> Dict:
         """Get watched data from managed Plex users."""

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -24,6 +24,7 @@ from utils import (
     RATING_MULTIPLIER_2_STAR,
     RATING_MULTIPLIER_UNRATED,
     get_plex_account_ids, fetch_plex_watch_history_movies, get_watched_movie_count,
+    fetch_tautulli_movie_history, merge_movie_history,
     log_warning, log_error,
     get_negative_multiplier,
     calculate_recency_multiplier, calculate_rewatch_multiplier,
@@ -276,6 +277,20 @@ class PlexMovieRecommender(BaseRecommender):
 
         # Fetch watch history using the history API (properly per-user)
         history_items, _ = fetch_plex_watch_history_movies(self.config, account_ids, movies_section)
+
+        # Optionally merge in Tautulli watch history, weighted the same way as
+        # Plex history. Covers users whose Plex-native history is thin (e.g.
+        # shared/external users). Falls back to Plex-only if disabled,
+        # unreachable, or no users could be mapped.
+        if self.config.get('tautulli', {}).get('enabled', False):
+            tautulli_items = fetch_tautulli_movie_history(self.config, account_ids)
+            if tautulli_items:
+                plex_unique = len({str(item.ratingKey) for item in history_items})
+                history_items = merge_movie_history(history_items, tautulli_items)
+                logger.info(
+                    f"Tautulli: merged {len(tautulli_items)} history entries "
+                    f"({len(history_items)} unique watched movies, was {plex_unique} from Plex alone)"
+                )
 
         # Process history items to extract IDs, dates, and ratings
         for item in history_items:

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -22,6 +22,7 @@ from utils import (
     get_plex_account_ids, get_watched_show_count,
     fetch_plex_watch_history_shows,
     fetch_show_completion_data, identify_dropped_shows,
+    fetch_tautulli_show_watched_data, merge_show_watched_data,
     log_warning, log_error,
     calculate_recency_multiplier, calculate_rewatch_multiplier,
     calculate_similarity_score,
@@ -273,6 +274,22 @@ class PlexTVRecommender(BaseRecommender):
         watched_ids, show_timestamps = fetch_plex_watch_history_shows(
             self.config, account_ids, shows_section, return_timestamps=True
         )
+
+        # Optionally merge in Tautulli watch history, weighted the same way as
+        # Plex history. Covers users whose Plex-native history is thin (e.g.
+        # shared/external users). Falls back to Plex-only if disabled,
+        # unreachable, or no users could be mapped.
+        if self.config.get('tautulli', {}).get('enabled', False):
+            tautulli_ids, tautulli_timestamps = fetch_tautulli_show_watched_data(self.config, account_ids)
+            if tautulli_ids:
+                plex_count = len(watched_ids)
+                watched_ids, show_timestamps = merge_show_watched_data(
+                    watched_ids, show_timestamps, tautulli_ids, tautulli_timestamps
+                )
+                logger.info(
+                    f"Tautulli: merged {len(tautulli_ids)} watched shows "
+                    f"({len(watched_ids)} unique watched shows, was {plex_count} from Plex alone)"
+                )
 
         # Store watched show IDs
         self.watched_ids.update(watched_ids)

--- a/tests/test_tautulli.py
+++ b/tests/test_tautulli.py
@@ -1,0 +1,590 @@
+"""Tests for utils/tautulli.py - Tautulli API client and watch-history merge."""
+
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from utils.tautulli import (
+    TautulliClient,
+    TautulliAPIError,
+    TautulliHistoryItem,
+    create_tautulli_client,
+    map_users,
+    build_user_map,
+    fetch_tautulli_movie_history,
+    fetch_tautulli_show_watched_data,
+    merge_movie_history,
+    merge_show_watched_data,
+    TAUTULLI_RATE_LIMIT_DELAY,
+)
+
+
+# ---------------------------------------------------------------------------
+# TautulliClient
+# ---------------------------------------------------------------------------
+
+class TestTautulliClientInit:
+    """Tests for TautulliClient initialization."""
+
+    def test_init_strips_trailing_slash(self):
+        client = TautulliClient(url="http://localhost:8181/", api_key="key123")
+        assert client.base_url == "http://localhost:8181"
+        assert client.api_key == "key123"
+
+    def test_init_sets_rate_limit_state(self):
+        client = TautulliClient(url="http://localhost:8181", api_key="key123")
+        assert client._last_request_time == 0
+        assert client.rate_limit_delay == TAUTULLI_RATE_LIMIT_DELAY
+
+
+class TestTautulliClientCall:
+    """Tests for the low-level _call() request/response handling."""
+
+    @patch('utils.api_client.requests.request')
+    def test_call_success_unwraps_data(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'response': {'result': 'success', 'message': None, 'data': [{'user_id': 1}]}
+        }
+        mock_request.return_value = mock_response
+
+        client = TautulliClient("http://localhost:8181", "key123")
+        data = client._call('get_users')
+
+        assert data == [{'user_id': 1}]
+        called_url = mock_request.call_args.kwargs['url']
+        called_params = mock_request.call_args.kwargs['params']
+        assert called_url == "http://localhost:8181/api/v2"
+        assert called_params['apikey'] == "key123"
+        assert called_params['cmd'] == 'get_users'
+
+    @patch('utils.api_client.requests.request')
+    def test_call_error_result_raises(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'response': {'result': 'error', 'message': 'Invalid apikey', 'data': {}}
+        }
+        mock_request.return_value = mock_response
+
+        client = TautulliClient("http://localhost:8181", "bad-key")
+        with pytest.raises(TautulliAPIError, match="Invalid apikey"):
+            client._call('get_users')
+
+    @patch('utils.api_client.requests.request')
+    def test_call_unexpected_shape_raises(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"unexpected": True}
+        mock_request.return_value = mock_response
+
+        client = TautulliClient("http://localhost:8181", "key123")
+        with pytest.raises(TautulliAPIError, match="Unexpected response shape"):
+            client._call('get_users')
+
+    @patch('utils.api_client.requests.request')
+    def test_call_http_error_raises(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_request.return_value = mock_response
+
+        client = TautulliClient("http://localhost:8181", "bad-key")
+        with pytest.raises(TautulliAPIError):
+            client._call('get_users')
+
+    @patch('utils.api_client.requests.request')
+    def test_call_timeout_raises_tautulli_error(self, mock_request):
+        import requests
+        mock_request.side_effect = requests.exceptions.Timeout()
+
+        client = TautulliClient("http://localhost:8181", "key123")
+        with pytest.raises(TautulliAPIError, match="timeout"):
+            client._call('get_history', params={'user_id': 1})
+
+    @patch('utils.api_client.requests.request')
+    def test_call_connection_error_raises_tautulli_error(self, mock_request):
+        import requests
+        mock_request.side_effect = requests.exceptions.ConnectionError()
+
+        client = TautulliClient("http://localhost:8181", "key123")
+        with pytest.raises(TautulliAPIError, match="Could not connect"):
+            client._call('get_users')
+
+
+class TestTautulliClientGetUsers:
+    """Tests for get_users()."""
+
+    def test_get_users_returns_data(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value=[{'user_id': 1, 'username': 'alice'}])
+
+        result = client.get_users()
+
+        assert result == [{'user_id': 1, 'username': 'alice'}]
+        client._call.assert_called_once_with('get_users')
+
+    def test_get_users_returns_empty_list_when_none(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value=None)
+
+        assert client.get_users() == []
+
+
+class TestTautulliClientGetHistory:
+    """Tests for get_history()."""
+
+    def test_get_history_unwraps_datatables_envelope(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value={'recordsTotal': 5, 'data': [{'rating_key': 100}]})
+
+        result = client.get_history(user_id=42)
+
+        assert result == [{'rating_key': 100}]
+        _, kwargs = client._call.call_args
+        assert kwargs['params'] == {'user_id': 42, 'length': 5000}
+
+    def test_get_history_handles_plain_list(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value=[{'rating_key': 1}])
+
+        assert client.get_history(user_id=42) == [{'rating_key': 1}]
+
+    def test_get_history_returns_empty_when_no_data(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value={'data': None})
+
+        assert client.get_history(user_id=42) == []
+
+    def test_get_history_custom_length(self):
+        client = TautulliClient("http://localhost:8181", "key123")
+        client._call = Mock(return_value=[])
+
+        client.get_history(user_id=42, length=50)
+
+        _, kwargs = client._call.call_args
+        assert kwargs['params']['length'] == 50
+
+
+# ---------------------------------------------------------------------------
+# create_tautulli_client
+# ---------------------------------------------------------------------------
+
+class TestCreateTautulliClient:
+    """Tests for create_tautulli_client()."""
+
+    def test_disabled_returns_none(self):
+        config = {'tautulli': {'enabled': False, 'url': 'http://x:8181', 'api_key': 'realkey'}}
+        assert create_tautulli_client(config) is None
+
+    def test_missing_section_returns_none(self):
+        assert create_tautulli_client({}) is None
+
+    def test_enabled_missing_url_returns_none(self):
+        config = {'tautulli': {'enabled': True, 'api_key': 'realkey'}}
+        assert create_tautulli_client(config) is None
+
+    def test_enabled_placeholder_key_returns_none(self):
+        config = {'tautulli': {'enabled': True, 'url': 'http://x:8181', 'api_key': 'YOUR_TAUTULLI_API_KEY'}}
+        assert create_tautulli_client(config) is None
+
+    def test_enabled_valid_returns_client(self):
+        config = {'tautulli': {'enabled': True, 'url': 'http://x:8181', 'api_key': 'realkey'}}
+        client = create_tautulli_client(config)
+        assert isinstance(client, TautulliClient)
+        assert client.base_url == 'http://x:8181'
+        assert client.api_key == 'realkey'
+
+
+# ---------------------------------------------------------------------------
+# User mapping
+# ---------------------------------------------------------------------------
+
+class TestMapUsers:
+    """Tests for map_users() - Plex <-> Tautulli identity matching."""
+
+    def test_matches_by_email(self):
+        plex_identities = [{'id': '1', 'username': 'jsmith', 'email': 'Jason@Example.com'}]
+        tautulli_users = [{'user_id': 501, 'username': 'jason_t', 'friendly_name': 'Jason T', 'email': 'jason@example.com'}]
+
+        result = map_users(plex_identities, tautulli_users)
+
+        assert result == {'1': '501'}
+
+    def test_falls_back_to_username_when_no_email_match(self):
+        plex_identities = [{'id': '2', 'username': 'ericarutyunov', 'email': None}]
+        tautulli_users = [{'user_id': 502, 'username': 'ericarutyunov', 'email': 'someone-else@example.com'}]
+
+        result = map_users(plex_identities, tautulli_users)
+
+        assert result == {'2': '502'}
+
+    def test_falls_back_to_friendly_name(self):
+        plex_identities = [{'id': '3', 'username': 'homehouse165', 'email': None}]
+        tautulli_users = [{'user_id': 503, 'username': 'random_login', 'friendly_name': 'homehouse165', 'email': None}]
+
+        result = map_users(plex_identities, tautulli_users)
+
+        assert result == {'3': '503'}
+
+    def test_unmapped_user_excluded_from_result(self):
+        plex_identities = [{'id': '4', 'username': 'ghost', 'email': 'ghost@example.com'}]
+        tautulli_users = [{'user_id': 504, 'username': 'someone_else', 'email': 'other@example.com'}]
+
+        result = map_users(plex_identities, tautulli_users)
+
+        assert result == {}
+
+    def test_empty_inputs_return_empty_map(self):
+        assert map_users([], []) == {}
+        assert map_users([{'id': '1', 'username': 'a', 'email': None}], []) == {}
+
+    def test_skips_tautulli_users_without_user_id(self):
+        plex_identities = [{'id': '1', 'username': 'a', 'email': 'a@example.com'}]
+        tautulli_users = [{'username': 'a', 'email': 'a@example.com'}]  # missing user_id
+
+        assert map_users(plex_identities, tautulli_users) == {}
+
+    def test_multiple_users_mixed_match_strategies(self):
+        plex_identities = [
+            {'id': '1', 'username': 'alice', 'email': 'alice@example.com'},
+            {'id': '2', 'username': 'bob', 'email': None},
+            {'id': '3', 'username': 'nomatch', 'email': 'nomatch@example.com'},
+        ]
+        tautulli_users = [
+            {'user_id': 10, 'username': 'alice_t', 'email': 'alice@example.com'},
+            {'user_id': 20, 'username': 'bob', 'email': None},
+        ]
+
+        result = map_users(plex_identities, tautulli_users)
+
+        assert result == {'1': '10', '2': '20'}
+
+
+class TestBuildUserMap:
+    """Tests for build_user_map() - orchestrates client + plexapi lookups."""
+
+    @patch('plexapi.myplex.MyPlexAccount')
+    def test_builds_map_from_client_and_plex_account(self, mock_account_cls):
+        mock_account = Mock()
+        mock_account.id = 245355570  # global plex.tv account id (owner)
+        mock_account.username = 'owner'
+        mock_account.email = 'owner@example.com'
+
+        mock_user = Mock()
+        mock_user.id = 2
+        mock_user.title = 'friend'
+        mock_user.email = 'friend@example.com'
+        mock_account.users.return_value = [mock_user]
+        mock_account_cls.return_value = mock_account
+
+        client = Mock()
+        client.get_users.return_value = [
+            {'user_id': 100, 'username': 'owner_t', 'email': 'owner@example.com'},
+            {'user_id': 200, 'username': 'friend_t', 'email': 'friend@example.com'},
+        ]
+
+        config = {'plex': {'token': 'tok'}}
+        result = build_user_map(client, config)
+
+        # Owner must be keyed by the local '1' convention (matches
+        # get_plex_account_ids()/fetch_plex_watch_history_movies()'s
+        # accountID for the owner), NOT their global plex.tv account.id.
+        assert result == {'1': '100', '2': '200'}
+
+    @patch('plexapi.myplex.MyPlexAccount')
+    def test_owner_keyed_by_local_id_not_global_id(self, mock_account_cls):
+        """Regression test: owner's global account.id must never leak into the map key."""
+        mock_account = Mock()
+        mock_account.id = 245355570
+        mock_account.username = 'owner'
+        mock_account.email = 'owner@example.com'
+        mock_account.users.return_value = []
+        mock_account_cls.return_value = mock_account
+
+        client = Mock()
+        client.get_users.return_value = [
+            {'user_id': 245355570, 'username': 'owner', 'email': 'owner@example.com'},
+        ]
+
+        result = build_user_map(client, {'plex': {'token': 'tok'}})
+
+        assert '1' in result
+        assert '245355570' not in result
+        assert result['1'] == '245355570'
+
+    def test_get_users_error_returns_empty_map(self):
+        client = Mock()
+        client.get_users.side_effect = TautulliAPIError("boom")
+
+        result = build_user_map(client, {'plex': {'token': 'tok'}})
+
+        assert result == {}
+
+    def test_no_tautulli_users_returns_empty_map(self):
+        client = Mock()
+        client.get_users.return_value = []
+
+        result = build_user_map(client, {'plex': {'token': 'tok'}})
+
+        assert result == {}
+
+    @patch('plexapi.myplex.MyPlexAccount')
+    def test_plex_account_error_returns_empty_map(self, mock_account_cls):
+        mock_account_cls.side_effect = Exception("Plex unreachable")
+
+        client = Mock()
+        client.get_users.return_value = [{'user_id': 100, 'username': 'x', 'email': 'x@example.com'}]
+
+        result = build_user_map(client, {'plex': {'token': 'tok'}})
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_tautulli_movie_history
+# ---------------------------------------------------------------------------
+
+class TestFetchTautulliMovieHistory:
+    """Tests for fetch_tautulli_movie_history() - and Plex-only fallback safety."""
+
+    def test_no_client_returns_empty_list(self):
+        # tautulli disabled/misconfigured -> create_tautulli_client() returns None internally
+        result = fetch_tautulli_movie_history({}, ['1'])
+        assert result == []
+
+    def test_empty_user_map_returns_empty_list(self):
+        client = Mock()
+        result = fetch_tautulli_movie_history({}, ['1'], client=client, user_map={})
+        assert result == []
+        client.get_history.assert_not_called()
+
+    def test_unmapped_account_id_skipped(self):
+        client = Mock()
+        result = fetch_tautulli_movie_history({}, ['999'], client=client, user_map={'1': '100'})
+        assert result == []
+        client.get_history.assert_not_called()
+
+    def test_filters_to_movies_and_watched(self):
+        client = Mock()
+        client.get_history.return_value = [
+            {'rating_key': 1, 'media_type': 'movie', 'watched_status': 1, 'stopped': 1700000000},
+            {'rating_key': 2, 'media_type': 'episode', 'watched_status': 1, 'stopped': 1700000000},
+            {'rating_key': 3, 'media_type': 'movie', 'watched_status': 0, 'stopped': 1700000000},
+            {'rating_key': None, 'media_type': 'movie', 'watched_status': 1, 'stopped': 1700000000},
+        ]
+
+        result = fetch_tautulli_movie_history({}, ['1'], client=client, user_map={'1': '100'})
+
+        assert len(result) == 1
+        assert result[0].ratingKey == '1'
+        assert isinstance(result[0].viewedAt, datetime)
+        assert result[0].userRating is None
+
+    def test_uses_date_fallback_when_stopped_missing(self):
+        client = Mock()
+        client.get_history.return_value = [
+            {'rating_key': 5, 'media_type': 'movie', 'watched_status': 1, 'date': 1700000000},
+        ]
+
+        result = fetch_tautulli_movie_history({}, ['1'], client=client, user_map={'1': '100'})
+
+        assert result[0].viewedAt == datetime.fromtimestamp(1700000000)
+
+    def test_history_fetch_error_for_one_user_does_not_stop_others(self):
+        client = Mock()
+
+        def side_effect(user_id, **kwargs):
+            if user_id == '100':
+                raise TautulliAPIError("timeout")
+            return [{'rating_key': 9, 'media_type': 'movie', 'watched_status': 1, 'stopped': 1700000000}]
+
+        client.get_history.side_effect = side_effect
+
+        result = fetch_tautulli_movie_history(
+            {}, ['1', '2'], client=client, user_map={'1': '100', '2': '200'}
+        )
+
+        assert len(result) == 1
+        assert result[0].ratingKey == '9'
+
+
+# ---------------------------------------------------------------------------
+# fetch_tautulli_show_watched_data
+# ---------------------------------------------------------------------------
+
+class TestFetchTautulliShowWatchedData:
+    """Tests for fetch_tautulli_show_watched_data()."""
+
+    def test_no_client_returns_empty(self):
+        ids, timestamps = fetch_tautulli_show_watched_data({}, ['1'])
+        assert ids == set()
+        assert timestamps == {}
+
+    def test_empty_user_map_returns_empty(self):
+        client = Mock()
+        ids, timestamps = fetch_tautulli_show_watched_data({}, ['1'], client=client, user_map={})
+        assert ids == set()
+        assert timestamps == {}
+        client.get_history.assert_not_called()
+
+    def test_filters_to_episodes_and_watched_builds_show_ids(self):
+        client = Mock()
+        client.get_history.return_value = [
+            {'grandparent_rating_key': 55, 'media_type': 'episode', 'watched_status': 1, 'stopped': 1700000000},
+            {'grandparent_rating_key': 55, 'media_type': 'episode', 'watched_status': 1, 'stopped': 1700003600},
+            {'grandparent_rating_key': 60, 'media_type': 'movie', 'watched_status': 1, 'stopped': 1700000000},
+            {'grandparent_rating_key': 70, 'media_type': 'episode', 'watched_status': 0, 'stopped': 1700000000},
+        ]
+
+        ids, timestamps = fetch_tautulli_show_watched_data({}, ['1'], client=client, user_map={'1': '100'})
+
+        assert ids == {55}
+        assert timestamps == {55: 1700003600}  # keeps latest timestamp
+
+    def test_missing_grandparent_rating_key_skipped(self):
+        client = Mock()
+        client.get_history.return_value = [
+            {'grandparent_rating_key': None, 'media_type': 'episode', 'watched_status': 1, 'stopped': 1700000000},
+        ]
+
+        ids, timestamps = fetch_tautulli_show_watched_data({}, ['1'], client=client, user_map={'1': '100'})
+
+        assert ids == set()
+        assert timestamps == {}
+
+
+# ---------------------------------------------------------------------------
+# merge_movie_history
+# ---------------------------------------------------------------------------
+
+class TestMergeMovieHistory:
+    """Tests for merge_movie_history() - dedupe + weighting-compatible output."""
+
+    def test_no_overlap_simple_union(self):
+        plex_item = TautulliHistoryItem('1', datetime(2026, 1, 1), 8.0)
+        tautulli_item = TautulliHistoryItem('2', datetime(2026, 2, 1), None)
+
+        result = merge_movie_history([plex_item], [tautulli_item])
+
+        keys = {item.ratingKey for item in result}
+        assert keys == {'1', '2'}
+
+    def test_dedupes_by_rating_key(self):
+        plex_item = TautulliHistoryItem('1', datetime(2026, 1, 1), None)
+        tautulli_item = TautulliHistoryItem('1', datetime(2026, 2, 1), None)
+
+        result = merge_movie_history([plex_item], [tautulli_item])
+
+        assert len(result) == 1
+
+    def test_plex_rating_wins_over_tautulli(self):
+        plex_item = TautulliHistoryItem('1', datetime(2026, 1, 1), 9.0)
+        tautulli_item = TautulliHistoryItem('1', datetime(2026, 2, 1), None)
+
+        result = merge_movie_history([plex_item], [tautulli_item])
+
+        assert result[0].userRating == 9.0
+
+    def test_keeps_most_recent_viewed_at(self):
+        plex_item = TautulliHistoryItem('1', datetime(2026, 1, 1), None)
+        tautulli_item = TautulliHistoryItem('1', datetime(2026, 6, 1), None)
+
+        result = merge_movie_history([plex_item], [tautulli_item])
+
+        assert result[0].viewedAt == datetime(2026, 6, 1)
+
+    def test_empty_plex_falls_back_to_tautulli_only(self):
+        tautulli_item = TautulliHistoryItem('1', datetime(2026, 2, 1), None)
+
+        result = merge_movie_history([], [tautulli_item])
+
+        assert len(result) == 1
+        assert result[0].ratingKey == '1'
+
+    def test_empty_tautulli_returns_plex_only(self):
+        plex_item = TautulliHistoryItem('1', datetime(2026, 1, 1), 7.0)
+
+        result = merge_movie_history([plex_item], [])
+
+        assert len(result) == 1
+        assert result[0].userRating == 7.0
+
+    def test_both_empty_returns_empty(self):
+        assert merge_movie_history([], []) == []
+
+
+# ---------------------------------------------------------------------------
+# merge_show_watched_data
+# ---------------------------------------------------------------------------
+
+class TestMergeShowWatchedData:
+    """Tests for merge_show_watched_data() - dedupe + weighting-compatible output."""
+
+    def test_union_of_ids(self):
+        ids, timestamps = merge_show_watched_data({1, 2}, {}, {2, 3}, {})
+        assert ids == {1, 2, 3}
+
+    def test_keeps_max_timestamp_per_show(self):
+        ids, timestamps = merge_show_watched_data(
+            {1}, {1: 1000}, {1}, {1: 2000}
+        )
+        assert timestamps == {1: 2000}
+
+    def test_plex_timestamp_kept_when_newer(self):
+        ids, timestamps = merge_show_watched_data(
+            {1}, {1: 5000}, {1}, {1: 2000}
+        )
+        assert timestamps == {1: 5000}
+
+    def test_tautulli_only_show_included(self):
+        ids, timestamps = merge_show_watched_data(set(), {}, {9}, {9: 1234})
+        assert ids == {9}
+        assert timestamps == {9: 1234}
+
+    def test_empty_tautulli_returns_plex_only(self):
+        ids, timestamps = merge_show_watched_data({1, 2}, {1: 100}, set(), {})
+        assert ids == {1, 2}
+        assert timestamps == {1: 100}
+
+    def test_both_empty_returns_empty(self):
+        ids, timestamps = merge_show_watched_data(set(), {}, set(), {})
+        assert ids == set()
+        assert timestamps == {}
+
+
+# ---------------------------------------------------------------------------
+# Disabled / unreachable / unmapped -> Plex-only fallback (no regression)
+# ---------------------------------------------------------------------------
+
+class TestPlexOnlyFallback:
+    """End-to-end-ish tests confirming safe fallback behavior."""
+
+    def test_disabled_config_never_calls_tautulli(self):
+        config = {'tautulli': {'enabled': False, 'url': 'http://x:8181', 'api_key': 'realkey'}}
+
+        movie_items = fetch_tautulli_movie_history(config, ['1'])
+        show_ids, show_timestamps = fetch_tautulli_show_watched_data(config, ['1'])
+
+        assert movie_items == []
+        assert show_ids == set()
+        assert show_timestamps == {}
+
+    def test_missing_tautulli_config_never_calls_tautulli(self):
+        assert fetch_tautulli_movie_history({}, ['1']) == []
+        ids, timestamps = fetch_tautulli_show_watched_data({}, ['1'])
+        assert ids == set()
+        assert timestamps == {}
+
+    @patch('utils.tautulli.create_tautulli_client')
+    def test_unreachable_tautulli_falls_back_cleanly(self, mock_create_client):
+        client = Mock()
+        client.get_users.side_effect = TautulliAPIError("Could not connect to Tautulli")
+        mock_create_client.return_value = client
+
+        config = {'tautulli': {'enabled': True, 'url': 'http://x:8181', 'api_key': 'realkey'}, 'plex': {'token': 'tok'}}
+
+        result = fetch_tautulli_movie_history(config, ['1'])
+
+        assert result == []

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -246,6 +246,20 @@ from .simkl import (
     get_authenticated_simkl_client,
 )
 
+# Tautulli utilities
+from .tautulli import (
+    TautulliAPIError,
+    TautulliClient,
+    TautulliHistoryItem,
+    create_tautulli_client,
+    build_user_map,
+    map_users,
+    fetch_tautulli_movie_history,
+    fetch_tautulli_show_watched_data,
+    merge_movie_history,
+    merge_show_watched_data,
+)
+
 # Define __all__ for explicit public API
 __all__ = [
     # Config
@@ -407,4 +421,15 @@ __all__ = [
     'SimklClient',
     'create_simkl_client',
     'get_authenticated_simkl_client',
+    # Tautulli
+    'TautulliAPIError',
+    'TautulliClient',
+    'TautulliHistoryItem',
+    'create_tautulli_client',
+    'build_user_map',
+    'map_users',
+    'fetch_tautulli_movie_history',
+    'fetch_tautulli_show_watched_data',
+    'merge_movie_history',
+    'merge_show_watched_data',
 ]

--- a/utils/config.py
+++ b/utils/config.py
@@ -9,7 +9,7 @@ import yaml
 from typing import Dict
 
 # Project version - single source of truth
-__version__ = "2.8.19"
+__version__ = "2.8.20"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/tautulli.py
+++ b/utils/tautulli.py
@@ -1,0 +1,463 @@
+"""
+Tautulli API client for Curatarr.
+
+Optional integration: supplements Plex-native watch history with history
+pulled from a Tautulli instance, weighted the same way as Plex history.
+Mainly useful for shared/external Plex users whose Plex-native history
+retention is thin.
+
+Never raises out of the high-level fetch_/merge_ helpers below - if
+Tautulli is disabled, unreachable, or a user can't be mapped, callers
+should transparently fall back to Plex-only behavior.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .api_client import BaseAPIClient
+from .display import log_warning
+
+logger = logging.getLogger('curatarr')
+
+TAUTULLI_RATE_LIMIT_DELAY = 0.1
+TAUTULLI_REQUEST_TIMEOUT = 30
+
+# Generous default page size for get_history - large enough to cover most
+# users' full history in one call without paging.
+TAUTULLI_DEFAULT_HISTORY_LENGTH = 5000
+
+PLACEHOLDER_API_KEY = 'YOUR_TAUTULLI_API_KEY'
+
+
+class TautulliAPIError(Exception):
+    """Raised when a Tautulli API request fails."""
+    pass
+
+
+class TautulliClient(BaseAPIClient):
+    """
+    Tautulli API client (api/v2), authenticated via `apikey` query param.
+
+    See: https://github.com/Tautulli/Tautulli/wiki/API-Reference
+    """
+
+    api_name = "Tautulli"
+    exception_class = TautulliAPIError
+    rate_limit_delay = TAUTULLI_RATE_LIMIT_DELAY
+    request_timeout = TAUTULLI_REQUEST_TIMEOUT
+
+    def __init__(self, url: str, api_key: str):
+        """
+        Initialize Tautulli client.
+
+        Args:
+            url: Base Tautulli URL, e.g. http://192.168.1.10:8181
+            api_key: Tautulli API key (Settings -> Web Interface -> API Key)
+        """
+        super().__init__()
+        self.base_url = url.rstrip('/')
+        self.api_key = api_key
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Tautulli doesn't require auth headers (uses query param)."""
+        return {}
+
+    def _call(self, cmd: str, params: Optional[Dict] = None) -> Any:
+        """
+        Call {base_url}/api/v2?apikey=<key>&cmd=<cmd> and unwrap response.data.
+
+        Args:
+            cmd: Tautulli API command (e.g. 'get_users', 'get_history')
+            params: Additional query params for the command
+
+        Returns:
+            The `response.data` payload
+
+        Raises:
+            TautulliAPIError: On HTTP errors, timeouts, or an error result
+        """
+        query = {'apikey': self.api_key, 'cmd': cmd}
+        if params:
+            query.update(params)
+
+        url = f"{self.base_url}/api/v2"
+        result = self._make_request_to_url("GET", url, params=query)
+
+        if not isinstance(result, dict) or 'response' not in result:
+            raise TautulliAPIError(f"Unexpected response shape from Tautulli cmd={cmd}")
+
+        envelope = result['response']
+        if envelope.get('result') != 'success':
+            raise TautulliAPIError(envelope.get('message') or f"Tautulli cmd={cmd} failed")
+
+        return envelope.get('data')
+
+    def get_users(self) -> List[Dict]:
+        """
+        Get all Tautulli-tracked users.
+
+        Returns:
+            List of user dicts (user_id, username, email, friendly_name, ...)
+        """
+        data = self._call('get_users')
+        return data or []
+
+    def get_history(self, user_id: Any, length: int = TAUTULLI_DEFAULT_HISTORY_LENGTH) -> List[Dict]:
+        """
+        Get watch history rows for a Tautulli user.
+
+        Args:
+            user_id: Tautulli user_id
+            length: Max number of history rows to return
+
+        Returns:
+            List of history row dicts (rating_key, grandparent_rating_key,
+            media_type, stopped, date, watched_status, ...)
+        """
+        data = self._call('get_history', params={'user_id': user_id, 'length': length})
+        if isinstance(data, dict):
+            # Tautulli wraps history in a DataTables-style envelope: {"data": [...], ...}
+            return data.get('data') or []
+        return data or []
+
+
+def create_tautulli_client(config: Dict) -> Optional[TautulliClient]:
+    """
+    Create a TautulliClient from config, if configured and enabled.
+
+    Args:
+        config: Full config dict containing an optional 'tautulli' section
+
+    Returns:
+        TautulliClient if configured and enabled, None otherwise
+    """
+    tautulli_config = config.get('tautulli', {}) or {}
+
+    if not tautulli_config.get('enabled', False):
+        return None
+
+    url = tautulli_config.get('url')
+    api_key = tautulli_config.get('api_key')
+
+    if not url or not api_key or api_key == PLACEHOLDER_API_KEY:
+        log_warning("Tautulli enabled but 'url'/'api_key' not configured - skipping Tautulli history")
+        return None
+
+    return TautulliClient(url, api_key)
+
+
+class TautulliHistoryItem:
+    """
+    Minimal duck-type of a plexapi history Video item.
+
+    Exposes the same attributes (`ratingKey`, `viewedAt`, `userRating`) that
+    utils.plex.fetch_plex_watch_history_movies' HistoryItem exposes, so it can
+    be merged with real Plex history items and processed by the exact same
+    downstream weighting code.
+    """
+
+    def __init__(self, rating_key: str, viewed_at: Optional[datetime] = None,
+                 user_rating: Optional[float] = None):
+        self.ratingKey = rating_key
+        self.viewedAt = viewed_at
+        self.userRating = user_rating
+
+
+def build_user_map(client: TautulliClient, config: Dict) -> Dict[str, str]:
+    """
+    Map Plex account IDs to Tautulli user IDs.
+
+    Matches on email first (most stable across username changes), falling
+    back to username/friendly_name. Never raises - returns {} on any error
+    so callers can fall back to Plex-only behavior.
+
+    Args:
+        client: TautulliClient instance
+        config: Full config dict with plex.token
+
+    Returns:
+        Dict mapping Plex account_id (str) -> Tautulli user_id (str)
+    """
+    try:
+        tautulli_users = client.get_users()
+    except TautulliAPIError as e:
+        log_warning(f"Tautulli: could not fetch users for mapping: {e}")
+        return {}
+
+    if not tautulli_users:
+        return {}
+
+    try:
+        # Imported here to avoid a hard dependency for callers that only
+        # need the API client (and to keep this module easy to unit test).
+        from plexapi.myplex import MyPlexAccount
+
+        account = MyPlexAccount(token=config['plex']['token'])
+        plex_identities = [{
+            # Plex convention: the server owner's account_id in the
+            # `/accounts` endpoint (what get_plex_account_ids() /
+            # fetch_plex_watch_history_movies/shows() actually use) is
+            # always local id '1', which differs from the owner's global
+            # plex.tv account.id used everywhere else in this account
+            # object. Key on '1' here so owner history correctly merges.
+            'id': '1',
+            'username': account.username,
+            'email': getattr(account, 'email', None),
+        }]
+        for u in account.users():
+            plex_identities.append({
+                'id': str(u.id),
+                'username': u.title,
+                'email': getattr(u, 'email', None),
+            })
+    except Exception as e:
+        log_warning(f"Tautulli: could not fetch Plex users for mapping: {e}")
+        return {}
+
+    return map_users(plex_identities, tautulli_users)
+
+
+def map_users(plex_identities: List[Dict], tautulli_users: List[Dict]) -> Dict[str, str]:
+    """
+    Match Plex users to Tautulli users by email, falling back to username.
+
+    Args:
+        plex_identities: List of dicts with 'id', 'username', 'email'
+        tautulli_users: List of raw Tautulli user dicts (get_users() output)
+
+    Returns:
+        Dict mapping Plex account_id (str) -> Tautulli user_id (str)
+    """
+    by_email: Dict[str, str] = {}
+    by_username: Dict[str, str] = {}
+
+    for tu in tautulli_users:
+        if tu.get('user_id') is None:
+            continue
+        tautulli_id = str(tu['user_id'])
+
+        email = (tu.get('email') or '').strip().lower()
+        if email and email not in by_email:
+            by_email[email] = tautulli_id
+
+        for name_field in ('username', 'friendly_name'):
+            name = (tu.get(name_field) or '').strip().lower()
+            if name and name not in by_username:
+                by_username[name] = tautulli_id
+
+    user_map: Dict[str, str] = {}
+    for identity in plex_identities:
+        plex_id = identity.get('id')
+        if not plex_id:
+            continue
+
+        email = (identity.get('email') or '').strip().lower()
+        username = (identity.get('username') or '').strip().lower()
+
+        tautulli_id = None
+        if email and email in by_email:
+            tautulli_id = by_email[email]
+        elif username and username in by_username:
+            tautulli_id = by_username[username]
+
+        if tautulli_id:
+            user_map[str(plex_id)] = tautulli_id
+        else:
+            logger.debug(f"Tautulli: no match found for Plex user '{identity.get('username')}'")
+
+    return user_map
+
+
+def fetch_tautulli_movie_history(
+    config: Dict,
+    account_ids: List[str],
+    client: Optional[TautulliClient] = None,
+    user_map: Optional[Dict[str, str]] = None,
+) -> List[TautulliHistoryItem]:
+    """
+    Fetch movie watch history from Tautulli for the given Plex account IDs.
+
+    Safe no-op (returns []) if Tautulli is disabled, unreachable, or none of
+    the account_ids can be mapped to a Tautulli user.
+
+    Args:
+        config: Full config dict
+        account_ids: Plex account IDs to fetch Tautulli history for
+        client: Optional pre-built TautulliClient (mainly for testing)
+        user_map: Optional pre-built account_id -> tautulli_user_id map
+
+    Returns:
+        List of TautulliHistoryItem (duck-typed like plexapi history Video items)
+    """
+    client = client or create_tautulli_client(config)
+    if not client:
+        return []
+
+    user_map = user_map if user_map is not None else build_user_map(client, config)
+    if not user_map:
+        return []
+
+    items: List[TautulliHistoryItem] = []
+    for account_id in account_ids:
+        tautulli_user_id = user_map.get(str(account_id))
+        if not tautulli_user_id:
+            continue
+
+        try:
+            rows = client.get_history(tautulli_user_id)
+        except TautulliAPIError as e:
+            log_warning(f"Tautulli: history fetch failed for user {tautulli_user_id}: {e}")
+            continue
+
+        for row in rows:
+            if row.get('media_type') != 'movie':
+                continue
+            if row.get('watched_status') != 1:
+                continue
+
+            rating_key = row.get('rating_key')
+            if not rating_key:
+                continue
+
+            ts = row.get('stopped') or row.get('date')
+            viewed_at = datetime.fromtimestamp(int(ts)) if ts else None
+
+            items.append(TautulliHistoryItem(str(rating_key), viewed_at, None))
+
+    return items
+
+
+def fetch_tautulli_show_watched_data(
+    config: Dict,
+    account_ids: List[str],
+    client: Optional[TautulliClient] = None,
+    user_map: Optional[Dict[str, str]] = None,
+) -> Tuple[Set[int], Dict[int, int]]:
+    """
+    Fetch TV watch history from Tautulli for the given Plex account IDs.
+
+    Safe no-op (returns (set(), {})) if Tautulli is disabled, unreachable, or
+    none of the account_ids can be mapped to a Tautulli user.
+
+    Args:
+        config: Full config dict
+        account_ids: Plex account IDs to fetch Tautulli history for
+        client: Optional pre-built TautulliClient (mainly for testing)
+        user_map: Optional pre-built account_id -> tautulli_user_id map
+
+    Returns:
+        Tuple of (watched_show_ids set, show_id -> latest viewed_at epoch dict)
+    """
+    client = client or create_tautulli_client(config)
+    if not client:
+        return set(), {}
+
+    user_map = user_map if user_map is not None else build_user_map(client, config)
+    if not user_map:
+        return set(), {}
+
+    watched_ids: Set[int] = set()
+    timestamps: Dict[int, int] = {}
+
+    for account_id in account_ids:
+        tautulli_user_id = user_map.get(str(account_id))
+        if not tautulli_user_id:
+            continue
+
+        try:
+            rows = client.get_history(tautulli_user_id)
+        except TautulliAPIError as e:
+            log_warning(f"Tautulli: history fetch failed for user {tautulli_user_id}: {e}")
+            continue
+
+        for row in rows:
+            if row.get('media_type') != 'episode':
+                continue
+            if row.get('watched_status') != 1:
+                continue
+
+            show_key = row.get('grandparent_rating_key')
+            if not show_key:
+                continue
+
+            show_id = int(show_key)
+            watched_ids.add(show_id)
+
+            ts = row.get('stopped') or row.get('date')
+            if ts:
+                ts = int(ts)
+                if show_id not in timestamps or ts > timestamps[show_id]:
+                    timestamps[show_id] = ts
+
+    return watched_ids, timestamps
+
+
+def merge_movie_history(plex_items: List[Any], tautulli_items: List[Any]) -> List[Any]:
+    """
+    Merge Plex + Tautulli movie history, de-duplicated by rating_key.
+
+    Weighted the same way as Plex-only history since the merged items are
+    fed through the exact same downstream processing (recency decay from
+    `.viewedAt`, rating multiplier from `.userRating`).
+
+    A Plex-sourced rating always wins (Tautulli doesn't track star ratings).
+    The most recent `viewedAt` across both sources is kept.
+
+    Args:
+        plex_items: History items from utils.plex.fetch_plex_watch_history_movies
+        tautulli_items: History items from fetch_tautulli_movie_history
+
+    Returns:
+        List of merged, de-duplicated history items
+    """
+    merged: Dict[str, TautulliHistoryItem] = {}
+
+    for item in list(plex_items) + list(tautulli_items):
+        key = str(item.ratingKey)
+        existing = merged.get(key)
+
+        if existing is None:
+            merged[key] = TautulliHistoryItem(key, item.viewedAt, item.userRating)
+            continue
+
+        best_rating = existing.userRating if existing.userRating is not None else item.userRating
+
+        best_viewed_at = existing.viewedAt
+        if item.viewedAt and (best_viewed_at is None or item.viewedAt > best_viewed_at):
+            best_viewed_at = item.viewedAt
+
+        merged[key] = TautulliHistoryItem(key, best_viewed_at, best_rating)
+
+    return list(merged.values())
+
+
+def merge_show_watched_data(
+    plex_ids: Set[int],
+    plex_timestamps: Dict[int, int],
+    tautulli_ids: Set[int],
+    tautulli_timestamps: Dict[int, int],
+) -> Tuple[Set[int], Dict[int, int]]:
+    """
+    Merge Plex + Tautulli watched-show data, de-duplicated by show ID.
+
+    Weighted the same way as Plex-only history since the merged result feeds
+    the exact same downstream recency-decay processing.
+
+    Args:
+        plex_ids: Watched show IDs from Plex history
+        plex_timestamps: show_id -> latest viewedAt epoch from Plex history
+        tautulli_ids: Watched show IDs from Tautulli history
+        tautulli_timestamps: show_id -> latest viewedAt epoch from Tautulli history
+
+    Returns:
+        Tuple of (merged watched_show_ids set, merged show_id -> latest viewedAt dict)
+    """
+    merged_ids = set(plex_ids) | set(tautulli_ids)
+
+    merged_timestamps = dict(plex_timestamps)
+    for show_id, ts in tautulli_timestamps.items():
+        if show_id not in merged_timestamps or ts > merged_timestamps[show_id]:
+            merged_timestamps[show_id] = ts
+
+    return merged_ids, merged_timestamps


### PR DESCRIPTION
## Summary

Adds an optional integration that supplements Plex's own per-user watch history with history pulled from a [Tautulli](https://tautulli.com/) instance, weighted the same way as Plex history (recency decay, rating multiplier, rewatch bonus). Mainly useful for shared/external Plex users whose Plex-native history retention is thin.

Disabled by default. If Tautulli is disabled, unreachable, or a given user can't be mapped, Curatarr silently falls back to today's Plex-only behavior - no regression.

Closes #150.

## What's new

- **`utils/tautulli.py`** - new module:
  - `TautulliClient` (follows the existing `BaseAPIClient` pattern used by MDBList/Simkl/Sonarr/Radarr) - calls `cmd=get_users` and `cmd=get_history` against `{url}/api/v2`, parses Tautulli's `response.data` envelope, raises `TautulliAPIError` on HTTP errors/timeouts.
  - `create_tautulli_client()` - builds a client from config, or `None` if disabled/unconfigured/placeholder key.
  - `build_user_map()` / `map_users()` - maps Plex users to Tautulli users, matching on **email first**, falling back to username/friendly_name. Never raises; returns `{}` on any failure so callers fall back cleanly.
  - `fetch_tautulli_movie_history()` / `fetch_tautulli_show_watched_data()` - high-level fetchers that are safe no-ops (return empty) when disabled/unreachable/unmapped.
  - `merge_movie_history()` / `merge_show_watched_data()` - de-duplicate Plex + Tautulli history by rating_key (movies) / show ID (TV), producing output that's fed through the *exact same* downstream weighting code as Plex-only history.
- **`config/config.example.yml`** - new `tautulli` block (`enabled`, `url`, `api_key`) with placeholder values.
- **`recommenders/movie.py`** / **`recommenders/tv.py`** - when `tautulli.enabled`, merge in each user's Tautulli history alongside their Plex history before the existing recency/rating/rewatch weighting runs.
- **`recommenders/base.py`** - removed the dead `_get_plex_user_ids` scaffolding (0 callers, undocumented `plex_users.url`/`plex_users.api_key` config that was never wired up) - superseded by `utils/tautulli.py`'s user-mapping logic.
- `utils/config.py` bumped to **2.8.20**.

## User mapping / a real gotcha found during live validation

Plex has two different account ID spaces in this codebase: `get_plex_account_ids()` (used by the actual per-user history-fetch path in movie.py/tv.py) returns the server-local `/accounts` ID, where the **server owner is always local ID `'1'`**. `MyPlexAccount.users()`/`account.id` return the **global plex.tv account ID** instead. For shared/friend users these happen to be numerically identical, but for the owner they differ. `build_user_map()` keys the owner as local `'1'` to match what `fetch_plex_watch_history_movies()`/`fetch_plex_watch_history_shows()` actually receive - otherwise the *owner's own* Tautulli history would silently never merge. Covered by a regression test (`test_owner_keyed_by_local_id_not_global_id`).

## Version reconciliation note

`main` was at 2.8.18 when this branch was cut. PR #155 (also 2.8.19-targeted, same as `dev`) merged into `main` while this PR was in progress, bumping `main` to 2.8.19. This branch has been rebased onto the post-#155 `main` and kept its version at **2.8.20** to avoid colliding with #155/`dev`'s 2.8.19.

## Tests

`pytest tests/ --cov=. --cov-fail-under=85`: **1176 passed**, coverage **85.91%** (`utils/tautulli.py` itself at 97%; full suite run against `main` post-#155 merge). New `tests/test_tautulli.py` (57 tests) covers the API client (success/error/timeout/connection-error), `get_users`/`get_history` parsing, email/username/friendly_name mapping (incl. unmapped users, the owner local-ID regression case), movie/show history fetch filtering (media_type, watched_status, missing keys, per-user fetch errors not aborting the batch), merge/dedupe/weighting-compatible output, and the disabled/unconfigured/unreachable fallback-to-Plex-only paths. All mocked - no live network calls in the unit suite.

## Live validation (read-only, against the real instance)

Ran the new client against a live Tautulli instance and the paired Plex server (GET-only, no writes):

- `get_users`: **7** Tautulli users returned.
- Mapping: **6/6** configured Plex users matched to a Tautulli user (100% match rate) - including the owner, via the local-ID fix above.
- `get_history` for the owner: 50 rows fetched, parsed correctly (sample title/media_type present).
- Merge results (Plex-only unique watched movies -> merged unique, per user):

  | account | plex-only | tautulli rows | merged unique |
  |---|---|---|---|
  | owner | 81 | 104 | 173 |
  | user 2 | 21 | 24 | 41 |
  | user 3 | 12 | 62 | 60 |
  | user 4 | 24 | 11 | 35 |
  | user 5 | 26 | 101 | 62 |
  | user 6 | 12 | 34 | 26 |

  Every user gained meaningfully fuller history from the merge, including the owner - confirming the reporter's use case.

No real API key or token was committed; the live validation script read the key from local Tautulli config at runtime and was deleted afterward. `config.example.yml` only contains a placeholder.

## Not merging yet

Holding for owner review per usual process - please confirm the 2.8.20 version choice given #155/dev are on 2.8.19.
