### PR TITLE
Automated signed-release workflow + release helper

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -1,6 +1,17 @@
 # SSH allowed-signers file used to verify signed Curatarr release tags.
 # Format: git's allowed-signers format (see ssh-keygen(1) / git-verify-tag(1)).
-# Principal must match the tagger email used when signing a release tag.
 # Only the PUBLIC half of the release-signing key lives here; the private
 # key is kept offline on the maintainer's machine. See RELEASING.md.
+#
+# Two principal lines below point at the SAME key (same fingerprint,
+# SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU). The second line
+# (GitHub's noreply address) lets release.sh sign tags with an email
+# GitHub won't reject via push protection (GH007 - "push would publish a
+# private email address"), while the first keeps older tags (e.g.
+# v2.8.21) verifying under the maintainer's real address. git's SSH
+# signature verification checks "was this signed by a key listed here",
+# not "does the tagger email match a specific principal" - the release
+# workflow additionally pins the key fingerprint itself, so adding a
+# second principal for the same key does not widen trust to a new key.
 jasonbsmith1568@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q curatarr-release-signing
+252325559+OrchestratedChaos@users.noreply.github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q curatarr-release-signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+env:
+  # Pinned fingerprint of the maintainer's release-signing key. This is
+  # checked in addition to `git verify-tag` succeeding, so that widening
+  # .github/allowed_signers to a new key can't silently widen trust here.
+  RELEASE_SIGNER_FINGERPRINT: "SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is signed by the trusted release key
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          git config gpg.ssh.allowedSignersFile .github/allowed_signers
+
+          VERIFY_OUTPUT="$(git verify-tag "$GITHUB_REF_NAME" 2>&1)"
+          VERIFY_EXIT=$?
+          echo "$VERIFY_OUTPUT"
+
+          if [ "$VERIFY_EXIT" -ne 0 ]; then
+            echo "::error::git verify-tag failed for $GITHUB_REF_NAME - refusing to release an unsigned or untrusted tag"
+            exit 1
+          fi
+
+          if ! echo "$VERIFY_OUTPUT" | grep -qF "$RELEASE_SIGNER_FINGERPRINT"; then
+            echo "::error::Tag $GITHUB_REF_NAME did not verify against the pinned release-signing key fingerprint ($RELEASE_SIGNER_FINGERPRINT)"
+            exit 1
+          fi
+
+          echo "Verified: $GITHUB_REF_NAME is signed by the pinned release-signing key."
+
+      - name: Verify tag version matches utils/config.py
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CODE_VERSION="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' utils/config.py)"
+
+          if [ -z "$CODE_VERSION" ]; then
+            echo "::error::Could not parse __version__ from utils/config.py"
+            exit 1
+          fi
+
+          if [ "$TAG_VERSION" != "$CODE_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match utils/config.py __version__ ($CODE_VERSION)"
+            exit 1
+          fi
+
+          echo "Tag version matches __version__ ($CODE_VERSION)."
+
+      - name: Generate release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PREV_TAG="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
+
+          {
+            if [ -n "$PREV_TAG" ]; then
+              echo "## Changes since $PREV_TAG"
+              echo
+              git log "${PREV_TAG}..${GITHUB_REF_NAME}" --no-merges --pretty=format:'- %s (%h)'
+            else
+              echo "## Changes"
+              echo
+              echo "Initial tracked release."
+              git log "$GITHUB_REF_NAME" --no-merges --pretty=format:'- %s (%h)'
+            fi
+            echo
+          } > release-notes.md
+
+          cat release-notes.md
+
+      - name: Build source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME#v}"
+          PREFIX="curatarr-${VERSION}/"
+          ARCHIVE="curatarr-${VERSION}.tar.gz"
+
+          git archive --format=tar.gz --prefix="$PREFIX" -o "$ARCHIVE" "$GITHUB_REF_NAME"
+          sha256sum "$ARCHIVE" > SHA256SUMS.txt
+
+          cat SHA256SUMS.txt
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            "curatarr-${VERSION}.tar.gz" \
+            "SHA256SUMS.txt"
+
+      # -----------------------------------------------------------------
+      # Phase 2 extension point (not implemented yet):
+      #
+      # Add a matrix job here that builds per-OS standalone binaries with
+      # PyInstaller (ubuntu-latest / macos-latest / windows-latest),
+      # depends on `release` above (needs: release), and uploads each
+      # binary as an additional release asset with:
+      #
+      #   gh release upload "$GITHUB_REF_NAME" <binary-path>
+      #
+      # Keep the signed-tag + version-match gates in this job as the
+      # single source of truth for "is this a legitimate release" -
+      # binary-build jobs should only run after this job succeeds.
+      # -----------------------------------------------------------------

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,16 +4,26 @@ The auto-updater (`run.sh` / `run.ps1`) only applies a new version if the
 release's git tag is a **signed annotated tag** verified against the
 maintainer's release-signing key. Unsigned tags, tags signed by any other
 key, or a client that can't verify signatures all fail closed: nothing
-gets applied and the client stays on its current version.
+gets applied and the client stays on its current version. GitHub Releases
+are cut the same way: `.github/workflows/release.yml` only publishes a
+release for tags that pass the same signature + fingerprint check.
 
 ## Trust anchor
 
-- Public key lives at `.github/allowed_signers` in this repo (principal:
-  `jasonbsmith1568@gmail.com`).
-- Fingerprint is additionally pinned as a literal constant inside
-  `run.sh` and `run.ps1` (`RELEASE_SIGNER_FINGERPRINT` /
-  `$script:ReleaseSignerFingerprint`), so a tampered `allowed_signers`
-  file alone can't widen trust to a new key.
+- Public key lives at `.github/allowed_signers` in this repo. It has two
+  principal lines for the **same key** (same fingerprint):
+  - `jasonbsmith1568@gmail.com` - the maintainer's real address, used by
+    older tags (e.g. `v2.8.21`).
+  - `<id>+OrchestratedChaos@users.noreply.github.com` - GitHub's noreply
+    address, used by `scripts/release.sh` so `git push` of a signed tag
+    doesn't get blocked by GitHub's GH007 "push would publish a private
+    email address" protection. Git's SSH tag verification checks "was
+    this signed by a key listed here", not which principal line matched,
+    so adding a second principal for the same key doesn't widen trust.
+- Fingerprint is additionally pinned as a literal constant in `run.sh`,
+  `run.ps1`, and `.github/workflows/release.yml`
+  (`SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU`), so a tampered
+  `allowed_signers` file alone can't widen trust to a new key.
 - The **private** signing key never touches the server or this repo. It
   lives only on the maintainer's machine.
 
@@ -26,7 +36,7 @@ ssh-keygen -t ed25519 -f ~/.ssh/curatarr_release_signing -C "curatarr-release-si
 ```
 
 Confirm the fingerprint matches what's pinned in `.github/allowed_signers`
-and in `run.sh`/`run.ps1`:
+and in `run.sh`/`run.ps1`/`release.yml`:
 
 ```
 ssh-keygen -lf ~/.ssh/curatarr_release_signing.pub
@@ -37,42 +47,63 @@ Configure git to sign tags with this key using SSH-format signatures:
 ```
 git config user.signingkey ~/.ssh/curatarr_release_signing
 git config gpg.format ssh
-git config user.email jasonbsmith1568@gmail.com
 ```
 
-(Use `--global` if you want this to apply to all repos on the machine,
-or leave it repo-local if you'd rather scope it to `curatarr` only.)
+(`scripts/release.sh` overrides `user.email` to the noreply address only
+for the tag-signing command itself - it doesn't need to be your default
+`user.email`.)
 
-## Cutting a release
+Also make sure `gh auth status` is logged in with repo write access.
 
-1. Bump `__version__` in `utils/config.py`.
-2. Commit the version bump and push to `main` (via PR, per normal
-   branch protection).
-3. Tag the release commit with a **signed annotated tag** — plain
-   `git tag vX.Y.Z` (lightweight) or `-a` without `-s` will NOT verify
-   and will be ignored by the updater:
+## Cutting a release (one command)
 
-   ```
-   git tag -s vX.Y.Z -m "vX.Y.Z"
-   ```
+```
+./scripts/release.sh 2.8.22
+```
 
-4. Push the tag:
+This does everything end to end:
 
-   ```
-   git push origin vX.Y.Z
-   ```
+1. Checks you're on a clean, up-to-date `main`.
+2. Bumps `__version__` in `utils/config.py` on a `release/vX.Y.Z` branch.
+3. Pushes the branch, opens a PR, waits for the `test` check, and
+   squash-merges it.
+4. Pulls the merged commit back into local `main`.
+5. Creates a **signed annotated tag** `vX.Y.Z` (`git tag -s`), signed with
+   the noreply principal so the push won't hit GH007.
+6. Verifies the tag locally against `.github/allowed_signers` and the
+   pinned fingerprint - if that fails, it aborts and does **not** push.
+7. Pushes the tag.
 
-5. Sanity-check the signature yourself before announcing the release:
+Pushing the tag triggers `.github/workflows/release.yml`, which:
 
-   ```
-   git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag vX.Y.Z
-   ```
+1. Checks out full history/tags (`fetch-depth: 0`).
+2. Re-verifies the tag's signature against `.github/allowed_signers` and
+   asserts the pinned key fingerprint - fails the job (no release) if
+   either check fails.
+3. Asserts the tag version matches `__version__` in `utils/config.py`.
+4. Generates release notes from `git log <prev-tag>..<tag>`.
+5. Builds a versioned source archive (`git archive` tar.gz) and a
+   `SHA256SUMS.txt`.
+6. Publishes the GitHub Release via `gh release create` (GitHub CLI only
+   - no third-party marketplace actions), attaching both files.
 
-   Expected output: `Good "git" signature for jasonbsmith1568@gmail.com
-   with ED25519 key SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU`.
+The workflow has a commented extension point for Phase 2: per-OS
+PyInstaller binary builds. That is **not implemented yet** - releases
+today ship a source archive + checksums only.
+
+## Manual sanity-check
+
+You can always independently re-verify any published tag yourself:
+
+```
+git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag vX.Y.Z
+```
+
+Expected output includes: `... with ED25519 key
+SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU`.
 
 Once the tag is pushed, clients with `auto_update: true` will pick it up
-on their next run — but only after independently re-verifying the
+on their next run - but only after independently re-verifying the
 signature themselves against their own local `.github/allowed_signers`.
 Version numbers are monotonic: a client will never downgrade, and will
 never apply a tag whose version isn't strictly greater than its current

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# One-command release helper for Curatarr.
+#
+# Usage: ./scripts/release.sh <version>   (e.g. ./scripts/release.sh 2.8.22)
+#
+# Run this from a machine that has:
+#   - `gh` authenticated (`gh auth status`) with repo write access
+#   - the release-signing key configured for git (see RELEASING.md):
+#       git config user.signingkey ~/.ssh/curatarr_release_signing
+#       git config gpg.format ssh
+#
+# What it does:
+#   1. Verifies you're on a clean, up-to-date main.
+#   2. Bumps __version__ in utils/config.py.
+#   3. Opens a PR with the bump, waits for the `test` check, squash-merges it.
+#   4. Pulls the merged commit into main.
+#   5. Creates a signed annotated tag vX.Y.Z on that commit.
+#   6. Verifies the tag locally against .github/allowed_signers before
+#      pushing anything (fail closed if the signature/fingerprint is wrong).
+#   7. Pushes the tag, which triggers .github/workflows/release.yml.
+#
+# GH007 ("push would publish a private email address"): the tag is signed
+# with user.email set to the maintainer's GitHub noreply address
+# (see RELEASE_TAG_EMAIL below), which is also listed as a principal in
+# .github/allowed_signers for the same signing key. This avoids GitHub's
+# push-protection rejection while still verifying under the pinned key
+# fingerprint. The version-bump commit itself uses your normal git identity.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+REMOTE="origin"
+MAIN_BRANCH="main"
+REQUIRED_CHECK="test"
+ALLOWED_SIGNERS_FILE=".github/allowed_signers"
+RELEASE_SIGNER_FINGERPRINT="SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
+RELEASE_TAG_EMAIL="252325559+OrchestratedChaos@users.noreply.github.com"
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <version>   (e.g. $0 2.8.22)" >&2
+  exit 1
+fi
+
+VERSION="$1"
+TAG="v${VERSION}"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: version must look like X.Y.Z (got: $VERSION)" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "==> Releasing ${TAG} from $(pwd)"
+
+# ---------------------------------------------------------------------------
+# Safety checks
+# ---------------------------------------------------------------------------
+echo "==> Checking prerequisites"
+
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh is not authenticated (run: gh auth login)" >&2; exit 1; }
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ]; then
+  echo "ERROR: must be on '$MAIN_BRANCH' (currently on '$CURRENT_BRANCH')" >&2
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: working tree is not clean" >&2
+  git status --short
+  exit 1
+fi
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "ERROR: tag $TAG already exists locally" >&2
+  exit 1
+fi
+
+if git ls-remote --tags "$REMOTE" | grep -qF "refs/tags/${TAG}"; then
+  echo "ERROR: tag $TAG already exists on $REMOTE" >&2
+  exit 1
+fi
+
+echo "==> Pulling latest $MAIN_BRANCH"
+git fetch "$REMOTE" "$MAIN_BRANCH"
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse "$REMOTE/$MAIN_BRANCH")" ]; then
+  git pull --ff-only "$REMOTE" "$MAIN_BRANCH"
+fi
+
+# ---------------------------------------------------------------------------
+# Bump __version__ and open the PR
+# ---------------------------------------------------------------------------
+CONFIG_FILE="utils/config.py"
+CURRENT_VERSION="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' "$CONFIG_FILE")"
+echo "==> Current version: ${CURRENT_VERSION:-<unknown>}, bumping to ${VERSION}"
+
+if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+  echo "ERROR: $CONFIG_FILE already has __version__ = \"$VERSION\"" >&2
+  exit 1
+fi
+
+BUMP_BRANCH="release/${TAG}"
+git checkout -b "$BUMP_BRANCH"
+
+# Portable in-place sed (GNU/BSD)
+sed -i.bak "s/^__version__ = \".*\"/__version__ = \"${VERSION}\"/" "$CONFIG_FILE"
+rm -f "${CONFIG_FILE}.bak"
+
+if [ -z "$(git status --porcelain "$CONFIG_FILE")" ]; then
+  echo "ERROR: version bump produced no change in $CONFIG_FILE" >&2
+  git checkout "$MAIN_BRANCH"
+  git branch -D "$BUMP_BRANCH"
+  exit 1
+fi
+
+git add "$CONFIG_FILE"
+git commit -m "${VERSION}"
+
+echo "==> Pushing ${BUMP_BRANCH} and opening PR"
+git push -u "$REMOTE" "$BUMP_BRANCH"
+
+PR_URL="$(gh pr create \
+  --base "$MAIN_BRANCH" \
+  --head "$BUMP_BRANCH" \
+  --title "${VERSION}" \
+  --body "Version bump for release ${TAG}.")"
+echo "==> PR: $PR_URL"
+PR_NUMBER="$(basename "$PR_URL")"
+
+echo "==> Waiting for required check '${REQUIRED_CHECK}' on PR #${PR_NUMBER}"
+gh pr checks "$PR_NUMBER" --watch --fail-fast
+
+echo "==> Squash-merging PR #${PR_NUMBER}"
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+
+# ---------------------------------------------------------------------------
+# Sync main, tag, verify, push
+# ---------------------------------------------------------------------------
+echo "==> Syncing local $MAIN_BRANCH"
+git checkout "$MAIN_BRANCH"
+git pull --ff-only "$REMOTE" "$MAIN_BRANCH"
+
+MERGED_VERSION="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' "$CONFIG_FILE")"
+if [ "$MERGED_VERSION" != "$VERSION" ]; then
+  echo "ERROR: after merge, $CONFIG_FILE has __version__ = \"$MERGED_VERSION\", expected \"$VERSION\"" >&2
+  exit 1
+fi
+
+echo "==> Creating signed tag ${TAG} (signer email: ${RELEASE_TAG_EMAIL})"
+git -c user.email="$RELEASE_TAG_EMAIL" tag -s "$TAG" -m "$TAG"
+
+echo "==> Verifying ${TAG} locally against ${ALLOWED_SIGNERS_FILE} before pushing"
+git config gpg.ssh.allowedSignersFile "$ALLOWED_SIGNERS_FILE"
+
+VERIFY_OUTPUT="$(git verify-tag "$TAG" 2>&1)" || {
+  echo "ERROR: local verify-tag failed for $TAG - not pushing" >&2
+  echo "$VERIFY_OUTPUT" >&2
+  git tag -d "$TAG"
+  exit 1
+}
+echo "$VERIFY_OUTPUT"
+
+if ! echo "$VERIFY_OUTPUT" | grep -qF "$RELEASE_SIGNER_FINGERPRINT"; then
+  echo "ERROR: $TAG did not verify against the pinned fingerprint ($RELEASE_SIGNER_FINGERPRINT) - not pushing" >&2
+  git tag -d "$TAG"
+  exit 1
+fi
+
+echo "==> Verified. Pushing ${TAG}"
+git push "$REMOTE" "$TAG"
+
+echo "==> Done. .github/workflows/release.yml will publish the GitHub Release for ${TAG}."


### PR DESCRIPTION
Adds .github/workflows/release.yml: on push of a vX.Y.Z tag, re-verifies the tag's SSH signature against .github/allowed_signers, asserts the pinned key fingerprint, checks the tag version matches utils/config.py __version__, then publishes a GitHub Release (source archive + SHA256SUMS.txt) via gh CLI only - no third-party marketplace actions. Unsigned/unmatched tags fail the job with no release published.

Adds scripts/release.sh: one-command release flow (bump __version__ -> PR -> wait for test check -> squash-merge -> signed tag -> verify locally -> push tag).

Adds a second .github/allowed_signers principal (GitHub noreply address, same signing key) so scripts/release.sh can sign tags without git push hitting GH007 ("push would publish a private email address"). The original jasonbsmith1568@gmail.com principal is kept so existing tags (v2.8.21) still verify.

Updates RELEASING.md for the new one-command flow, what the workflow does, and the trust model. Binaries are a documented Phase 2 extension point in release.yml, not built yet.

No real release triggered by this PR - the workflow only runs on tag push.