### PR TITLE
Web UI MVP: dashboard, run-with-live-log, results

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ First run takes 5-10 minutes to analyze your library. After that, it's fast.
 
 ---
 
+## Web UI (beta)
+
+A local dashboard for running recommendations and checking status without the terminal:
+
+```bash
+./run-ui.sh     # macOS/Linux
+.\run-ui.ps1   # Windows (PowerShell)
+```
+
+Opens `http://127.0.0.1:8787` in your browser once the server is ready (binds to
+localhost only). From there you can see each user's last-run status, trigger a
+run (full pipeline, or just movie/tv/external) with a live streaming log, and
+browse generated watchlists and past logs.
+
+---
+
 ## What You Get
 
 ### In Plex
@@ -442,6 +458,9 @@ curatarr/
 ├── tests/                   # Unit tests (960+)
 ├── run.sh                   # Main entry point (macOS/Linux)
 ├── run.ps1                  # Main entry point (Windows)
+├── run-ui.sh                # Web UI launcher (macOS/Linux)
+├── run-ui.ps1               # Web UI launcher (Windows)
+├── web/                     # Local web UI (Flask, beta)
 ├── Dockerfile               # Docker image definition
 ├── docker-compose.yml       # Docker Compose config
 ├── cache/                   # TMDB metadata cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ requests==2.34.2
 
 # YAML configuration parser
 pyyaml==6.0.3
+
+# Local web UI (dashboard, run-with-live-log, results) - see web/
+flask==3.1.3

--- a/run-ui.ps1
+++ b/run-ui.ps1
@@ -1,0 +1,25 @@
+# Curatarr Web UI launcher (Windows).
+# Starts the local-only (127.0.0.1) Flask dashboard and opens it in
+# your browser once it's listening. See web/app.py for the app itself.
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Error "Python not found. Install Python 3.8+ first."
+    exit 1
+}
+
+python -c "import flask" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Installing web UI dependencies..."
+    pip install -r requirements.txt --quiet
+}
+
+if (-not $env:CURATARR_UI_PORT) {
+    $env:CURATARR_UI_PORT = "8787"
+}
+
+Write-Host "Starting Curatarr web UI on http://127.0.0.1:$($env:CURATARR_UI_PORT) (Ctrl+C to stop) ..."
+python -m web.app

--- a/run-ui.sh
+++ b/run-ui.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Curatarr Web UI launcher (macOS/Linux).
+# Starts the local-only (127.0.0.1) Flask dashboard and opens it in
+# your browser once it's listening. See web/app.py for the app itself.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v python3 &> /dev/null; then
+    echo "Python 3 not found. Install Python 3.8+ first." >&2
+    exit 1
+fi
+
+if ! python3 -c "import flask" &> /dev/null; then
+    echo "Installing web UI dependencies..."
+    pip3 install -r requirements.txt --quiet
+fi
+
+export CURATARR_UI_PORT="${CURATARR_UI_PORT:-8787}"
+echo "Starting Curatarr web UI on http://127.0.0.1:${CURATARR_UI_PORT} (Ctrl+C to stop) ..."
+exec python3 -m web.app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Shared fixtures for the web/ (Flask UI) test suite."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_FAKE_MOVIE_PY = '''\
+import os
+import sys
+import time
+
+print("Movie recommendations starting")
+user = sys.argv[1] if len(sys.argv) > 1 else "all"
+print(f"user={user}")
+delay = os.environ.get("CURATARR_TEST_SLOW")
+if delay:
+    time.sleep(float(delay))
+print("Movie recommendations done")
+'''
+
+_FAKE_TV_PY = _FAKE_MOVIE_PY.replace("Movie", "TV")
+
+_FAKE_EXTERNAL_PY = '''\
+print("External watchlists starting")
+print("External watchlists done")
+'''
+
+_FAKE_RUN_SH = '''#!/bin/bash
+echo "full run starting"
+echo "full run done"
+'''
+
+_FAKE_RUN_PS1 = '''
+Write-Host "full run starting"
+Write-Host "full run done"
+'''
+
+_CONFIG_YML = '''\
+plex:
+  url: "http://localhost:32400"
+  token: "not-a-real-token"
+users:
+  list: "alice, bob"
+'''
+
+
+@pytest.fixture
+def curatarr_web_root(tmp_path):
+    """A throwaway fake curatarr project root for web/ tests.
+
+    Mirrors the real repo layout that web/app.py and web/job_runner.py
+    expect (config/config.yml, logs/, recommendations/external/,
+    recommenders/*.py, run.sh/run.ps1) without touching the real repo
+    or running the real (slow, Plex/TMDB-dependent) recommenders.
+    """
+    root = tmp_path
+    (root / 'config').mkdir()
+    (root / 'config' / 'config.yml').write_text(_CONFIG_YML, encoding='utf-8')
+    (root / 'logs').mkdir()
+    (root / 'recommendations' / 'external').mkdir(parents=True)
+    (root / 'recommenders').mkdir()
+    (root / 'recommenders' / 'movie.py').write_text(_FAKE_MOVIE_PY, encoding='utf-8')
+    (root / 'recommenders' / 'tv.py').write_text(_FAKE_TV_PY, encoding='utf-8')
+    (root / 'recommenders' / 'external.py').write_text(_FAKE_EXTERNAL_PY, encoding='utf-8')
+    (root / 'run.sh').write_text(_FAKE_RUN_SH, encoding='utf-8')
+    (root / 'run.ps1').write_text(_FAKE_RUN_PS1, encoding='utf-8')
+    return str(root)

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -1,0 +1,157 @@
+"""Tests for web/job_runner.py - the subprocess job runner, single-run
+lock, and SSE subscriber fan-out.
+
+These use the curatarr_web_root fixture (see tests/conftest.py), which
+provides fake recommenders/*.py + run.sh/run.ps1 scripts so tests are
+fast and hermetic - they never touch Plex/TMDB or the real repo.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from web.job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
+
+
+def _wait_until_done(job, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if job.state != 'running':
+            return
+        time.sleep(0.05)
+    raise AssertionError('job did not finish in time')
+
+
+def _manager(root):
+    return JobManager(root, os.path.join(root, 'logs'))
+
+
+class TestJobManagerStart:
+    """Tests for JobManager.start()"""
+
+    def test_runs_movie_engine_for_single_user(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice', 'bob'])
+        _wait_until_done(job)
+        assert job.returncode == 0
+        assert any('user=alice' in line for line in job.lines)
+        assert os.path.isfile(job.log_path)
+        with open(job.log_path) as f:
+            assert 'user=alice' in f.read()
+
+    def test_runs_movie_engine_for_all_users(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'all', ['alice', 'bob'])
+        _wait_until_done(job)
+        assert job.returncode == 0
+        assert any('user=all' in line for line in job.lines)
+
+    def test_runs_full_engine(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job = manager.start('full', 'all', ['alice', 'bob'])
+        _wait_until_done(job)
+        assert job.returncode == 0
+        assert any('full run' in line for line in job.lines)
+
+    def test_runs_external_engine(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job = manager.start('external', 'all', ['alice', 'bob'])
+        _wait_until_done(job)
+        assert job.returncode == 0
+
+    def test_rejects_unknown_engine(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        with pytest.raises(JobError):
+            manager.start('bogus', 'all', ['alice'])
+
+    def test_rejects_unknown_user(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        with pytest.raises(JobError):
+            manager.start('movie', 'mallory', ['alice', 'bob'])
+
+    def test_rejects_single_user_for_full_engine(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        with pytest.raises(JobError):
+            manager.start('full', 'alice', ['alice'])
+
+    def test_rejects_single_user_for_external_engine(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        with pytest.raises(JobError):
+            manager.start('external', 'alice', ['alice'])
+
+    def test_rejects_concurrent_run(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '1')
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice', 'bob'])
+        with pytest.raises(JobAlreadyRunningError):
+            manager.start('movie', 'bob', ['alice', 'bob'])
+        _wait_until_done(job)
+
+    def test_second_run_allowed_after_first_completes(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job1 = manager.start('movie', 'alice', ['alice', 'bob'])
+        _wait_until_done(job1)
+        job2 = manager.start('movie', 'bob', ['alice', 'bob'])
+        _wait_until_done(job2)
+        assert job2.returncode == 0
+
+
+class TestJobManagerStatus:
+    """Tests for JobManager.status()/current_job()/is_running()"""
+
+    def test_status_none_before_any_run(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        assert manager.status() is None
+        assert manager.current_job() is None
+        assert manager.is_running() is False
+
+    def test_status_reflects_running_then_finished_job(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '1')
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice', 'bob'])
+        assert manager.is_running() is True
+        status = manager.status()
+        assert status['state'] == 'running'
+        assert status['engine'] == 'movie'
+        assert status['user'] == 'alice'
+        _wait_until_done(job)
+        assert manager.is_running() is False
+        assert manager.status()['state'] == 'succeeded'
+
+
+class TestJobSubscribe:
+    """Tests for Job.subscribe()/unsubscribe() - the SSE fan-out."""
+
+    def test_subscribe_after_completion_replays_backlog_then_done(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        job = manager.start('external', 'all', ['alice'])
+        _wait_until_done(job)
+
+        q = job.subscribe()
+        collected = []
+        while True:
+            item = q.get(timeout=2)
+            if item is DONE_SENTINEL:
+                break
+            collected.append(item)
+        assert collected == job.lines
+
+    def test_subscribe_while_running_receives_live_lines(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '0.3')
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice'])
+        q = job.subscribe()
+
+        collected = []
+        while True:
+            item = q.get(timeout=5)
+            if item is DONE_SENTINEL:
+                break
+            collected.append(item)
+
+        assert 'Movie recommendations done' in collected
+        job.unsubscribe(q)  # already removed on completion; must be a no-op

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,232 @@
+"""Tests for web/app.py - Flask routes for the dashboard, run, and
+results screens, plus the localhost-only binding guardrail.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from web.app import create_app, _wait_for_listening
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _wait_until_idle(app, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not app.job_manager.is_running():
+            return
+        time.sleep(0.05)
+    raise AssertionError('job did not finish in time')
+
+
+class TestDashboard:
+    """Tests for GET /"""
+
+    def test_renders_users_from_config(self, client):
+        c, app, root = client
+        resp = c.get('/')
+        assert resp.status_code == 200
+        assert b'alice' in resp.data
+        assert b'bob' in resp.data
+
+    def test_shows_never_run_when_no_logs(self, client):
+        c, app, root = client
+        resp = c.get('/')
+        assert b'never_run' in resp.data
+
+    def test_shows_success_status_from_log(self, client):
+        c, app, root = client
+        log_path = os.path.join(root, 'logs', 'recommendations_alice_20260101_030000.log')
+        with open(log_path, 'w') as f:
+            f.write('Processing alice\nDone\n')
+        resp = c.get('/')
+        assert b'success' in resp.data
+
+    def test_handles_missing_config_gracefully(self, tmp_path):
+        (tmp_path / 'logs').mkdir()
+        (tmp_path / 'recommendations' / 'external').mkdir(parents=True)
+        app = create_app(project_root=str(tmp_path))
+        app.testing = True
+        resp = app.test_client().get('/')
+        assert resp.status_code == 200
+        assert b'No users configured' in resp.data
+
+
+class TestRunPage:
+    """Tests for GET/POST /run and /run/stream, /run/status"""
+
+    def test_get_run_form(self, client):
+        c, app, root = client
+        resp = c.get('/run')
+        assert resp.status_code == 200
+        assert b'alice' in resp.data
+        assert b'bob' in resp.data
+
+    def test_post_run_triggers_job_and_redirects(self, client):
+        c, app, root = client
+        resp = c.post('/run', data={'engine': 'external', 'user': 'all'})
+        assert resp.status_code == 303
+        assert app.job_manager.current_job() is not None
+        _wait_until_idle(app)
+
+    def test_post_run_rejects_concurrent_run(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '1')
+        resp1 = c.post('/run', data={'engine': 'movie', 'user': 'alice'})
+        assert resp1.status_code == 303
+        resp2 = c.post('/run', data={'engine': 'movie', 'user': 'bob'})
+        assert resp2.status_code == 303
+        assert 'error=busy' in resp2.headers['Location']
+        _wait_until_idle(app)
+
+    def test_post_run_rejects_unknown_user(self, client):
+        c, app, root = client
+        resp = c.post('/run', data={'engine': 'movie', 'user': 'mallory'})
+        assert resp.status_code == 303
+        assert 'error=' in resp.headers['Location']
+
+    def test_run_stream_before_any_job_404s(self, client):
+        c, app, root = client
+        resp = c.get('/run/stream')
+        assert resp.status_code == 404
+
+    def test_run_stream_after_job_streams_events(self, client):
+        c, app, root = client
+        c.post('/run', data={'engine': 'external', 'user': 'all'})
+        _wait_until_idle(app)
+        resp = c.get('/run/stream')
+        assert resp.status_code == 200
+        assert resp.mimetype == 'text/event-stream'
+        body = resp.get_data(as_text=True)
+        assert 'event: done' in body
+
+    def test_run_status_json_idle(self, client):
+        c, app, root = client
+        resp = c.get('/run/status')
+        assert resp.status_code == 200
+        assert resp.get_json() == {'state': 'idle'}
+
+    def test_run_status_json_after_run(self, client):
+        c, app, root = client
+        c.post('/run', data={'engine': 'external', 'user': 'all'})
+        _wait_until_idle(app)
+        resp = c.get('/run/status')
+        assert resp.get_json()['state'] == 'succeeded'
+
+
+class TestResults:
+    """Tests for GET /results, /results/watchlist/<file>, /results/log/<file>"""
+
+    def test_lists_watchlists_and_logs(self, client):
+        c, app, root = client
+        ext_dir = os.path.join(root, 'recommendations', 'external')
+        with open(os.path.join(ext_dir, 'watchlist.html'), 'w') as f:
+            f.write('<html>hi</html>')
+        with open(os.path.join(root, 'logs', 'daily-run.log'), 'w') as f:
+            f.write('cron output\n')
+        resp = c.get('/results')
+        assert resp.status_code == 200
+        assert b'watchlist.html' in resp.data
+        assert b'daily-run.log' in resp.data
+
+    def test_no_watchlists_or_logs_yet(self, client):
+        c, app, root = client
+        resp = c.get('/results')
+        assert resp.status_code == 200
+        assert b'No watchlists generated yet' in resp.data
+        assert b'No logs yet' in resp.data
+
+    def test_serves_watchlist_file(self, client):
+        c, app, root = client
+        ext_dir = os.path.join(root, 'recommendations', 'external')
+        with open(os.path.join(ext_dir, 'watchlist.html'), 'w') as f:
+            f.write('<html>hello world</html>')
+        resp = c.get('/results/watchlist/watchlist.html')
+        assert resp.status_code == 200
+        assert b'hello world' in resp.data
+
+    def test_watchlist_rejects_non_html_md_extension(self, client):
+        c, app, root = client
+        resp = c.get('/results/watchlist/evil.txt')
+        assert resp.status_code == 404
+
+    def test_watchlist_rejects_traversal(self, client):
+        c, app, root = client
+        # A secret one directory above recommendations/external/, that a
+        # traversal attempt with an allow-listed extension might target.
+        with open(os.path.join(root, 'secret.html'), 'w') as f:
+            f.write('TOP SECRET MARKER')
+        resp = c.get('/results/watchlist/..%2Fsecret.html')
+        assert resp.status_code == 404
+        assert b'TOP SECRET MARKER' not in resp.data
+
+    def test_views_log_tail(self, client):
+        c, app, root = client
+        with open(os.path.join(root, 'logs', 'a.log'), 'w') as f:
+            f.write('line one\ntoken=abcdef123456\n')
+        resp = c.get('/results/log/a.log')
+        assert resp.status_code == 200
+        assert b'line one' in resp.data
+        assert b'abcdef123456' not in resp.data
+
+    def test_log_view_missing_file_404s(self, client):
+        c, app, root = client
+        resp = c.get('/results/log/missing.log')
+        assert resp.status_code == 404
+
+    def test_log_view_rejects_traversal(self, client):
+        c, app, root = client
+        resp = c.get('/results/log/..%2Fconfig%2Fconfig.yml')
+        assert resp.status_code == 404
+
+
+class TestWaitForListening:
+    """Tests for the launcher's "server is actually listening" poll."""
+
+    def test_returns_true_when_port_open(self):
+        import socket
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(('127.0.0.1', 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        try:
+            assert _wait_for_listening(port, timeout=2) is True
+        finally:
+            server.close()
+
+    def test_returns_false_when_nothing_listening(self):
+        import socket
+
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(('127.0.0.1', 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        assert _wait_for_listening(port, timeout=0.3) is False
+
+
+class TestBindingGuardrail:
+    """Guardrail: the app must only ever bind 127.0.0.1, never 0.0.0.0."""
+
+    def test_binds_localhost_only(self):
+        import inspect
+        import re
+
+        import web.app as app_module
+
+        source = inspect.getsource(app_module)
+        assert "host='127.0.0.1'" in source
+        # Only the redaction/no-wildcard-bind explanation may mention
+        # 0.0.0.0 in prose; app.run() itself must never pass it as host=.
+        assert not re.search(r'host\s*=\s*[\'"]0\.0\.0\.0[\'"]', source)

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1,0 +1,67 @@
+"""Tests for web/security.py - secret redaction and safe path joins."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from web.security import redact, redact_lines, safe_join
+
+
+class TestRedact:
+    """Tests for redact()"""
+
+    def test_masks_key_value_secret(self):
+        assert redact("token=abcd1234efgh") == "token=***REDACTED***"
+
+    def test_masks_case_insensitive_key(self):
+        assert redact("API_KEY: supersecretvalue123") == "API_KEY=***REDACTED***"
+
+    def test_masks_quoted_value(self):
+        assert redact('password="hunter2hunter2"') == "password=***REDACTED***"
+
+    def test_masks_plex_token_in_url(self):
+        text = "GET http://localhost:32400/library?X-Plex-Token=abcd1234efgh5678"
+        result = redact(text)
+        assert "abcd1234efgh5678" not in result
+        assert "***REDACTED***" in result
+
+    def test_masks_bearer_header(self):
+        result = redact("Authorization: Bearer abcdefghijklmnop")
+        assert "abcdefghijklmnop" not in result
+        assert "Bearer ***REDACTED***" in result
+
+    def test_leaves_normal_text_untouched(self):
+        text = "Processing recommendations for alice: 20 movies found"
+        assert redact(text) == text
+
+    def test_empty_string_passthrough(self):
+        assert redact("") == ""
+
+    def test_none_passthrough(self):
+        assert redact(None) is None
+
+    def test_redact_lines(self):
+        lines = ["normal line", "token=secretvalue1"]
+        result = redact_lines(lines)
+        assert result[0] == "normal line"
+        assert "secretvalue1" not in result[1]
+
+
+class TestSafeJoin:
+    """Tests for safe_join()"""
+
+    def test_joins_within_base_dir(self, tmp_path):
+        (tmp_path / "a.log").write_text("hi")
+        result = safe_join(str(tmp_path), "a.log")
+        assert result == str(tmp_path / "a.log")
+
+    def test_rejects_parent_traversal(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            safe_join(str(tmp_path), "../secret.txt")
+
+    def test_rejects_absolute_path_escape(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            safe_join(str(tmp_path), os.path.join(os.sep, "etc", "passwd"))

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -1,0 +1,119 @@
+"""Tests for web/status.py - log parsing for the dashboard and results page."""
+
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from web.status import get_last_run_status, list_log_files, read_log_tail
+
+
+def _write_log(logs_dir, name, content):
+    path = os.path.join(str(logs_dir), name)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    return path
+
+
+class TestGetLastRunStatus:
+    """Tests for get_last_run_status()"""
+
+    def test_never_run_when_no_logs(self, tmp_path):
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result == {'status': 'never_run', 'timestamp': None, 'log_file': None}
+
+    def test_success_when_no_failure_markers(self, tmp_path):
+        _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', 'Processing alice\nDone\n')
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'success'
+        assert result['log_file'] == 'recommendations_alice_20260101_030000.log'
+        assert result['timestamp'] == datetime(2026, 1, 1, 3, 0, 0)
+
+    def test_failed_when_traceback_present(self, tmp_path):
+        _write_log(
+            tmp_path, 'recommendations_alice_20260101_030000.log',
+            'Processing alice\nTraceback (most recent call last):\nValueError\n',
+        )
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'failed'
+
+    def test_failed_when_fatal_error_present(self, tmp_path):
+        _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', 'Fatal error detected\n')
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'failed'
+
+    def test_unknown_when_log_empty(self, tmp_path):
+        _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', '')
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'unknown'
+
+    def test_picks_newest_log_by_mtime(self, tmp_path):
+        older = _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', 'ok\n')
+        newer = _write_log(
+            tmp_path, 'recommendations_alice_20260102_030000.log',
+            'Traceback (most recent call last):\n',
+        )
+        os.utime(older, (1, 1))
+        os.utime(newer, (100, 100))
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['log_file'] == 'recommendations_alice_20260102_030000.log'
+        assert result['status'] == 'failed'
+
+    def test_only_matches_this_users_logs(self, tmp_path):
+        _write_log(tmp_path, 'recommendations_bob_20260101_030000.log', 'ok\n')
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'never_run'
+
+    def test_falls_back_to_mtime_for_unparseable_timestamp(self, tmp_path):
+        # Month 13 doesn't parse as a real date - status.py should fall
+        # back to the file's mtime instead of raising.
+        path = _write_log(tmp_path, 'recommendations_alice_20261301_030000.log', 'ok\n')
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert isinstance(result['timestamp'], datetime)
+        assert result['timestamp'] == datetime.fromtimestamp(os.path.getmtime(path))
+
+
+class TestListLogFiles:
+    """Tests for list_log_files()"""
+
+    def test_empty_when_dir_missing(self, tmp_path):
+        assert list_log_files(str(tmp_path / 'missing')) == []
+
+    def test_lists_only_log_files_newest_first(self, tmp_path):
+        a = _write_log(tmp_path, 'a.log', 'a')
+        b = _write_log(tmp_path, 'b.log', 'b')
+        (tmp_path / 'notes.txt').write_text('not a log')
+        os.utime(a, (1, 1))
+        os.utime(b, (100, 100))
+        result = list_log_files(str(tmp_path))
+        assert [e['name'] for e in result] == ['b.log', 'a.log']
+
+
+class TestReadLogTail:
+    """Tests for read_log_tail()"""
+
+    def test_reads_content(self, tmp_path):
+        _write_log(tmp_path, 'a.log', 'line1\nline2\n')
+        assert read_log_tail(str(tmp_path), 'a.log') == 'line1\nline2'
+
+    def test_raises_for_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_log_tail(str(tmp_path), 'missing.log')
+
+    def test_raises_for_path_traversal(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_log_tail(str(tmp_path), '../secret.log')
+
+    def test_redacts_secrets(self, tmp_path):
+        _write_log(tmp_path, 'a.log', 'token=abcdef123456\n')
+        result = read_log_tail(str(tmp_path), 'a.log')
+        assert 'abcdef123456' not in result
+
+    def test_truncates_to_max_lines(self, tmp_path):
+        content = '\n'.join(f'line{i}' for i in range(10))
+        _write_log(tmp_path, 'a.log', content)
+        result = read_log_tail(str(tmp_path), 'a.log', max_lines=3)
+        assert result.splitlines() == ['line7', 'line8', 'line9']

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,10 @@
+"""Curatarr local web UI (MVP): dashboard, run-with-live-log, results.
+
+Self-contained package - templates/ and static/ are bundled inside this
+package (not read from elsewhere) so it can later be frozen with
+PyInstaller --onefile without extra data-file wiring.
+
+This package only reads existing curatarr state (config, logs,
+generated watchlists) and triggers recommender runs as subprocesses.
+It never imports recommenders/*.py in-process - see web/job_runner.py.
+"""

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,183 @@
+"""Flask web UI for curatarr - MVP: dashboard, trigger-a-run with a live
+log stream, and a read-only results/history viewer.
+
+Design notes:
+- Binds to 127.0.0.1 ONLY (see run-ui.sh / run-ui.ps1) - never 0.0.0.0.
+- Recommender runs are always subprocesses (see web/job_runner.py). The
+  entry points hijack sys.stdout and call sys.exit(), so importing them
+  in-process into a long-lived Flask server would be unsafe.
+- Config is read through utils.load_config / utils.get_users_from_config,
+  same helpers the CLI uses - no ad hoc open() calls here, so a future
+  multi-tenant refactor of the utils layer carries the web UI with it.
+- This module does not alter any existing recommender/CLI behavior; it
+  only shells out to it.
+"""
+
+import os
+import socket
+import threading
+import time
+import webbrowser
+from datetime import datetime
+
+from flask import (
+    Flask, Response, abort, jsonify, redirect, render_template,
+    request, send_from_directory, stream_with_context, url_for,
+)
+
+from utils import get_project_root, get_users_from_config, load_config
+
+from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
+from .security import redact
+from .status import get_last_run_status, list_log_files, read_log_tail
+
+DEFAULT_PORT = 8787
+
+
+def create_app(project_root: str = None) -> Flask:
+    """Application factory. project_root is overridable so tests can
+    point the app at a throwaway fixture repo instead of the real one.
+    """
+    project_root = project_root or get_project_root()
+    logs_dir = os.path.join(project_root, 'logs')
+    external_dir = os.path.join(project_root, 'recommendations', 'external')
+
+    app = Flask(__name__)
+    app.config['PROJECT_ROOT'] = project_root
+    app.config['LOGS_DIR'] = logs_dir
+    app.config['EXTERNAL_DIR'] = external_dir
+    app.job_manager = JobManager(project_root, logs_dir)
+
+    def _load_users():
+        config_path = os.path.join(project_root, 'config', 'config.yml')
+        try:
+            config = load_config(config_path)
+        except Exception:
+            return []
+        return get_users_from_config(config)
+
+    @app.get('/')
+    def dashboard():
+        rows = [
+            {'username': user, **get_last_run_status(logs_dir, user)}
+            for user in _load_users()
+        ]
+        return render_template('dashboard.html', rows=rows, job=app.job_manager.status())
+
+    @app.get('/run')
+    def run_form():
+        return render_template(
+            'run.html',
+            users=_load_users(),
+            job=app.job_manager.status(),
+            running=app.job_manager.is_running(),
+            error=request.args.get('error'),
+        )
+
+    @app.post('/run')
+    def run_trigger():
+        engine = request.form.get('engine', 'full')
+        user = request.form.get('user', 'all')
+        try:
+            app.job_manager.start(engine, user, _load_users())
+        except JobAlreadyRunningError:
+            return redirect(url_for('run_form', error='busy'), code=303)
+        except JobError as exc:
+            return redirect(url_for('run_form', error=str(exc)), code=303)
+        return redirect(url_for('run_form'), code=303)
+
+    @app.get('/run/stream')
+    def run_stream():
+        job = app.job_manager.current_job()
+        if job is None:
+            abort(404)
+
+        def generate():
+            q = job.subscribe()
+            try:
+                while True:
+                    item = q.get()
+                    if item is DONE_SENTINEL:
+                        yield f"event: done\ndata: {job.returncode}\n\n"
+                        break
+                    yield f"data: {redact(item)}\n\n"
+            finally:
+                job.unsubscribe(q)
+
+        return Response(
+            stream_with_context(generate()),
+            mimetype='text/event-stream',
+            headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'},
+        )
+
+    @app.get('/run/status')
+    def run_status():
+        return jsonify(app.job_manager.status() or {'state': 'idle'})
+
+    @app.get('/results')
+    def results():
+        watchlists = []
+        if os.path.isdir(external_dir):
+            for name in sorted(os.listdir(external_dir)):
+                if name.endswith(('.html', '.md')):
+                    path = os.path.join(external_dir, name)
+                    watchlists.append({
+                        'name': name,
+                        'mtime': datetime.fromtimestamp(os.path.getmtime(path)),
+                    })
+        return render_template('results.html', watchlists=watchlists, logs=list_log_files(logs_dir))
+
+    @app.get('/results/watchlist/<path:filename>')
+    def results_watchlist(filename):
+        if not filename.endswith(('.html', '.md')) or not os.path.isdir(external_dir):
+            abort(404)
+        # send_from_directory refuses path traversal on its own; the
+        # extension check above is belt-and-suspenders since this only
+        # ever serves generated watchlist output, not arbitrary files.
+        return send_from_directory(external_dir, filename)
+
+    @app.get('/results/log/<path:filename>')
+    def results_log(filename):
+        try:
+            tail = read_log_tail(logs_dir, filename)
+        except FileNotFoundError:
+            abort(404)
+        return render_template('log_view.html', filename=filename, content=tail)
+
+    return app
+
+
+def _wait_for_listening(port: int, timeout: float = 15.0) -> bool:
+    """Poll 127.0.0.1:port until it accepts connections or timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex(('127.0.0.1', port)) == 0:
+                return True
+        time.sleep(0.1)
+    return False
+
+
+def main():
+    """Launcher entry point - see run-ui.sh / run-ui.ps1.
+
+    Starts Flask bound to 127.0.0.1 only, and opens the browser once the
+    server is actually accepting connections (not on a fixed timer).
+    """
+    port = int(os.environ.get('CURATARR_UI_PORT', DEFAULT_PORT))
+    app = create_app()
+
+    def _open_when_ready():
+        if _wait_for_listening(port):
+            webbrowser.open(f'http://127.0.0.1:{port}/')
+
+    threading.Thread(target=_open_when_ready, daemon=True).start()
+
+    # 127.0.0.1 ONLY - never 0.0.0.0. threaded=True so the SSE stream
+    # doesn't block other requests (dashboard/results while a run is live).
+    app.run(host='127.0.0.1', port=port, debug=False, use_reloader=False, threaded=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -1,0 +1,215 @@
+"""Subprocess job runner for triggering curatarr recommendation runs
+from the web UI.
+
+Runs are always subprocesses, never in-process imports. The recommender
+entry points (recommenders/movie.py, tv.py, external.py) hijack
+sys.stdout with a TeeLogger and call sys.exit() - fine for a
+short-lived CLI invocation, unsafe inside a long-running Flask process.
+
+Only one job may run at a time (a run mutates shared caches under
+cache/ and Plex collections), enforced by JobManager's lock.
+"""
+
+import os
+import queue
+import subprocess
+import sys
+import threading
+from datetime import datetime
+from typing import Dict, List, Optional
+
+ENGINES = ('full', 'movie', 'tv', 'external')
+
+# Sentinel pushed onto subscriber queues when a job finishes, so SSE
+# consumers know to stop waiting for more output.
+DONE_SENTINEL = object()
+
+
+class JobError(Exception):
+    """Raised for invalid job requests (bad engine/user, etc)."""
+
+
+class JobAlreadyRunningError(JobError):
+    """Raised when a run is requested while another run is in progress."""
+
+
+class Job:
+    """State for a single triggered run. Construct via JobManager.start()."""
+
+    def __init__(self, engine: str, user: str, cmd: List[str], log_path: str):
+        self.engine = engine
+        self.user = user
+        self.cmd = cmd
+        self.log_path = log_path
+        self.started_at = datetime.now()
+        self.finished_at: Optional[datetime] = None
+        self.returncode: Optional[int] = None
+        self.process: Optional[subprocess.Popen] = None
+
+        self._data_lock = threading.Lock()
+        self.lines: List[str] = []
+        self._subscribers: List["queue.Queue"] = []
+
+    @property
+    def state(self) -> str:
+        if self.returncode is None:
+            return 'running'
+        return 'succeeded' if self.returncode == 0 else 'failed'
+
+    def _append_line(self, line: str) -> None:
+        with self._data_lock:
+            self.lines.append(line)
+            for q in self._subscribers:
+                q.put(line)
+
+    def _finish(self, returncode: int) -> None:
+        with self._data_lock:
+            self.returncode = returncode
+            self.finished_at = datetime.now()
+            for q in self._subscribers:
+                q.put(DONE_SENTINEL)
+
+    def subscribe(self) -> "queue.Queue":
+        """Register a new SSE listener.
+
+        Returns a queue pre-loaded with any output already produced, so
+        a browser tab that connects mid-run still sees the backlog
+        before live lines start arriving.
+        """
+        q: "queue.Queue" = queue.Queue()
+        with self._data_lock:
+            for line in self.lines:
+                q.put(line)
+            if self.returncode is not None:
+                q.put(DONE_SENTINEL)
+            else:
+                self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: "queue.Queue") -> None:
+        with self._data_lock:
+            if q in self._subscribers:
+                self._subscribers.remove(q)
+
+    def to_dict(self) -> Dict:
+        return {
+            'engine': self.engine,
+            'user': self.user,
+            'state': self.state,
+            'started_at': self.started_at,
+            'finished_at': self.finished_at,
+            'returncode': self.returncode,
+            'log_file': os.path.basename(self.log_path),
+        }
+
+
+class JobManager:
+    """Owns the single-run lock and launches recommender subprocesses."""
+
+    def __init__(self, project_root: str, logs_dir: str):
+        self.project_root = project_root
+        self.logs_dir = logs_dir
+        self._lock = threading.Lock()
+        self._current: Optional[Job] = None
+
+    def status(self) -> Optional[Dict]:
+        job = self._current
+        return job.to_dict() if job else None
+
+    def current_job(self) -> Optional[Job]:
+        return self._current
+
+    def is_running(self) -> bool:
+        job = self._current
+        return job is not None and job.state == 'running'
+
+    def start(self, engine: str, user: str, allowed_users: List[str]) -> Job:
+        """Validate and launch a run. Raises JobError/JobAlreadyRunningError."""
+        if engine not in ENGINES:
+            raise JobError(f"Unknown engine: {engine}")
+        if user != 'all' and user not in allowed_users:
+            raise JobError(f"Unknown user: {user}")
+        if engine in ('full', 'external') and user != 'all':
+            raise JobError(f"The '{engine}' engine does not support a single-user run")
+
+        with self._lock:
+            if self.is_running():
+                raise JobAlreadyRunningError("A run is already in progress")
+
+            cmd, env, log_name = self._build_command(engine, user)
+            os.makedirs(self.logs_dir, exist_ok=True)
+            log_path = os.path.join(self.logs_dir, log_name)
+
+            job = Job(engine, user, cmd, log_path)
+            process = subprocess.Popen(
+                cmd,
+                cwd=self.project_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=env,
+            )
+            job.process = process
+            self._current = job
+
+            thread = threading.Thread(target=self._pump, args=(job,), daemon=True)
+            thread.start()
+            return job
+
+    def _build_command(self, engine: str, user: str):
+        """Build the subprocess argv, environment, and job log filename.
+
+        Mirrors run.sh's own invocations (python3 recommenders/<x>.py
+        [username] [--debug]) so the UI-triggered run behaves exactly
+        like a normal cron/manual run.
+        """
+        env = dict(os.environ)
+        ts = datetime.now().strftime('%Y%m%d_%H%M%S')
+
+        if engine == 'full':
+            if os.name == 'nt':
+                cmd = ['powershell', '-ExecutionPolicy', 'Bypass', '-File',
+                       os.path.join(self.project_root, 'run.ps1')]
+            else:
+                cmd = ['bash', os.path.join(self.project_root, 'run.sh')]
+            # Skip the interactive setup wizard / auto-update git-checkout
+            # dance for UI-triggered runs - config is assumed already
+            # set up, same bypass run.sh already supports for Docker.
+            env['RUNNING_IN_DOCKER'] = 'true'
+            target = 'all'
+        elif engine in ('movie', 'tv'):
+            script = os.path.join(self.project_root, 'recommenders', f'{engine}.py')
+            cmd = [sys.executable, script]
+            if user != 'all':
+                cmd.append(user)
+            target = user
+        elif engine == 'external':
+            script = os.path.join(self.project_root, 'recommenders', 'external.py')
+            cmd = [sys.executable, script]
+            target = 'all'
+        else:  # pragma: no cover - guarded by start()'s validation above
+            raise JobError(f"Unknown engine: {engine}")
+
+        log_name = f'webui_{engine}_{target}_{ts}.log'
+        return cmd, env, log_name
+
+    def _pump(self, job: Job) -> None:
+        """Background thread: read subprocess output, tee to a log file
+        and to every SSE subscriber, then record the exit code."""
+        log_file = open(job.log_path, 'w', encoding='utf-8')
+        returncode = -1
+        try:
+            assert job.process is not None and job.process.stdout is not None
+            for line in job.process.stdout:
+                log_file.write(line)
+                log_file.flush()
+                job._append_line(line.rstrip('\n'))
+            returncode = job.process.wait()
+        except Exception as exc:
+            # Subprocess plumbing failure (e.g. couldn't read pipe), not
+            # a recommender-level error - surface it in the live output.
+            job._append_line(f'[web UI] job runner error: {exc}')
+        finally:
+            log_file.close()
+            job._finish(returncode)

--- a/web/security.py
+++ b/web/security.py
@@ -1,0 +1,68 @@
+"""Defense-in-depth secret redaction for anything the web UI renders.
+
+The MVP has no config/settings forms, so it never renders config values
+directly. But recommender subprocess output (streamed live and written
+to logs) could in principle echo a URL or header containing a token
+(e.g. a stray ``X-Plex-Token`` query parameter in an error message).
+Everything the UI displays - streamed job output and log tails - is
+passed through :func:`redact` first.
+"""
+
+import re
+from typing import Iterable, List
+
+# Common secret-ish key names, matched case-insensitively.
+_SECRET_KEY_NAMES = (
+    "x-plex-token",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "api_key",
+    "apikey",
+    "password",
+    "token",
+    "secret",
+)
+
+_KEY_ALTERNATION = "|".join(re.escape(name) for name in _SECRET_KEY_NAMES)
+
+# Matches key=value / key: value / key="value" style occurrences.
+# The key name is kept (so redaction is still informative); only the
+# value is masked.
+_SECRET_PATTERN = re.compile(
+    r'(?i)\b(' + _KEY_ALTERNATION + r')\b\s*[:=]\s*["\']?([A-Za-z0-9._\-+/]{4,})["\']?'
+)
+
+# "Authorization: Bearer <token>" style headers.
+_BEARER_PATTERN = re.compile(r'(?i)\bBearer\s+([A-Za-z0-9._\-]{8,})')
+
+REDACTED = "***REDACTED***"
+
+
+def redact(text: str) -> str:
+    """Return *text* with anything that looks like a secret masked out."""
+    if not text:
+        return text
+    text = _SECRET_PATTERN.sub(lambda m: f"{m.group(1)}={REDACTED}", text)
+    text = _BEARER_PATTERN.sub(lambda m: f"Bearer {REDACTED}", text)
+    return text
+
+
+def redact_lines(lines: Iterable[str]) -> List[str]:
+    """Apply :func:`redact` to every line in *lines*."""
+    return [redact(line) for line in lines]
+
+
+def safe_join(base_dir: str, filename: str) -> str:
+    """Join *filename* onto *base_dir*, refusing path traversal.
+
+    Raises FileNotFoundError if the resolved path would escape base_dir
+    (e.g. via ``..`` segments or an absolute path).
+    """
+    import os
+
+    base_dir = os.path.abspath(base_dir)
+    candidate = os.path.abspath(os.path.join(base_dir, filename))
+    if os.path.commonpath([base_dir, candidate]) != base_dir:
+        raise FileNotFoundError(filename)
+    return candidate

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,42 @@
+// Run page behavior: toggle the user selector for engines that don't
+// support a single-user run, and stream live output over SSE.
+(function () {
+  var engineSelect = document.getElementById('engine-select');
+  var userSelect = document.getElementById('user-select');
+
+  function syncUserSelect() {
+    if (!engineSelect || !userSelect) return;
+    var perUser = engineSelect.value === 'movie' || engineSelect.value === 'tv';
+    userSelect.disabled = !perUser;
+    if (!perUser) userSelect.value = 'all';
+  }
+
+  if (engineSelect) {
+    engineSelect.addEventListener('change', syncUserSelect);
+    syncUserSelect();
+  }
+
+  var output = document.getElementById('output');
+  if (output && window.CURATARR_HAS_JOB) {
+    var stateEl = document.getElementById('job-state');
+    var source = new EventSource('/run/stream');
+
+    source.onmessage = function (event) {
+      output.textContent += event.data + '\n';
+      output.scrollTop = output.scrollHeight;
+    };
+
+    source.addEventListener('done', function (event) {
+      if (stateEl) {
+        stateEl.textContent = (event.data === '0') ? 'succeeded' : 'failed';
+      }
+      var btn = document.querySelector('#run-form button[type="submit"]');
+      if (btn) btn.disabled = false;
+      source.close();
+    });
+
+    source.onerror = function () {
+      source.close();
+    };
+  }
+})();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,131 @@
+:root {
+  --bg: #12151a;
+  --panel: #1b1f27;
+  --border: #2b303b;
+  --text: #e6e8eb;
+  --muted: #8a919e;
+  --accent: #4f8cff;
+  --ok: #2fb872;
+  --fail: #e5534b;
+  --warn: #d8a12a;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 24px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar .brand {
+  font-weight: 700;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+.topbar nav a {
+  color: var(--muted);
+  text-decoration: none;
+  margin-right: 16px;
+}
+
+.topbar nav a:hover { color: var(--text); }
+
+main { padding: 24px; max-width: 960px; margin: 0 auto; }
+
+h1 { margin-top: 0; }
+
+a { color: var(--accent); }
+
+.status-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.status-table th, .status-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.badge.success { background: rgba(47, 184, 114, 0.15); color: var(--ok); }
+.badge.failed { background: rgba(229, 83, 75, 0.15); color: var(--fail); }
+.badge.never_run { background: rgba(138, 145, 158, 0.15); color: var(--muted); }
+.badge.unknown { background: rgba(216, 161, 42, 0.15); color: var(--warn); }
+
+.button, button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+form label {
+  display: inline-block;
+  margin-right: 16px;
+  color: var(--muted);
+}
+
+form select {
+  display: block;
+  margin-top: 4px;
+  padding: 6px;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.banner {
+  padding: 10px 14px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.banner.running { background: rgba(79, 140, 255, 0.15); }
+.banner.error { background: rgba(229, 83, 75, 0.15); color: var(--fail); }
+
+.log-output {
+  background: #0b0d11;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  max-height: 480px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.file-list { list-style: none; padding: 0; }
+.file-list li { padding: 4px 0; }
+.muted { color: var(--muted); font-size: 0.85rem; }

--- a/web/status.py
+++ b/web/status.py
@@ -1,0 +1,126 @@
+"""Read-only helpers for parsing curatarr's existing log files and
+generated output. Nothing here writes logs or mutates recommender
+state - it only globs/reads files that recommenders/*.py and
+web/job_runner.py already produce.
+"""
+
+import glob
+import os
+import re
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from .security import redact, safe_join
+
+_TIMESTAMP_RE = re.compile(r'_(\d{8}_\d{6})\.log$')
+
+# Lowercased substrings that indicate a recommender run hit an error.
+# This is a heuristic (per the MVP spec), not a guarantee - a run can
+# print warnings along the way and still succeed overall.
+_FAILURE_MARKERS = (
+    'traceback (most recent call last)',
+    'fatal error',
+    'an error occurred',
+)
+
+# Cap how much of a log file we read for status/display purposes.
+TAIL_BYTES = 200_000
+
+
+def _parse_timestamp(filename: str) -> Optional[datetime]:
+    match = _TIMESTAMP_RE.search(filename)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), '%Y%m%d_%H%M%S')
+    except ValueError:
+        return None
+
+
+def _read_tail(path: str, max_bytes: int = TAIL_BYTES) -> str:
+    """Best-effort read of up to the last max_bytes of a file as text."""
+    try:
+        size = os.path.getsize(path)
+        with open(path, 'rb') as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+            data = f.read()
+        return data.decode('utf-8', errors='replace')
+    except OSError:
+        return ''
+
+
+def latest_user_log(logs_dir: str, username: str) -> Optional[str]:
+    """Return the path to the newest recommendations_<username>_*.log file.
+
+    Note: movie.py and tv.py both write into this same naming pattern,
+    so "latest" reflects whichever of the two most recently ran for
+    this user, not necessarily a single combined run.
+    """
+    pattern = os.path.join(logs_dir, f'recommendations_{username}_*.log')
+    candidates = glob.glob(pattern)
+    if not candidates:
+        return None
+    return max(candidates, key=os.path.getmtime)
+
+
+def get_last_run_status(logs_dir: str, username: str) -> Dict:
+    """Heuristic last-run status for one user, derived from their newest log.
+
+    Returns a dict with keys:
+      status: 'never_run' | 'success' | 'failed' | 'unknown'
+      timestamp: datetime or None
+      log_file: basename of the log, or None
+    """
+    log_path = latest_user_log(logs_dir, username)
+    if not log_path:
+        return {'status': 'never_run', 'timestamp': None, 'log_file': None}
+
+    basename = os.path.basename(log_path)
+    timestamp = _parse_timestamp(basename)
+    if timestamp is None:
+        timestamp = datetime.fromtimestamp(os.path.getmtime(log_path))
+
+    content = _read_tail(log_path)
+    if not content.strip():
+        status = 'unknown'
+    elif any(marker in content.lower() for marker in _FAILURE_MARKERS):
+        status = 'failed'
+    else:
+        status = 'success'
+
+    return {'status': status, 'timestamp': timestamp, 'log_file': basename}
+
+
+def list_log_files(logs_dir: str) -> List[Dict]:
+    """List every logs/*.log file, newest first, with size + mtime."""
+    if not os.path.isdir(logs_dir):
+        return []
+    entries = []
+    for name in os.listdir(logs_dir):
+        if not name.endswith('.log'):
+            continue
+        path = os.path.join(logs_dir, name)
+        if not os.path.isfile(path):
+            continue
+        entries.append({
+            'name': name,
+            'size': os.path.getsize(path),
+            'mtime': datetime.fromtimestamp(os.path.getmtime(path)),
+        })
+    entries.sort(key=lambda e: e['mtime'], reverse=True)
+    return entries
+
+
+def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> str:
+    """Read the last max_lines of logs_dir/filename, secrets redacted.
+
+    Raises FileNotFoundError if filename escapes logs_dir or doesn't
+    resolve to a real file.
+    """
+    path = safe_join(logs_dir, filename)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(filename)
+    content = _read_tail(path)
+    lines = content.splitlines()[-max_lines:]
+    return redact('\n'.join(lines))

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Curatarr{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="{{ url_for('dashboard') }}">Curatarr</a>
+    <nav>
+      <a href="{{ url_for('dashboard') }}">Dashboard</a>
+      <a href="{{ url_for('run_form') }}">Run</a>
+      <a href="{{ url_for('results') }}">Results</a>
+    </nav>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard - Curatarr{% endblock %}
+{% block content %}
+<h1>Dashboard</h1>
+
+{% if job and job.state == 'running' %}
+<p class="banner running">
+  A run is in progress ({{ job.engine }} / {{ job.user }}) -
+  <a href="{{ url_for('run_form') }}">watch live</a>
+</p>
+{% endif %}
+
+<table class="status-table">
+  <thead>
+    <tr><th>User</th><th>Last Run</th><th>Status</th><th>Log</th></tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>{{ row.username }}</td>
+      <td>{{ row.timestamp.strftime('%Y-%m-%d %H:%M:%S') if row.timestamp else '—' }}</td>
+      <td><span class="badge {{ row.status }}">{{ row.status }}</span></td>
+      <td>
+        {% if row.log_file %}
+        <a href="{{ url_for('results_log', filename=row.log_file) }}">view log</a>
+        {% else %}
+        —
+        {% endif %}
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">No users configured in config/config.yml (users.list).</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<p>
+  <a class="button" href="{{ url_for('run_form') }}">Run recommendations</a>
+  &middot;
+  <a href="{{ url_for('results') }}">View watchlists &amp; logs</a>
+</p>
+{% endblock %}

--- a/web/templates/log_view.html
+++ b/web/templates/log_view.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}{{ filename }} - Curatarr{% endblock %}
+{% block content %}
+<h1>{{ filename }}</h1>
+<p><a href="{{ url_for('results') }}">&larr; back to results</a></p>
+<pre class="log-output">{{ content }}</pre>
+{% endblock %}

--- a/web/templates/results.html
+++ b/web/templates/results.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block title %}Results - Curatarr{% endblock %}
+{% block content %}
+<h1>Results</h1>
+
+<h2>Watchlists</h2>
+{% if watchlists %}
+<ul class="file-list">
+  {% for w in watchlists %}
+  <li>
+    <a href="{{ url_for('results_watchlist', filename=w.name) }}" target="_blank" rel="noopener">{{ w.name }}</a>
+    <span class="muted">({{ w.mtime.strftime('%Y-%m-%d %H:%M') }})</span>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No watchlists generated yet - run recommendations first.</p>
+{% endif %}
+
+<h2>Logs</h2>
+{% if logs %}
+<table class="status-table">
+  <thead><tr><th>Log file</th><th>Modified</th><th>Size</th></tr></thead>
+  <tbody>
+    {% for log in logs %}
+    <tr>
+      <td><a href="{{ url_for('results_log', filename=log.name) }}">{{ log.name }}</a></td>
+      <td>{{ log.mtime.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+      <td>{{ (log.size / 1024) | round(1) }} KB</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No logs yet.</p>
+{% endif %}
+{% endblock %}

--- a/web/templates/run.html
+++ b/web/templates/run.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+{% block title %}Run - Curatarr{% endblock %}
+{% block content %}
+<h1>Run Recommendations</h1>
+
+{% if error == 'busy' %}
+<p class="banner error">A run is already in progress - wait for it to finish.</p>
+{% elif error %}
+<p class="banner error">{{ error }}</p>
+{% endif %}
+
+<form method="post" action="{{ url_for('run_trigger') }}" id="run-form">
+  <label>Engine
+    <select name="engine" id="engine-select">
+      <option value="full">Full run (movie + tv + external)</option>
+      <option value="movie">Movie recommendations</option>
+      <option value="tv">TV recommendations</option>
+      <option value="external">External watchlists</option>
+    </select>
+  </label>
+  <label>User
+    <select name="user" id="user-select">
+      <option value="all">All users</option>
+      {% for u in users %}
+      <option value="{{ u }}">{{ u }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <button type="submit" {% if running %}disabled{% endif %}>Run</button>
+</form>
+
+<h2>Output</h2>
+<p id="job-status">
+  {% if job %}
+  {{ job.engine }} / {{ job.user }} - <span id="job-state">{{ job.state }}</span>
+  {% else %}
+  No run yet.
+  {% endif %}
+</p>
+<pre id="output" class="log-output"></pre>
+
+<script>
+  window.CURATARR_HAS_JOB = {{ 'true' if job else 'false' }};
+</script>
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds a self-contained local web UI (`web/`, Flask) for curatarr: dashboard with per-user last-run status, a Run screen to trigger movie/tv/external/full recommendation runs as subprocesses with a live SSE-streamed log and a single-run lock, and a read-only Results screen for generated watchlists and log history.
- Recommender runs are always launched as subprocesses (never imported in-process) since the entry points hijack `sys.stdout` and call `sys.exit()`. Config is read through the existing `utils` layer.
- Binds `127.0.0.1` only, never `0.0.0.0`. Secrets are redacted from anything the UI renders (log tails, streamed job output) as defense in depth.
- Adds `run-ui.sh` / `run-ui.ps1` launchers (mirroring `run.sh`/`run.ps1`) that start the server and open the browser once it's actually listening.
- Adds `flask==3.1.3` to `requirements.txt`.
- Does not alter any existing recommender/CLI behavior - purely additive.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85` passes locally (Python 3.12, matching CI's 3.11 requirement of plexapi>=3.10): 1240 passed, 86.46% total coverage (web/ files individually at 92-100%).
- [x] New tests cover: route rendering (dashboard/run/results), job-runner single-run lock, SSE stream backlog+live+done events, log/status parsing heuristics, path-traversal rejection on file-serving endpoints, and a source-level guardrail test asserting the app never binds `0.0.0.0`.
- [ ] CI `test` check (incl. coverage gate) green on this PR.