### PR TITLE
Web UI config screens: connections, users, settings/tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ localhost only). From there you can see each user's last-run status, trigger a
 run (full pipeline, or just movie/tv/external) with a live streaming log, and
 browse generated watchlists and past logs.
 
+**Config screens** let you set up curatarr entirely from the browser instead of
+hand-editing YAML:
+
+- **Connections** (`/config/connections`) - Plex, TMDB, Tautulli, Sonarr, Radarr,
+  and Trakt, each with a Test Connection button.
+- **Users** (`/config/users`) - add/remove Plex users and per-user preferences
+  (display name, excluded genres, max content rating, streaming services).
+- **Settings** (`/config/settings`) - scoring weights, quality filters, recency
+  decay, rating multipliers, negative signals, external recommendation limits,
+  and the Sonarr/Radarr/Trakt auto-sync safety toggles (surfaced with a warning -
+  turning auto-sync on starts writing to your download clients on every run).
+
+Secrets (tokens/API keys) are never shown once saved - fields show a
+"configured" / "not set" status, and you only need to enter a new value to
+change one. Saves are validated (e.g. scoring weights must sum to 1.0) and
+written atomically, so a bad submission can't corrupt your config files.
+
 ---
 
 ## What You Get

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ pyyaml==6.0.3
 
 # Local web UI (dashboard, run-with-live-log, results) - see web/
 flask==3.1.3
+
+# Round-trip YAML for the web UI config screens (preserves comments/
+# structure in config/*.yml on save) - see web/config_io.py
+ruamel.yaml==0.18.6

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -1,0 +1,252 @@
+"""Tests for the /config/connections screen: form render, save
+(correct modular YAML + round-trip), secret masking/blank-keeps-
+existing, validation rejection without corrupting the file, and the
+/config/test/<service> endpoints (clients mocked - no real network)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import yaml
+
+from web.app import create_app
+from web.config_io import load_module, module_path
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _read_yaml(root, name):
+    path = module_path(root, name)
+    if not os.path.isfile(path):
+        return {}
+    with open(path, encoding='utf-8') as f:
+        return yaml.safe_load(f) or {}
+
+
+VALID_FORM = {
+    'plex_url': 'http://localhost:32400',
+    'plex_token': '',
+    'plex_movie_library': 'Movies',
+    'plex_tv_library': 'TV Shows',
+    'tmdb_api_key': '',
+    'tautulli_url': '',
+    'tautulli_api_key': '',
+    'sonarr_url': 'http://localhost:8989',
+    'sonarr_api_key': 'sonarr-key-123',
+    'sonarr_user_mode': 'mapping',
+    'sonarr_plex_users': 'alice',
+    'radarr_url': 'http://localhost:7878',
+    'radarr_api_key': 'radarr-key-123',
+    'radarr_user_mode': 'mapping',
+    'radarr_plex_users': 'alice',
+    'trakt_client_id': 'client-id-123',
+    'trakt_client_secret': 'client-secret-123',
+    'trakt_user_mode': 'mapping',
+    'trakt_plex_users': 'alice',
+}
+
+
+class TestGet:
+    def test_renders_form(self, client):
+        c, app, root = client
+        resp = c.get('/config/connections')
+        assert resp.status_code == 200
+        assert b'Setup / Connections' in resp.data
+
+    def test_shows_masked_secret_status_not_raw_value(self, client):
+        c, app, root = client
+        resp = c.get('/config/connections')
+        assert b'not-a-real-token' not in resp.data
+        assert b'configured' in resp.data
+
+
+class TestSave:
+    def test_saves_plex_and_tmdb_to_config_yml(self, client):
+        c, app, root = client
+        resp = c.post('/config/connections', data=VALID_FORM)
+        assert resp.status_code == 303
+
+        core = _read_yaml(root, 'config')
+        assert core['plex']['url'] == 'http://localhost:32400'
+        assert core['plex']['movie_library'] == 'Movies'
+        assert core['plex']['tv_library'] == 'TV Shows'
+
+    def test_saves_sonarr_radarr_trakt_to_their_own_files(self, client):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)
+
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr['url'] == 'http://localhost:8989'
+        assert sonarr['api_key'] == 'sonarr-key-123'
+        assert sonarr['plex_users'] == ['alice']
+
+        radarr = _read_yaml(root, 'radarr')
+        assert radarr['url'] == 'http://localhost:7878'
+
+        trakt = _read_yaml(root, 'trakt')
+        assert trakt['client_id'] == 'client-id-123'
+        assert trakt['export']['plex_users'] == ['alice']
+
+    def test_never_renders_secret_after_save(self, client):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)
+        resp = c.get('/config/connections')
+        assert b'sonarr-key-123' not in resp.data
+        assert b'radarr-key-123' not in resp.data
+        assert b'client-secret-123' not in resp.data
+
+    def test_blank_secret_on_resave_keeps_existing_value(self, client):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)
+
+        second = dict(VALID_FORM)
+        second['sonarr_api_key'] = ''  # blank = keep existing
+        second['sonarr_url'] = 'http://localhost:9999'  # change a non-secret field too
+        c.post('/config/connections', data=second)
+
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr['api_key'] == 'sonarr-key-123'  # unchanged
+        assert sonarr['url'] == 'http://localhost:9999'  # changed
+
+    def test_nonblank_secret_overwrites(self, client):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)
+
+        second = dict(VALID_FORM)
+        second['sonarr_api_key'] = 'brand-new-key'
+        c.post('/config/connections', data=second)
+
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr['api_key'] == 'brand-new-key'
+
+    def test_round_trip_preserves_untouched_yaml_comments_and_keys(self, client):
+        c, app, root = client
+        sonarr_path = module_path(root, 'sonarr')
+        os.makedirs(os.path.dirname(sonarr_path), exist_ok=True)
+        with open(sonarr_path, 'w', encoding='utf-8') as f:
+            f.write(
+                "# Curatarr Sonarr Configuration\n"
+                "enabled: true\n"
+                "url: http://localhost:8989\n"
+                "api_key: old-key\n"
+                "root_folder: /Volumes/TV\n"
+                "quality_profile: HD-1080p\n"
+            )
+
+        c.post('/config/connections', data=VALID_FORM)
+
+        content = open(sonarr_path, encoding='utf-8').read()
+        assert '# Curatarr Sonarr Configuration' in content
+        assert 'root_folder: /Volumes/TV' in content
+        assert 'quality_profile: HD-1080p' in content
+
+
+class TestValidation:
+    def test_invalid_plex_url_rejected_with_400(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['plex_url'] = 'not-a-url'
+        resp = c.post('/config/connections', data=bad)
+        assert resp.status_code == 400
+        assert b'valid http' in resp.data or b'Must be a valid' in resp.data
+
+    def test_invalid_input_does_not_corrupt_existing_file(self, client):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)
+        before = _read_yaml(root, 'config')
+
+        bad = dict(VALID_FORM)
+        bad['plex_url'] = 'not-a-url'
+        c.post('/config/connections', data=bad)
+
+        after = _read_yaml(root, 'config')
+        assert after == before
+
+    def test_missing_required_movie_library_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['plex_movie_library'] = ''
+        resp = c.post('/config/connections', data=bad)
+        assert resp.status_code == 400
+
+    def test_invalid_user_mode_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['sonarr_user_mode'] = 'not-a-real-mode'
+        resp = c.post('/config/connections', data=bad)
+        assert resp.status_code == 400
+
+
+class TestConnectionsTestEndpoint:
+    def test_unknown_service_404s(self, client):
+        c, app, root = client
+        resp = c.post('/config/test/not-a-service')
+        assert resp.status_code == 404
+
+    def test_plex_test_success(self, client, monkeypatch):
+        c, app, root = client
+
+        class _FakeServer:
+            class library:
+                @staticmethod
+                def sections():
+                    return [object()]
+
+        import web.config_test_connection as cc
+        monkeypatch.setattr(cc, 'init_plex', lambda config: _FakeServer())
+
+        resp = c.post('/config/test/plex', data={'url': 'http://localhost:32400', 'token': 'tok'})
+        assert resp.status_code == 200
+        assert resp.get_json()['ok'] is True
+
+    def test_plex_test_failure_message_is_redacted(self, client, monkeypatch):
+        c, app, root = client
+
+        def _raise(config):
+            raise ConnectionError('failed for X-Plex-Token=abcdef1234567890 on request')
+
+        import web.config_test_connection as cc
+        monkeypatch.setattr(cc, 'init_plex', _raise)
+
+        resp = c.post('/config/test/plex', data={'url': 'http://localhost:32400', 'token': 'abcdef1234567890'})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body['ok'] is False
+        assert 'abcdef1234567890' not in body['message']
+
+    def test_sonarr_test_uses_saved_key_when_submission_blank(self, client, monkeypatch):
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)  # saves sonarr api_key
+
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                captured['url'] = url
+                captured['api_key'] = api_key
+
+            def test_connection(self):
+                return True
+
+        import web.config_test_connection as cc
+        monkeypatch.setattr(cc, 'SonarrClient', _FakeClient)
+
+        resp = c.post('/config/test/sonarr', data={'url': 'http://localhost:8989', 'api_key': ''})
+        assert resp.status_code == 200
+        assert resp.get_json()['ok'] is True
+        assert captured['api_key'] == 'sonarr-key-123'
+
+    def test_trakt_test_reports_missing_auth(self, client):
+        c, app, root = client
+        resp = c.post('/config/test/trakt', data={'client_id': 'cid', 'client_secret': 'csecret'})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body['ok'] is False
+        assert 'trakt_auth' in body['message']

--- a/tests/test_web_config_io.py
+++ b/tests/test_web_config_io.py
@@ -1,0 +1,151 @@
+"""Tests for web/config_io.py - round-trip YAML load/save, atomic
+writes, and the secret-masking helpers the config screens rely on."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from web.config_io import (
+    format_csv_list,
+    is_secret_field,
+    load_module,
+    merge_secret,
+    module_path,
+    parse_csv_list,
+    save_module,
+    secret_status,
+)
+
+
+class TestModulePath:
+    def test_builds_path_under_config_dir(self, tmp_path):
+        path = module_path(str(tmp_path), 'sonarr')
+        assert path == os.path.join(str(tmp_path), 'config', 'sonarr.yml')
+
+    def test_rejects_unknown_module(self, tmp_path):
+        import pytest
+        with pytest.raises(ValueError):
+            module_path(str(tmp_path), 'not-a-real-module')
+
+
+class TestLoadSaveRoundTrip:
+    def test_load_missing_file_returns_empty_map(self, tmp_path):
+        data = load_module(str(tmp_path / 'config' / 'sonarr.yml'))
+        assert dict(data) == {}
+
+    def test_save_then_load_round_trips_values(self, tmp_path):
+        path = str(tmp_path / 'config' / 'sonarr.yml')
+        data = load_module(path)
+        data['enabled'] = True
+        data['url'] = 'http://localhost:8989'
+        data['plex_users'] = ['alice']
+        save_module(path, data)
+
+        reloaded = load_module(path)
+        assert reloaded['enabled'] is True
+        assert reloaded['url'] == 'http://localhost:8989'
+        assert reloaded['plex_users'] == ['alice']
+
+    def test_save_preserves_comments(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        path = config_dir / 'sonarr.yml'
+        path.write_text(
+            "# Curatarr Sonarr Configuration\n"
+            "\n"
+            "enabled: true\n"
+            "url: http://localhost:8989\n"
+            "api_key: secret123\n",
+            encoding='utf-8',
+        )
+
+        data = load_module(str(path))
+        data['url'] = 'http://newhost:8989'
+        save_module(str(path), data)
+
+        content = path.read_text(encoding='utf-8')
+        assert '# Curatarr Sonarr Configuration' in content
+        assert 'http://newhost:8989' in content
+        # untouched key survives
+        assert 'api_key: secret123' in content
+
+    def test_save_preserves_untouched_sibling_keys(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        path = config_dir / 'radarr.yml'
+        path.write_text(
+            "enabled: false\n"
+            "url: http://localhost:7878\n"
+            "root_folder: /movies\n"
+            "quality_profile: HD-1080p\n",
+            encoding='utf-8',
+        )
+
+        data = load_module(str(path))
+        data['enabled'] = True
+        save_module(str(path), data)
+
+        reloaded = load_module(str(path))
+        assert reloaded['enabled'] is True
+        assert reloaded['root_folder'] == '/movies'
+        assert reloaded['quality_profile'] == 'HD-1080p'
+
+    def test_save_is_atomic_no_temp_file_left_behind(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        path = config_dir / 'tuning.yml'
+        data = load_module(str(path))
+        data['movies'] = {'limit_results': 50}
+        save_module(str(path), data)
+
+        leftovers = [f for f in os.listdir(config_dir) if f.startswith('.tmp-')]
+        assert leftovers == []
+        assert path.exists()
+
+    def test_load_empty_file_returns_empty_map(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        path = config_dir / 'trakt.yml'
+        path.write_text('', encoding='utf-8')
+        assert dict(load_module(str(path))) == {}
+
+
+class TestSecretHelpers:
+    def test_is_secret_field(self):
+        assert is_secret_field('token') is True
+        assert is_secret_field('api_key') is True
+        assert is_secret_field('client_secret') is True
+        assert is_secret_field('url') is False
+        assert is_secret_field('display_name') is False
+
+    def test_merge_secret_blank_keeps_existing(self):
+        assert merge_secret('old-token', '') == 'old-token'
+        assert merge_secret('old-token', '   ') == 'old-token'
+
+    def test_merge_secret_nonblank_overwrites(self):
+        assert merge_secret('old-token', 'new-token') == 'new-token'
+
+    def test_merge_secret_no_existing_no_submission(self):
+        assert merge_secret(None, '') == ''
+        assert merge_secret('', '') == ''
+
+    def test_secret_status(self):
+        assert secret_status('a-real-token') == 'configured'
+        assert secret_status('') == 'not set'
+        assert secret_status(None) == 'not set'
+        assert secret_status('   ') == 'not set'
+
+
+class TestCsvHelpers:
+    def test_parse_csv_list(self):
+        assert parse_csv_list('a, b, c') == ['a', 'b', 'c']
+        assert parse_csv_list('a,,b') == ['a', 'b']
+        assert parse_csv_list('') == []
+        assert parse_csv_list(None) == []
+
+    def test_format_csv_list(self):
+        assert format_csv_list(['a', 'b']) == 'a, b'
+        assert format_csv_list([]) == ''
+        assert format_csv_list(None) == ''
+        assert format_csv_list('already-a-string') == 'already-a-string'

--- a/tests/test_web_config_settings.py
+++ b/tests/test_web_config_settings.py
@@ -1,0 +1,178 @@
+"""Tests for the /config/settings screen: tuning.yml weights (with
+sum-to-1.0 validation), quality filters, recency decay, rating
+multipliers, negative signals, external recommendations, general/
+logging, and the sonarr/radarr/trakt export-safety toggles."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import yaml
+
+from web.app import create_app
+from web.config_io import module_path
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _read_yaml(root, name):
+    path = module_path(root, name)
+    if not os.path.isfile(path):
+        return {}
+    with open(path, encoding='utf-8') as f:
+        return yaml.safe_load(f) or {}
+
+
+VALID_FORM = {
+    'movies_weight_genre': '0.25', 'movies_weight_director': '0.05',
+    'movies_weight_actor': '0.20', 'movies_weight_keyword': '0.50',
+    'movies_limit_results': '50', 'movies_min_rating': '5.0', 'movies_min_vote_count': '50',
+
+    'tv_weight_genre': '0.25', 'tv_weight_studio': '0.10',
+    'tv_weight_actor': '0.20', 'tv_weight_keyword': '0.45',
+    'tv_limit_results': '20', 'tv_min_rating': '0.0', 'tv_min_vote_count': '0',
+
+    'recency_days_0_30': '1.0', 'recency_days_31_90': '0.75', 'recency_days_91_180': '0.5',
+    'recency_days_181_365': '0.25', 'recency_days_365_plus': '0.1',
+
+    'rating_star_5': '2.5', 'rating_star_4': '1.7', 'rating_star_3': '1.0',
+    'rating_star_2': '0.4', 'rating_star_1': '0.2',
+
+    'negsig_bad_ratings_threshold': '3', 'negsig_bad_ratings_cap_penalty': '0.5',
+    'negsig_dropped_min_episodes': '2', 'negsig_dropped_max_completion': '25',
+    'negsig_dropped_penalty_multiplier': '-0.4',
+
+    'ext_movie_limit': '50', 'ext_show_limit': '20', 'ext_min_relevance_score': '0.65',
+    'ext_min_votes': '50', 'ext_max_iterations': '5', 'ext_language': '',
+
+    'general_log_retention_days': '7',
+    'logging_level': 'INFO',
+
+    'sonarr_user_mode': 'mapping', 'sonarr_plex_users': 'alice',
+    'radarr_user_mode': 'mapping', 'radarr_plex_users': 'alice',
+    'trakt_user_mode': 'mapping', 'trakt_plex_users': 'alice',
+}
+
+
+class TestGet:
+    def test_renders_defaults(self, client):
+        c, app, root = client
+        resp = c.get('/config/settings')
+        assert resp.status_code == 200
+        assert b'Settings / Tuning' in resp.data
+
+    def test_surfaces_sync_safety_warning(self, client):
+        c, app, root = client
+        resp = c.get('/config/settings')
+        assert b'Auto-sync' in resp.data
+
+
+class TestSave:
+    def test_saves_weights_and_quality_filters_to_tuning_yml(self, client):
+        c, app, root = client
+        resp = c.post('/config/settings', data=VALID_FORM)
+        assert resp.status_code == 303
+
+        tuning = _read_yaml(root, 'tuning')
+        assert tuning['movies']['weights']['genre'] == 0.25
+        assert tuning['movies']['weights']['keyword'] == 0.50
+        assert tuning['movies']['quality_filters']['min_rating'] == 5.0
+        assert tuning['tv']['weights']['studio'] == 0.10
+        assert tuning['tv']['limit_results'] == 20
+
+    def test_saves_recency_rating_negsig_external(self, client):
+        c, app, root = client
+        c.post('/config/settings', data=VALID_FORM)
+        tuning = _read_yaml(root, 'tuning')
+
+        assert tuning['recency_decay']['days_0_30'] == 1.0
+        assert tuning['rating_multipliers']['star_5'] == 2.5
+        assert tuning['negative_signals']['bad_ratings']['threshold'] == 3
+        assert tuning['negative_signals']['dropped_shows']['penalty_multiplier'] == -0.4
+        assert tuning['external_recommendations']['movie_limit'] == 50
+
+    def test_saves_general_and_logging_to_config_yml(self, client):
+        c, app, root = client
+        c.post('/config/settings', data=VALID_FORM)
+        core = _read_yaml(root, 'config')
+        assert core['general']['log_retention_days'] == 7
+        assert core['logging']['level'] == 'INFO'
+
+    def test_saves_sync_safety_toggles_to_module_files(self, client):
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form['sonarr_auto_sync'] = 'on'
+        c.post('/config/settings', data=form)
+
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr['auto_sync'] is True
+        assert sonarr['user_mode'] == 'mapping'
+        assert sonarr['plex_users'] == ['alice']
+
+    def test_round_trip_preserves_untouched_keys(self, client):
+        c, app, root = client
+        tuning_path = module_path(root, 'tuning')
+        os.makedirs(os.path.dirname(tuning_path), exist_ok=True)
+        with open(tuning_path, 'w', encoding='utf-8') as f:
+            f.write(
+                "# Curatarr Tuning Configuration\n"
+                "collections:\n"
+                "  add_label: true\n"
+                "  label_name: Recommended\n"
+            )
+
+        c.post('/config/settings', data=VALID_FORM)
+
+        content = open(tuning_path, encoding='utf-8').read()
+        assert '# Curatarr Tuning Configuration' in content
+        assert 'label_name: Recommended' in content
+
+
+class TestValidation:
+    def test_weights_not_summing_to_one_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['movies_weight_genre'] = '0.9'  # now sums to > 1
+        resp = c.post('/config/settings', data=bad)
+        assert resp.status_code == 400
+        assert b'sum to 1.0' in resp.data
+
+    def test_tv_weights_not_summing_to_one_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['tv_weight_genre'] = '0.9'
+        resp = c.post('/config/settings', data=bad)
+        assert resp.status_code == 400
+
+    def test_non_numeric_weight_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['movies_weight_genre'] = 'not-a-number'
+        resp = c.post('/config/settings', data=bad)
+        assert resp.status_code == 400
+
+    def test_invalid_logging_level_rejected(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad['logging_level'] = 'VERBOSE'
+        resp = c.post('/config/settings', data=bad)
+        assert resp.status_code == 400
+
+    def test_invalid_input_does_not_corrupt_existing_tuning_file(self, client):
+        c, app, root = client
+        c.post('/config/settings', data=VALID_FORM)  # establish a valid baseline
+        before = _read_yaml(root, 'tuning')
+
+        bad = dict(VALID_FORM)
+        bad['movies_weight_genre'] = '0.9'
+        c.post('/config/settings', data=bad)
+
+        after = _read_yaml(root, 'tuning')
+        assert after == before

--- a/tests/test_web_config_test_connection.py
+++ b/tests/test_web_config_test_connection.py
@@ -1,0 +1,196 @@
+"""Tests for web/config_test_connection.py - the Test Connection checks
+behind the Connections screen's buttons. Every external client is
+mocked here; nothing in this file makes a real network call."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import web.config_test_connection as cc
+
+
+class _FakeSections(list):
+    pass
+
+
+class _FakeServer:
+    class library:
+        @staticmethod
+        def sections():
+            return _FakeSections([object(), object()])
+
+
+class TestPlex:
+    def test_missing_fields_fail_fast(self):
+        result = cc.test_plex('', '')
+        assert result['ok'] is False
+
+    def test_success(self, monkeypatch):
+        monkeypatch.setattr(cc, 'init_plex', lambda config: _FakeServer())
+        result = cc.test_plex('http://localhost:32400', 'tok123')
+        assert result['ok'] is True
+        assert '2' in result['message']
+
+    def test_failure_raises_are_caught(self, monkeypatch):
+        def _raise(config):
+            raise ConnectionError('boom')
+        monkeypatch.setattr(cc, 'init_plex', _raise)
+        result = cc.test_plex('http://localhost:32400', 'tok123')
+        assert result['ok'] is False
+        assert 'boom' in result['message']
+
+
+class TestTmdb:
+    def test_missing_key_fails_fast(self):
+        result = cc.test_tmdb('')
+        assert result['ok'] is False
+
+    def test_success(self, monkeypatch):
+        monkeypatch.setattr(cc, 'fetch_tmdb_with_retry', lambda *a, **k: {'images': {}})
+        result = cc.test_tmdb('a-real-key')
+        assert result['ok'] is True
+
+    def test_failure(self, monkeypatch):
+        monkeypatch.setattr(cc, 'fetch_tmdb_with_retry', lambda *a, **k: None)
+        result = cc.test_tmdb('bad-key')
+        assert result['ok'] is False
+
+
+class TestTautulli:
+    def test_missing_fields_fail_fast(self):
+        result = cc.test_tautulli('', '')
+        assert result['ok'] is False
+
+    def test_success(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def get_users(self):
+                return [{'user': 'a'}, {'user': 'b'}]
+
+        monkeypatch.setattr(cc, 'TautulliClient', _FakeClient)
+        result = cc.test_tautulli('http://localhost:8181', 'key')
+        assert result['ok'] is True
+        assert '2' in result['message']
+
+    def test_api_error_caught(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def get_users(self):
+                raise cc.TautulliAPIError('unreachable')
+
+        monkeypatch.setattr(cc, 'TautulliClient', _FakeClient)
+        result = cc.test_tautulli('http://localhost:8181', 'key')
+        assert result['ok'] is False
+        assert 'unreachable' in result['message']
+
+
+class TestSonarr:
+    def test_missing_fields_fail_fast(self):
+        result = cc.test_sonarr('', '')
+        assert result['ok'] is False
+
+    def test_success(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def test_connection(self):
+                return True
+
+        monkeypatch.setattr(cc, 'SonarrClient', _FakeClient)
+        result = cc.test_sonarr('http://localhost:8989', 'key')
+        assert result['ok'] is True
+
+    def test_api_error_caught(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def test_connection(self):
+                raise cc.SonarrAPIError('unauthorized')
+
+        monkeypatch.setattr(cc, 'SonarrClient', _FakeClient)
+        result = cc.test_sonarr('http://localhost:8989', 'bad-key')
+        assert result['ok'] is False
+        assert 'unauthorized' in result['message']
+
+
+class TestRadarr:
+    def test_missing_fields_fail_fast(self):
+        result = cc.test_radarr('', '')
+        assert result['ok'] is False
+
+    def test_success(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def test_connection(self):
+                return True
+
+        monkeypatch.setattr(cc, 'RadarrClient', _FakeClient)
+        result = cc.test_radarr('http://localhost:7878', 'key')
+        assert result['ok'] is True
+
+    def test_api_error_caught(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                pass
+
+            def test_connection(self):
+                raise cc.RadarrAPIError('unauthorized')
+
+        monkeypatch.setattr(cc, 'RadarrClient', _FakeClient)
+        result = cc.test_radarr('http://localhost:7878', 'bad-key')
+        assert result['ok'] is False
+
+
+class TestTrakt:
+    def test_missing_creds_fail_fast(self):
+        result = cc.test_trakt('', '', '', '')
+        assert result['ok'] is False
+
+    def test_missing_access_token_prompts_auth_flow(self):
+        result = cc.test_trakt('client-id', 'client-secret', '', '')
+        assert result['ok'] is False
+        assert 'trakt_auth' in result['message']
+
+    def test_success(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, client_id, client_secret, access_token, refresh_token):
+                pass
+
+            def get_username(self):
+                return 'jasonsmith523'
+
+        monkeypatch.setattr(cc, 'TraktClient', _FakeClient)
+        result = cc.test_trakt('cid', 'csecret', 'atoken', 'rtoken')
+        assert result['ok'] is True
+        assert 'jasonsmith523' in result['message']
+
+    def test_expired_token_fails(self, monkeypatch):
+        class _FakeClient:
+            def __init__(self, client_id, client_secret, access_token, refresh_token):
+                pass
+
+            def get_username(self):
+                return None
+
+        monkeypatch.setattr(cc, 'TraktClient', _FakeClient)
+        result = cc.test_trakt('cid', 'csecret', 'atoken', 'rtoken')
+        assert result['ok'] is False
+
+
+class TestTestersRegistry:
+    def test_all_services_registered(self):
+        assert set(cc.TESTERS.keys()) == {'plex', 'tmdb', 'tautulli', 'sonarr', 'radarr', 'trakt'}
+
+    def test_tester_dispatch_reads_expected_form_keys(self, monkeypatch):
+        monkeypatch.setattr(cc, 'init_plex', lambda config: _FakeServer())
+        result = cc.TESTERS['plex']({'url': 'http://localhost:32400', 'token': 'tok'})
+        assert result['ok'] is True

--- a/tests/test_web_config_users.py
+++ b/tests/test_web_config_users.py
@@ -1,0 +1,131 @@
+"""Tests for the /config/users screen: add/remove users.list, per-user
+preferences (display_name, exclude_genres, max_rating,
+streaming_services), and validation/round-trip behavior."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import yaml
+
+from web.app import create_app
+from web.config_io import module_path
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _read_config(root):
+    with open(module_path(root, 'config'), encoding='utf-8') as f:
+        return yaml.safe_load(f) or {}
+
+
+class TestGet:
+    def test_renders_existing_users_from_fixture(self, client):
+        c, app, root = client
+        resp = c.get('/config/users')
+        assert resp.status_code == 200
+        assert b'alice' in resp.data
+        assert b'bob' in resp.data
+
+
+class TestSave:
+    def test_edits_existing_user_preferences(self, client):
+        c, app, root = client
+        resp = c.post('/config/users', data={
+            'user_count': '2',
+            'username_0': 'alice',
+            'display_name_0': 'Alice A',
+            'exclude_genres_0': 'horror, children',
+            'max_rating_0': 'PG-13',
+            'streaming_services_0': 'netflix, hulu',
+            'username_1': 'bob',
+            'display_name_1': 'Bob B',
+            'exclude_genres_1': '',
+            'max_rating_1': '',
+            'streaming_services_1': '',
+            'new_username': '',
+        })
+        assert resp.status_code == 303
+
+        core = _read_config(root)
+        prefs = core['users']['preferences']
+        assert prefs['alice']['display_name'] == 'Alice A'
+        assert prefs['alice']['exclude_genres'] == ['horror', 'children']
+        assert prefs['alice']['max_rating'] == 'PG-13'
+        assert prefs['alice']['streaming_services'] == ['netflix', 'hulu']
+        assert prefs['bob']['display_name'] == 'Bob B'
+        assert 'exclude_genres' not in prefs['bob']
+
+    def test_adds_new_user(self, client):
+        c, app, root = client
+        c.post('/config/users', data={
+            'user_count': '2',
+            'username_0': 'alice', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': '', 'streaming_services_0': '',
+            'username_1': 'bob', 'display_name_1': '', 'exclude_genres_1': '',
+            'max_rating_1': '', 'streaming_services_1': '',
+            'new_username': 'carol',
+        })
+
+        core = _read_config(root)
+        usernames = [u.strip() for u in core['users']['list'].split(',')]
+        assert 'carol' in usernames
+        assert core['users']['preferences']['carol']['display_name'] == 'carol'
+
+    def test_removes_a_user(self, client):
+        c, app, root = client
+        c.post('/config/users', data={
+            'user_count': '2',
+            'username_0': 'alice', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': '', 'streaming_services_0': '', 'remove_0': 'on',
+            'username_1': 'bob', 'display_name_1': '', 'exclude_genres_1': '',
+            'max_rating_1': '', 'streaming_services_1': '',
+            'new_username': '',
+        })
+
+        core = _read_config(root)
+        usernames = [u.strip() for u in core['users']['list'].split(',')]
+        assert 'alice' not in usernames
+        assert 'bob' in usernames
+        assert 'alice' not in (core['users'].get('preferences') or {})
+
+
+class TestValidation:
+    def test_invalid_max_rating_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/users', data={
+            'user_count': '1',
+            'username_0': 'alice', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': 'NOT-A-RATING', 'streaming_services_0': '',
+            'new_username': '',
+        })
+        assert resp.status_code == 400
+
+    def test_duplicate_new_username_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/users', data={
+            'user_count': '1',
+            'username_0': 'alice', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': '', 'streaming_services_0': '',
+            'new_username': 'alice',
+        })
+        assert resp.status_code == 400
+
+    def test_invalid_input_does_not_corrupt_existing_file(self, client):
+        c, app, root = client
+        before = _read_config(root)
+        c.post('/config/users', data={
+            'user_count': '1',
+            'username_0': 'alice', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': 'GARBAGE', 'streaming_services_0': '',
+            'new_username': '',
+        })
+        after = _read_config(root)
+        assert after == before

--- a/tests/test_web_config_validate.py
+++ b/tests/test_web_config_validate.py
@@ -1,0 +1,130 @@
+"""Tests for web/config_validate.py - field-level validation used before
+any config screen writes to disk."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from web.config_validate import (
+    validate_choice,
+    validate_float,
+    validate_int,
+    validate_required,
+    validate_url,
+    validate_weights_sum,
+)
+
+
+class TestValidateUrl:
+    def test_valid_http_url_passes(self):
+        errors = {}
+        validate_url('http://localhost:8989', 'f', errors)
+        assert errors == {}
+
+    def test_valid_https_url_passes(self):
+        errors = {}
+        validate_url('https://example.plex.direct:32400', 'f', errors)
+        assert errors == {}
+
+    def test_missing_scheme_fails(self):
+        errors = {}
+        validate_url('localhost:8989', 'f', errors)
+        assert 'f' in errors
+
+    def test_garbage_fails(self):
+        errors = {}
+        validate_url('not a url at all', 'f', errors)
+        assert 'f' in errors
+
+    def test_blank_not_required_is_fine(self):
+        errors = {}
+        validate_url('', 'f', errors, required=False)
+        assert errors == {}
+
+    def test_blank_required_fails(self):
+        errors = {}
+        validate_url('', 'f', errors, required=True)
+        assert 'f' in errors
+
+
+class TestValidateRequired:
+    def test_present_passes(self):
+        errors = {}
+        validate_required('Movies', 'f', errors)
+        assert errors == {}
+
+    def test_blank_fails(self):
+        errors = {}
+        validate_required('   ', 'f', errors, label='Movie library')
+        assert 'f' in errors
+        assert 'Movie library' in errors['f']
+
+
+class TestValidateChoice:
+    def test_valid_choice_passes(self):
+        errors = {}
+        validate_choice('mapping', 'f', errors, ('mapping', 'per_user', 'combined'))
+        assert errors == {}
+
+    def test_invalid_choice_fails(self):
+        errors = {}
+        validate_choice('bogus', 'f', errors, ('mapping', 'per_user', 'combined'))
+        assert 'f' in errors
+
+
+class TestValidateFloat:
+    def test_parses_valid_float(self):
+        errors = {}
+        assert validate_float('0.25', 'f', errors) == 0.25
+        assert errors == {}
+
+    def test_non_numeric_records_error_returns_none(self):
+        errors = {}
+        assert validate_float('not-a-number', 'f', errors) is None
+        assert 'f' in errors
+
+    def test_below_range_records_error(self):
+        errors = {}
+        validate_float('-1', 'f', errors, lo=0, hi=1)
+        assert 'f' in errors
+
+    def test_above_range_records_error(self):
+        errors = {}
+        validate_float('1.5', 'f', errors, lo=0, hi=1)
+        assert 'f' in errors
+
+
+class TestValidateInt:
+    def test_parses_valid_int(self):
+        errors = {}
+        assert validate_int('50', 'f', errors) == 50
+        assert errors == {}
+
+    def test_non_numeric_records_error_returns_none(self):
+        errors = {}
+        assert validate_int('abc', 'f', errors) is None
+        assert 'f' in errors
+
+    def test_out_of_range(self):
+        errors = {}
+        validate_int('500', 'f', errors, lo=0, hi=100)
+        assert 'f' in errors
+
+
+class TestValidateWeightsSum:
+    def test_sum_to_one_passes(self):
+        errors = {}
+        validate_weights_sum({'a': 0.25, 'b': 0.25, 'c': 0.5}, 'weights', errors)
+        assert errors == {}
+
+    def test_sum_not_one_fails(self):
+        errors = {}
+        validate_weights_sum({'a': 0.5, 'b': 0.6}, 'weights', errors)
+        assert 'weights' in errors
+        assert '1.1' in errors['weights']
+
+    def test_within_tolerance_passes(self):
+        errors = {}
+        validate_weights_sum({'a': 0.3333333, 'b': 0.3333333, 'c': 0.3333334}, 'weights', errors)
+        assert errors == {}

--- a/web/app.py
+++ b/web/app.py
@@ -27,6 +27,7 @@ from flask import (
 
 from utils import get_project_root, get_users_from_config, load_config
 
+from .config_app import register_config_routes
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
 from .security import redact
 from .status import find_user_watchlist, get_last_run_status, list_log_files, read_log_tail
@@ -47,6 +48,8 @@ def create_app(project_root: str = None) -> Flask:
     app.config['LOGS_DIR'] = logs_dir
     app.config['EXTERNAL_DIR'] = external_dir
     app.job_manager = JobManager(project_root, logs_dir)
+
+    register_config_routes(app)
 
     def _load_config():
         config_path = os.path.join(project_root, 'config', 'config.yml')

--- a/web/config_app.py
+++ b/web/config_app.py
@@ -1,0 +1,905 @@
+"""Config screens: Setup/Connections, Users, Settings/Tuning.
+
+Extends web/app.py with three additional screens so curatarr can be set
+up entirely from the browser instead of hand-editing YAML. Reads and
+writes through web.config_io's round-trip helpers, which respect the
+same modular config/*.yml layout utils.config._load_module_configs
+already merges at run time:
+
+    config.yml  - plex, tmdb, tautulli, users, general, logging
+    tuning.yml  - movies/tv weights+quality_filters+limit_results,
+                  recency_decay, rating_multipliers, negative_signals,
+                  external_recommendations
+    sonarr.yml / radarr.yml / trakt.yml - one file per integration
+
+This module is purely additive: register_config_routes() is called once
+from web.app.create_app() and only adds new routes. It never touches
+the dashboard/run/results routes or the recommenders themselves.
+
+mdblist.yml/simkl.yml are deliberately NOT exposed here - see the "mdblist
+/simkl gap" note in the PR description. utils.config._load_module_configs
+never loads those two files into the merged config, so an mdblist.yml or
+simkl.yml a user hand-writes today is silently ignored at run time. Fixing
+that loader gap is a behavior change for anyone who already has one of
+those files sitting in config/ (it would suddenly start exporting), so
+it's left as a follow-up rather than bundled into this UI-only PR.
+"""
+
+import logging
+from typing import Dict, Optional
+
+from flask import jsonify, redirect, render_template, request, url_for
+from ruamel.yaml.comments import CommentedMap
+
+from utils import load_config
+from utils.plex import MOVIE_RATING_HIERARCHY, TV_RATING_HIERARCHY
+
+from .config_io import (
+    format_csv_list,
+    load_module,
+    merge_secret,
+    module_path,
+    parse_csv_list,
+    save_module,
+    secret_status,
+)
+from .config_test_connection import TESTERS
+from .security import redact
+from .config_validate import (
+    validate_choice,
+    validate_float,
+    validate_int,
+    validate_required,
+    validate_url,
+    validate_weights_sum,
+)
+
+logger = logging.getLogger('curatarr')
+
+USER_MODE_CHOICES = ('mapping', 'per_user', 'combined')
+LOG_LEVEL_CHOICES = ('DEBUG', 'INFO', 'WARNING', 'ERROR')
+RATING_CHOICES = MOVIE_RATING_HIERARCHY + TV_RATING_HIERARCHY
+
+
+def _reload_error(project_root: str) -> Optional[str]:
+    """Post-write sanity check: reload everything just written through the
+    same utils.load_config merge path the recommenders use at run time.
+
+    Field-level validation (weights sum, URLs, choices - see
+    config_validate.py) happens *before* any file is touched, which is
+    what actually prevents bad input from ever reaching disk. This is a
+    second, defense-in-depth check that the files we just wrote still
+    parse and merge cleanly - it should never fire given the writers
+    above only ever set well-typed values, but if it does, the operator
+    finds out immediately instead of on the next scheduled run.
+    """
+    try:
+        load_config(module_path(project_root, 'config'))
+    except Exception as exc:
+        logger.error(f"Post-write config reload check failed: {exc}")
+        return str(exc)
+    return None
+
+
+def register_config_routes(app) -> None:
+    project_root = app.config['PROJECT_ROOT']
+
+    # -------------------------------------------------------------------
+    # Setup / Connections
+    # -------------------------------------------------------------------
+
+    @app.get('/config/connections')
+    def config_connections():
+        data = _load_connections(project_root)
+        return render_template(
+            'config_connections.html',
+            saved=request.args.get('saved') == '1',
+            errors={},
+            **_connections_view(data),
+        )
+
+    @app.post('/config/connections')
+    def config_connections_save():
+        data = _load_connections(project_root)
+        errors: Dict[str, str] = {}
+        parsed = _parse_connections_form(request.form, errors)
+
+        if errors:
+            return render_template(
+                'config_connections.html',
+                saved=False,
+                errors=errors,
+                **_connections_view(data, overrides=parsed),
+            ), 400
+
+        _apply_connections(project_root, data, parsed)
+        reload_error = _reload_error(project_root)
+        if reload_error:
+            return render_template(
+                'config_connections.html',
+                saved=False,
+                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                **_connections_view(_load_connections(project_root)),
+            ), 500
+        return redirect(url_for('config_connections', saved='1'), code=303)
+
+    @app.post('/config/test/<service>')
+    def config_test_connection(service):
+        tester = TESTERS.get(service)
+        if tester is None:
+            return jsonify({'ok': False, 'message': f'Unknown service: {service}'}), 404
+
+        data = _load_connections(project_root)
+        form = dict(request.form)
+
+        # Secret fields: an empty submission means "use the already-saved
+        # value" so Test Connection works without retyping a token that
+        # was configured on a previous save.
+        existing = _existing_secret_lookup(data, service)
+        for key, existing_value in existing.items():
+            form[key] = merge_secret(existing_value, form.get(key, ''))
+
+        result = tester(form)
+        # Defense in depth: an underlying client's exception message could
+        # in principle echo a token (e.g. a Plex URL with X-Plex-Token as a
+        # query param) - redact before it ever reaches the browser, same as
+        # every other UI surface that displays external output (web/status.py).
+        result['message'] = redact(result.get('message', ''))
+        return jsonify(result)
+
+    # -------------------------------------------------------------------
+    # Users
+    # -------------------------------------------------------------------
+
+    @app.get('/config/users')
+    def config_users():
+        core = load_module(module_path(project_root, 'config'))
+        return render_template(
+            'config_users.html',
+            saved=request.args.get('saved') == '1',
+            errors={},
+            **_users_view(core),
+        )
+
+    @app.post('/config/users')
+    def config_users_save():
+        core = load_module(module_path(project_root, 'config'))
+        errors: Dict[str, str] = {}
+        parsed = _parse_users_form(request.form, errors)
+
+        if errors:
+            return render_template(
+                'config_users.html',
+                saved=False,
+                errors=errors,
+                **_users_view(core, overrides=parsed),
+            ), 400
+
+        _apply_users(project_root, core, parsed)
+        reload_error = _reload_error(project_root)
+        if reload_error:
+            return render_template(
+                'config_users.html',
+                saved=False,
+                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                **_users_view(load_module(module_path(project_root, 'config'))),
+            ), 500
+        return redirect(url_for('config_users', saved='1'), code=303)
+
+    # -------------------------------------------------------------------
+    # Settings / Tuning
+    # -------------------------------------------------------------------
+
+    @app.get('/config/settings')
+    def config_settings():
+        tuning = load_module(module_path(project_root, 'tuning'))
+        core = load_module(module_path(project_root, 'config'))
+        sonarr = load_module(module_path(project_root, 'sonarr'))
+        radarr = load_module(module_path(project_root, 'radarr'))
+        trakt = load_module(module_path(project_root, 'trakt'))
+        return render_template(
+            'config_settings.html',
+            saved=request.args.get('saved') == '1',
+            errors={},
+            **_settings_view(tuning, core, sonarr, radarr, trakt),
+        )
+
+    @app.post('/config/settings')
+    def config_settings_save():
+        tuning = load_module(module_path(project_root, 'tuning'))
+        core = load_module(module_path(project_root, 'config'))
+        sonarr = load_module(module_path(project_root, 'sonarr'))
+        radarr = load_module(module_path(project_root, 'radarr'))
+        trakt = load_module(module_path(project_root, 'trakt'))
+
+        errors: Dict[str, str] = {}
+        parsed = _parse_settings_form(request.form, errors)
+
+        if errors:
+            return render_template(
+                'config_settings.html',
+                saved=False,
+                errors=errors,
+                **_settings_view(tuning, core, sonarr, radarr, trakt, overrides=parsed),
+            ), 400
+
+        _apply_settings(project_root, tuning, core, sonarr, radarr, trakt, parsed)
+        reload_error = _reload_error(project_root)
+        if reload_error:
+            return render_template(
+                'config_settings.html',
+                saved=False,
+                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                **_settings_view(
+                    load_module(module_path(project_root, 'tuning')),
+                    load_module(module_path(project_root, 'config')),
+                    load_module(module_path(project_root, 'sonarr')),
+                    load_module(module_path(project_root, 'radarr')),
+                    load_module(module_path(project_root, 'trakt')),
+                ),
+            ), 500
+        return redirect(url_for('config_settings', saved='1'), code=303)
+
+
+# =========================================================================
+# Connections screen
+# =========================================================================
+
+def _load_connections(project_root: str) -> Dict[str, CommentedMap]:
+    return {
+        'core': load_module(module_path(project_root, 'config')),
+        'sonarr': load_module(module_path(project_root, 'sonarr')),
+        'radarr': load_module(module_path(project_root, 'radarr')),
+        'trakt': load_module(module_path(project_root, 'trakt')),
+    }
+
+
+def _existing_secret_lookup(data: Dict[str, CommentedMap], service: str) -> Dict[str, str]:
+    core = data['core']
+    if service == 'plex':
+        return {'token': (core.get('plex') or {}).get('token', '')}
+    if service == 'tmdb':
+        return {'api_key': (core.get('tmdb') or {}).get('api_key', '')}
+    if service == 'tautulli':
+        return {'api_key': (core.get('tautulli') or {}).get('api_key', '')}
+    if service in ('sonarr', 'radarr'):
+        return {'api_key': (data[service] or {}).get('api_key', '')}
+    if service == 'trakt':
+        trakt = data['trakt'] or {}
+        return {
+            'client_secret': trakt.get('client_secret', ''),
+            'access_token': trakt.get('access_token', ''),
+            'refresh_token': trakt.get('refresh_token', ''),
+        }
+    return {}
+
+
+def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] = None) -> Dict:
+    core = data['core']
+    sonarr = data['sonarr'] or {}
+    radarr = data['radarr'] or {}
+    trakt = data['trakt'] or {}
+    plex = core.get('plex') or {}
+    tmdb = core.get('tmdb') or {}
+    tautulli = core.get('tautulli') or {}
+    trakt_export = trakt.get('export') or {}
+
+    o = overrides or {}
+
+    def pick(section: str, field: str, disk_value):
+        return o[section][field] if section in o and field in o[section] else disk_value
+
+    return {
+        'plex': {
+            'url': pick('plex', 'url', plex.get('url', '')),
+            'movie_library': pick('plex', 'movie_library', plex.get('movie_library', '')),
+            'tv_library': pick('plex', 'tv_library', plex.get('tv_library', '')),
+            'token_status': secret_status(
+                merge_secret(plex.get('token'), o.get('plex', {}).get('token_submitted', ''))
+                if 'plex' in o else plex.get('token')
+            ),
+        },
+        'tmdb': {
+            'api_key_status': secret_status(
+                merge_secret(tmdb.get('api_key'), o.get('tmdb', {}).get('api_key_submitted', ''))
+                if 'tmdb' in o else tmdb.get('api_key')
+            ),
+        },
+        'tautulli': {
+            'enabled': pick('tautulli', 'enabled', bool(tautulli.get('enabled', False))),
+            'url': pick('tautulli', 'url', tautulli.get('url', '')),
+            'api_key_status': secret_status(
+                merge_secret(tautulli.get('api_key'), o.get('tautulli', {}).get('api_key_submitted', ''))
+                if 'tautulli' in o else tautulli.get('api_key')
+            ),
+        },
+        'sonarr': {
+            'enabled': pick('sonarr', 'enabled', bool(sonarr.get('enabled', False))),
+            'url': pick('sonarr', 'url', sonarr.get('url', '')),
+            'api_key_status': secret_status(
+                merge_secret(sonarr.get('api_key'), o.get('sonarr', {}).get('api_key_submitted', ''))
+                if 'sonarr' in o else sonarr.get('api_key')
+            ),
+            'auto_sync': pick('sonarr', 'auto_sync', bool(sonarr.get('auto_sync', False))),
+            'user_mode': pick('sonarr', 'user_mode', sonarr.get('user_mode', 'mapping')),
+            'plex_users': pick('sonarr', 'plex_users', format_csv_list(sonarr.get('plex_users'))),
+        },
+        'radarr': {
+            'enabled': pick('radarr', 'enabled', bool(radarr.get('enabled', False))),
+            'url': pick('radarr', 'url', radarr.get('url', '')),
+            'api_key_status': secret_status(
+                merge_secret(radarr.get('api_key'), o.get('radarr', {}).get('api_key_submitted', ''))
+                if 'radarr' in o else radarr.get('api_key')
+            ),
+            'auto_sync': pick('radarr', 'auto_sync', bool(radarr.get('auto_sync', False))),
+            'user_mode': pick('radarr', 'user_mode', radarr.get('user_mode', 'mapping')),
+            'plex_users': pick('radarr', 'plex_users', format_csv_list(radarr.get('plex_users'))),
+        },
+        'trakt': {
+            'enabled': pick('trakt', 'enabled', bool(trakt.get('enabled', False))),
+            'client_id': pick('trakt', 'client_id', trakt.get('client_id', '')),
+            'client_secret_status': secret_status(
+                merge_secret(trakt.get('client_secret'), o.get('trakt', {}).get('client_secret_submitted', ''))
+                if 'trakt' in o else trakt.get('client_secret')
+            ),
+            'access_token_status': secret_status(trakt.get('access_token')),
+            'auto_sync': pick('trakt', 'auto_sync', bool(trakt_export.get('auto_sync', False))),
+            'user_mode': pick('trakt', 'user_mode', trakt_export.get('user_mode', 'mapping')),
+            'plex_users': pick('trakt', 'plex_users', format_csv_list(trakt_export.get('plex_users'))),
+        },
+        'user_mode_choices': USER_MODE_CHOICES,
+    }
+
+
+def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
+    def flag(name: str) -> bool:
+        return form.get(name) in ('on', 'true', '1')
+
+    plex_url = form.get('plex_url', '').strip()
+    validate_url(plex_url, 'plex_url', errors, required=True)
+    plex_movie_library = form.get('plex_movie_library', '').strip()
+    validate_required(plex_movie_library, 'plex_movie_library', errors, 'Movie library')
+    plex_tv_library = form.get('plex_tv_library', '').strip()
+    validate_required(plex_tv_library, 'plex_tv_library', errors, 'TV library')
+
+    tautulli_enabled = flag('tautulli_enabled')
+    tautulli_url = form.get('tautulli_url', '').strip()
+    if tautulli_enabled:
+        validate_url(tautulli_url, 'tautulli_url', errors, required=True)
+
+    sonarr_enabled = flag('sonarr_enabled')
+    sonarr_url = form.get('sonarr_url', '').strip()
+    if sonarr_enabled:
+        validate_url(sonarr_url, 'sonarr_url', errors, required=True)
+    sonarr_user_mode = form.get('sonarr_user_mode', 'mapping')
+    validate_choice(sonarr_user_mode, 'sonarr_user_mode', errors, USER_MODE_CHOICES)
+
+    radarr_enabled = flag('radarr_enabled')
+    radarr_url = form.get('radarr_url', '').strip()
+    if radarr_enabled:
+        validate_url(radarr_url, 'radarr_url', errors, required=True)
+    radarr_user_mode = form.get('radarr_user_mode', 'mapping')
+    validate_choice(radarr_user_mode, 'radarr_user_mode', errors, USER_MODE_CHOICES)
+
+    trakt_enabled = flag('trakt_enabled')
+    trakt_client_id = form.get('trakt_client_id', '').strip()
+    if trakt_enabled:
+        validate_required(trakt_client_id, 'trakt_client_id', errors, 'Client ID')
+    trakt_user_mode = form.get('trakt_user_mode', 'mapping')
+    validate_choice(trakt_user_mode, 'trakt_user_mode', errors, USER_MODE_CHOICES)
+
+    return {
+        'plex': {
+            'url': plex_url,
+            'movie_library': plex_movie_library,
+            'tv_library': plex_tv_library,
+            'token_submitted': form.get('plex_token', ''),
+        },
+        'tmdb': {
+            'api_key_submitted': form.get('tmdb_api_key', ''),
+        },
+        'tautulli': {
+            'enabled': tautulli_enabled,
+            'url': tautulli_url,
+            'api_key_submitted': form.get('tautulli_api_key', ''),
+        },
+        'sonarr': {
+            'enabled': sonarr_enabled,
+            'url': sonarr_url,
+            'api_key_submitted': form.get('sonarr_api_key', ''),
+            'auto_sync': flag('sonarr_auto_sync'),
+            'user_mode': sonarr_user_mode,
+            'plex_users': format_csv_list(parse_csv_list(form.get('sonarr_plex_users', ''))),
+        },
+        'radarr': {
+            'enabled': radarr_enabled,
+            'url': radarr_url,
+            'api_key_submitted': form.get('radarr_api_key', ''),
+            'auto_sync': flag('radarr_auto_sync'),
+            'user_mode': radarr_user_mode,
+            'plex_users': format_csv_list(parse_csv_list(form.get('radarr_plex_users', ''))),
+        },
+        'trakt': {
+            'enabled': trakt_enabled,
+            'client_id': trakt_client_id,
+            'client_secret_submitted': form.get('trakt_client_secret', ''),
+            'auto_sync': flag('trakt_auto_sync'),
+            'user_mode': trakt_user_mode,
+            'plex_users': format_csv_list(parse_csv_list(form.get('trakt_plex_users', ''))),
+        },
+    }
+
+
+def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed: Dict) -> None:
+    core = data['core']
+
+    core.setdefault('plex', CommentedMap())
+    core['plex']['url'] = parsed['plex']['url']
+    core['plex']['movie_library'] = parsed['plex']['movie_library']
+    core['plex']['tv_library'] = parsed['plex']['tv_library']
+    core['plex']['token'] = merge_secret(core['plex'].get('token'), parsed['plex']['token_submitted'])
+
+    core.setdefault('tmdb', CommentedMap())
+    core['tmdb']['api_key'] = merge_secret(core['tmdb'].get('api_key'), parsed['tmdb']['api_key_submitted'])
+
+    core.setdefault('tautulli', CommentedMap())
+    core['tautulli']['enabled'] = parsed['tautulli']['enabled']
+    core['tautulli']['url'] = parsed['tautulli']['url']
+    core['tautulli']['api_key'] = merge_secret(core['tautulli'].get('api_key'), parsed['tautulli']['api_key_submitted'])
+
+    save_module(module_path(project_root, 'config'), core)
+
+    sonarr = data['sonarr']
+    sonarr['enabled'] = parsed['sonarr']['enabled']
+    sonarr['url'] = parsed['sonarr']['url']
+    sonarr['api_key'] = merge_secret(sonarr.get('api_key'), parsed['sonarr']['api_key_submitted'])
+    sonarr['auto_sync'] = parsed['sonarr']['auto_sync']
+    sonarr['user_mode'] = parsed['sonarr']['user_mode']
+    sonarr['plex_users'] = parse_csv_list(parsed['sonarr']['plex_users'])
+    save_module(module_path(project_root, 'sonarr'), sonarr)
+
+    radarr = data['radarr']
+    radarr['enabled'] = parsed['radarr']['enabled']
+    radarr['url'] = parsed['radarr']['url']
+    radarr['api_key'] = merge_secret(radarr.get('api_key'), parsed['radarr']['api_key_submitted'])
+    radarr['auto_sync'] = parsed['radarr']['auto_sync']
+    radarr['user_mode'] = parsed['radarr']['user_mode']
+    radarr['plex_users'] = parse_csv_list(parsed['radarr']['plex_users'])
+    save_module(module_path(project_root, 'radarr'), radarr)
+
+    trakt = data['trakt']
+    trakt['enabled'] = parsed['trakt']['enabled']
+    trakt['client_id'] = parsed['trakt']['client_id']
+    trakt['client_secret'] = merge_secret(trakt.get('client_secret'), parsed['trakt']['client_secret_submitted'])
+    export = trakt.get('export') or CommentedMap()
+    export['auto_sync'] = parsed['trakt']['auto_sync']
+    export['user_mode'] = parsed['trakt']['user_mode']
+    export['plex_users'] = parse_csv_list(parsed['trakt']['plex_users'])
+    trakt['export'] = export
+    save_module(module_path(project_root, 'trakt'), trakt)
+
+
+# =========================================================================
+# Users screen
+# =========================================================================
+#
+# NOTE for a future per-library (#157) pass: preferences are keyed only
+# by username today (preferences.<user>.exclude_genres/max_rating/...).
+# Adding a library dimension later means changing this one key shape
+# (e.g. preferences.<user>.<library>.exclude_genres) - _users_view/
+# _parse_users_form/_apply_users below are the only places that shape is
+# read or written, so that's a contained change when #157 lands.
+
+def _users_view(core: CommentedMap, overrides: Optional[Dict] = None) -> Dict:
+    if overrides is not None:
+        return {
+            'users': overrides['users'],
+            'new_username': overrides.get('new_username', ''),
+            'rating_choices': RATING_CHOICES,
+        }
+
+    users_section = core.get('users') or {}
+    raw_list = users_section.get('list', '')
+    if isinstance(raw_list, str):
+        usernames = [u.strip() for u in raw_list.split(',') if u.strip()]
+    else:
+        usernames = list(raw_list or [])
+
+    preferences = users_section.get('preferences') or {}
+    rows = []
+    for username in usernames:
+        prefs = preferences.get(username) or {}
+        rows.append({
+            'username': username,
+            'display_name': prefs.get('display_name', ''),
+            'exclude_genres': format_csv_list(prefs.get('exclude_genres')),
+            'max_rating': prefs.get('max_rating', ''),
+            'streaming_services': format_csv_list(prefs.get('streaming_services')),
+            'remove': False,
+        })
+    return {'users': rows, 'new_username': '', 'rating_choices': RATING_CHOICES}
+
+
+def _parse_users_form(form, errors: Dict[str, str]) -> Dict:
+    rows = []
+    count = int(form.get('user_count', '0') or '0')
+    for i in range(count):
+        username = form.get(f'username_{i}', '').strip()
+        if not username:
+            continue
+        remove = form.get(f'remove_{i}') in ('on', 'true', '1')
+        max_rating = form.get(f'max_rating_{i}', '').strip()
+        if max_rating and max_rating.upper() not in RATING_CHOICES:
+            errors[f'max_rating_{i}'] = f'{username}: must be one of {", ".join(RATING_CHOICES)} (or blank)'
+        rows.append({
+            'username': username,
+            'display_name': form.get(f'display_name_{i}', '').strip(),
+            'exclude_genres': form.get(f'exclude_genres_{i}', ''),
+            'max_rating': max_rating,
+            'streaming_services': form.get(f'streaming_services_{i}', ''),
+            'remove': remove,
+        })
+
+    new_username = form.get('new_username', '').strip()
+    if new_username:
+        if any(r['username'] == new_username for r in rows if not r['remove']):
+            errors['new_username'] = f'{new_username} is already in the user list'
+        rows.append({
+            'username': new_username,
+            'display_name': '',
+            'exclude_genres': '',
+            'max_rating': '',
+            'streaming_services': '',
+            'remove': False,
+        })
+
+    return {'users': rows, 'new_username': ''}
+
+
+def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> None:
+    core.setdefault('users', CommentedMap())
+    kept = [row for row in parsed['users'] if not row['remove']]
+
+    core['users']['list'] = ', '.join(row['username'] for row in kept)
+
+    preferences = core['users'].get('preferences')
+    if preferences is None:
+        preferences = CommentedMap()
+        core['users']['preferences'] = preferences
+
+    # Drop removed users' preferences entirely.
+    for row in parsed['users']:
+        if row['remove']:
+            preferences.pop(row['username'], None)
+
+    for row in kept:
+        entry = preferences.get(row['username'])
+        if entry is None:
+            entry = CommentedMap()
+            preferences[row['username']] = entry
+        entry['display_name'] = row['display_name'] or row['username']
+        exclude_genres = parse_csv_list(row['exclude_genres'])
+        if exclude_genres:
+            entry['exclude_genres'] = exclude_genres
+        else:
+            entry.pop('exclude_genres', None)
+        if row['max_rating']:
+            entry['max_rating'] = row['max_rating'].upper()
+        else:
+            entry.pop('max_rating', None)
+        streaming_services = parse_csv_list(row['streaming_services'])
+        if streaming_services:
+            entry['streaming_services'] = streaming_services
+        else:
+            entry.pop('streaming_services', None)
+
+    save_module(module_path(project_root, 'config'), core)
+
+
+# =========================================================================
+# Settings / Tuning screen
+# =========================================================================
+
+def _settings_view(tuning: CommentedMap, core: CommentedMap, sonarr: CommentedMap,
+                    radarr: CommentedMap, trakt: CommentedMap,
+                    overrides: Optional[Dict] = None) -> Dict:
+    if overrides is not None:
+        return overrides
+
+    movies = tuning.get('movies') or {}
+    tv = tuning.get('tv') or {}
+    movies_weights = movies.get('weights') or {}
+    tv_weights = tv.get('weights') or {}
+    movies_quality = movies.get('quality_filters') or {}
+    tv_quality = tv.get('quality_filters') or {}
+    recency = tuning.get('recency_decay') or {}
+    rating_mult = tuning.get('rating_multipliers') or {}
+    negsig = tuning.get('negative_signals') or {}
+    bad_ratings = negsig.get('bad_ratings') or {}
+    dropped_shows = negsig.get('dropped_shows') or {}
+    external = tuning.get('external_recommendations') or {}
+    general = core.get('general') or {}
+    logging_cfg = core.get('logging') or {}
+    trakt_export = trakt.get('export') or {}
+
+    return {
+        'movies': {
+            'weights': {
+                'genre': movies_weights.get('genre', 0.25),
+                'director': movies_weights.get('director', 0.05),
+                'actor': movies_weights.get('actor', 0.20),
+                'keyword': movies_weights.get('keyword', 0.50),
+            },
+            'limit_results': movies.get('limit_results', 50),
+            'min_rating': movies_quality.get('min_rating', 5.0),
+            'min_vote_count': movies_quality.get('min_vote_count', 50),
+        },
+        'tv': {
+            'weights': {
+                'genre': tv_weights.get('genre', 0.25),
+                'studio': tv_weights.get('studio', 0.10),
+                'actor': tv_weights.get('actor', 0.20),
+                'keyword': tv_weights.get('keyword', 0.45),
+            },
+            'limit_results': tv.get('limit_results', 20),
+            'min_rating': tv_quality.get('min_rating', 0.0),
+            'min_vote_count': tv_quality.get('min_vote_count', 0),
+        },
+        'recency': {
+            'enabled': bool(recency.get('enabled', True)),
+            'days_0_30': recency.get('days_0_30', 1.0),
+            'days_31_90': recency.get('days_31_90', 0.75),
+            'days_91_180': recency.get('days_91_180', 0.50),
+            'days_181_365': recency.get('days_181_365', 0.25),
+            'days_365_plus': recency.get('days_365_plus', 0.10),
+        },
+        'rating_multipliers': {
+            'star_5': rating_mult.get('star_5', 2.5),
+            'star_4': rating_mult.get('star_4', 1.7),
+            'star_3': rating_mult.get('star_3', 1.0),
+            'star_2': rating_mult.get('star_2', 0.4),
+            'star_1': rating_mult.get('star_1', 0.2),
+        },
+        'negative_signals': {
+            'enabled': bool(negsig.get('enabled', True)),
+            'bad_ratings_enabled': bool(bad_ratings.get('enabled', True)),
+            'bad_ratings_threshold': bad_ratings.get('threshold', 3),
+            'bad_ratings_cap_penalty': bad_ratings.get('cap_penalty', 0.5),
+            'dropped_enabled': bool(dropped_shows.get('enabled', True)),
+            'dropped_min_episodes': dropped_shows.get('min_episodes_watched', 2),
+            'dropped_max_completion': dropped_shows.get('max_completion_percent', 25),
+            'dropped_penalty_multiplier': dropped_shows.get('penalty_multiplier', -0.4),
+        },
+        'external': {
+            'enabled': bool(external.get('enabled', True)),
+            'movie_limit': external.get('movie_limit', 50),
+            'show_limit': external.get('show_limit', 20),
+            'min_relevance_score': external.get('min_relevance_score', 0.65),
+            'min_votes': external.get('min_votes', 50),
+            'max_iterations': external.get('max_iterations', 5),
+            'language': external.get('language') or '',
+            'auto_open_html': bool(external.get('auto_open_html', False)),
+        },
+        'general': {
+            'auto_update': bool(general.get('auto_update', False)),
+            'log_retention_days': general.get('log_retention_days', 7),
+            'plex_only': bool(general.get('plex_only', True)),
+        },
+        'logging': {
+            'level': logging_cfg.get('level', 'INFO'),
+        },
+        'sync_safety': {
+            'sonarr': {
+                'auto_sync': bool(sonarr.get('auto_sync', False)),
+                'user_mode': sonarr.get('user_mode', 'mapping'),
+                'plex_users': format_csv_list(sonarr.get('plex_users')),
+            },
+            'radarr': {
+                'auto_sync': bool(radarr.get('auto_sync', False)),
+                'user_mode': radarr.get('user_mode', 'mapping'),
+                'plex_users': format_csv_list(radarr.get('plex_users')),
+            },
+            'trakt': {
+                'auto_sync': bool(trakt_export.get('auto_sync', False)),
+                'user_mode': trakt_export.get('user_mode', 'mapping'),
+                'plex_users': format_csv_list(trakt_export.get('plex_users')),
+            },
+        },
+        'log_level_choices': LOG_LEVEL_CHOICES,
+        'user_mode_choices': USER_MODE_CHOICES,
+    }
+
+
+def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
+    def flag(name: str) -> bool:
+        return form.get(name) in ('on', 'true', '1')
+
+    def f(name, lo=None, hi=None, label=None):
+        # On a parse failure, redisplay whatever the user typed (instead of
+        # None) so the error-correction round trip doesn't show "None" in
+        # the field they need to fix.
+        parsed = validate_float(form.get(name), name, errors, lo=lo, hi=hi, label=label)
+        return parsed if parsed is not None else form.get(name, '')
+
+    def i(name, lo=None, hi=None, label=None):
+        parsed = validate_int(form.get(name), name, errors, lo=lo, hi=hi, label=label)
+        return parsed if parsed is not None else form.get(name, '')
+
+    movies_weight_fields = (
+        'movies_weight_genre', 'movies_weight_director', 'movies_weight_actor', 'movies_weight_keyword',
+    )
+    movies_weights = {
+        'genre': f('movies_weight_genre', 0, 1, 'Movie genre weight'),
+        'director': f('movies_weight_director', 0, 1, 'Movie director weight'),
+        'actor': f('movies_weight_actor', 0, 1, 'Movie actor weight'),
+        'keyword': f('movies_weight_keyword', 0, 1, 'Movie keyword weight'),
+    }
+    # Only check the sum if every individual weight parsed cleanly -
+    # summing raw invalid strings would raise instead of reporting a
+    # clean validation error.
+    if not any(field in errors for field in movies_weight_fields):
+        validate_weights_sum(movies_weights, 'movies_weights', errors)
+
+    tv_weight_fields = ('tv_weight_genre', 'tv_weight_studio', 'tv_weight_actor', 'tv_weight_keyword')
+    tv_weights = {
+        'genre': f('tv_weight_genre', 0, 1, 'TV genre weight'),
+        'studio': f('tv_weight_studio', 0, 1, 'TV studio weight'),
+        'actor': f('tv_weight_actor', 0, 1, 'TV actor weight'),
+        'keyword': f('tv_weight_keyword', 0, 1, 'TV keyword weight'),
+    }
+    if not any(field in errors for field in tv_weight_fields):
+        validate_weights_sum(tv_weights, 'tv_weights', errors)
+
+    movies = {
+        'weights': movies_weights,
+        'limit_results': i('movies_limit_results', 1, 1000, 'Movie result limit'),
+        'min_rating': f('movies_min_rating', 0, 10, 'Movie min rating'),
+        'min_vote_count': i('movies_min_vote_count', 0, None, 'Movie min vote count'),
+    }
+    tv = {
+        'weights': tv_weights,
+        'limit_results': i('tv_limit_results', 1, 1000, 'TV result limit'),
+        'min_rating': f('tv_min_rating', 0, 10, 'TV min rating'),
+        'min_vote_count': i('tv_min_vote_count', 0, None, 'TV min vote count'),
+    }
+    recency = {
+        'enabled': flag('recency_enabled'),
+        'days_0_30': f('recency_days_0_30', 0, None, '0-30 day weight'),
+        'days_31_90': f('recency_days_31_90', 0, None, '31-90 day weight'),
+        'days_91_180': f('recency_days_91_180', 0, None, '91-180 day weight'),
+        'days_181_365': f('recency_days_181_365', 0, None, '181-365 day weight'),
+        'days_365_plus': f('recency_days_365_plus', 0, None, '365+ day weight'),
+    }
+    rating_multipliers = {
+        'star_5': f('rating_star_5', 0, None, '5-star multiplier'),
+        'star_4': f('rating_star_4', 0, None, '4-star multiplier'),
+        'star_3': f('rating_star_3', 0, None, '3-star multiplier'),
+        'star_2': f('rating_star_2', 0, None, '2-star multiplier'),
+        'star_1': f('rating_star_1', 0, None, '1-star multiplier'),
+    }
+    negative_signals = {
+        'enabled': flag('negsig_enabled'),
+        'bad_ratings_enabled': flag('negsig_bad_ratings_enabled'),
+        'bad_ratings_threshold': i('negsig_bad_ratings_threshold', 0, 10, 'Bad rating threshold'),
+        'bad_ratings_cap_penalty': f('negsig_bad_ratings_cap_penalty', 0, 1, 'Bad rating cap penalty'),
+        'dropped_enabled': flag('negsig_dropped_enabled'),
+        'dropped_min_episodes': i('negsig_dropped_min_episodes', 0, None, 'Min episodes watched'),
+        'dropped_max_completion': i('negsig_dropped_max_completion', 0, 100, 'Max completion percent'),
+        'dropped_penalty_multiplier': f('negsig_dropped_penalty_multiplier', None, None, 'Dropped show penalty'),
+    }
+    external = {
+        'enabled': flag('ext_enabled'),
+        'movie_limit': i('ext_movie_limit', 0, None, 'External movie limit'),
+        'show_limit': i('ext_show_limit', 0, None, 'External show limit'),
+        'min_relevance_score': f('ext_min_relevance_score', 0, 1, 'Min relevance score'),
+        'min_votes': i('ext_min_votes', 0, None, 'Min votes'),
+        'max_iterations': i('ext_max_iterations', 1, None, 'Max iterations'),
+        'language': form.get('ext_language', '').strip(),
+        'auto_open_html': flag('ext_auto_open_html'),
+    }
+    general = {
+        'auto_update': flag('general_auto_update'),
+        'log_retention_days': i('general_log_retention_days', 0, None, 'Log retention days'),
+        'plex_only': flag('general_plex_only'),
+    }
+    logging_level = form.get('logging_level', 'INFO')
+    validate_choice(logging_level, 'logging_level', errors, LOG_LEVEL_CHOICES)
+
+    sync_safety = {}
+    for svc in ('sonarr', 'radarr', 'trakt'):
+        user_mode = form.get(f'{svc}_user_mode', 'mapping')
+        validate_choice(user_mode, f'{svc}_user_mode', errors, USER_MODE_CHOICES)
+        sync_safety[svc] = {
+            'auto_sync': flag(f'{svc}_auto_sync'),
+            'user_mode': user_mode,
+            'plex_users': format_csv_list(parse_csv_list(form.get(f'{svc}_plex_users', ''))),
+        }
+
+    return {
+        'movies': movies,
+        'tv': tv,
+        'recency': recency,
+        'rating_multipliers': rating_multipliers,
+        'negative_signals': negative_signals,
+        'external': external,
+        'general': general,
+        'logging': {'level': logging_level},
+        'sync_safety': sync_safety,
+        'log_level_choices': LOG_LEVEL_CHOICES,
+        'user_mode_choices': USER_MODE_CHOICES,
+    }
+
+
+def _apply_settings(project_root: str, tuning: CommentedMap, core: CommentedMap,
+                     sonarr: CommentedMap, radarr: CommentedMap, trakt: CommentedMap,
+                     parsed: Dict) -> None:
+    tuning.setdefault('movies', CommentedMap())
+    tuning['movies']['limit_results'] = parsed['movies']['limit_results']
+    tuning['movies'].setdefault('weights', CommentedMap())
+    tuning['movies']['weights'].update(parsed['movies']['weights'])
+    tuning['movies'].setdefault('quality_filters', CommentedMap())
+    tuning['movies']['quality_filters']['min_rating'] = parsed['movies']['min_rating']
+    tuning['movies']['quality_filters']['min_vote_count'] = parsed['movies']['min_vote_count']
+
+    tuning.setdefault('tv', CommentedMap())
+    tuning['tv']['limit_results'] = parsed['tv']['limit_results']
+    tuning['tv'].setdefault('weights', CommentedMap())
+    tuning['tv']['weights'].update(parsed['tv']['weights'])
+    tuning['tv'].setdefault('quality_filters', CommentedMap())
+    tuning['tv']['quality_filters']['min_rating'] = parsed['tv']['min_rating']
+    tuning['tv']['quality_filters']['min_vote_count'] = parsed['tv']['min_vote_count']
+
+    tuning.setdefault('recency_decay', CommentedMap())
+    tuning['recency_decay'].update(parsed['recency'])
+
+    tuning.setdefault('rating_multipliers', CommentedMap())
+    tuning['rating_multipliers'].update(parsed['rating_multipliers'])
+
+    ns = parsed['negative_signals']
+    tuning.setdefault('negative_signals', CommentedMap())
+    tuning['negative_signals']['enabled'] = ns['enabled']
+    tuning['negative_signals'].setdefault('bad_ratings', CommentedMap())
+    tuning['negative_signals']['bad_ratings']['enabled'] = ns['bad_ratings_enabled']
+    tuning['negative_signals']['bad_ratings']['threshold'] = ns['bad_ratings_threshold']
+    tuning['negative_signals']['bad_ratings']['cap_penalty'] = ns['bad_ratings_cap_penalty']
+    tuning['negative_signals'].setdefault('dropped_shows', CommentedMap())
+    tuning['negative_signals']['dropped_shows']['enabled'] = ns['dropped_enabled']
+    tuning['negative_signals']['dropped_shows']['min_episodes_watched'] = ns['dropped_min_episodes']
+    tuning['negative_signals']['dropped_shows']['max_completion_percent'] = ns['dropped_max_completion']
+    tuning['negative_signals']['dropped_shows']['penalty_multiplier'] = ns['dropped_penalty_multiplier']
+
+    ext = parsed['external']
+    tuning.setdefault('external_recommendations', CommentedMap())
+    tuning['external_recommendations']['enabled'] = ext['enabled']
+    tuning['external_recommendations']['movie_limit'] = ext['movie_limit']
+    tuning['external_recommendations']['show_limit'] = ext['show_limit']
+    tuning['external_recommendations']['min_relevance_score'] = ext['min_relevance_score']
+    tuning['external_recommendations']['min_votes'] = ext['min_votes']
+    tuning['external_recommendations']['max_iterations'] = ext['max_iterations']
+    tuning['external_recommendations']['language'] = ext['language'] or None
+    tuning['external_recommendations']['auto_open_html'] = ext['auto_open_html']
+
+    save_module(module_path(project_root, 'tuning'), tuning)
+
+    core.setdefault('general', CommentedMap())
+    core['general'].update(parsed['general'])
+    core.setdefault('logging', CommentedMap())
+    core['logging']['level'] = parsed['logging']['level']
+    save_module(module_path(project_root, 'config'), core)
+
+    sonarr['auto_sync'] = parsed['sync_safety']['sonarr']['auto_sync']
+    sonarr['user_mode'] = parsed['sync_safety']['sonarr']['user_mode']
+    sonarr['plex_users'] = parse_csv_list(parsed['sync_safety']['sonarr']['plex_users'])
+    save_module(module_path(project_root, 'sonarr'), sonarr)
+
+    radarr['auto_sync'] = parsed['sync_safety']['radarr']['auto_sync']
+    radarr['user_mode'] = parsed['sync_safety']['radarr']['user_mode']
+    radarr['plex_users'] = parse_csv_list(parsed['sync_safety']['radarr']['plex_users'])
+    save_module(module_path(project_root, 'radarr'), radarr)
+
+    trakt_export = trakt.get('export') or CommentedMap()
+    trakt_export['auto_sync'] = parsed['sync_safety']['trakt']['auto_sync']
+    trakt_export['user_mode'] = parsed['sync_safety']['trakt']['user_mode']
+    trakt_export['plex_users'] = parse_csv_list(parsed['sync_safety']['trakt']['plex_users'])
+    trakt['export'] = trakt_export
+    save_module(module_path(project_root, 'trakt'), trakt)

--- a/web/config_io.py
+++ b/web/config_io.py
@@ -1,0 +1,127 @@
+"""Round-trip YAML load/save for the web UI config screens.
+
+utils.config.load_config (used for *reading* at run time) uses plain
+pyyaml safe_load/dump, which is fine for the recommenders but would
+silently drop every comment in config.yml/tuning.yml/sonarr.yml/
+radarr.yml/trakt.yml if used to *write* them back out. This module uses
+ruamel.yaml's round-trip mode instead: load a file into a CommentedMap,
+mutate only the keys a given screen owns, and dump the same object back
+out - untouched keys, comments, and ordering all survive.
+
+Writes are atomic: dumped to a temp file in the same directory, then
+os.replace()'d over the target, so a crash mid-write (or a validation
+bug that slips through) never leaves a half-written config file behind.
+"""
+
+import os
+import tempfile
+from typing import Optional
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+# Matches the plain-yaml.dump() formatting the rest of the codebase
+# already produces (utils/migrate_config.py, config.example.yml, etc.):
+# list items at the same column as their parent key, not indented an
+# extra level under the dash.
+_yaml = YAML()
+_yaml.preserve_quotes = True
+_yaml.indent(mapping=2, sequence=2, offset=0)
+_yaml.width = 4096  # don't hard-wrap long values (URLs, tokens)
+
+# Config keys the web UI never renders in HTML and never overwrites with
+# a blank submitted value (blank means "keep the existing secret").
+SECRET_KEYS = frozenset({
+    'token', 'api_key', 'client_secret', 'access_token', 'refresh_token', 'password',
+})
+
+# Module file name -> which top-level config key it lives under once
+# loaded, mirroring utils.config._load_module_configs. 'config' is the
+# root file itself (plex/tmdb/tautulli/users/general live there
+# directly, not merged under a module key).
+MODULE_FILES = ('config', 'tuning', 'sonarr', 'radarr', 'trakt')
+
+
+def config_dir(project_root: str) -> str:
+    return os.path.join(project_root, 'config')
+
+
+def module_path(project_root: str, name: str) -> str:
+    """*name* is one of MODULE_FILES ('config', 'tuning', 'sonarr', ...)."""
+    if name not in MODULE_FILES:
+        raise ValueError(f"Unknown config module: {name}")
+    return os.path.join(config_dir(project_root), f'{name}.yml')
+
+
+def load_module(path: str) -> CommentedMap:
+    """Load one YAML module file in round-trip mode.
+
+    Returns an empty CommentedMap (not an error) if the file doesn't
+    exist yet - module files (tuning.yml, trakt.yml, radarr.yml,
+    sonarr.yml) are all optional, and a fresh install may not have them.
+    """
+    if not os.path.isfile(path):
+        return CommentedMap()
+    with open(path, 'r', encoding='utf-8') as f:
+        data = _yaml.load(f)
+    return data if data is not None else CommentedMap()
+
+
+def save_module(path: str, data: CommentedMap) -> None:
+    """Atomically write *data* to *path* as round-trip YAML.
+
+    Writes to a temp file in the same directory first, then renames it
+    over the target - a crash partway through never corrupts the
+    existing file, and readers never see a partially-written one.
+    """
+    directory = os.path.dirname(path) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix='.tmp-', suffix='.yml', dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            _yaml.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
+
+def is_secret_field(key: str) -> bool:
+    return key in SECRET_KEYS
+
+
+def merge_secret(existing: Optional[str], submitted: Optional[str]) -> str:
+    """A blank submitted value keeps the existing secret; non-blank overwrites.
+
+    This is the one rule that lets the UI show a "value configured, enter
+    a new one to change it" field instead of ever round-tripping a real
+    secret through the browser.
+    """
+    submitted = (submitted or '').strip()
+    if not submitted:
+        return existing or ''
+    return submitted
+
+
+def secret_status(value: Optional[str]) -> str:
+    """'configured' / 'not set' - for display only, never the value itself."""
+    return 'configured' if (value or '').strip() else 'not set'
+
+
+def parse_csv_list(value: Optional[str]) -> list:
+    """'a, b, c' -> ['a', 'b', 'c'], dropping blanks. Used for the small
+    comma-separated list fields (plex_users, exclude_genres, etc.)."""
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def format_csv_list(value) -> str:
+    """Inverse of parse_csv_list, for pre-filling a text input from a
+    YAML list (or a legacy comma-string) on GET."""
+    if not value:
+        return ''
+    if isinstance(value, str):
+        return value
+    return ', '.join(str(item) for item in value)

--- a/web/config_test_connection.py
+++ b/web/config_test_connection.py
@@ -1,0 +1,124 @@
+"""Test Connection checks for the Setup / Connections screen.
+
+Reuses the same client classes/helpers the recommenders use at run time
+(utils.plex.init_plex, utils.radarr.RadarrClient, etc.) so "Test
+Connection" in the browser exercises exactly the same code path a real
+run would. Every check here is read-only - it confirms the given
+credentials can reach the service, it never writes/adds/removes
+anything.
+
+Each test_* function takes raw candidate values (not the saved config)
+so a user can check a URL/token before saving it. web/config_app.py is
+responsible for merging a blank "keep existing secret" submission with
+the already-saved value before calling in here.
+"""
+
+import logging
+from typing import Callable, Dict
+
+from utils.plex import init_plex
+from utils.radarr import RadarrAPIError, RadarrClient
+from utils.sonarr import SonarrAPIError, SonarrClient
+from utils.tautulli import TautulliAPIError, TautulliClient
+from utils.tmdb import fetch_tmdb_with_retry
+from utils.trakt import TraktClient
+
+from .security import redact
+
+logger = logging.getLogger('curatarr')
+
+
+def _connection_failed(exc: Exception, service: str) -> Dict:
+    """Build the {ok, message} failure result for a raised client
+    exception, redacting it first - some client errors can echo the
+    request URL (e.g. Plex's X-Plex-Token as a query param), and this
+    message is both logged server-side and shown in the browser."""
+    message = redact(f'Connection failed: {exc}')
+    logger.debug(f"{service} test connection failed: {message}")
+    return {'ok': False, 'message': message}
+
+
+def test_plex(url: str, token: str) -> Dict:
+    if not url or not token:
+        return {'ok': False, 'message': 'URL and token are required'}
+    try:
+        server = init_plex({'plex': {'url': url, 'token': token}})
+        count = len(server.library.sections())
+        return {'ok': True, 'message': f'Connected - {count} librar{"y" if count == 1 else "ies"} found'}
+    except Exception as exc:
+        return _connection_failed(exc, 'Plex')
+
+
+def test_tmdb(api_key: str) -> Dict:
+    if not api_key:
+        return {'ok': False, 'message': 'API key is required'}
+    result = fetch_tmdb_with_retry(
+        'https://api.themoviedb.org/3/configuration', {'api_key': api_key},
+        max_retries=1, timeout=8,
+    )
+    if result:
+        return {'ok': True, 'message': 'Connected to TMDB'}
+    return {'ok': False, 'message': 'Could not authenticate with TMDB - check the API key'}
+
+
+def test_tautulli(url: str, api_key: str) -> Dict:
+    if not url or not api_key:
+        return {'ok': False, 'message': 'URL and API key are required'}
+    try:
+        client = TautulliClient(url, api_key)
+        users = client.get_users()
+        return {'ok': True, 'message': f'Connected - {len(users)} Tautulli user(s) found'}
+    except Exception as exc:
+        return _connection_failed(exc, 'Tautulli')
+
+
+def test_sonarr(url: str, api_key: str) -> Dict:
+    if not url or not api_key:
+        return {'ok': False, 'message': 'URL and API key are required'}
+    try:
+        SonarrClient(url, api_key).test_connection()
+        return {'ok': True, 'message': 'Connected to Sonarr'}
+    except Exception as exc:
+        return _connection_failed(exc, 'Sonarr')
+
+
+def test_radarr(url: str, api_key: str) -> Dict:
+    if not url or not api_key:
+        return {'ok': False, 'message': 'URL and API key are required'}
+    try:
+        RadarrClient(url, api_key).test_connection()
+        return {'ok': True, 'message': 'Connected to Radarr'}
+    except Exception as exc:
+        return _connection_failed(exc, 'Radarr')
+
+
+def test_trakt(client_id: str, client_secret: str, access_token: str, refresh_token: str) -> Dict:
+    if not client_id or not client_secret:
+        return {'ok': False, 'message': 'Client ID and client secret are required'}
+    if not access_token:
+        return {
+            'ok': False,
+            'message': "Not authenticated yet - run 'python3 -m utils.trakt_auth' to link your Trakt account",
+        }
+    client = TraktClient(client_id, client_secret, access_token, refresh_token)
+    username = client.get_username()
+    if username:
+        return {'ok': True, 'message': f'Connected as {username}'}
+    return {
+        'ok': False,
+        'message': "Connection failed - token may be expired. Re-run 'python3 -m utils.trakt_auth'",
+    }
+
+
+# service name -> (test_fn, required form field names in order)
+TESTERS: Dict[str, Callable] = {
+    'plex': lambda f: test_plex(f.get('url', ''), f.get('token', '')),
+    'tmdb': lambda f: test_tmdb(f.get('api_key', '')),
+    'tautulli': lambda f: test_tautulli(f.get('url', ''), f.get('api_key', '')),
+    'sonarr': lambda f: test_sonarr(f.get('url', ''), f.get('api_key', '')),
+    'radarr': lambda f: test_radarr(f.get('url', ''), f.get('api_key', '')),
+    'trakt': lambda f: test_trakt(
+        f.get('client_id', ''), f.get('client_secret', ''),
+        f.get('access_token', ''), f.get('refresh_token', ''),
+    ),
+}

--- a/web/config_validate.py
+++ b/web/config_validate.py
@@ -1,0 +1,86 @@
+"""Field-level validation for the config screens.
+
+This is a companion to, not a replacement for, utils.migrate_config -
+that module validates config.yml's overall *shape* (monolithic vs.
+modular layout). Nothing in the existing codebase validates individual
+field values (weights summing to 1.0, well-formed URLs, etc.) before
+writing them out, so web/config_app.py uses these helpers to reject bad
+input before it ever reaches config_io.save_module.
+
+Every validate_* function appends to a shared `errors` dict of
+field_name -> message instead of raising immediately, so a form
+submission can report every problem at once instead of one at a time.
+"""
+
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from utils import WEIGHT_SUM_TOLERANCE
+
+
+class ValidationError(Exception):
+    """Raised with a field -> message dict when a submitted form is invalid."""
+
+    def __init__(self, errors: Dict[str, str]):
+        self.errors = errors
+        super().__init__('; '.join(f'{k}: {v}' for k, v in errors.items()))
+
+
+def validate_url(value: str, field: str, errors: Dict[str, str], required: bool = False) -> None:
+    value = (value or '').strip()
+    if not value:
+        if required:
+            errors[field] = 'URL is required'
+        return
+    parsed = urlparse(value)
+    if parsed.scheme not in ('http', 'https') or not parsed.netloc:
+        errors[field] = 'Must be a valid http:// or https:// URL'
+
+
+def validate_required(value: Optional[str], field: str, errors: Dict[str, str], label: str = None) -> None:
+    if not (value or '').strip():
+        errors[field] = f'{label or field} is required'
+
+
+def validate_choice(value: str, field: str, errors: Dict[str, str], choices) -> None:
+    if value not in choices:
+        errors[field] = f'Must be one of: {", ".join(choices)}'
+
+
+def validate_float(value, field: str, errors: Dict[str, str], lo: float = None,
+                    hi: float = None, label: str = None) -> Optional[float]:
+    """Parse *value* as a float, recording an error and returning None on
+    failure so callers can skip using an invalid value downstream."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        errors[field] = f'{label or field} must be a number'
+        return None
+    if lo is not None and parsed < lo:
+        errors[field] = f'{label or field} must be >= {lo}'
+    elif hi is not None and parsed > hi:
+        errors[field] = f'{label or field} must be <= {hi}'
+    return parsed
+
+
+def validate_int(value, field: str, errors: Dict[str, str], lo: int = None,
+                  hi: int = None, label: str = None) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        errors[field] = f'{label or field} must be a whole number'
+        return None
+    if lo is not None and parsed < lo:
+        errors[field] = f'{label or field} must be >= {lo}'
+    elif hi is not None and parsed > hi:
+        errors[field] = f'{label or field} must be <= {hi}'
+    return parsed
+
+
+def validate_weights_sum(weights: Dict[str, float], field: str, errors: Dict[str, str]) -> None:
+    """Mirrors recommenders/base.py's own sum-to-1.0 check (WEIGHT_SUM_TOLERANCE),
+    but rejects the save outright instead of just logging a warning - a
+    UI-driven typo shouldn't silently skew every recommendation."""
+    total = sum(float(v) for v in weights.values())
+    if abs(total - 1.0) > WEIGHT_SUM_TOLERANCE:
+        errors[field] = f'Weights must sum to 1.0 (currently {total:.4f})'

--- a/web/static/config.js
+++ b/web/static/config.js
@@ -1,0 +1,49 @@
+// Connections screen behavior: "Test Connection" buttons POST the
+// relevant fields (as currently typed, not yet saved) to
+// /config/test/<service> and show the ok/fail message inline.
+(function () {
+  function fieldValue(name) {
+    var el = document.querySelector('[name="' + name + '"]');
+    return el ? el.value : '';
+  }
+
+  document.querySelectorAll('.test-connection').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var service = btn.dataset.service;
+      var fieldMap = JSON.parse(btn.dataset.fieldMap || '{}');
+      var payload = {};
+      Object.keys(fieldMap).forEach(function (key) {
+        payload[key] = fieldValue(fieldMap[key]);
+      });
+
+      var resultEl = document.querySelector('.test-result[data-result-for="' + service + '"]');
+      if (resultEl) {
+        resultEl.textContent = 'Testing...';
+        resultEl.className = 'test-result';
+      }
+      btn.disabled = true;
+
+      fetch('/config/test/' + service, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(payload).toString(),
+      })
+        .then(function (resp) { return resp.json(); })
+        .then(function (data) {
+          if (resultEl) {
+            resultEl.textContent = data.message;
+            resultEl.className = 'test-result ' + (data.ok ? 'ok' : 'fail');
+          }
+        })
+        .catch(function () {
+          if (resultEl) {
+            resultEl.textContent = 'Request failed';
+            resultEl.className = 'test-result fail';
+          }
+        })
+        .finally(function () {
+          btn.disabled = false;
+        });
+    });
+  });
+})();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -112,6 +112,69 @@ form select {
 
 .banner.running { background: rgba(79, 140, 255, 0.15); }
 .banner.error { background: rgba(229, 83, 75, 0.15); color: var(--fail); }
+.banner.warn { background: rgba(216, 161, 42, 0.15); color: var(--warn); }
+
+.config-form fieldset {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 16px 16px;
+  margin-bottom: 16px;
+}
+
+.config-form legend {
+  padding: 0 6px;
+  font-weight: 600;
+}
+
+.config-form h3 {
+  font-size: 0.95rem;
+  color: var(--muted);
+  margin: 12px 0 4px;
+}
+
+.config-form label {
+  display: block;
+  margin: 8px 0;
+  color: var(--muted);
+}
+
+.config-form input[type="text"],
+.config-form input[type="password"] {
+  display: block;
+  margin-top: 4px;
+  padding: 6px;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.config-form input[type="checkbox"] {
+  margin-right: 6px;
+}
+
+.field-error {
+  color: var(--fail);
+  font-size: 0.85rem;
+  margin: 2px 0 8px;
+}
+
+.test-result {
+  margin-left: 10px;
+  font-size: 0.85rem;
+}
+
+.test-result.ok { color: var(--ok); }
+.test-result.fail { color: var(--fail); }
+
+.sync-safety-row {
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+  margin-top: 8px;
+}
+.sync-safety-row:first-of-type { border-top: none; margin-top: 0; }
 
 .log-output {
   background: #0b0d11;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -13,6 +13,9 @@
       <a href="{{ url_for('dashboard') }}">Dashboard</a>
       <a href="{{ url_for('run_form') }}">Run</a>
       <a href="{{ url_for('results') }}">Results</a>
+      <a href="{{ url_for('config_connections') }}">Connections</a>
+      <a href="{{ url_for('config_users') }}">Users</a>
+      <a href="{{ url_for('config_settings') }}">Settings</a>
     </nav>
   </header>
   <main>

--- a/web/templates/config_connections.html
+++ b/web/templates/config_connections.html
@@ -1,0 +1,162 @@
+{% extends 'base.html' %}
+{% block title %}Connections - Curatarr{% endblock %}
+{% block content %}
+<h1>Setup / Connections</h1>
+
+{% if saved %}
+<p class="banner running">Saved.</p>
+{% endif %}
+{% if errors['_global'] %}
+<p class="banner error">{{ errors['_global'] }}</p>
+{% endif %}
+
+<form method="post" action="{{ url_for('config_connections_save') }}" class="config-form">
+
+  <fieldset>
+    <legend>Plex</legend>
+    <label>Server URL
+      <input type="text" name="plex_url" value="{{ plex.url }}" placeholder="http://localhost:32400">
+    </label>
+    {% if errors.plex_url %}<p class="field-error">{{ errors.plex_url }}</p>{% endif %}
+
+    <label>Token ({{ plex.token_status }})
+      <input type="password" name="plex_token" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+
+    <label>Movie library
+      <input type="text" name="plex_movie_library" value="{{ plex.movie_library }}">
+    </label>
+    {% if errors.plex_movie_library %}<p class="field-error">{{ errors.plex_movie_library }}</p>{% endif %}
+
+    <label>TV library
+      <input type="text" name="plex_tv_library" value="{{ plex.tv_library }}">
+    </label>
+    {% if errors.plex_tv_library %}<p class="field-error">{{ errors.plex_tv_library }}</p>{% endif %}
+
+    <button type="button" class="test-connection" data-service="plex"
+            data-field-map='{"url": "plex_url", "token": "plex_token"}'>Test Connection</button>
+    <span class="test-result" data-result-for="plex"></span>
+  </fieldset>
+
+  <fieldset>
+    <legend>TMDB</legend>
+    <label>API key ({{ tmdb.api_key_status }})
+      <input type="password" name="tmdb_api_key" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+    <button type="button" class="test-connection" data-service="tmdb"
+            data-field-map='{"api_key": "tmdb_api_key"}'>Test Connection</button>
+    <span class="test-result" data-result-for="tmdb"></span>
+  </fieldset>
+
+  <fieldset>
+    <legend>Tautulli</legend>
+    <label><input type="checkbox" name="tautulli_enabled" {% if tautulli.enabled %}checked{% endif %}> Enabled</label>
+    <label>URL
+      <input type="text" name="tautulli_url" value="{{ tautulli.url }}" placeholder="http://localhost:8181">
+    </label>
+    {% if errors.tautulli_url %}<p class="field-error">{{ errors.tautulli_url }}</p>{% endif %}
+    <label>API key ({{ tautulli.api_key_status }})
+      <input type="password" name="tautulli_api_key" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+    <button type="button" class="test-connection" data-service="tautulli"
+            data-field-map='{"url": "tautulli_url", "api_key": "tautulli_api_key"}'>Test Connection</button>
+    <span class="test-result" data-result-for="tautulli"></span>
+  </fieldset>
+
+  <fieldset>
+    <legend>Sonarr</legend>
+    <label><input type="checkbox" name="sonarr_enabled" {% if sonarr.enabled %}checked{% endif %}> Enabled</label>
+    <label>URL
+      <input type="text" name="sonarr_url" value="{{ sonarr.url }}" placeholder="http://localhost:8989">
+    </label>
+    {% if errors.sonarr_url %}<p class="field-error">{{ errors.sonarr_url }}</p>{% endif %}
+    <label>API key ({{ sonarr.api_key_status }})
+      <input type="password" name="sonarr_api_key" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+    <button type="button" class="test-connection" data-service="sonarr"
+            data-field-map='{"url": "sonarr_url", "api_key": "sonarr_api_key"}'>Test Connection</button>
+    <span class="test-result" data-result-for="sonarr"></span>
+
+    <p class="muted">Sync-safety fields (also editable, with more context, on the Settings screen):</p>
+    <label><input type="checkbox" name="sonarr_auto_sync" {% if sonarr.auto_sync %}checked{% endif %}> Auto-sync every run</label>
+    <label>User mode
+      <select name="sonarr_user_mode">
+        {% for choice in user_mode_choices %}
+        <option value="{{ choice }}" {% if sonarr.user_mode == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if errors.sonarr_user_mode %}<p class="field-error">{{ errors.sonarr_user_mode }}</p>{% endif %}
+    <label>Plex users to sync (comma-separated)
+      <input type="text" name="sonarr_plex_users" value="{{ sonarr.plex_users }}">
+    </label>
+  </fieldset>
+
+  <fieldset>
+    <legend>Radarr</legend>
+    <label><input type="checkbox" name="radarr_enabled" {% if radarr.enabled %}checked{% endif %}> Enabled</label>
+    <label>URL
+      <input type="text" name="radarr_url" value="{{ radarr.url }}" placeholder="http://localhost:7878">
+    </label>
+    {% if errors.radarr_url %}<p class="field-error">{{ errors.radarr_url }}</p>{% endif %}
+    <label>API key ({{ radarr.api_key_status }})
+      <input type="password" name="radarr_api_key" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+    <button type="button" class="test-connection" data-service="radarr"
+            data-field-map='{"url": "radarr_url", "api_key": "radarr_api_key"}'>Test Connection</button>
+    <span class="test-result" data-result-for="radarr"></span>
+
+    <p class="muted">Sync-safety fields (also editable, with more context, on the Settings screen):</p>
+    <label><input type="checkbox" name="radarr_auto_sync" {% if radarr.auto_sync %}checked{% endif %}> Auto-sync every run</label>
+    <label>User mode
+      <select name="radarr_user_mode">
+        {% for choice in user_mode_choices %}
+        <option value="{{ choice }}" {% if radarr.user_mode == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if errors.radarr_user_mode %}<p class="field-error">{{ errors.radarr_user_mode }}</p>{% endif %}
+    <label>Plex users to sync (comma-separated)
+      <input type="text" name="radarr_plex_users" value="{{ radarr.plex_users }}">
+    </label>
+  </fieldset>
+
+  <fieldset>
+    <legend>Trakt</legend>
+    <label><input type="checkbox" name="trakt_enabled" {% if trakt.enabled %}checked{% endif %}> Enabled</label>
+    <label>Client ID
+      <input type="text" name="trakt_client_id" value="{{ trakt.client_id }}">
+    </label>
+    {% if errors.trakt_client_id %}<p class="field-error">{{ errors.trakt_client_id }}</p>{% endif %}
+    <label>Client secret ({{ trakt.client_secret_status }})
+      <input type="password" name="trakt_client_secret" placeholder="Leave blank to keep existing" autocomplete="off">
+    </label>
+    <p class="muted">
+      Account link: {{ trakt.access_token_status }}.
+      Run <code>python3 -m utils.trakt_auth</code> from the project root to link/relink a Trakt account
+      (device-code OAuth can't be completed from this form).
+    </p>
+    <button type="button" class="test-connection" data-service="trakt"
+            data-field-map='{"client_id": "trakt_client_id", "client_secret": "trakt_client_secret"}'>Test Connection</button>
+    <span class="test-result" data-result-for="trakt"></span>
+
+    <p class="muted">Sync-safety fields (also editable, with more context, on the Settings screen):</p>
+    <label><input type="checkbox" name="trakt_auto_sync" {% if trakt.auto_sync %}checked{% endif %}> Auto-sync every run</label>
+    <label>User mode
+      <select name="trakt_user_mode">
+        {% for choice in user_mode_choices %}
+        <option value="{{ choice }}" {% if trakt.user_mode == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if errors.trakt_user_mode %}<p class="field-error">{{ errors.trakt_user_mode }}</p>{% endif %}
+    <label>Plex users to sync (comma-separated)
+      <input type="text" name="trakt_plex_users" value="{{ trakt.plex_users }}">
+    </label>
+  </fieldset>
+
+  <button type="submit">Save</button>
+</form>
+
+<script src="{{ url_for('static', filename='config.js') }}"></script>
+{% endblock %}

--- a/web/templates/config_settings.html
+++ b/web/templates/config_settings.html
@@ -1,0 +1,168 @@
+{% extends 'base.html' %}
+{% block title %}Settings - Curatarr{% endblock %}
+{% block content %}
+<h1>Settings / Tuning</h1>
+
+{% if saved %}
+<p class="banner running">Saved.</p>
+{% endif %}
+{% if errors['_global'] %}
+<p class="banner error">{{ errors['_global'] }}</p>
+{% endif %}
+
+<form method="post" action="{{ url_for('config_settings_save') }}" class="config-form">
+
+  <fieldset>
+    <legend>Export safety - Sonarr / Radarr / Trakt</legend>
+    <p class="banner warn">
+      Turning <strong>Auto-sync</strong> ON here means curatarr starts writing to your
+      download clients (adding movies/shows to Sonarr/Radarr, or syncing lists to Trakt) on
+      every run, with no confirmation prompt. <strong>User mode</strong> and
+      <strong>Plex users</strong> control whose recommendations get synced - double-check
+      both before enabling auto-sync for anyone but yourself.
+    </p>
+
+    {% for svc in ['sonarr', 'radarr', 'trakt'] %}
+    <div class="sync-safety-row">
+      <h3>{{ svc|capitalize }}</h3>
+      <label>
+        <input type="checkbox" name="{{ svc }}_auto_sync" {% if sync_safety[svc].auto_sync %}checked{% endif %}>
+        Auto-sync every run
+      </label>
+      <label>User mode
+        <select name="{{ svc }}_user_mode">
+          {% for choice in user_mode_choices %}
+          <option value="{{ choice }}" {% if sync_safety[svc].user_mode == choice %}selected{% endif %}>{{ choice }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      {% if errors[svc ~ '_user_mode'] %}<p class="field-error">{{ errors[svc ~ '_user_mode'] }}</p>{% endif %}
+      <label>Plex users to sync (comma-separated, used when user mode is "mapping")
+        <input type="text" name="{{ svc }}_plex_users" value="{{ sync_safety[svc].plex_users }}">
+      </label>
+    </div>
+    {% endfor %}
+  </fieldset>
+
+  <fieldset>
+    <legend>Movie scoring weights (must sum to 1.0)</legend>
+    <label>Genre <input type="text" name="movies_weight_genre" value="{{ movies.weights.genre }}"></label>
+    <label>Director <input type="text" name="movies_weight_director" value="{{ movies.weights.director }}"></label>
+    <label>Actor <input type="text" name="movies_weight_actor" value="{{ movies.weights.actor }}"></label>
+    <label>Keyword <input type="text" name="movies_weight_keyword" value="{{ movies.weights.keyword }}"></label>
+    {% for f in ['movies_weight_genre', 'movies_weight_director', 'movies_weight_actor', 'movies_weight_keyword', 'movies_weights'] %}
+      {% if errors[f] %}<p class="field-error">{{ errors[f] }}</p>{% endif %}
+    {% endfor %}
+
+    <label>Result limit <input type="text" name="movies_limit_results" value="{{ movies.limit_results }}"></label>
+    {% if errors.movies_limit_results %}<p class="field-error">{{ errors.movies_limit_results }}</p>{% endif %}
+    <label>Min TMDB rating <input type="text" name="movies_min_rating" value="{{ movies.min_rating }}"></label>
+    {% if errors.movies_min_rating %}<p class="field-error">{{ errors.movies_min_rating }}</p>{% endif %}
+    <label>Min vote count <input type="text" name="movies_min_vote_count" value="{{ movies.min_vote_count }}"></label>
+    {% if errors.movies_min_vote_count %}<p class="field-error">{{ errors.movies_min_vote_count }}</p>{% endif %}
+  </fieldset>
+
+  <fieldset>
+    <legend>TV scoring weights (must sum to 1.0)</legend>
+    <label>Genre <input type="text" name="tv_weight_genre" value="{{ tv.weights.genre }}"></label>
+    <label>Studio <input type="text" name="tv_weight_studio" value="{{ tv.weights.studio }}"></label>
+    <label>Actor <input type="text" name="tv_weight_actor" value="{{ tv.weights.actor }}"></label>
+    <label>Keyword <input type="text" name="tv_weight_keyword" value="{{ tv.weights.keyword }}"></label>
+    {% for f in ['tv_weight_genre', 'tv_weight_studio', 'tv_weight_actor', 'tv_weight_keyword', 'tv_weights'] %}
+      {% if errors[f] %}<p class="field-error">{{ errors[f] }}</p>{% endif %}
+    {% endfor %}
+
+    <label>Result limit <input type="text" name="tv_limit_results" value="{{ tv.limit_results }}"></label>
+    {% if errors.tv_limit_results %}<p class="field-error">{{ errors.tv_limit_results }}</p>{% endif %}
+    <label>Min TMDB rating <input type="text" name="tv_min_rating" value="{{ tv.min_rating }}"></label>
+    {% if errors.tv_min_rating %}<p class="field-error">{{ errors.tv_min_rating }}</p>{% endif %}
+    <label>Min vote count <input type="text" name="tv_min_vote_count" value="{{ tv.min_vote_count }}"></label>
+    {% if errors.tv_min_vote_count %}<p class="field-error">{{ errors.tv_min_vote_count }}</p>{% endif %}
+  </fieldset>
+
+  <fieldset>
+    <legend>Recency decay</legend>
+    <label><input type="checkbox" name="recency_enabled" {% if recency.enabled %}checked{% endif %}> Enabled</label>
+    <label>0-30 days <input type="text" name="recency_days_0_30" value="{{ recency.days_0_30 }}"></label>
+    <label>31-90 days <input type="text" name="recency_days_31_90" value="{{ recency.days_31_90 }}"></label>
+    <label>91-180 days <input type="text" name="recency_days_91_180" value="{{ recency.days_91_180 }}"></label>
+    <label>181-365 days <input type="text" name="recency_days_181_365" value="{{ recency.days_181_365 }}"></label>
+    <label>365+ days <input type="text" name="recency_days_365_plus" value="{{ recency.days_365_plus }}"></label>
+    {% for f in ['recency_days_0_30', 'recency_days_31_90', 'recency_days_91_180', 'recency_days_181_365', 'recency_days_365_plus'] %}
+      {% if errors[f] %}<p class="field-error">{{ errors[f] }}</p>{% endif %}
+    {% endfor %}
+  </fieldset>
+
+  <fieldset>
+    <legend>Rating multipliers (5-star scale)</legend>
+    <label>5 star <input type="text" name="rating_star_5" value="{{ rating_multipliers.star_5 }}"></label>
+    <label>4 star <input type="text" name="rating_star_4" value="{{ rating_multipliers.star_4 }}"></label>
+    <label>3 star <input type="text" name="rating_star_3" value="{{ rating_multipliers.star_3 }}"></label>
+    <label>2 star <input type="text" name="rating_star_2" value="{{ rating_multipliers.star_2 }}"></label>
+    <label>1 star <input type="text" name="rating_star_1" value="{{ rating_multipliers.star_1 }}"></label>
+    {% for f in ['rating_star_5', 'rating_star_4', 'rating_star_3', 'rating_star_2', 'rating_star_1'] %}
+      {% if errors[f] %}<p class="field-error">{{ errors[f] }}</p>{% endif %}
+    {% endfor %}
+  </fieldset>
+
+  <fieldset>
+    <legend>Negative signals</legend>
+    <label><input type="checkbox" name="negsig_enabled" {% if negative_signals.enabled %}checked{% endif %}> Enabled</label>
+
+    <h3>Bad ratings</h3>
+    <label><input type="checkbox" name="negsig_bad_ratings_enabled" {% if negative_signals.bad_ratings_enabled %}checked{% endif %}> Enabled</label>
+    <label>Threshold (Plex 0-10 scale) <input type="text" name="negsig_bad_ratings_threshold" value="{{ negative_signals.bad_ratings_threshold }}"></label>
+    {% if errors.negsig_bad_ratings_threshold %}<p class="field-error">{{ errors.negsig_bad_ratings_threshold }}</p>{% endif %}
+    <label>Cap penalty <input type="text" name="negsig_bad_ratings_cap_penalty" value="{{ negative_signals.bad_ratings_cap_penalty }}"></label>
+    {% if errors.negsig_bad_ratings_cap_penalty %}<p class="field-error">{{ errors.negsig_bad_ratings_cap_penalty }}</p>{% endif %}
+
+    <h3>Dropped shows</h3>
+    <label><input type="checkbox" name="negsig_dropped_enabled" {% if negative_signals.dropped_enabled %}checked{% endif %}> Enabled</label>
+    <label>Min episodes watched <input type="text" name="negsig_dropped_min_episodes" value="{{ negative_signals.dropped_min_episodes }}"></label>
+    {% if errors.negsig_dropped_min_episodes %}<p class="field-error">{{ errors.negsig_dropped_min_episodes }}</p>{% endif %}
+    <label>Max completion percent <input type="text" name="negsig_dropped_max_completion" value="{{ negative_signals.dropped_max_completion }}"></label>
+    {% if errors.negsig_dropped_max_completion %}<p class="field-error">{{ errors.negsig_dropped_max_completion }}</p>{% endif %}
+    <label>Penalty multiplier <input type="text" name="negsig_dropped_penalty_multiplier" value="{{ negative_signals.dropped_penalty_multiplier }}"></label>
+    {% if errors.negsig_dropped_penalty_multiplier %}<p class="field-error">{{ errors.negsig_dropped_penalty_multiplier }}</p>{% endif %}
+  </fieldset>
+
+  <fieldset>
+    <legend>External recommendations</legend>
+    <label><input type="checkbox" name="ext_enabled" {% if external.enabled %}checked{% endif %}> Enabled</label>
+    <label>Movie limit <input type="text" name="ext_movie_limit" value="{{ external.movie_limit }}"></label>
+    {% if errors.ext_movie_limit %}<p class="field-error">{{ errors.ext_movie_limit }}</p>{% endif %}
+    <label>Show limit <input type="text" name="ext_show_limit" value="{{ external.show_limit }}"></label>
+    {% if errors.ext_show_limit %}<p class="field-error">{{ errors.ext_show_limit }}</p>{% endif %}
+    <label>Min relevance score (0-1) <input type="text" name="ext_min_relevance_score" value="{{ external.min_relevance_score }}"></label>
+    {% if errors.ext_min_relevance_score %}<p class="field-error">{{ errors.ext_min_relevance_score }}</p>{% endif %}
+    <label>Min votes <input type="text" name="ext_min_votes" value="{{ external.min_votes }}"></label>
+    {% if errors.ext_min_votes %}<p class="field-error">{{ errors.ext_min_votes }}</p>{% endif %}
+    <label>Max discovery iterations <input type="text" name="ext_max_iterations" value="{{ external.max_iterations }}"></label>
+    {% if errors.ext_max_iterations %}<p class="field-error">{{ errors.ext_max_iterations }}</p>{% endif %}
+    <label>Language filter (ISO 639-1, blank = any) <input type="text" name="ext_language" value="{{ external.language }}"></label>
+    <label><input type="checkbox" name="ext_auto_open_html" {% if external.auto_open_html %}checked{% endif %}> Auto-open watchlist HTML after generation</label>
+  </fieldset>
+
+  <fieldset>
+    <legend>General</legend>
+    <label><input type="checkbox" name="general_auto_update" {% if general.auto_update %}checked{% endif %}> Auto-update on run</label>
+    <label><input type="checkbox" name="general_plex_only" {% if general.plex_only %}checked{% endif %}> Plex-only (only recommend from Plex library)</label>
+    <label>Log retention days <input type="text" name="general_log_retention_days" value="{{ general.log_retention_days }}"></label>
+    {% if errors.general_log_retention_days %}<p class="field-error">{{ errors.general_log_retention_days }}</p>{% endif %}
+  </fieldset>
+
+  <fieldset>
+    <legend>Logging</legend>
+    <label>Level
+      <select name="logging_level">
+        {% for choice in log_level_choices %}
+        <option value="{{ choice }}" {% if logging.level == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if errors.logging_level %}<p class="field-error">{{ errors.logging_level }}</p>{% endif %}
+  </fieldset>
+
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/web/templates/config_users.html
+++ b/web/templates/config_users.html
@@ -1,0 +1,75 @@
+{% extends 'base.html' %}
+{% block title %}Users - Curatarr{% endblock %}
+{% block content %}
+<h1>Users</h1>
+
+{% if saved %}
+<p class="banner running">Saved.</p>
+{% endif %}
+{% if errors['_global'] %}
+<p class="banner error">{{ errors['_global'] }}</p>
+{% endif %}
+
+<!--
+  Per-library recommendation mapping (#157) is deferred. Preferences here
+  are keyed only by username (preferences.<user>.exclude_genres/
+  max_rating/streaming_services). When #157 lands, this table gains a
+  library-selector dimension per user - see the NOTE in
+  web/config_app.py's Users screen section for where that shape change
+  is contained.
+-->
+
+<form method="post" action="{{ url_for('config_users_save') }}" class="config-form">
+  <input type="hidden" name="user_count" value="{{ users|length }}">
+
+  <table class="status-table">
+    <thead>
+      <tr>
+        <th>Username</th>
+        <th>Display name</th>
+        <th>Exclude genres</th>
+        <th>Max rating</th>
+        <th>Streaming services</th>
+        <th>Remove</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for u in users %}
+      <tr>
+        <td>
+          <input type="hidden" name="username_{{ loop.index0 }}" value="{{ u.username }}">
+          {{ u.username }}
+        </td>
+        <td><input type="text" name="display_name_{{ loop.index0 }}" value="{{ u.display_name }}"></td>
+        <td><input type="text" name="exclude_genres_{{ loop.index0 }}" value="{{ u.exclude_genres }}" placeholder="horror, children"></td>
+        <td>
+          <select name="max_rating_{{ loop.index0 }}">
+            <option value="" {% if not u.max_rating %}selected{% endif %}>(no restriction)</option>
+            {% for choice in rating_choices %}
+            <option value="{{ choice }}" {% if u.max_rating == choice %}selected{% endif %}>{{ choice }}</option>
+            {% endfor %}
+          </select>
+          {% if errors['max_rating_' ~ loop.index0] %}
+          <p class="field-error">{{ errors['max_rating_' ~ loop.index0] }}</p>
+          {% endif %}
+        </td>
+        <td><input type="text" name="streaming_services_{{ loop.index0 }}" value="{{ u.streaming_services }}" placeholder="netflix, hulu"></td>
+        <td><label><input type="checkbox" name="remove_{{ loop.index0 }}"> remove</label></td>
+      </tr>
+      {% else %}
+      <tr><td colspan="6">No users configured yet - add one below.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <fieldset>
+    <legend>Add a user</legend>
+    <label>Plex username
+      <input type="text" name="new_username" value="{{ new_username }}" placeholder="plex_username">
+    </label>
+    {% if errors.new_username %}<p class="field-error">{{ errors.new_username }}</p>{% endif %}
+  </fieldset>
+
+  <button type="submit">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds three browser-based config screens (/config/connections, /config/users, /config/settings) so curatarr can be set up without hand-editing YAML, extending the existing MVP web UI (web/app.py, web/job_runner.py, web/status.py, web/security.py).
- Round-trip YAML via ruamel.yaml (web/config_io.py) preserves comments and untouched keys/files on save; writes are atomic (temp file + os.replace).
- Field validation (web/config_validate.py) rejects bad input (weights not summing to 1.0, malformed URLs, invalid choices) before anything is written, plus a post-write reload sanity check through the real utils.load_config merge path.
- Secrets (tokens/API keys) are never rendered - only a configured/not-set status; a blank submission keeps the existing value.
- Test Connection buttons (web/config_test_connection.py) reuse the same client classes the recommenders use (Plex, TMDB, Tautulli, Sonarr, Radarr, Trakt); error messages are redacted (web/security.py) before they reach a log or the browser.
- Settings screen surfaces the Sonarr/Radarr/Trakt auto-sync safety toggles with a prominent warning banner.
- mdblist.yml/simkl.yml are confirmed dead paths (utils.config._load_module_configs never loads them) - deliberately left unexposed in this PR rather than silently changed, since fixing the loader would be a behavior change for anyone with an existing mdblist.yml/simkl.yml.
- 91 new tests (config_io, config_validate, config_test_connection, and the three screens' routes); full suite 1340 passed, coverage 87.25% (threshold 85%).

## Test plan
- [x]  - 1340 passed, 87.25% coverage
- [x] Manual smoke test against a throwaway project root (dashboard + all three config screens render; invalid POST returns 400 without leaking the configured token)
- [x] Existing MVP screens (dashboard/run/results) unaffected - all prior tests still pass