### PR TITLE
Fix requests CVE-2026-25645 + refresh pinned deps and actions

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.user.login != 'OrchestratedChaos'
     steps:
       - name: Close PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@
 # integrity beyond version pinning.
 
 # Core Plex API client
-plexapi==4.17.2
+plexapi==4.18.2
 
 # HTTP requests library
-requests==2.32.5
+requests==2.34.2
 
 # YAML configuration parser
 pyyaml==6.0.3


### PR DESCRIPTION
## Summary
- Bumps `requests` from 2.32.5 to 2.34.2 to patch CVE-2026-25645 / GHSA-gc5v-m9x4-r6x2 (requests < 2.33.0 vulnerable)
- Bumps `plexapi` from 4.17.2 to 4.18.2 (latest stable)
- `pyyaml` stays at 6.0.3 (already current)
- Bumps `actions/checkout` v6 -> v7 and `actions/github-script` v8 -> v9 in workflows
- Folds in the stale Dependabot dep PRs (#151, #148, #149) and action PRs (#152, #146), which have been superseded by the switch to exact `==` pins in requirements.txt

## Test plan
- [x] Clean `pip install -r requirements.txt` in a fresh venv (Python 3.12)
- [x] Full test suite: 1176 passed, coverage 85.93% (threshold 85%)
- [x] `recommenders/movie.py --help`, `recommenders/tv.py --help`, `recommenders/external.py --help` all run cleanly
- [x] YAML validated for both workflow files