### PR TITLE
Dashboard: link each user to their generated watchlist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,9 @@ plex:
   token: "not-a-real-token"
 users:
   list: "alice, bob"
+  preferences:
+    alice:
+      display_name: "Alice A"
 '''
 
 

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -52,6 +52,21 @@ class TestDashboard:
         resp = c.get('/')
         assert b'success' in resp.data
 
+    def test_links_to_per_user_watchlist_when_generated(self, client):
+        c, app, root = client
+        ext_dir = os.path.join(root, 'recommendations', 'external')
+        with open(os.path.join(ext_dir, 'alice_a_watchlist.html'), 'w') as f:
+            f.write('<html>alice list</html>')
+        resp = c.get('/')
+        assert resp.status_code == 200
+        assert b'alice_a_watchlist.html' in resp.data
+
+    def test_dashboard_watchlist_link_absent_when_nothing_generated(self, client):
+        c, app, root = client
+        resp = c.get('/')
+        assert resp.status_code == 200
+        assert b'_watchlist.html' not in resp.data
+
     def test_handles_missing_config_gracefully(self, tmp_path):
         (tmp_path / 'logs').mkdir()
         (tmp_path / 'recommendations' / 'external').mkdir(parents=True)

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -8,7 +8,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
-from web.status import get_last_run_status, list_log_files, read_log_tail
+from web.status import (
+    display_name_safe_slug, find_user_watchlist, get_last_run_status,
+    list_log_files, read_log_tail,
+)
 
 
 def _write_log(logs_dir, name, content):
@@ -117,3 +120,39 @@ class TestReadLogTail:
         _write_log(tmp_path, 'a.log', content)
         result = read_log_tail(str(tmp_path), 'a.log', max_lines=3)
         assert result.splitlines() == ['line7', 'line8', 'line9']
+
+class TestDisplayNameSafeSlug:
+    """Tests for display_name_safe_slug()"""
+
+    def test_uses_display_name_when_configured(self):
+        config = {'users': {'preferences': {'alice': {'display_name': 'Alice A'}}}}
+        assert display_name_safe_slug(config, 'alice') == 'alice_a'
+
+    def test_falls_back_to_username_when_no_display_name(self):
+        config = {'users': {'preferences': {}}}
+        assert display_name_safe_slug(config, 'bob') == 'bob'
+
+    def test_handles_none_config(self):
+        assert display_name_safe_slug(None, 'bob') == 'bob'
+
+
+class TestFindUserWatchlist:
+    """Tests for find_user_watchlist()"""
+
+    def test_prefers_per_user_file(self, tmp_path):
+        config = {'users': {'preferences': {'alice': {'display_name': 'Alice A'}}}}
+        (tmp_path / 'alice_a_watchlist.html').write_text('<html></html>')
+        (tmp_path / 'watchlist.html').write_text('<html></html>')
+        result = find_user_watchlist(str(tmp_path), config, 'alice')
+        assert result == 'alice_a_watchlist.html'
+
+    def test_falls_back_to_combined_file(self, tmp_path):
+        config = {'users': {'preferences': {'alice': {'display_name': 'Alice A'}}}}
+        (tmp_path / 'watchlist.html').write_text('<html></html>')
+        result = find_user_watchlist(str(tmp_path), config, 'alice')
+        assert result == 'watchlist.html'
+
+    def test_returns_none_when_nothing_generated(self, tmp_path):
+        config = {'users': {'preferences': {}}}
+        result = find_user_watchlist(str(tmp_path), config, 'bob')
+        assert result is None

--- a/web/app.py
+++ b/web/app.py
@@ -29,7 +29,7 @@ from utils import get_project_root, get_users_from_config, load_config
 
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
 from .security import redact
-from .status import get_last_run_status, list_log_files, read_log_tail
+from .status import find_user_watchlist, get_last_run_status, list_log_files, read_log_tail
 
 DEFAULT_PORT = 8787
 
@@ -48,19 +48,27 @@ def create_app(project_root: str = None) -> Flask:
     app.config['EXTERNAL_DIR'] = external_dir
     app.job_manager = JobManager(project_root, logs_dir)
 
-    def _load_users():
+    def _load_config():
         config_path = os.path.join(project_root, 'config', 'config.yml')
         try:
-            config = load_config(config_path)
+            return load_config(config_path)
         except Exception:
-            return []
-        return get_users_from_config(config)
+            return None
+
+    def _load_users():
+        config = _load_config()
+        return get_users_from_config(config) if config else []
 
     @app.get('/')
     def dashboard():
+        config = _load_config()
         rows = [
-            {'username': user, **get_last_run_status(logs_dir, user)}
-            for user in _load_users()
+            {
+                'username': user,
+                **get_last_run_status(logs_dir, user),
+                'watchlist_file': find_user_watchlist(external_dir, config, user),
+            }
+            for user in (get_users_from_config(config) if config else [])
         ]
         return render_template('dashboard.html', rows=rows, job=app.job_manager.status())
 

--- a/web/status.py
+++ b/web/status.py
@@ -112,6 +112,36 @@ def list_log_files(logs_dir: str) -> List[Dict]:
     return entries
 
 
+def display_name_safe_slug(config: Dict, username: str) -> str:
+    """Mirror recommenders/external_output.py's filename derivation:
+    display_name (falling back to the username itself), lowercased,
+    spaces replaced with underscores.
+    """
+    prefs = (config or {}).get('users', {}).get('preferences', {}) or {}
+    display_name = (prefs.get(username) or {}).get('display_name', username)
+    return str(display_name).lower().replace(' ', '_')
+
+
+def find_user_watchlist(external_dir: str, config: Dict, username: str) -> Optional[str]:
+    """Return the basename of this user's generated watchlist, if any.
+
+    Prefers the per-user "<display_name>_watchlist.html" file that
+    recommenders/external_output.py writes; falls back to the combined
+    (all-users, tabbed) "watchlist.html" if that's all that exists yet.
+    Returns None if neither has been generated.
+    """
+    slug = display_name_safe_slug(config, username)
+    per_user = f'{slug}_watchlist.html'
+    if os.path.isfile(os.path.join(external_dir, per_user)):
+        return per_user
+
+    combined = 'watchlist.html'
+    if os.path.isfile(os.path.join(external_dir, combined)):
+        return combined
+
+    return None
+
+
 def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> str:
     """Read the last max_lines of logs_dir/filename, secrets redacted.
 

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -12,7 +12,7 @@
 
 <table class="status-table">
   <thead>
-    <tr><th>User</th><th>Last Run</th><th>Status</th><th>Log</th></tr>
+    <tr><th>User</th><th>Last Run</th><th>Status</th><th>Log</th><th>Watchlist</th></tr>
   </thead>
   <tbody>
     {% for row in rows %}
@@ -27,9 +27,16 @@
         —
         {% endif %}
       </td>
+      <td>
+        {% if row.watchlist_file %}
+        <a href="{{ url_for('results_watchlist', filename=row.watchlist_file) }}" target="_blank" rel="noopener">watchlist.html</a>
+        {% else %}
+        —
+        {% endif %}
+      </td>
     </tr>
     {% else %}
-    <tr><td colspan="4">No users configured in config/config.yml (users.list).</td></tr>
+    <tr><td colspan="5">No users configured in config/config.yml (users.list).</td></tr>
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Follow-up to #162 (Web UI MVP). The MVP spec calls for the dashboard to link each user row to their watchlist.html, not just their log - this closes that gap.
- Adds `find_user_watchlist()` / `display_name_safe_slug()` to `web/status.py`, mirroring the `<display_name>_watchlist.html` naming `recommenders/external_output.py` already uses, with fallback to the combined (all-users) `watchlist.html` when no per-user file exists yet.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85` passes locally: 1248 passed, 86.50% total coverage.
- [x] New tests cover the slug derivation, per-user-file-preferred / combined-fallback / none-generated cases, and the dashboard route rendering the link.
- [ ] CI `test` check green on this PR.