### PR TITLE
Cross-platform binary packaging (PyInstaller, Win/Mac/Linux)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,17 +119,85 @@ jobs:
             "curatarr-${VERSION}.tar.gz" \
             "SHA256SUMS.txt"
 
-      # -----------------------------------------------------------------
-      # Phase 2 extension point (not implemented yet):
-      #
-      # Add a matrix job here that builds per-OS standalone binaries with
-      # PyInstaller (ubuntu-latest / macos-latest / windows-latest),
-      # depends on `release` above (needs: release), and uploads each
-      # binary as an additional release asset with:
-      #
-      #   gh release upload "$GITHUB_REF_NAME" <binary-path>
-      #
-      # Keep the signed-tag + version-match gates in this job as the
-      # single source of truth for "is this a legitimate release" -
-      # binary-build jobs should only run after this job succeeds.
-      # -----------------------------------------------------------------
+  # ---------------------------------------------------------------------
+  # Standalone per-OS binaries (PyInstaller --onefile, see curatarr.spec
+  # and docs/BINARIES.md). `needs: release` is the whole gate here - the
+  # `release` job above is the single source of truth for "is this a
+  # legitimate release" (signed tag + pinned fingerprint + version
+  # match), so this job only runs at all once that one has succeeded.
+  # No independent re-verification here on purpose - one gate, not two
+  # that could drift out of sync.
+  # ---------------------------------------------------------------------
+  build-binaries:
+    name: Build binary (${{ matrix.asset_name }})
+    needs: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            asset_name: curatarr-windows-x86_64.exe
+            dist_name: curatarr.exe
+          - os: macos-latest
+            asset_name: curatarr-macos-arm64
+            dist_name: curatarr
+          - os: macos-13
+            asset_name: curatarr-macos-x86_64
+            dist_name: curatarr
+          - os: ubuntu-latest
+            asset_name: curatarr-linux-x86_64
+            dist_name: curatarr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r build-requirements.txt
+
+      - name: Build binary with PyInstaller
+        shell: bash
+        run: |
+          set -euo pipefail
+          pyinstaller --clean --noconfirm curatarr.spec
+
+      - name: Rename binary and compute SHA256
+        shell: bash
+        env:
+          ASSET_NAME: ${{ matrix.asset_name }}
+          DIST_NAME: ${{ matrix.dist_name }}
+        run: |
+          set -euo pipefail
+          mv "dist/$DIST_NAME" "$ASSET_NAME"
+          python -c "
+          import hashlib, os
+          path = os.environ['ASSET_NAME']
+          h = hashlib.sha256()
+          with open(path, 'rb') as f:
+              for chunk in iter(lambda: f.read(1 << 20), b''):
+                  h.update(chunk)
+          with open(path + '.sha256', 'w') as out:
+              out.write(f'{h.hexdigest()}  {path}\n')
+          "
+          cat "$ASSET_NAME.sha256"
+
+      - name: Upload binary to the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET_NAME: ${{ matrix.asset_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$GITHUB_REF_NAME" \
+            "$ASSET_NAME" \
+            "$ASSET_NAME.sha256" \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ __pycache__/
 CLAUDE.md
 TODO.md
 .coverage
+
+# PyInstaller build output (see curatarr.spec / docs/BINARIES.md)
+build/
+dist/
+*.buildvenv/
+.buildvenv/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Your Plex library has thousands of titles. Your users have watched maybe 10% of 
 
 ## Quick Start
 
+### Standalone binary (no Python required)
+
+Download the binary for your OS from the
+[latest release](https://github.com/OrchestratedChaos/curatarr/releases),
+run it, and it opens the web UI in your browser. See
+[docs/BINARIES.md](docs/BINARIES.md) for platform-specific run
+instructions (Windows SmartScreen / macOS Gatekeeper both warn on an
+unsigned binary the first time - that doc covers getting past it),
+where config/cache/logs live for a binary install, and current
+limitations.
+
 ### macOS / Linux
 ```bash
 git clone https://github.com/OrchestratedChaos/curatarr.git
@@ -92,6 +103,10 @@ A local dashboard for running recommendations and checking status without the te
 ./run-ui.sh     # macOS/Linux
 .\run-ui.ps1   # Windows (PowerShell)
 ```
+
+Or skip the source install entirely and download a
+[standalone binary](docs/BINARIES.md) - it opens straight to this same
+UI.
 
 Opens `http://127.0.0.1:8787` in your browser once the server is ready (binds to
 localhost only). From there you can see each user's last-run status, trigger a
@@ -478,6 +493,8 @@ curatarr/
 ├── run-ui.sh                # Web UI launcher (macOS/Linux)
 ├── run-ui.ps1               # Web UI launcher (Windows)
 ├── web/                     # Local web UI (Flask, beta)
+├── curatarr_app.py          # Standalone-binary entry point (see docs/BINARIES.md)
+├── curatarr.spec            # PyInstaller build spec
 ├── Dockerfile               # Docker image definition
 ├── docker-compose.yml       # Docker Compose config
 ├── cache/                   # TMDB metadata cache

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,10 +86,18 @@ Pushing the tag triggers `.github/workflows/release.yml`, which:
    `SHA256SUMS.txt`.
 6. Publishes the GitHub Release via `gh release create` (GitHub CLI only
    - no third-party marketplace actions), attaching both files.
-
-The workflow has a commented extension point for Phase 2: per-OS
-PyInstaller binary builds. That is **not implemented yet** - releases
-today ship a source archive + checksums only.
+7. Once that job succeeds, the `build-binaries` matrix job builds a
+   standalone PyInstaller binary for Windows, macOS (arm64 + Intel),
+   and Linux and uploads each one - plus a matching `.sha256` checksum
+   file - to the same release. This job depends on `release`
+   (`needs: release`) as its only gate: it never runs for a tag that
+   failed the signature/fingerprint/version checks above, and it does
+   not re-verify them independently on top - one gate, not two that
+   could drift out of sync. See `curatarr.spec` and `docs/BINARIES.md`
+   for what's bundled, where a binary's config/cache/logs live, and
+   current limitations (binaries are manual-download / no auto-update -
+   the updater above is source/git-install only - and don't yet
+   support triggering a run from the UI).
 
 ## Manual sanity-check
 

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,7 @@
+# Build-only dependencies for packaging the standalone binary
+# (curatarr.spec). Not needed to run curatarr from source - see
+# requirements.txt for that. Install alongside requirements.txt only
+# when building a binary: pip install -r requirements.txt -r build-requirements.txt
+#
+# See docs/BINARIES.md for the build command and CI matrix.
+pyinstaller==6.21.0

--- a/curatarr.spec
+++ b/curatarr.spec
@@ -1,0 +1,69 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the curatarr standalone (--onefile) binary.
+
+Build: pyinstaller curatarr.spec  (see docs/BINARIES.md)
+
+Notes:
+- datas bundles web/templates and web/static so Flask can find them at
+  runtime - PyInstaller's onefile mode extracts `datas` entries next to
+  where the frozen `web` package itself lands (sys._MEIPASS/web/...),
+  which is where Flask(__name__) resolves its template/static folders
+  from (see web/app.py). Confirmed by an actual local build+run - see
+  docs/BINARIES.md.
+- hiddenimports covers packages PyInstaller's static import analysis
+  doesn't always resolve on its own: ruamel.yaml and plexapi both do
+  a fair amount of lazy/conditional importing internally.
+"""
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hidden_imports = (
+    collect_submodules('ruamel.yaml')
+    + collect_submodules('plexapi')
+    + [
+        'flask',
+        'jinja2',
+        'werkzeug',
+        'yaml',
+        'requests',
+    ]
+)
+
+a = Analysis(
+    ['curatarr_app.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('web/templates', 'web/templates'),
+        ('web/static', 'web/static'),
+    ],
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='curatarr',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -1,0 +1,20 @@
+"""PyInstaller entry point for the curatarr standalone binary.
+
+Packaged via `pyinstaller curatarr.spec` (see docs/BINARIES.md and
+RELEASING.md). This file is intentionally thin: it just calls the same
+web.app.main() that run-ui.sh / run-ui.ps1 already use for a source
+install, so the binary and the source-install web UI stay identical in
+behavior. All real logic lives in web/app.py - keep it that way rather
+than adding anything here.
+
+Where a packaged binary reads/writes config/cache/logs: see
+utils.helpers.get_project_root() - when running frozen (this file,
+built by PyInstaller), that resolves to a per-user data directory
+instead of a repo checkout, since a downloaded binary has no repo
+checkout to anchor to.
+"""
+
+from web.app import main
+
+if __name__ == '__main__':
+    main()

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -1,0 +1,141 @@
+# Standalone Binaries
+
+Every [release](https://github.com/OrchestratedChaos/curatarr/releases)
+ships a self-contained, single-file executable for each major OS, in
+addition to the source archive. Download the one for your platform, run
+it, and it opens the web UI in your browser - no Python install, no
+`git clone`, no `pip install`.
+
+| Platform | Asset |
+|---|---|
+| Windows (x86_64) | `curatarr-windows-x86_64.exe` |
+| macOS (Apple Silicon) | `curatarr-macos-arm64` |
+| macOS (Intel) | `curatarr-macos-x86_64` |
+| Linux (x86_64) | `curatarr-linux-x86_64` |
+
+Each asset has a matching `<asset>.sha256` file with its checksum.
+
+## Running it
+
+### Windows
+
+1. Download `curatarr-windows-x86_64.exe` and put it in a folder of its
+   own (see [Where data lives](#where-data-lives) below).
+2. Double-click it. Windows SmartScreen will likely say "Windows
+   protected your PC" because the binary isn't code-signed yet (see
+   [Unsigned binaries](#unsigned-binaries)) - click **More info**, then
+   **Run anyway**.
+3. A console window opens (that's the server log) and your browser
+   opens to `http://127.0.0.1:8787`.
+
+### macOS
+
+1. Download `curatarr-macos-arm64` (Apple Silicon: M1/M2/M3/M4) or
+   `curatarr-macos-x86_64` (Intel), and make it executable:
+   `chmod +x curatarr-macos-*`.
+2. Gatekeeper will refuse to open an unsigned binary downloaded from
+   the internet the normal way - see
+   [Unsigned binaries](#unsigned-binaries) for the two ways around
+   that.
+3. Run it (double-click in Finder after clearing Gatekeeper, or
+   `./curatarr-macos-arm64` in Terminal). Your browser opens to
+   `http://127.0.0.1:8787`.
+
+### Linux
+
+1. Download `curatarr-linux-x86_64` and `chmod +x` it.
+2. Run it: `./curatarr-linux-x86_64`. It opens `http://127.0.0.1:8787`
+   in your default browser (via `xdg-open`/`webbrowser`); if nothing
+   opens (e.g. no desktop environment), the terminal output shows the
+   URL to open manually.
+
+## Verifying the checksum
+
+```bash
+# macOS/Linux
+shasum -a 256 -c curatarr-macos-arm64.sha256
+
+# Windows (PowerShell)
+(Get-FileHash .\curatarr-windows-x86_64.exe -Algorithm SHA256).Hash.ToLower()
+# compare against the contents of curatarr-windows-x86_64.exe.sha256
+```
+
+This confirms the file wasn't corrupted or tampered with in transit -
+it is **not** a substitute for code signing (see below); the checksum
+file itself is just another asset on the same GitHub Release.
+
+## Unsigned binaries
+
+These binaries are **not code-signed**. Code-signing certificates
+(a Windows EV/OV cert, an Apple Developer ID + notarization) are a
+future option, not implemented yet - until then, expect your OS to
+warn you the first time you run a downloaded binary:
+
+- **Windows SmartScreen**: "Windows protected your PC" -> click
+  **More info** -> **Run anyway**.
+- **macOS Gatekeeper**: right-click (or Control-click) the binary in
+  Finder -> **Open** -> confirm **Open** in the dialog. (A plain
+  double-click on a freshly-downloaded unsigned binary will just say
+  it "cannot be opened" and won't offer this option - it has to be the
+  right-click path the first time.) Alternatively, clear the quarantine
+  attribute from a terminal: `xattr -d com.apple.quarantine curatarr-macos-arm64`.
+- **Linux**: no equivalent gate; just needs `chmod +x`.
+
+Only download binaries from the official
+[GitHub Releases page](https://github.com/OrchestratedChaos/curatarr/releases) -
+each release is only published by CI for a tag independently verified
+against the maintainer's signed-tag key (see `RELEASING.md`), and each
+binary is built by that same CI run from that same verified tag.
+
+## No auto-update
+
+The auto-updater in `run.sh` / `run.ps1` (which checks for and applies
+new signed tags) is for **source/git installs only** - it re-`git pull`s
+and re-verifies a signed tag, which a standalone binary has no
+equivalent of. Binaries are **manual-download, no auto-update**: to
+upgrade, download the newer binary from Releases and replace the old
+one. A self-updating binary (checking Releases, downloading, and
+replacing itself) is a possible future item, not implemented yet.
+
+## Where data lives
+
+A downloaded binary has no `git clone` checkout to anchor `config/`,
+`cache/`, and `logs/` to, so it uses a per-user data directory instead,
+created automatically on first run:
+
+- **Windows**: `%APPDATA%\curatarr`
+- **macOS/Linux**: `~/.curatarr`
+
+This is separate from (and does not affect) a `config/`/`cache/`/`logs/`
+directory belonging to a source-install checkout - the two never
+collide, since a git checkout keeps using its own repo-relative paths
+(see `utils.helpers.get_project_root()`). First run works with no
+config at all: open the **Connections** / **Users** / **Settings**
+screens in the web UI to set everything up from the browser instead of
+hand-editing YAML.
+
+## Known limitation: triggering a run from the binary
+
+The web UI's **Run** button normally launches `recommenders/movie.py`
+etc. as a subprocess (see `web/job_runner.py`) using the current Python
+interpreter and an on-disk script path. Inside a frozen binary neither
+of those exist in the expected form (`sys.executable` is the binary
+itself, not a Python interpreter, and there's no `recommenders/`
+directory on disk next to the data dir). Browsing the dashboard,
+results, and config screens all work fully from the binary; triggering
+a run from it does not yet. Bundling the recommenders as additional
+onefile targets (or invoking them in-process with a safer entry point
+than their current `sys.exit()`-calling CLI shape) is a follow-up, not
+implemented in this change.
+
+## Building it yourself
+
+```bash
+pip install -r requirements.txt -r build-requirements.txt
+pyinstaller --clean --noconfirm curatarr.spec
+```
+
+Produces `dist/curatarr` (`dist/curatarr.exe` on Windows). See
+`curatarr.spec` for what's bundled and why, and
+`.github/workflows/release.yml` for the CI matrix that does this for
+every tagged release.

--- a/tests/test_curatarr_app.py
+++ b/tests/test_curatarr_app.py
@@ -1,0 +1,26 @@
+"""
+Tests for curatarr_app.py - the PyInstaller binary entry point.
+
+Deliberately thin (see the module docstring): the only behavior worth
+asserting is "running this module calls web.app.main()", since all
+real logic already lives in - and is already tested via - web/app.py.
+"""
+
+import runpy
+from unittest.mock import patch
+
+import curatarr_app
+
+
+class TestCuratarrApp:
+    def test_imports_main_from_web_app(self):
+        """curatarr_app.main is the same function web.app.main() is."""
+        from web.app import main as web_app_main
+        assert curatarr_app.main is web_app_main
+
+    @patch('web.app.main')
+    def test_running_as_script_calls_main(self, mock_main):
+        """PyInstaller runs this file as __main__ - confirm that path
+        calls main() exactly once, matching run-ui.sh / run-ui.ps1."""
+        runpy.run_module('curatarr_app', run_name='__main__')
+        mock_main.assert_called_once_with()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,7 +7,10 @@ import os
 import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import patch
-from utils.helpers import normalize_title, map_path, cleanup_old_logs, compute_profile_hash, TITLE_SUFFIXES_TO_STRIP
+from utils.helpers import (
+    normalize_title, map_path, cleanup_old_logs, compute_profile_hash,
+    get_project_root, TITLE_SUFFIXES_TO_STRIP,
+)
 
 
 class TestNormalizeTitle:
@@ -316,3 +319,66 @@ class TestComputeProfileHash:
         result = compute_profile_hash(profile)
         assert len(result) == 16
         assert isinstance(result, str)
+
+
+class TestGetProjectRoot:
+    """Tests for get_project_root().
+
+    get_project_root() is @lru_cache(maxsize=1), so every test clears
+    the cache before and after - otherwise a frozen/mocked result from
+    one test would leak into whichever test (in this file or another)
+    happens to call the real function next.
+    """
+
+    def setup_method(self):
+        get_project_root.cache_clear()
+
+    def teardown_method(self):
+        get_project_root.cache_clear()
+
+    def test_non_frozen_returns_repo_root(self):
+        """Normal (non-frozen) run: unchanged behavior - parent of utils/."""
+        root = get_project_root()
+        assert os.path.isdir(os.path.join(root, 'utils'))
+        assert os.path.isdir(os.path.join(root, 'web'))
+
+    @patch('utils.helpers.sys.frozen', True, create=True)
+    def test_frozen_windows_uses_appdata(self, tmp_path, monkeypatch):
+        """A frozen binary on Windows uses %APPDATA%\\curatarr."""
+        monkeypatch.setattr(os, 'name', 'nt')
+        monkeypatch.setenv('APPDATA', str(tmp_path))
+        root = get_project_root()
+        assert root == os.path.join(str(tmp_path), 'curatarr')
+        assert os.path.isdir(root)
+
+    @patch('utils.helpers.sys.frozen', True, create=True)
+    def test_frozen_windows_falls_back_to_home_without_appdata(self, tmp_path, monkeypatch):
+        """No %APPDATA% set (unusual, but shouldn't crash): fall back to ~\\curatarr."""
+        monkeypatch.setattr(os, 'name', 'nt')
+        monkeypatch.delenv('APPDATA', raising=False)
+        monkeypatch.setenv('HOME', str(tmp_path))
+        root = get_project_root()
+        assert root == os.path.join(str(tmp_path), 'curatarr')
+        assert os.path.isdir(root)
+
+    @patch('utils.helpers.sys.frozen', True, create=True)
+    def test_frozen_posix_uses_dot_curatarr_in_home(self, tmp_path, monkeypatch):
+        """A frozen binary on macOS/Linux uses ~/.curatarr."""
+        monkeypatch.setattr(os, 'name', 'posix')
+        monkeypatch.setenv('HOME', str(tmp_path))
+        root = get_project_root()
+        assert root == os.path.join(str(tmp_path), '.curatarr')
+        assert os.path.isdir(root)
+
+    @patch('utils.helpers.sys.frozen', True, create=True)
+    def test_frozen_reuses_existing_dir(self, tmp_path, monkeypatch):
+        """Second run against an already-populated data dir doesn't error."""
+        monkeypatch.setattr(os, 'name', 'posix')
+        monkeypatch.setenv('HOME', str(tmp_path))
+        existing = os.path.join(str(tmp_path), '.curatarr')
+        os.makedirs(existing)
+        with open(os.path.join(existing, 'marker.txt'), 'w') as f:
+            f.write('keep me')
+        root = get_project_root()
+        assert root == existing
+        assert os.path.isfile(os.path.join(existing, 'marker.txt'))

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,6 +5,7 @@ Miscellaneous helper utilities for Curatarr.
 import hashlib
 import json
 import os
+import sys
 from datetime import datetime, timedelta
 from functools import lru_cache
 from typing import Dict
@@ -17,9 +18,33 @@ def get_project_root() -> str:
     """
     Get the project root directory path.
 
+    For a normal source checkout / Docker image this is the parent of
+    utils/ (repo root), same as always.
+
+    For a PyInstaller --onefile binary (`sys.frozen` is set - see
+    curatarr_app.py / curatarr.spec) there is no on-disk repo to anchor
+    to: the running executable unpacks itself into a throwaway temp dir
+    (sys._MEIPASS) that's deleted on exit, so config/cache/logs can't
+    live there. Frozen binaries instead read/write a per-user data
+    directory that persists across runs and across re-downloading a
+    newer binary:
+      - Windows: %APPDATA%\\curatarr
+      - macOS/Linux: ~/.curatarr
+    Created on first use if it doesn't already exist. See
+    docs/BINARIES.md for the full rationale.
+
     Returns:
-        Absolute path to the project root (parent of utils/).
+        Absolute path to the project root (or the per-user data dir
+        when running as a frozen binary).
     """
+    if getattr(sys, 'frozen', False):
+        if os.name == 'nt':
+            base = os.environ.get('APPDATA') or os.path.expanduser('~')
+            root = os.path.join(base, 'curatarr')
+        else:
+            root = os.path.join(os.path.expanduser('~'), '.curatarr')
+        os.makedirs(root, exist_ok=True)
+        return root
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,8 +1,10 @@
 """Curatarr local web UI (MVP): dashboard, run-with-live-log, results.
 
 Self-contained package - templates/ and static/ are bundled inside this
-package (not read from elsewhere) so it can later be frozen with
-PyInstaller --onefile without extra data-file wiring.
+package (not read from elsewhere), which is what lets it be frozen with
+PyInstaller --onefile (see curatarr.spec / curatarr_app.py / docs/BINARIES.md)
+without extra data-file wiring beyond declaring those two folders as
+`datas` in the spec.
 
 This package only reads existing curatarr state (config, logs,
 generated watchlists) and triggers recommender runs as subprocesses.


### PR DESCRIPTION
## Summary
- Adds a single-file, double-click executable per OS (Windows/macOS-arm64/macOS-Intel/Linux) that opens the web UI on 127.0.0.1 and launches the browser - no Python install or `git clone` needed.
- `curatarr_app.py` (PyInstaller entry point) + `curatarr.spec` (onefile build, bundles `web/templates` + `web/static`, forces hidden imports for `ruamel.yaml`/`plexapi`).
- `utils.helpers.get_project_root()` now resolves to a per-user data dir when running as a frozen binary (`%APPDATA%\curatarr` / `~/.curatarr`), since a downloaded binary has no repo checkout to anchor `config/`/`cache/`/`logs/` to. Source/Docker installs are unchanged.
- `release.yml` gains a `build-binaries` matrix job (`windows-latest`, `macos-latest` arm64, `macos-13` Intel, `ubuntu-latest`), gated on `needs: release` so it only runs for tags that already passed the signed-tag + fingerprint + version checks. Each binary is uploaded to the same release with a `.sha256` checksum.
- `docs/BINARIES.md` documents per-OS run instructions (SmartScreen/Gatekeeper), checksum verification, no-auto-update, where data lives, and a known limitation (see below).

## Verified locally (macOS, arm64)
Built with `pyinstaller --clean --noconfirm curatarr.spec` in a clean venv, ran the resulting binary from an empty throwaway directory (simulating a fresh download, no repo checkout), and confirmed:
- `GET /` -> `HTTP 200`, `<title>Dashboard - Curatarr</title>`, "No users configured" (first run with no config works).
- `GET /config/connections` -> `HTTP 200`.
- `GET /static/style.css` -> `HTTP 200`, 3864 bytes (bundled static assets resolve correctly).
- `~/.curatarr` was created automatically by the binary (confirms the frozen-mode data-dir path).

## Known limitation (documented, not fixed here)
Triggering a run from the UI's **Run** button doesn't work from a frozen binary yet - `web/job_runner.py` shells out via `sys.executable` + an on-disk `recommenders/*.py` path, neither of which exist in the expected form inside a onefile build. Dashboard/results/config screens all work fully. Documented in `docs/BINARIES.md`.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85` - 1347 passed, 87.30% coverage
- [x] `python -m py_compile` on all changed/new `.py` files
- [x] YAML-parsed `.github/workflows/release.yml` (`yaml.safe_load`) - no `actionlint` available in this environment
- [x] Local PyInstaller build + run proof above
- [ ] Windows / Linux / Intel-mac CI binary jobs only run on a real signed release tag - not exercised by this PR (by design, per the signature gate); the local macOS build + valid YAML are the pre-merge proof they'll work
