### PR TITLE
Verify SSH-signed release tags before auto-update (+ pin deps, fail-closed, keep auto-update on)

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -1,0 +1,6 @@
+# SSH allowed-signers file used to verify signed Curatarr release tags.
+# Format: git's allowed-signers format (see ssh-keygen(1) / git-verify-tag(1)).
+# Principal must match the tagger email used when signing a release tag.
+# Only the PUBLIC half of the release-signing key lives here; the private
+# key is kept offline on the maintainer's machine. See RELEASING.md.
+jasonbsmith1568@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q curatarr-release-signing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Your Plex library has thousands of titles. Your users have watched maybe 10% of 
 ### For You (Simple & Robust)
 - **One command** — `./run.sh` handles everything
 - **Modular config** — Main settings plus optional integration files
-- **Auto-updates** — Pulls latest code from GitHub on each run (optional)
+- **Auto-updates** — Applies SSH-signed release updates from GitHub on each run (optional)
 - **Smart caching** — Auto-clears incompatible caches after updates
 - **Auto-scheduling** — Optional daily cron job
 - **Clean logs** — Know exactly what happened
@@ -175,7 +175,7 @@ users:
 ### General Settings
 ```yaml
 general:
-  auto_update: true           # Pull latest code from GitHub on run
+  auto_update: true           # Apply verified signed releases from GitHub on run
   log_retention_days: 7       # Keep logs for 7 days
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,86 @@
+# Releasing Curatarr
+
+The auto-updater (`run.sh` / `run.ps1`) only applies a new version if the
+release's git tag is a **signed annotated tag** verified against the
+maintainer's release-signing key. Unsigned tags, tags signed by any other
+key, or a client that can't verify signatures all fail closed: nothing
+gets applied and the client stays on its current version.
+
+## Trust anchor
+
+- Public key lives at `.github/allowed_signers` in this repo (principal:
+  `jasonbsmith1568@gmail.com`).
+- Fingerprint is additionally pinned as a literal constant inside
+  `run.sh` and `run.ps1` (`RELEASE_SIGNER_FINGERPRINT` /
+  `$script:ReleaseSignerFingerprint`), so a tampered `allowed_signers`
+  file alone can't widen trust to a new key.
+- The **private** signing key never touches the server or this repo. It
+  lives only on the maintainer's machine.
+
+## One-time setup (maintainer's machine)
+
+Generate the release-signing keypair once, keep the private half offline:
+
+```
+ssh-keygen -t ed25519 -f ~/.ssh/curatarr_release_signing -C "curatarr-release-signing"
+```
+
+Confirm the fingerprint matches what's pinned in `.github/allowed_signers`
+and in `run.sh`/`run.ps1`:
+
+```
+ssh-keygen -lf ~/.ssh/curatarr_release_signing.pub
+```
+
+Configure git to sign tags with this key using SSH-format signatures:
+
+```
+git config user.signingkey ~/.ssh/curatarr_release_signing
+git config gpg.format ssh
+git config user.email jasonbsmith1568@gmail.com
+```
+
+(Use `--global` if you want this to apply to all repos on the machine,
+or leave it repo-local if you'd rather scope it to `curatarr` only.)
+
+## Cutting a release
+
+1. Bump `__version__` in `utils/config.py`.
+2. Commit the version bump and push to `main` (via PR, per normal
+   branch protection).
+3. Tag the release commit with a **signed annotated tag** — plain
+   `git tag vX.Y.Z` (lightweight) or `-a` without `-s` will NOT verify
+   and will be ignored by the updater:
+
+   ```
+   git tag -s vX.Y.Z -m "vX.Y.Z"
+   ```
+
+4. Push the tag:
+
+   ```
+   git push origin vX.Y.Z
+   ```
+
+5. Sanity-check the signature yourself before announcing the release:
+
+   ```
+   git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag vX.Y.Z
+   ```
+
+   Expected output: `Good "git" signature for jasonbsmith1568@gmail.com
+   with ED25519 key SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU`.
+
+Once the tag is pushed, clients with `auto_update: true` will pick it up
+on their next run — but only after independently re-verifying the
+signature themselves against their own local `.github/allowed_signers`.
+Version numbers are monotonic: a client will never downgrade, and will
+never apply a tag whose version isn't strictly greater than its current
+`__version__`.
+
+## Repo hygiene this depends on
+
+- Branch protection on `main` (required PR review, no direct pushes).
+- 2FA enforced on all maintainer GitHub accounts.
+- The release-signing private key stays off any server; only the
+  maintainer's own machine(s) hold it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,15 @@
 # Python dependencies for Plex recommendation system
+#
+# Pinned to exact versions so `pip install -r requirements.txt` (no
+# --upgrade) is reproducible. Bump deliberately, one PR at a time.
+# Follow-up: move to `pip install --require-hashes` for supply-chain
+# integrity beyond version pinning.
 
 # Core Plex API client
-plexapi>=4.13.0
+plexapi==4.17.2
 
 # HTTP requests library
-requests>=2.28.0
+requests==2.32.5
 
 # YAML configuration parser
-pyyaml>=6.0
+pyyaml==6.0.3

--- a/run.ps1
+++ b/run.ps1
@@ -19,6 +19,12 @@ Set-Location $ScriptDir
 
 $DebugFlag = if ($Debug) { "--debug" } else { "" }
 
+# Trust anchor for signed release verification. Fingerprint is pinned in
+# this script (not just in the allowed_signers file) so a tampered
+# allowed_signers file alone cannot widen trust. See RELEASING.md.
+$script:ReleaseSignerFingerprint = "SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
+$script:AllowedSignersFile = Join-Path $ScriptDir ".github/allowed_signers"
+
 # ------------------------------------------------------------------------
 # DEPENDENCY CHECKING AND INSTALLATION
 # ------------------------------------------------------------------------
@@ -60,16 +66,19 @@ function Check-Dependencies {
     }
     Write-Green "OK pip found"
 
-    # Install/update Python requirements
+    # Install/update Python requirements (versions are pinned in
+    # requirements.txt; no --upgrade so pinned versions are respected)
     if (Test-Path "requirements.txt") {
         Write-Cyan "Installing Python dependencies..."
-        & $pythonCmd -m pip install -r requirements.txt --quiet --upgrade 2>&1 | Out-Null
+        & $pythonCmd -m pip install -r requirements.txt --quiet 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             Write-Red "X Failed to install Python dependencies"
             Write-Host "Try running manually: python -m pip install -r requirements.txt"
             exit 1
         }
         Write-Green "OK All dependencies installed"
+        # TODO follow-up: switch to `pip install --require-hashes` once
+        # requirements.txt carries per-package hashes.
     }
 
     Write-Host ""
@@ -77,8 +86,84 @@ function Check-Dependencies {
 }
 
 # ------------------------------------------------------------------------
-# AUTO-UPDATE FROM GITHUB
+# AUTO-UPDATE FROM GITHUB (SSH-signed release tags only)
 # ------------------------------------------------------------------------
+
+# Select-VerifiedRelease: walks release tags (vX.Y.Z) newest-first,
+# skipping any that aren't strictly newer than $currentVersion. For each
+# remaining candidate, verifies it is a signed annotated tag whose
+# signature checks out against $script:AllowedSignersFile (the
+# locally-trusted copy, never one fetched from the candidate ref) AND
+# whose signing key fingerprint equals the pinned
+# $script:ReleaseSignerFingerprint. Returns the first (newest) tag that
+# passes both checks, or $null if no candidate qualifies (fail-closed) or
+# verification tooling is unavailable.
+function Select-VerifiedRelease {
+    param($pythonCmd, $currentVersion)
+
+    if (-not (Get-Command ssh-keygen -ErrorAction SilentlyContinue)) {
+        Write-Yellow "ssh-keygen not available - cannot verify signed releases."
+        return $null
+    }
+
+    if (-not (Test-Path $script:AllowedSignersFile)) {
+        Write-Yellow "Missing .github/allowed_signers - cannot verify signed releases."
+        return $null
+    }
+
+    $candidates = @(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' 2>$null)
+    if ($candidates.Count -eq 0 -or [string]::IsNullOrWhiteSpace($candidates[0])) {
+        return $null
+    }
+
+    # Sort candidates newest-first by numeric version (portable; mirrors
+    # run.sh's approach so behavior is identical cross-platform). Non
+    # vX.Y.Z tags are dropped here too.
+    $sortScript = @'
+import sys
+def key(t):
+    try:
+        return tuple(int(p) for p in t.lstrip("v").split("."))
+    except ValueError:
+        return None
+tags = [(key(t), t) for t in sys.argv[1:]]
+tags = [t for t in tags if t[0] is not None]
+tags.sort(key=lambda t: t[0], reverse=True)
+print("\n".join(t[1] for t in tags))
+'@
+    $sorted = @(& $pythonCmd -c $sortScript @candidates)
+
+    $cmpScript = @'
+import sys
+def parse(v):
+    return tuple(int(p) for p in v.strip().split("."))
+try:
+    a = parse(sys.argv[1])
+    b = parse(sys.argv[2])
+except ValueError:
+    sys.exit(1)
+sys.exit(0 if a > b else 1)
+'@
+
+    foreach ($tag in $sorted) {
+        if ([string]::IsNullOrWhiteSpace($tag)) { continue }
+        $tagVersion = $tag.TrimStart('v')
+
+        $null = & $pythonCmd -c $cmpScript $tagVersion $currentVersion 2>$null
+        if ($LASTEXITCODE -ne 0) { continue }
+
+        $verifyOutput = git -c "gpg.ssh.allowedSignersFile=$script:AllowedSignersFile" verify-tag --raw $tag 2>&1
+        if ($LASTEXITCODE -ne 0) { continue }
+
+        $tagFpr = ([regex]::Match(($verifyOutput | Out-String), 'SHA256:[A-Za-z0-9+/=]+')).Value
+        if ($tagFpr -eq $script:ReleaseSignerFingerprint) {
+            return $tag
+        }
+    }
+
+    return $null
+}
+
 function Check-ForUpdates {
     param($pythonCmd)
 
@@ -93,35 +178,48 @@ function Check-ForUpdates {
             Write-Cyan "Checking for updates..."
 
             if (Test-Path ".git") {
-                # Fetch latest from remote
-                git fetch origin main --quiet 2>$null
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Yellow "Could not check for updates (network error)"
+                $currentVersion = $null
+                $configPyContent = Get-Content "utils/config.py" -Raw
+                if ($configPyContent -match '__version__\s*=\s*"(\d+\.\d+\.\d+)"') {
+                    $currentVersion = $Matches[1]
+                }
+
+                if (-not $currentVersion) {
+                    Write-Yellow "Could not determine current version, skipping update check"
+                    Write-Host ""
                     return
                 }
 
-                $local = git rev-parse HEAD 2>$null
-                $remote = git rev-parse origin/main 2>$null
+                # Fetch latest release tags from remote
+                git fetch --tags --force --prune origin --quiet 2>$null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Yellow "Could not check for updates (network error)"
+                    Write-Host ""
+                    return
+                }
 
-                if ($local -ne $remote) {
-                    Write-Yellow "Update available! Pulling latest changes..."
+                $selectedTag = Select-VerifiedRelease -pythonCmd $pythonCmd -currentVersion $currentVersion
 
-                    git stash --quiet 2>$null
-                    $pullResult = git pull origin main --quiet 2>&1
+                if (-not $selectedTag) {
+                    Write-Green "OK No verified signed release available - staying on current version v$currentVersion"
+                    Write-Host ""
+                    return
+                }
 
-                    if ($LASTEXITCODE -eq 0) {
-                        Write-Green "OK Updated successfully!"
-                        git stash pop --quiet 2>$null
-                        Write-Yellow "Restarting with updated code..."
-                        Write-Host ""
-                        & $MyInvocation.MyCommand.Path @PSBoundParameters
-                        exit
-                    } else {
-                        Write-Red "Update failed, continuing with current version"
-                        git stash pop --quiet 2>$null
-                    }
+                Write-Yellow "Verified signed release $selectedTag available! Updating..."
+
+                git stash --quiet 2>$null
+
+                git checkout $selectedTag --quiet 2>$null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Green "OK Updated to $selectedTag!"
+                    Write-Yellow "Restarting with updated code..."
+                    Write-Host ""
+                    & $MyInvocation.MyCommand.Path @PSBoundParameters
+                    exit
                 } else {
-                    Write-Green "OK Already up to date"
+                    Write-Red "Update failed, continuing with current version"
+                    git stash pop --quiet 2>$null
                 }
             } else {
                 Write-Yellow "Not a git repository, skipping update check"

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,12 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Trust anchor for signed release verification. Fingerprint is pinned in
+# this script (not just in the allowed_signers file) so a tampered
+# allowed_signers file alone cannot widen trust. See RELEASING.md.
+RELEASE_SIGNER_FINGERPRINT="SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
+ALLOWED_SIGNERS_FILE="$SCRIPT_DIR/.github/allowed_signers"
+
 # ------------------------------------------------------------------------
 # DEPENDENCY CHECKING AND INSTALLATION
 # ------------------------------------------------------------------------
@@ -64,23 +70,113 @@ check_and_install_dependencies() {
     fi
     echo -e "${GREEN}✓ pip3 found${NC}"
 
-    # Install/update Python requirements
+    # Install/update Python requirements (versions are pinned in
+    # requirements.txt; no --upgrade so pinned versions are respected)
     if [ -f "requirements.txt" ]; then
         echo -e "${CYAN}Installing Python dependencies...${NC}"
-        pip3 install -r requirements.txt --quiet --upgrade || {
+        pip3 install -r requirements.txt --quiet || {
             echo -e "${RED}❌ Failed to install Python dependencies${NC}"
             echo "Try running manually: pip3 install -r requirements.txt"
             exit 1
         }
         echo -e "${GREEN}✓ All dependencies installed${NC}"
+        # TODO follow-up: switch to `pip3 install --require-hashes` once
+        # requirements.txt carries per-package hashes.
     fi
 
     echo ""
 }
 
 # ------------------------------------------------------------------------
-# AUTO-UPDATE FROM GITHUB
+# AUTO-UPDATE FROM GITHUB (SSH-signed release tags only)
 # ------------------------------------------------------------------------
+
+# version_gt A B: succeeds (exit 0) if dotted version A is strictly
+# greater than dotted version B. Pure-python so behavior is identical on
+# macOS/Linux regardless of whether `sort -V` is available.
+version_gt() {
+    python3 -c "
+import sys
+def parse(v):
+    return tuple(int(p) for p in v.strip().split('.'))
+try:
+    a = parse(sys.argv[1])
+    b = parse(sys.argv[2])
+except ValueError:
+    sys.exit(1)
+sys.exit(0 if a > b else 1)
+" "$1" "$2" 2>/dev/null
+}
+
+# select_verified_release CURRENT_VERSION: walks release tags (vX.Y.Z)
+# newest-first, skipping any that aren't strictly newer than
+# CURRENT_VERSION. For each remaining candidate, verifies it is a signed
+# annotated tag whose signature checks out against ALLOWED_SIGNERS_FILE
+# (the locally-trusted copy, never one fetched from the candidate ref)
+# AND whose signing key fingerprint equals the pinned
+# RELEASE_SIGNER_FINGERPRINT. Echoes the first (newest) tag that passes
+# both checks. Prints nothing and returns non-zero if no candidate
+# qualifies (fail-closed) or if verification tooling is unavailable.
+select_verified_release() {
+    local current_version="$1"
+
+    if ! command -v ssh-keygen >/dev/null 2>&1; then
+        echo -e "${YELLOW}ssh-keygen not available — cannot verify signed releases.${NC}" >&2
+        return 1
+    fi
+
+    if [ ! -f "$ALLOWED_SIGNERS_FILE" ]; then
+        echo -e "${YELLOW}Missing .github/allowed_signers — cannot verify signed releases.${NC}" >&2
+        return 1
+    fi
+
+    local candidates
+    candidates=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null)
+    [ -z "$candidates" ] && return 1
+
+    # Sort candidates newest-first by numeric version (portable; avoids
+    # relying on `sort -V`, which isn't available on every platform).
+    # Non vX.Y.Z tags are dropped here too.
+    local sorted
+    sorted=$(python3 -c "
+import sys
+def key(t):
+    try:
+        return tuple(int(p) for p in t.lstrip('v').split('.'))
+    except ValueError:
+        return None
+tags = [(key(t), t) for t in sys.argv[1:]]
+tags = [t for t in tags if t[0] is not None]
+tags.sort(key=lambda t: t[0], reverse=True)
+print('\n'.join(t[1] for t in tags))
+" $candidates)
+
+    local tag tag_version verify_output tag_fpr
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        tag_version="${tag#v}"
+
+        version_gt "$tag_version" "$current_version" || continue
+
+        # Guarded as an `if` condition (not a bare assignment) because
+        # under `set -e` a failed verify-tag (the normal outcome for any
+        # unsigned/wrong-key tag) inside `VAR=$(...)` would otherwise
+        # abort this whole function instead of letting the loop try the
+        # next-newest candidate.
+        if ! verify_output=$(git -c gpg.ssh.allowedSignersFile="$ALLOWED_SIGNERS_FILE" verify-tag --raw "$tag" 2>&1); then
+            continue
+        fi
+
+        tag_fpr=$(printf '%s\n' "$verify_output" | grep -oE 'SHA256:[A-Za-z0-9+/=]+' | head -1)
+        if [ "$tag_fpr" = "$RELEASE_SIGNER_FINGERPRINT" ]; then
+            echo "$tag"
+            return 0
+        fi
+    done <<< "$sorted"
+
+    return 1
+}
+
 check_for_updates() {
     # Skip update check in Docker (users should rebuild to update)
     if [ "$RUNNING_IN_DOCKER" = "true" ]; then
@@ -96,38 +192,46 @@ check_for_updates() {
 
             # Check if we're in a git repo
             if [ -d ".git" ]; then
-                # Fetch latest from remote
-                git fetch origin main --quiet 2>/dev/null || {
-                    echo -e "${YELLOW}Could not check for updates (network error)${NC}"
+                CURRENT_VERSION=$(grep -oE '__version__ = "[0-9]+\.[0-9]+\.[0-9]+"' utils/config.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+                if [ -z "$CURRENT_VERSION" ]; then
+                    echo -e "${YELLOW}Could not determine current version, skipping update check${NC}"
+                    echo ""
                     return
-                }
+                fi
 
-                # Compare local and remote
-                LOCAL=$(git rev-parse HEAD 2>/dev/null)
-                REMOTE=$(git rev-parse origin/main 2>/dev/null)
+                # Fetch latest release tags from remote
+                if ! git fetch --tags --force --prune origin --quiet 2>/dev/null; then
+                    echo -e "${YELLOW}Could not check for updates (network error)${NC}"
+                    echo ""
+                    return
+                fi
 
-                if [ "$LOCAL" != "$REMOTE" ]; then
-                    echo -e "${YELLOW}Update available! Pulling latest changes...${NC}"
+                # `|| true` matters here: under `set -e`, a non-zero exit
+                # from select_verified_release (the normal fail-closed
+                # case when nothing verifies) would otherwise kill the
+                # whole script instead of falling through to the
+                # "staying on current version" branch below.
+                SELECTED_TAG=$(select_verified_release "$CURRENT_VERSION") || true
 
-                    # Stash any local changes
-                    git stash --quiet 2>/dev/null || true
+                if [ -z "$SELECTED_TAG" ]; then
+                    echo -e "${GREEN}✓ No verified signed release available — staying on current version v${CURRENT_VERSION}${NC}"
+                    echo ""
+                    return
+                fi
 
-                    # Pull updates
-                    if git pull origin main --quiet 2>/dev/null; then
-                        echo -e "${GREEN}✓ Updated successfully!${NC}"
+                echo -e "${YELLOW}Verified signed release ${SELECTED_TAG} available! Updating...${NC}"
 
-                        # Re-apply stashed changes if any
-                        git stash pop --quiet 2>/dev/null || true
+                # Stash any local changes
+                git stash --quiet 2>/dev/null || true
 
-                        echo -e "${YELLOW}Restarting with updated code...${NC}"
-                        echo ""
-                        exec "$0" "$@"  # Restart script with same arguments
-                    else
-                        echo -e "${RED}Update failed, continuing with current version${NC}"
-                        git stash pop --quiet 2>/dev/null || true
-                    fi
+                if git checkout "$SELECTED_TAG" --quiet 2>/dev/null; then
+                    echo -e "${GREEN}✓ Updated to ${SELECTED_TAG}!${NC}"
+                    echo -e "${YELLOW}Restarting with updated code...${NC}"
+                    echo ""
+                    exec "$0" "$@"  # Restart script with same arguments
                 else
-                    echo -e "${GREEN}✓ Already up to date${NC}"
+                    echo -e "${RED}Update failed, continuing with current version${NC}"
+                    git stash pop --quiet 2>/dev/null || true
                 fi
             else
                 echo -e "${YELLOW}Not a git repository, skipping update check${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -463,7 +463,7 @@ users:
 
 general:
   plex_only: true
-  auto_update: false
+  auto_update: true
   log_retention_days: 7
 EOF
 


### PR DESCRIPTION
## Summary

- The updater (`run.sh` + `run.ps1`) no longer does `git pull origin main` (any commit, unverified). It now fetches release tags, walks them newest-first, and only checks out a tag that is (a) strictly newer than the running `__version__` and (b) a signed annotated tag whose signature verifies against the pinned release-signing key. Any candidate that fails verification is skipped in favor of the next-newest; if none verify, nothing is applied and the client stays on its current version (fail-closed).
- Trust anchor: `.github/allowed_signers` (principal `jasonbsmith1568@gmail.com`), fingerprint additionally pinned as a literal constant inside both scripts so a tampered `allowed_signers` file alone can't widen trust.
- `requirements.txt` pinned to exact resolved versions; `--upgrade` dropped from both scripts' pip install step. `--require-hashes` noted as the follow-up.
- `config.example.yml` / `run.ps1` wizard / `setup.sh` all default `auto_update: true` (setup.sh previously wrote `false`).
- Docker skip (`RUNNING_IN_DOCKER`) and the `auto_update` config gate are unchanged.
- Adds `RELEASING.md` documenting how to cut a signed release.
- Existing release tags are all lightweight/unsigned, so the updater will fail-closed for every current client until the maintainer cuts the first signed release. Safe to merge now.

Supersedes #154 (closing separately) — that PR's `git reset --hard origin/main` fallback is intentionally dropped in favor of signed-tag verification; its exec-mode concern doesn't apply since `run.sh` is already 100755 on `main`.

## Testing

- Full suite: `pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=85` → 1176 passed, 85.91% coverage (threshold 85%).
- Mechanism proven with a throwaway SSH key (never pushed, deleted after): a tag signed by the throwaway key verified successfully against a temp `allowed_signers`/fingerprint pointing at that key; an unsigned tag and a tag signed by a *different* throwaway key were both refused. The real selection loop, run against all 52 existing (unsigned) tags in this repo, correctly walked every candidate and fail-closed (no premature abort under `set -e`).
- Confirmed production `.github/allowed_signers` byte-matches the pinned production public key, and `ssh-keygen -lf` on it reproduces the pinned fingerprint.
- Confirmed Docker path (`RUNNING_IN_DOCKER=true`) still skips the updater entirely.
- `run.ps1` mirrors `run.sh`'s logic; not runtime-tested here (no Windows runner on this box) but PowerShell-parsed clean.

## Test plan

- [x] CI (`tests.yml`) green
- [x] Mechanism positive/negative verification (throwaway key)
- [x] Production allowed_signers matches pinned key/fingerprint
- [x] Docker path still skips updater
- [ ] Maintainer cuts first signed release per RELEASING.md