### PR TITLE
Web UI hardening: CSRF/Host guard, job-runner reliability, binary Run, +tests

### DIFF
--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -1,10 +1,10 @@
 """PyInstaller entry point for the curatarr standalone binary.
 
 Packaged via `pyinstaller curatarr.spec` (see docs/BINARIES.md and
-RELEASING.md). This file is intentionally thin: it just calls the same
+RELEASING.md). With no arguments, this just calls the same
 web.app.main() that run-ui.sh / run-ui.ps1 already use for a source
 install, so the binary and the source-install web UI stay identical in
-behavior. All real logic lives in web/app.py - keep it that way rather
+behavior. All UI logic lives in web/app.py - keep it that way rather
 than adding anything here.
 
 Where a packaged binary reads/writes config/cache/logs: see
@@ -12,9 +12,95 @@ utils.helpers.get_project_root() - when running frozen (this file,
 built by PyInstaller), that resolves to a per-user data directory
 instead of a repo checkout, since a downloaded binary has no repo
 checkout to anchor to.
+
+Dispatcher mode - what makes the web UI's Run button work in a frozen
+binary
+------------------------------------------------------------------
+The web UI normally triggers a run by shelling out to
+`sys.executable recommenders/<x>.py [user]` (see web/job_runner.py).
+That file doesn't exist next to a packaged onefile exe - there is no
+`recommenders/` directory on disk once everything is bundled into the
+binary, and `sys.executable` for a frozen process IS the curatarr exe
+itself, not a python.exe that could run an arbitrary .py path anyway.
+
+So when frozen, web/job_runner.py instead re-invokes this exe as:
+
+    curatarr --run-recommender <engine> [user]
+
+and THIS file recognizes that flag and runs the requested recommender
+module's own main() in-process - but "in-process" here means inside
+that fresh, short-lived subprocess the web UI just spawned, never
+inside the long-lived Flask server process itself. That distinction is
+what keeps this safe: the recommender entry points hijack sys.stdout
+and call sys.exit() (see web/app.py's module docstring for why that's
+unsafe inside the server), which is exactly fine for a process whose
+only job is to run one recommender and exit - the same contract as the
+`python3 recommenders/<x>.py` invocation this replaces for a source
+install.
 """
+
+import sys
 
 from web.app import main
 
+
+def _run_one_recommender(engine: str, rest: list) -> None:
+    """Run a single recommender's own main() with sys.argv rewritten to
+    look like a normal `recommenders/<engine>.py [user] [--debug]`
+    invocation, since that's what each one's own argparse expects.
+
+    Deliberately plain `from recommenders.X import main` statements
+    (rather than e.g. a dict of lazy __import__() lambdas) even though
+    they're inside a function body and only one branch ever actually
+    runs - PyInstaller's static analysis walks the AST for import
+    statements wherever they appear, but can't see into a dynamic
+    __import__("recommenders." + engine) call, so that form would
+    silently leave the recommenders package out of the frozen build.
+    """
+    sys.argv = [f'curatarr --run-recommender {engine}'] + list(rest)
+    if engine == 'movie':
+        from recommenders.movie import main as run
+    elif engine == 'tv':
+        from recommenders.tv import main as run
+    elif engine == 'external':
+        from recommenders.external import main as run
+    else:
+        print(f"curatarr: unknown recommender engine: {engine}", file=sys.stderr)
+        sys.exit(2)
+        return
+    run()
+
+
+def _dispatch_recommender(argv: list) -> None:
+    """argv is sys.argv[2:], e.g. ['movie', 'alice'] or ['external'] or
+    ['full']. See the module docstring above for why this exists."""
+    if not argv:
+        print(
+            "curatarr: --run-recommender requires an engine "
+            "(movie, tv, external, full)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    engine, rest = argv[0], argv[1:]
+
+    if engine == 'full':
+        # Mirrors run.sh's RUNNING_IN_DOCKER-bypassed core path: no
+        # dependency-install / auto-update / setup-wizard / cron-prompt
+        # steps - those are source-install-only concerns that don't
+        # apply to a packaged binary - just movie, then tv, then
+        # external, in sequence. A fatal error in one (sys.exit from
+        # run_recommender_main) stops the rest, same as run.sh's own
+        # `... || exit 1` after each step.
+        for sub_engine in ('movie', 'tv', 'external'):
+            _run_one_recommender(sub_engine, [])
+        return
+
+    _run_one_recommender(engine, rest)
+
+
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) > 2 and sys.argv[1] == '--run-recommender':
+        _dispatch_recommender(sys.argv[2:])
+    else:
+        main()

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -114,19 +114,21 @@ config at all: open the **Connections** / **Users** / **Settings**
 screens in the web UI to set everything up from the browser instead of
 hand-editing YAML.
 
-## Known limitation: triggering a run from the binary
+## Triggering a run from the binary
 
 The web UI's **Run** button normally launches `recommenders/movie.py`
 etc. as a subprocess (see `web/job_runner.py`) using the current Python
-interpreter and an on-disk script path. Inside a frozen binary neither
-of those exist in the expected form (`sys.executable` is the binary
+interpreter and an on-disk script path - neither of which exists in the
+expected form inside a frozen binary (`sys.executable` is the binary
 itself, not a Python interpreter, and there's no `recommenders/`
-directory on disk next to the data dir). Browsing the dashboard,
-results, and config screens all work fully from the binary; triggering
-a run from it does not yet. Bundling the recommenders as additional
-onefile targets (or invoking them in-process with a safer entry point
-than their current `sys.exit()`-calling CLI shape) is a follow-up, not
-implemented in this change.
+directory on disk next to the data dir). Instead, when running frozen,
+`web/job_runner.py` re-invokes the packaged exe itself as
+`curatarr --run-recommender <engine> [user]`; `curatarr_app.py`
+recognizes that flag and runs the requested recommender's own `main()`
+in that fresh subprocess (never inside the long-lived server process -
+see `curatarr_app.py`'s module docstring for why that distinction
+matters). The Movie/TV/External/Full Pipeline buttons all work from the
+binary the same as a source install.
 
 ## Building it yourself
 

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -831,7 +831,7 @@ def find_missing_sequels(
     from utils.display import show_progress
 
     # Cache paths
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    project_root = get_project_root()
     cache_path = os.path.join(project_root, 'cache', 'huntarr_cache.json')
 
     try:
@@ -1173,7 +1173,7 @@ def find_horizon_movies(
     """
     from utils.display import show_progress
 
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    project_root = get_project_root()
     cache_path = os.path.join(project_root, 'cache', 'horizon_huntarr_cache.json')
     sequel_cache_path = os.path.join(project_root, 'cache', 'huntarr_cache.json')
 
@@ -1708,7 +1708,7 @@ def find_similar_content_with_profile(
     # Get Trakt candidates once (not per-iteration)
     trakt_candidates = {}
     if config:
-        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        project_root = get_project_root()
         cache_dir = os.path.join(project_root, config.get('cache_dir', 'cache'))
         library_tmdb_ids = library_data.get('tmdb_ids', set())
 
@@ -1873,7 +1873,7 @@ def find_similar_content_with_profile(
 
 def load_cache(display_name: str, media_type: str) -> Dict:
     """Load existing recommendations cache, filtering out items below quality thresholds"""
-    cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'cache')
+    cache_dir = os.path.join(get_project_root(), 'cache')
     os.makedirs(cache_dir, exist_ok=True)
     safe_name = display_name.lower().replace(' ', '_')
     cache_file = os.path.join(cache_dir, f'external_recs_{safe_name}_{media_type}.json')
@@ -1913,7 +1913,7 @@ def load_cache(display_name: str, media_type: str) -> Dict:
 
 def save_cache(display_name: str, media_type: str, cache_data: Dict) -> None:
     """Save recommendations cache with version."""
-    cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'cache')
+    cache_dir = os.path.join(get_project_root(), 'cache')
     os.makedirs(cache_dir, exist_ok=True)
     safe_name = display_name.lower().replace(' ', '_')
     cache_file = os.path.join(cache_dir, f'external_recs_{safe_name}_{media_type}.json')
@@ -1928,7 +1928,7 @@ def save_cache(display_name: str, media_type: str, cache_data: Dict) -> None:
 def load_ignore_list(display_name: str) -> Set[str]:
     """Load user's manual ignore list"""
     safe_name = display_name.lower().replace(' ', '_')
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    project_root = get_project_root()
     ignore_file = os.path.join(project_root, 'recommendations', 'external', f'{safe_name}_ignore.txt')
     if os.path.exists(ignore_file):
         with open(ignore_file, 'r') as f:
@@ -2232,7 +2232,7 @@ def process_user(config, plex, username):
     )
 
     # Generate markdown per user
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    project_root = get_project_root()
     output_dir = os.path.join(project_root, 'recommendations', 'external')
     generate_markdown(username, display_name, movies_categorized, shows_categorized, output_dir)
 
@@ -2265,8 +2265,9 @@ def main():
                         help='Run only Huntarr features (skip recommendations)')
     args = parser.parse_args()
 
-    # Load config from project root (one level up from recommenders/)
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # Load config from project root (repo root for a source install, the
+    # per-user data dir when frozen - see utils.helpers.get_project_root)
+    project_root = get_project_root()
     config_path = os.path.join(project_root, 'config/config.yml')
     config = load_config(config_path)
 

--- a/recommenders/external_output.py
+++ b/recommenders/external_output.py
@@ -3,6 +3,7 @@ Output generation for external recommendations.
 Generates markdown watchlists and combined HTML views.
 """
 
+import html
 import json
 import os
 from datetime import datetime
@@ -10,6 +11,22 @@ from typing import Dict, List
 from urllib.parse import quote_plus
 
 from utils.config import TMDB_ANIMATION_GENRE_ID
+
+
+def _esc(value) -> str:
+    """HTML-escape a value pulled from TMDB (title, collection name,
+    status, etc.) or from local config (display name) before it's
+    interpolated into watchlist.html.
+
+    Every field rendered by generate_combined_html below used to be
+    dropped into an f-string unescaped - a movie/show title containing
+    `<script>` (a real, if rare, possibility for anything sourced from
+    TMDB's public catalog, or from a locally-configured display_name)
+    would execute in the browser as stored XSS against this app's own
+    origin the moment someone opened their generated watchlist. str()
+    first so non-string values (year ints, etc.) go through cleanly.
+    """
+    return html.escape(str(value), quote=True)
 
 
 def _load_imdb_cache(cache_path: str) -> Dict[str, str]:
@@ -362,10 +379,10 @@ def generate_combined_html(
             genre_ids = item.get('genre_ids', [])
             animated_badge = '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ''
             rows.append(f'''
-                <tr data-tmdb="{tmdb_id}" data-imdb="{imdb_id}" data-type="{media_type}" data-user="{user_id}">
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="{_esc(media_type)}" data-user="{_esc(user_id)}">
                     <td><input type="checkbox" class="select-item"></td>
-                    <td>{item['title']} {animated_badge}{shared_badge}</td>
-                    <td>{item['year']}</td>
+                    <td>{_esc(item['title'])} {animated_badge}{shared_badge}</td>
+                    <td>{_esc(item['year'])}</td>
                     <td>{item['rating']:.1f}</td>
                     <td>{item['score']:.0%}</td>
                     <td><div class="streaming-icons">{streaming_html}</div></td>
@@ -393,11 +410,11 @@ def generate_combined_html(
             if item.get('is_tv_movie'):
                 badges += '<span class="tv-special-badge">TV Special</span>'
             rows.append(f'''
-                <tr data-tmdb="{tmdb_id}" data-imdb="{imdb_id}" data-type="movie" data-user="sequel-huntarr">
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="sequel-huntarr">
                     <td><input type="checkbox" class="select-item"></td>
-                    <td>{item['title']} {badges}</td>
-                    <td>{item.get('year', '')}</td>
-                    <td>{collection_name}</td>
+                    <td>{_esc(item['title'])} {badges}</td>
+                    <td>{_esc(item.get('year', ''))}</td>
+                    <td>{_esc(collection_name)}</td>
                     <td>{owned}/{total}</td>
                     <td><div class="streaming-icons">{streaming_html}</div></td>
                 </tr>''')
@@ -418,12 +435,12 @@ def generate_combined_html(
             genre_ids = item.get('genre_ids', [])
             animated_badge = '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ''
             rows.append(f'''
-                <tr data-tmdb="{tmdb_id}" data-imdb="{imdb_id}" data-type="movie" data-user="horizon-huntarr">
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="horizon-huntarr">
                     <td><input type="checkbox" class="select-item"></td>
-                    <td>{item['title']} {animated_badge}</td>
-                    <td>{collection_name}</td>
-                    <td>{release_date}</td>
-                    <td><span class="status-badge {status_class}">{status}</span></td>
+                    <td>{_esc(item['title'])} {animated_badge}</td>
+                    <td>{_esc(collection_name)}</td>
+                    <td>{_esc(release_date)}</td>
+                    <td><span class="status-badge {_esc(status_class)}">{_esc(status)}</span></td>
                 </tr>''')
         return '\n'.join(rows)
 
@@ -440,7 +457,7 @@ def generate_combined_html(
         is_active = "active" if i == 0 else ""
 
         # Tab button
-        tabs_html += f'<button class="tab-btn {is_active}" data-user="{user_id}">{display_name}</button>\n'
+        tabs_html += f'<button class="tab-btn {is_active}" data-user="{_esc(user_id)}">{_esc(display_name)}</button>\n'
 
         # Panel content - use flat all_items sorted by score
         panel_content = ""
@@ -476,7 +493,7 @@ def generate_combined_html(
         if not panel_content:
             panel_content = "<p>No recommendations available for this user.</p>"
 
-        panels_html += f'<div class="tab-panel {is_active}" data-user="{user_id}">{panel_content}</div>\n'
+        panels_html += f'<div class="tab-panel {is_active}" data-user="{_esc(user_id)}">{panel_content}</div>\n'
 
     # Build Huntarr tabs (separate row below user tabs)
     huntarr_tabs_html = ""

--- a/tests/test_curatarr_app.py
+++ b/tests/test_curatarr_app.py
@@ -1,13 +1,23 @@
 """
 Tests for curatarr_app.py - the PyInstaller binary entry point.
 
-Deliberately thin (see the module docstring): the only behavior worth
-asserting is "running this module calls web.app.main()", since all
-real logic already lives in - and is already tested via - web/app.py.
+With no `--run-recommender` argument this is deliberately thin (see the
+module docstring): "running this module calls web.app.main()", since
+all real UI logic already lives in - and is already tested via -
+web/app.py.
+
+With `--run-recommender <engine> [user]`, this module is what makes the
+web UI's Run button work in a frozen PyInstaller binary (see
+web/job_runner.py's _build_command) - it dispatches to the requested
+recommender's own main() instead of shelling out to a
+recommenders/<x>.py file that doesn't exist once packaged.
 """
 
 import runpy
+import sys
 from unittest.mock import patch
+
+import pytest
 
 import curatarr_app
 
@@ -24,3 +34,65 @@ class TestCuratarrApp:
         calls main() exactly once, matching run-ui.sh / run-ui.ps1."""
         runpy.run_module('curatarr_app', run_name='__main__')
         mock_main.assert_called_once_with()
+
+
+class TestRunOneRecommender:
+    """Tests for _run_one_recommender() - the dispatch used when frozen
+    (see web/job_runner.py._build_command's `--run-recommender` path)."""
+
+    def test_dispatches_movie_engine_with_rewritten_argv(self, monkeypatch):
+        called = {}
+
+        def _fake_main():
+            called['argv'] = list(sys.argv)
+
+        monkeypatch.setattr('recommenders.movie.main', _fake_main)
+        curatarr_app._run_one_recommender('movie', ['alice'])
+        assert called['argv'][1:] == ['alice']
+
+    def test_dispatches_tv_engine(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr('recommenders.tv.main', lambda: called.setdefault('ran', True))
+        curatarr_app._run_one_recommender('tv', [])
+        assert called.get('ran') is True
+
+    def test_dispatches_external_engine(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr('recommenders.external.main', lambda: called.setdefault('ran', True))
+        curatarr_app._run_one_recommender('external', [])
+        assert called.get('ran') is True
+
+    def test_unknown_engine_exits_with_error(self):
+        with pytest.raises(SystemExit) as exc_info:
+            curatarr_app._run_one_recommender('bogus', [])
+        assert exc_info.value.code == 2
+
+
+class TestDispatchRecommender:
+    """Tests for _dispatch_recommender() - the --run-recommender argv
+    parsing, including the 'full' engine's movie->tv->external chain."""
+
+    def test_no_engine_argument_exits_with_error(self):
+        with pytest.raises(SystemExit) as exc_info:
+            curatarr_app._dispatch_recommender([])
+        assert exc_info.value.code == 2
+
+    def test_full_engine_runs_movie_tv_external_in_order(self, monkeypatch):
+        order = []
+        monkeypatch.setattr('recommenders.movie.main', lambda: order.append('movie'))
+        monkeypatch.setattr('recommenders.tv.main', lambda: order.append('tv'))
+        monkeypatch.setattr('recommenders.external.main', lambda: order.append('external'))
+
+        curatarr_app._dispatch_recommender(['full'])
+
+        assert order == ['movie', 'tv', 'external']
+
+    def test_single_engine_with_user_passes_user_through(self, monkeypatch):
+        called = {}
+
+        def _fake_main():
+            called['argv'] = list(sys.argv)
+
+        monkeypatch.setattr('recommenders.movie.main', _fake_main)
+        curatarr_app._dispatch_recommender(['movie', 'alice'])
+        assert called['argv'][1:] == ['alice']

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -363,9 +363,7 @@ class TestCacheOperations:
     def test_save_and_load_cache(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             # Patch the cache directory
-            with patch('recommenders.external.os.path.dirname') as mock_dirname:
-                mock_dirname.return_value = tmpdir
-
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
                 cache_data = {
                     '12345': {
                         'tmdb_id': 12345,
@@ -390,9 +388,7 @@ class TestCacheOperations:
 
     def test_load_empty_cache(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch('recommenders.external.os.path.dirname') as mock_dirname:
-                mock_dirname.return_value = tmpdir
-
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
                 loaded = load_cache('NonExistent', 'movies')
 
                 assert loaded == {}
@@ -1321,8 +1317,7 @@ class TestExternalRecsCacheVersioning:
                 shutil.copy(cache_path, dest_path)
 
                 # Patch the project root detection
-                with patch('recommenders.external.os.path.dirname') as mock_dirname:
-                    mock_dirname.return_value = tmpdir
+                with patch('recommenders.external.get_project_root', return_value=tmpdir):
                     result = load_cache('testuser', 'movie')
                     # Old version should return empty
                     assert result == {}
@@ -1333,9 +1328,7 @@ class TestExternalRecsCacheVersioning:
         """Test save adds version to cache."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Patch the project root detection
-            with patch('recommenders.external.os.path.dirname') as mock_dirname:
-                mock_dirname.return_value = tmpdir
-
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
                 cache_data = {'12345': {'title': 'Test', 'tmdb_id': 12345}}
                 save_cache('testuser', 'movie', cache_data)
 
@@ -1361,8 +1354,7 @@ class TestExternalRecsCacheVersioning:
             with open(cache_path, 'w') as f:
                 json.dump(cache_data, f)
 
-            with patch('recommenders.external.os.path.dirname') as mock_dirname:
-                mock_dirname.return_value = tmpdir
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
                 result = load_cache('testuser', 'movie')
 
                 assert '12345' in result

--- a/tests/test_external_output.py
+++ b/tests/test_external_output.py
@@ -429,6 +429,125 @@ class TestGenerateMarkdown:
             assert 'TV Shows to Watch' not in content
 
 
+class TestHtmlEscaping:
+    """Tests for the XSS fix: TMDB-derived (and locally-configured)
+    fields must be HTML-escaped before being interpolated into
+    watchlist.html - see web-audit finding #4."""
+
+    def _mock_get_imdb_id(self, api_key, tmdb_id, media_type):
+        return f'tt{tmdb_id}'
+
+    def test_malicious_movie_title_is_escaped_not_executable(self):
+        payload = '<script>alert(1)</script>'
+        all_users_data = [{
+            'username': 'user1',
+            'display_name': 'User1',
+            'movies_categorized': {
+                'all_items': [
+                    {'title': payload, 'year': '2024', 'rating': 7.0, 'score': 0.70,
+                     'tmdb_id': 1, 'streaming_services': [], 'on_user_services': [],
+                     'added_date': '2024-01-01T00:00:00'}
+                ],
+                'user_services': {}, 'other_services': {}, 'acquire': []
+            },
+            'shows_categorized': {'all_items': [], 'user_services': {},
+                                  'other_services': {}, 'acquire': []}
+        }]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_combined_html(
+                all_users_data, tmpdir, 'api_key', self._mock_get_imdb_id
+            )
+            with open(result) as f:
+                html = f.read()
+            assert payload not in html
+            assert '&lt;script&gt;alert(1)&lt;/script&gt;' in html
+
+    def test_malicious_display_name_is_escaped(self):
+        payload = '"><img src=x onerror=alert(1)>'
+        all_users_data = [{
+            'username': 'user1',
+            'display_name': payload,
+            'movies_categorized': {'all_items': [], 'user_services': {},
+                                   'other_services': {}, 'acquire': []},
+            'shows_categorized': {'all_items': [], 'user_services': {},
+                                  'other_services': {}, 'acquire': []}
+        }]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_combined_html(
+                all_users_data, tmpdir, 'api_key', self._mock_get_imdb_id
+            )
+            with open(result) as f:
+                html = f.read()
+            assert payload not in html
+            # The dangerous part is the payload breaking out into a real
+            # <img> tag - html.escape() neutralizes that by escaping the
+            # angle brackets/quotes, even though the literal substring
+            # "onerror=alert(1)" (no HTML-meaningful chars of its own)
+            # still appears as inert escaped text content.
+            assert '<img' not in html
+            assert '&lt;img' in html
+
+    def test_malicious_sequel_collection_name_is_escaped(self):
+        missing_sequels = [
+            {'title': 'Normal Movie', 'year': '2024',
+             'collection_name': '<script>alert(2)</script>',
+             'owned_count': 1, 'total_count': 2, 'tmdb_id': 456,
+             'streaming_services': [], 'on_user_services': []}
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_combined_html(
+                [], tmpdir, 'api_key', self._mock_get_imdb_id,
+                missing_sequels=missing_sequels,
+            )
+            with open(result) as f:
+                html = f.read()
+            assert '<script>alert(2)</script>' not in html
+
+    def test_malicious_horizon_status_is_escaped(self):
+        horizon_movies = [
+            {'title': 'Normal Movie', 'collection_name': 'Normal Collection',
+             'tmdb_id': 789, 'release_date': '2026-06-15',
+             'status': '"><script>alert(3)</script>'}
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_combined_html(
+                [], tmpdir, 'api_key', self._mock_get_imdb_id,
+                horizon_movies=horizon_movies,
+            )
+            with open(result) as f:
+                html = f.read()
+            assert '<script>alert(3)</script>' not in html
+
+    def test_normal_titles_still_render_readably(self):
+        # Sanity check the fix doesn't mangle ordinary titles containing
+        # characters that are legitimately part of HTML escaping's
+        # domain (apostrophes, ampersands) but aren't attacks.
+        all_users_data = [{
+            'username': 'user1',
+            'display_name': 'User1',
+            'movies_categorized': {
+                'all_items': [
+                    {'title': "Tom & Jerry: It's a Wonderful Movie", 'year': '2024',
+                     'rating': 7.0, 'score': 0.70, 'tmdb_id': 1,
+                     'streaming_services': [], 'on_user_services': [],
+                     'added_date': '2024-01-01T00:00:00'}
+                ],
+                'user_services': {}, 'other_services': {}, 'acquire': []
+            },
+            'shows_categorized': {'all_items': [], 'user_services': {},
+                                  'other_services': {}, 'acquire': []}
+        }]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_combined_html(
+                all_users_data, tmpdir, 'api_key', self._mock_get_imdb_id
+            )
+            with open(result) as f:
+                html = f.read()
+            assert 'Tom &amp; Jerry: It&#x27;s a Wonderful Movie' in html
+
+
 class TestHtmlSorting:
     """Tests for HTML table sorting functionality"""
 

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -250,3 +250,100 @@ class TestConnectionsTestEndpoint:
         body = resp.get_json()
         assert body['ok'] is False
         assert 'trakt_auth' in body['message']
+
+    def test_sonarr_test_with_different_url_does_not_leak_saved_key(self, client, monkeypatch):
+        """HIGH #1: submitting a blank secret alongside a URL that
+        differs from the saved one must never cause the stored secret to
+        be sent to that (possibly attacker-controlled) URL."""
+        c, app, root = client
+        c.post('/config/connections', data=VALID_FORM)  # saves sonarr api_key = sonarr-key-123
+
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, url, api_key):
+                captured['url'] = url
+                captured['api_key'] = api_key
+
+            def test_connection(self):
+                return True
+
+        import web.config_test_connection as cc
+        monkeypatch.setattr(cc, 'SonarrClient', _FakeClient)
+
+        resp = c.post(
+            '/config/test/sonarr',
+            data={'url': 'http://attacker.example.com', 'api_key': ''},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        # test_sonarr() fails fast on a blank api_key before ever
+        # constructing SonarrClient - the saved key was never merged in
+        # (and never even reaches the network).
+        assert body['ok'] is False
+        assert captured == {}
+
+    def test_plex_test_with_same_saved_url_still_uses_saved_token(self, client, monkeypatch):
+        """The blank-secret convenience still works for the normal case:
+        testing the URL that's already saved."""
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form['plex_token'] = 'plex-token-123'
+        c.post('/config/connections', data=form)
+
+        captured = {}
+
+        class _FakeServer:
+            class library:
+                @staticmethod
+                def sections():
+                    captured['called'] = True
+                    return [object()]
+
+        import web.config_test_connection as cc
+
+        def _fake_init_plex(config):
+            captured['token'] = config['plex']['token']
+            return _FakeServer()
+
+        monkeypatch.setattr(cc, 'init_plex', _fake_init_plex)
+
+        resp = c.post('/config/test/plex', data={'url': 'http://localhost:32400', 'token': ''})
+        assert resp.status_code == 200
+        assert resp.get_json()['ok'] is True
+        assert captured['token'] == 'plex-token-123'
+
+    def test_null_plex_section_in_hand_edited_yaml_does_not_500(self, client):
+        """M2: a bare `plex:` line (parses to None, not {}) must not 500
+        or half-save the connections form."""
+        c, app, root = client
+        config_path = module_path(root, 'config')
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write('plex:\nusers:\n  list: "alice, bob"\n')
+
+        resp = c.post('/config/connections', data=VALID_FORM)
+        assert resp.status_code == 303
+
+        core = _read_yaml(root, 'config')
+        assert core['plex']['url'] == 'http://localhost:32400'
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr['url'] == 'http://localhost:8989'
+
+    def test_merge_validation_failure_prevents_write_and_returns_500(self, client, monkeypatch):
+        """M4: a merge that fails the pre-write dry-run must not write
+        ANY of the module files for this save."""
+        c, app, root = client
+        import web.config_app as config_app_mod
+        monkeypatch.setattr(
+            config_app_mod, 'validate_merge',
+            lambda project_root, modules: 'simulated merge failure',
+        )
+
+        resp = c.post('/config/connections', data=VALID_FORM)
+        assert resp.status_code == 500
+
+        # sonarr.yml didn't exist before this save - if _commit_modules
+        # correctly gates every write on the dry-run passing, it's still
+        # absent (empty) after a failed one.
+        sonarr = _read_yaml(root, 'sonarr')
+        assert sonarr == {}

--- a/tests/test_web_config_io.py
+++ b/tests/test_web_config_io.py
@@ -6,7 +6,10 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from ruamel.yaml.comments import CommentedMap
+
 from web.config_io import (
+    ensure_section,
     format_csv_list,
     is_secret_field,
     load_module,
@@ -15,6 +18,7 @@ from web.config_io import (
     parse_csv_list,
     save_module,
     secret_status,
+    validate_merge,
 )
 
 
@@ -130,6 +134,15 @@ class TestSecretHelpers:
         assert merge_secret(None, '') == ''
         assert merge_secret('', '') == ''
 
+    def test_merge_secret_whitespace_only_submission_with_none_existing(self):
+        assert merge_secret(None, '   ') == ''
+
+    def test_merge_secret_strips_whitespace_around_new_value(self):
+        assert merge_secret('old-token', '  new-token  ') == 'new-token'
+
+    def test_merge_secret_none_existing_nonblank_submission(self):
+        assert merge_secret(None, 'brand-new') == 'brand-new'
+
     def test_secret_status(self):
         assert secret_status('a-real-token') == 'configured'
         assert secret_status('') == 'not set'
@@ -149,3 +162,90 @@ class TestCsvHelpers:
         assert format_csv_list([]) == ''
         assert format_csv_list(None) == ''
         assert format_csv_list('already-a-string') == 'already-a-string'
+
+
+class TestEnsureSection:
+    """Tests for ensure_section() - M2's fix for a present-but-null
+    config section (a bare `plex:`/`general:` line parses to None, not
+    an empty mapping)."""
+
+    def test_creates_missing_section(self):
+        parent = CommentedMap()
+        section = ensure_section(parent, 'plex')
+        assert isinstance(section, CommentedMap)
+        assert parent['plex'] is section
+
+    def test_replaces_null_section_with_empty_map(self):
+        parent = CommentedMap()
+        parent['general'] = None  # what a bare `general:` line loads as
+        section = ensure_section(parent, 'general')
+        assert isinstance(section, CommentedMap)
+        assert parent['general'] is section
+        section['auto_update'] = True
+        assert parent['general']['auto_update'] is True
+
+    def test_returns_existing_populated_section_unchanged(self):
+        parent = CommentedMap()
+        existing = CommentedMap()
+        existing['url'] = 'http://localhost:32400'
+        parent['plex'] = existing
+        section = ensure_section(parent, 'plex')
+        assert section is existing
+        assert section['url'] == 'http://localhost:32400'
+
+
+class TestValidateMerge:
+    """Tests for validate_merge() - M4's pre-write dry-run of the full
+    utils.load_config merge on a temp copy of config/."""
+
+    def test_clean_merge_returns_none(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        (config_dir / 'config.yml').write_text(
+            'plex:\n  url: http://localhost:32400\n  token: tok\nusers:\n  list: alice\n',
+            encoding='utf-8',
+        )
+        core = load_module(str(config_dir / 'config.yml'))
+        core['plex']['url'] = 'http://localhost:9999'
+
+        assert validate_merge(str(tmp_path), {'config': core}) is None
+        # and the real file was never touched by the dry run
+        real_content = (config_dir / 'config.yml').read_text(encoding='utf-8')
+        assert 'localhost:9999' not in real_content
+
+    def test_broken_merge_returns_error_without_touching_real_files(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        config_path = config_dir / 'config.yml'
+        config_path.write_text('plex:\n  url: http://localhost:32400\n', encoding='utf-8')
+        before = config_path.read_text(encoding='utf-8')
+        core = load_module(str(config_path))
+        core['plex']['url'] = 'http://localhost:9999'
+
+        def _boom(path):
+            raise ValueError('merge is broken')
+
+        monkeypatch.setattr('utils.load_config', _boom)
+
+        error = validate_merge(str(tmp_path), {'config': core})
+        assert error is not None
+        assert 'merge is broken' in error
+        assert config_path.read_text(encoding='utf-8') == before
+
+    def test_unrelated_module_files_are_carried_through_unchanged(self, tmp_path):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        (config_dir / 'config.yml').write_text(
+            'plex:\n  url: http://localhost:32400\n  token: tok\nusers:\n  list: alice\n',
+            encoding='utf-8',
+        )
+        (config_dir / 'sonarr.yml').write_text(
+            'enabled: true\nurl: http://localhost:8989\napi_key: abc\n', encoding='utf-8',
+        )
+        core = load_module(str(config_dir / 'config.yml'))
+        core['plex']['url'] = 'http://localhost:1111'
+
+        # Only 'config' is in the update set - sonarr.yml must still be
+        # read from the real config dir (unmodified) for the merge, not
+        # silently dropped.
+        assert validate_merge(str(tmp_path), {'config': core}) is None

--- a/tests/test_web_config_settings.py
+++ b/tests/test_web_config_settings.py
@@ -176,3 +176,32 @@ class TestValidation:
 
         after = _read_yaml(root, 'tuning')
         assert after == before
+
+
+class TestNullSection:
+    def test_null_general_section_in_hand_edited_yaml_does_not_500(self, client):
+        """M2: a bare `general:` line (parses to None, not {}) must not
+        500 - it should be treated the same as a missing section."""
+        c, app, root = client
+        config_path = module_path(root, 'config')
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write('plex:\n  url: "http://localhost:32400"\ngeneral:\nusers:\n  list: "alice, bob"\n')
+
+        resp = c.post('/config/settings', data=VALID_FORM)
+        assert resp.status_code == 303
+
+        core = _read_yaml(root, 'config')
+        assert core['general']['log_retention_days'] == 7
+
+    def test_null_negative_signals_section_in_tuning_yml_does_not_500(self, client):
+        c, app, root = client
+        tuning_path = module_path(root, 'tuning')
+        os.makedirs(os.path.dirname(tuning_path), exist_ok=True)
+        with open(tuning_path, 'w', encoding='utf-8') as f:
+            f.write('negative_signals:\n')
+
+        resp = c.post('/config/settings', data=VALID_FORM)
+        assert resp.status_code == 303
+
+        tuning = _read_yaml(root, 'tuning')
+        assert tuning['negative_signals']['bad_ratings']['threshold'] == 3

--- a/tests/test_web_config_test_connection.py
+++ b/tests/test_web_config_test_connection.py
@@ -185,6 +185,23 @@ class TestTrakt:
         result = cc.test_trakt('cid', 'csecret', 'atoken', 'rtoken')
         assert result['ok'] is False
 
+    def test_raw_client_exception_is_caught_not_a_500(self, monkeypatch):
+        # Matches every other tester in this module: a raw requests/API
+        # error must produce a normal {ok, message} failure, not an
+        # unhandled exception with an unredacted traceback.
+        class _FakeClient:
+            def __init__(self, client_id, client_secret, access_token, refresh_token):
+                pass
+
+            def get_username(self):
+                raise ConnectionError('boom: token=abcdef123456 leaked')
+
+        monkeypatch.setattr(cc, 'TraktClient', _FakeClient)
+        result = cc.test_trakt('cid', 'csecret', 'atoken', 'rtoken')
+        assert result['ok'] is False
+        assert 'boom' in result['message']
+        assert 'abcdef123456' not in result['message']
+
 
 class TestTestersRegistry:
     def test_all_services_registered(self):

--- a/tests/test_web_config_users.py
+++ b/tests/test_web_config_users.py
@@ -129,3 +129,44 @@ class TestValidation:
         })
         after = _read_config(root)
         assert after == before
+
+
+class TestNullSection:
+    def test_null_users_section_in_hand_edited_yaml_does_not_500(self, client):
+        """M2: a bare `users:` line (parses to None, not {}) must not
+        500 - it should be treated the same as a missing section."""
+        c, app, root = client
+        config_path = module_path(root, 'config')
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write('plex:\n  url: "http://localhost:32400"\nusers:\n')
+
+        resp = c.post('/config/users', data={
+            'user_count': '1',
+            'username_0': 'carol', 'display_name_0': '', 'exclude_genres_0': '',
+            'max_rating_0': '', 'streaming_services_0': '',
+            'new_username': '',
+        })
+        assert resp.status_code == 303
+
+        core = _read_config(root)
+        assert 'carol' in core['users']['list']
+
+    def test_null_preferences_subsection_does_not_500(self, client):
+        c, app, root = client
+        config_path = module_path(root, 'config')
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write(
+                'plex:\n  url: "http://localhost:32400"\n'
+                'users:\n  list: "alice"\n  preferences:\n'
+            )
+
+        resp = c.post('/config/users', data={
+            'user_count': '1',
+            'username_0': 'alice', 'display_name_0': 'Alice A', 'exclude_genres_0': '',
+            'max_rating_0': '', 'streaming_services_0': '',
+            'new_username': '',
+        })
+        assert resp.status_code == 303
+
+        core = _read_config(root)
+        assert core['users']['preferences']['alice']['display_name'] == 'Alice A'

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -7,6 +7,7 @@ fast and hermetic - they never touch Plex/TMDB or the real repo.
 """
 
 import os
+import subprocess
 import sys
 import time
 
@@ -14,7 +15,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
-from web.job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
+import web.job_runner as job_runner_mod
+from web.job_runner import DONE_SENTINEL, Job, JobAlreadyRunningError, JobError, JobManager
 
 
 def _wait_until_done(job, timeout=10):
@@ -28,6 +30,28 @@ def _wait_until_done(job, timeout=10):
 
 def _manager(root):
     return JobManager(root, os.path.join(root, 'logs'))
+
+
+def _make_root(tmp_path, movie_py):
+    """Like the curatarr_web_root fixture (tests/conftest.py) but with a
+    caller-supplied recommenders/movie.py body, for tests that need
+    control over exactly what the child process prints/does."""
+    root = tmp_path
+    (root / 'config').mkdir()
+    (root / 'config' / 'config.yml').write_text(
+        'plex:\n  url: "http://localhost:32400"\n  token: "not-a-real-token"\n'
+        'users:\n  list: "alice, bob"\n',
+        encoding='utf-8',
+    )
+    (root / 'logs').mkdir()
+    (root / 'recommendations' / 'external').mkdir(parents=True)
+    (root / 'recommenders').mkdir()
+    (root / 'recommenders' / 'movie.py').write_text(movie_py, encoding='utf-8')
+    (root / 'recommenders' / 'tv.py').write_text('print("tv done")\n', encoding='utf-8')
+    (root / 'recommenders' / 'external.py').write_text('print("external done")\n', encoding='utf-8')
+    (root / 'run.sh').write_text('#!/bin/bash\necho full done\n', encoding='utf-8')
+    (root / 'run.ps1').write_text('Write-Host "full done"\n', encoding='utf-8')
+    return str(root)
 
 
 class TestJobManagerStart:
@@ -155,3 +179,163 @@ class TestJobSubscribe:
 
         assert 'Movie recommendations done' in collected
         job.unsubscribe(q)  # already removed on completion; must be a no-op
+
+    def test_subscriber_queue_is_bounded_not_unbounded(self, curatarr_web_root):
+        """H2: a subscriber that never reads must not let _append_line
+        grow its queue without bound - the oldest entry is dropped once
+        the queue is full instead."""
+        job = Job('movie', 'alice', ['true'], os.path.join(curatarr_web_root, 'logs', 'x.log'))
+        q = job.subscribe()
+        for i in range(job_runner_mod.SUBSCRIBER_QUEUE_MAXSIZE + 500):
+            job._append_line(f'line {i}')
+        assert q.qsize() <= job_runner_mod.SUBSCRIBER_QUEUE_MAXSIZE
+        # the newest line survived; the earliest ones were dropped
+        last = None
+        while not q.empty():
+            last = q.get_nowait()
+        assert last == f'line {job_runner_mod.SUBSCRIBER_QUEUE_MAXSIZE + 499}'
+
+
+class TestPumpFailureHandling:
+    """Tests for _pump()'s failure paths - H1 (open() failure must not
+    wedge the job/lock forever) and M1 (non-UTF8 output, always reaping
+    the child)."""
+
+    def test_open_failure_marks_job_failed_and_unwedges_lock(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        # A directory, not a file, so open(log_path, 'w') always raises
+        # IsADirectoryError - simulates a bad log path (permissions,
+        # full disk, deleted logs dir, etc.) without OS-specific tricks.
+        bad_log_path = os.path.join(curatarr_web_root, 'logs', 'not_a_file')
+        os.makedirs(bad_log_path)
+        job = Job('movie', 'alice', [sys.executable, '-c', 'print("hi")'], bad_log_path)
+        job.process = subprocess.Popen(
+            job.cmd, cwd=curatarr_web_root, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, encoding='utf-8', errors='replace', bufsize=1,
+        )
+        manager._current = job
+
+        manager._pump(job)  # must return promptly, never hang
+
+        assert job.state == 'failed'
+        assert job.returncode == -1
+        assert manager.is_running() is False
+        assert any('job runner error' in line for line in job.lines)
+
+    def test_non_utf8_output_does_not_crash_and_job_still_completes(self, tmp_path):
+        root = _make_root(tmp_path, (
+            'import sys\n'
+            "sys.stdout.buffer.write(b'before \\xff\\xfe garbage after\\n')\n"
+            'sys.stdout.buffer.flush()\n'
+            "print('normal line after')\n"
+        ))
+        manager = _manager(root)
+        job = manager.start('movie', 'alice', ['alice'])
+        _wait_until_done(job)
+
+        assert job.returncode == 0
+        assert job.state == 'succeeded'
+        assert any('normal line after' in line for line in job.lines)
+        with open(job.log_path, encoding='utf-8') as f:
+            logged = f.read()
+        assert 'normal line after' in logged
+
+    def test_killed_child_marks_job_failed_and_releases_lock(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '10')
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice', 'bob'])
+
+        deadline = time.time() + 5
+        while job.process.poll() is not None and time.time() < deadline:
+            time.sleep(0.02)
+        assert job.process.poll() is None  # actually started
+
+        job.process.kill()
+        _wait_until_done(job)
+
+        assert job.state == 'failed'
+        assert manager.is_running() is False
+        assert not os.path.exists(manager._lock_path())
+
+
+class TestPopenFailure:
+    """Tests for M3 - a missing interpreter/shell must be a friendly
+    JobError, not an unhandled 500."""
+
+    def test_popen_failure_raises_friendly_joberror(self, curatarr_web_root, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise FileNotFoundError("[Errno 2] No such file or directory: 'bash'")
+
+        monkeypatch.setattr(job_runner_mod.subprocess, 'Popen', _boom)
+        manager = _manager(curatarr_web_root)
+
+        with pytest.raises(JobError) as exc_info:
+            manager.start('full', 'all', ['alice'])
+
+        assert 'Could not start' in str(exc_info.value)
+        assert manager.is_running() is False
+        assert manager.current_job() is None
+
+
+class TestTerminateRunning:
+    """Tests for H3 - terminating an in-flight run on server shutdown."""
+
+    def test_terminate_running_kills_in_flight_process(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '10')
+        manager = _manager(curatarr_web_root)
+        job = manager.start('movie', 'alice', ['alice', 'bob'])
+
+        deadline = time.time() + 5
+        while job.process.poll() is not None and time.time() < deadline:
+            time.sleep(0.02)
+        assert job.process.poll() is None
+
+        manager.terminate_running()
+
+        deadline = time.time() + 5
+        while job.process.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+        assert job.process.poll() is not None
+        assert not os.path.exists(manager._lock_path())
+
+    def test_terminate_running_is_a_noop_with_nothing_running(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        manager.terminate_running()  # must not raise
+
+
+class TestForeignLockfile:
+    """Tests for the cross-process lockfile (H3's "and" half): a fresh
+    JobManager (e.g. after a server restart) must detect a still-alive
+    PID left behind by a previous process, and must clean up a stale
+    one from a process that's since exited."""
+
+    def test_stale_lockfile_from_dead_pid_is_ignored_and_removed(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        os.makedirs(os.path.dirname(manager._lock_path()), exist_ok=True)
+        # PID 999999 should not correspond to a live process in any test
+        # environment.
+        with open(manager._lock_path(), 'w', encoding='utf-8') as f:
+            f.write('999999')
+
+        assert manager._foreign_run_in_progress() is False
+        assert not os.path.exists(manager._lock_path())
+
+    def test_live_foreign_pid_blocks_a_new_run(self, curatarr_web_root):
+        manager = _manager(curatarr_web_root)
+        os.makedirs(os.path.dirname(manager._lock_path()), exist_ok=True)
+        # A genuinely separate, currently-alive process - NOT this
+        # test's own PID, which _foreign_run_in_progress() deliberately
+        # treats as "my own lock", not a foreign one. Simulates a
+        # previous curatarr server process (different PID, still
+        # running) that left a lock behind after being killed without a
+        # clean shutdown.
+        helper = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(5)'])
+        try:
+            with open(manager._lock_path(), 'w', encoding='utf-8') as f:
+                f.write(str(helper.pid))
+
+            with pytest.raises(JobAlreadyRunningError):
+                manager.start('movie', 'alice', ['alice'])
+        finally:
+            helper.kill()
+            helper.wait()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -2,6 +2,7 @@
 results screens, plus the localhost-only binding guardrail.
 """
 
+import concurrent.futures
 import os
 import sys
 import time
@@ -10,6 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
+import web.app as app_module
 from web.app import create_app, _wait_for_listening
 
 
@@ -125,6 +127,38 @@ class TestRunPage:
         body = resp.get_data(as_text=True)
         assert 'event: done' in body
 
+    def test_run_stream_emits_heartbeat_when_idle(self, client, monkeypatch):
+        """H2: with no new output for SSE_HEARTBEAT_SECONDS, generate()
+        must send a keepalive comment instead of blocking forever."""
+        c, app, root = client
+        monkeypatch.setattr(app_module, 'SSE_HEARTBEAT_SECONDS', 0.05)
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '0.5')
+        c.post('/run', data={'engine': 'movie', 'user': 'alice'})
+        resp = c.get('/run/stream')
+        body = resp.get_data(as_text=True)
+        assert ': keepalive' in body
+        assert 'event: done' in body
+        _wait_until_idle(app)
+
+    def test_run_stream_disconnect_mid_run_unsubscribes(self, client, monkeypatch):
+        """H2: a client that disappears mid-stream (closed tab, dead
+        socket) must be unsubscribed - not left in job._subscribers
+        piling up output nobody will ever read."""
+        c, app, root = client
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '2')
+        c.post('/run', data={'engine': 'movie', 'user': 'alice'})
+        job = app.job_manager.current_job()
+
+        resp = c.get('/run/stream')
+        chunks = iter(resp.response)
+        next(chunks)  # pull one chunk so the generator has actually subscribed
+        assert len(job._subscribers) == 1
+
+        resp.close()  # simulates the browser socket going away mid-stream
+
+        assert len(job._subscribers) == 0
+        _wait_until_idle(app)
+
     def test_run_status_json_idle(self, client):
         c, app, root = client
         resp = c.get('/run/status')
@@ -169,6 +203,31 @@ class TestResults:
         resp = c.get('/results/watchlist/watchlist.html')
         assert resp.status_code == 200
         assert b'hello world' in resp.data
+
+    def test_watchlist_html_gets_restrictive_csp_header(self, client):
+        """Defense-in-depth on top of the escaping fix in
+        recommenders/external_output.py - even a future gap there
+        shouldn't be able to turn into a script driving this app's own
+        state-changing endpoints."""
+        c, app, root = client
+        ext_dir = os.path.join(root, 'recommendations', 'external')
+        with open(os.path.join(ext_dir, 'watchlist.html'), 'w') as f:
+            f.write('<html>hello</html>')
+        resp = c.get('/results/watchlist/watchlist.html')
+        assert resp.status_code == 200
+        csp = resp.headers.get('Content-Security-Policy', '')
+        assert "object-src 'none'" in csp
+        assert "frame-ancestors 'none'" in csp
+        assert resp.headers.get('X-Content-Type-Options') == 'nosniff'
+
+    def test_watchlist_md_does_not_get_html_csp_header(self, client):
+        c, app, root = client
+        ext_dir = os.path.join(root, 'recommendations', 'external')
+        with open(os.path.join(ext_dir, 'alice_watchlist.md'), 'w') as f:
+            f.write('# hello')
+        resp = c.get('/results/watchlist/alice_watchlist.md')
+        assert resp.status_code == 200
+        assert 'Content-Security-Policy' not in resp.headers
 
     def test_watchlist_rejects_non_html_md_extension(self, client):
         c, app, root = client
@@ -245,3 +304,103 @@ class TestBindingGuardrail:
         # Only the redaction/no-wildcard-bind explanation may mention
         # 0.0.0.0 in prose; app.run() itself must never pass it as host=.
         assert not re.search(r'host\s*=\s*[\'"]0\.0\.0\.0[\'"]', source)
+
+
+class TestOriginHostGuard:
+    """Tests for web.security.register_origin_host_guard, wired into
+    every request via create_app(). The `client` fixture's test client
+    stamps a same-origin Origin header by default (see
+    _BrowserLikeTestClient in web/app.py) so every *other* test in this
+    module models a real same-origin browser request; these tests
+    override that default to exercise rejection.
+    """
+
+    def test_cross_origin_post_rejected_403(self, client):
+        c, app, root = client
+        resp = c.post(
+            '/run', data={'engine': 'movie', 'user': 'alice'},
+            headers={'Origin': 'http://evil.example.com'},
+        )
+        assert resp.status_code == 403
+        assert app.job_manager.current_job() is None
+
+    def test_cross_origin_config_post_rejected_403(self, client):
+        c, app, root = client
+        resp = c.post(
+            '/config/users', data={'user_count': '0', 'new_username': ''},
+            headers={'Origin': 'https://attacker.example.com'},
+        )
+        assert resp.status_code == 403
+
+    def test_post_with_no_origin_or_referer_rejected_403(self, client):
+        c, app, root = client
+        resp = c.post(
+            '/run', data={'engine': 'movie', 'user': 'alice'},
+            headers={'Origin': ''},
+        )
+        assert resp.status_code == 403
+
+    def test_referer_fallback_accepted_when_origin_absent(self, client):
+        c, app, root = client
+        resp = c.post(
+            '/run', data={'engine': 'external', 'user': 'all'},
+            headers={'Origin': '', 'Referer': 'http://localhost/run'},
+        )
+        assert resp.status_code == 303
+        _wait_until_idle(app)
+
+    def test_same_origin_post_with_port_accepted(self, client):
+        c, app, root = client
+        resp = c.post(
+            '/run', data={'engine': 'external', 'user': 'all'},
+            headers={'Origin': 'http://127.0.0.1:8787'},
+        )
+        assert resp.status_code == 303
+        _wait_until_idle(app)
+
+    def test_get_requests_ignore_origin(self, client):
+        c, app, root = client
+        resp = c.get('/', headers={'Origin': 'http://evil.example.com'})
+        assert resp.status_code == 200
+
+    def test_bad_host_header_rejected_400(self, client):
+        c, app, root = client
+        resp = c.get('/', headers={'Host': 'evil.example.com'})
+        assert resp.status_code == 400
+
+    def test_bad_host_header_with_port_rejected_400(self, client):
+        c, app, root = client
+        resp = c.get('/', headers={'Host': 'evil.example.com:8787'})
+        assert resp.status_code == 400
+
+    def test_valid_host_with_port_accepted(self, client):
+        c, app, root = client
+        resp = c.get('/', headers={'Host': '127.0.0.1:8787'})
+        assert resp.status_code == 200
+
+    def test_valid_bare_localhost_host_accepted(self, client):
+        c, app, root = client
+        resp = c.get('/', headers={'Host': 'localhost'})
+        assert resp.status_code == 200
+
+
+class TestConcurrentRun:
+    """Concurrency test for JobManager's single-run lock, driven through
+    the actual HTTP route rather than calling JobManager.start()
+    directly - a true race, not a sequential simulation."""
+
+    def test_concurrent_double_post_run_only_one_launches(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.setenv('CURATARR_TEST_SLOW', '1')
+
+        def _post(_):
+            return c.post('/run', data={'engine': 'movie', 'user': 'alice'})
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+            responses = list(pool.map(_post, range(6)))
+
+        busy = [r for r in responses if 'error=busy' in r.headers.get('Location', '')]
+        launched = [r for r in responses if 'error=busy' not in r.headers.get('Location', '')]
+        assert len(launched) == 1
+        assert len(busy) == 5
+        _wait_until_idle(app)

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
-from web.security import redact, redact_lines, safe_join
+from web.security import is_allowed_host, redact, redact_lines, safe_join
 
 
 class TestRedact:
@@ -49,6 +49,37 @@ class TestRedact:
         assert result[0] == "normal line"
         assert "secretvalue1" not in result[1]
 
+    def test_masks_value_with_leading_special_char(self):
+        # A value starting with a non-alnum char (`$`, `#`, `!`, a
+        # leading base64 `+`/`/`, ...) used to fall entirely outside the
+        # old character class, so the whole key=value pair passed
+        # through unredacted.
+        result = redact('token: "$ecretValue123"')
+        assert "$ecretValue123" not in result
+        assert "token=***REDACTED***" in result
+
+    def test_masks_value_with_leading_special_char_unquoted(self):
+        result = redact("api_key=#deadbeef!123")
+        assert "#deadbeef!123" not in result
+        assert "api_key=***REDACTED***" in result
+
+    def test_masks_bare_known_prefix_token(self):
+        # No "key: "/"key=" prefix at all - just a raw vendor-formatted
+        # token (e.g. echoed inside a stack trace argument).
+        result = redact("auth failed using ghp_16C7e42F292c6912E7710c838347Ae178B4a during request")
+        assert "ghp_16C7e42F292c6912E7710c838347Ae178B4a" not in result
+        assert "ghp_***REDACTED***" in result
+
+    def test_masks_bare_aws_style_prefix_token(self):
+        result = redact("found leaked key AKIAABCDEFGHIJKLMNOP in output")
+        assert "AKIAABCDEFGHIJKLMNOP" not in result
+        assert "AKIA***REDACTED***" in result
+
+    def test_does_not_touch_unrelated_short_word_with_prefix_substring(self):
+        # Sanity check the prefix match isn't so loose it eats normal text.
+        text = "the skyline was beautiful"
+        assert redact(text) == text
+
 
 class TestSafeJoin:
     """Tests for safe_join()"""
@@ -65,3 +96,50 @@ class TestSafeJoin:
     def test_rejects_absolute_path_escape(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             safe_join(str(tmp_path), os.path.join(os.sep, "etc", "passwd"))
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.log").write_text("TOP SECRET")
+        base = tmp_path / "base"
+        base.mkdir()
+        link = base / "escape.log"
+        try:
+            os.symlink(str(outside / "secret.log"), str(link))
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported in this environment")
+        with pytest.raises(FileNotFoundError):
+            safe_join(str(base), "escape.log")
+
+
+class TestIsAllowedHost:
+    """Tests for is_allowed_host() - the Host/Origin allow-list used by
+    register_origin_host_guard()."""
+
+    def test_accepts_bare_localhost(self):
+        assert is_allowed_host("localhost") is True
+
+    def test_accepts_localhost_with_port(self):
+        assert is_allowed_host("localhost:8787") is True
+
+    def test_accepts_bare_loopback_ip(self):
+        assert is_allowed_host("127.0.0.1") is True
+
+    def test_accepts_loopback_ip_with_port(self):
+        assert is_allowed_host("127.0.0.1:8787") is True
+
+    def test_rejects_other_hostnames(self):
+        assert is_allowed_host("evil.example.com") is False
+
+    def test_rejects_other_hostnames_with_port(self):
+        assert is_allowed_host("evil.example.com:8787") is False
+
+    def test_rejects_empty(self):
+        assert is_allowed_host("") is False
+        assert is_allowed_host(None) is False
+
+    def test_rejects_lan_ip_even_though_it_could_reach_the_server(self):
+        # A LAN IP could, in principle, also route to this machine, but
+        # the app only ever binds 127.0.0.1 - a request claiming a LAN
+        # Host is either misconfigured or a rebinding attempt either way.
+        assert is_allowed_host("192.168.1.50:8787") is False

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -8,7 +8,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
+import web.status as status_mod
 from web.status import (
+    TAIL_BYTES,
     display_name_safe_slug, find_user_watchlist, get_last_run_status,
     list_log_files, read_log_tail,
 )
@@ -78,6 +80,57 @@ class TestGetLastRunStatus:
         assert isinstance(result['timestamp'], datetime)
         assert result['timestamp'] == datetime.fromtimestamp(os.path.getmtime(path))
 
+    def test_username_with_glob_special_chars_does_not_match_other_users(self, tmp_path):
+        # A Plex username of "*" (or containing "?"/"[...]") must not
+        # turn the glob pattern into a wildcard that leaks other users'
+        # last-run status onto this one's dashboard row.
+        _write_log(tmp_path, 'recommendations_bob_20260101_030000.log', 'ok\n')
+        result = get_last_run_status(str(tmp_path), '*')
+        assert result == {'status': 'never_run', 'timestamp': None, 'log_file': None}
+
+    def test_username_with_bracket_glob_chars_does_not_match(self, tmp_path):
+        _write_log(tmp_path, 'recommendations_bob_20260101_030000.log', 'ok\n')
+        result = get_last_run_status(str(tmp_path), '[ab]*')
+        assert result['status'] == 'never_run'
+
+    def test_traceback_marker_within_tail_window_is_detected(self, tmp_path):
+        filler = 'x' * (TAIL_BYTES + 1000)
+        content = filler + '\nTraceback (most recent call last):\nValueError\n'
+        _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', content)
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'failed'
+
+    def test_traceback_marker_beyond_tail_window_is_not_detected(self, tmp_path):
+        # Documents the heuristic's known limitation (per TAIL_BYTES):
+        # only the last TAIL_BYTES of a log are inspected, so a
+        # traceback appearing only earlier than that in a very large log
+        # won't flip status to 'failed'. The important thing this
+        # asserts is that it doesn't crash on a large file either way.
+        content = 'Traceback (most recent call last):\nValueError\n' + ('x' * (TAIL_BYTES + 1000))
+        _write_log(tmp_path, 'recommendations_alice_20260101_030000.log', content)
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['status'] == 'success'
+
+    def test_getmtime_oserror_falls_back_to_none_timestamp(self, tmp_path, monkeypatch):
+        # Unparseable-timestamp filename forces the getmtime() fallback;
+        # simulate the file vanishing (log-retention cleanup racing this
+        # request) right before that specific call. The first getmtime()
+        # call (inside latest_user_log()'s max(key=...) over glob
+        # results) must still succeed, so this only fails the second.
+        _write_log(tmp_path, 'recommendations_alice_20261301_030000.log', 'ok\n')
+        real_getmtime = os.path.getmtime
+        calls = {'n': 0}
+
+        def _flaky(path):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                return real_getmtime(path)
+            raise OSError('gone')
+
+        monkeypatch.setattr(status_mod.os.path, 'getmtime', _flaky)
+        result = get_last_run_status(str(tmp_path), 'alice')
+        assert result['timestamp'] is None
+
 
 class TestListLogFiles:
     """Tests for list_log_files()"""
@@ -93,6 +146,20 @@ class TestListLogFiles:
         os.utime(b, (100, 100))
         result = list_log_files(str(tmp_path))
         assert [e['name'] for e in result] == ['b.log', 'a.log']
+
+    def test_skips_file_deleted_mid_scan_instead_of_raising(self, tmp_path, monkeypatch):
+        _write_log(tmp_path, 'gone.log', 'a')
+        _write_log(tmp_path, 'still-here.log', 'b')
+        real_getsize = os.path.getsize
+
+        def _flaky(path):
+            if path.endswith('gone.log'):
+                raise OSError('deleted mid-scan')
+            return real_getsize(path)
+
+        monkeypatch.setattr(status_mod.os.path, 'getsize', _flaky)
+        result = list_log_files(str(tmp_path))
+        assert [e['name'] for e in result] == ['still-here.log']
 
 
 class TestReadLogTail:
@@ -120,6 +187,25 @@ class TestReadLogTail:
         _write_log(tmp_path, 'a.log', content)
         result = read_log_tail(str(tmp_path), 'a.log', max_lines=3)
         assert result.splitlines() == ['line7', 'line8', 'line9']
+
+    def test_rejects_non_log_extension(self, tmp_path):
+        (tmp_path / 'config.yml').write_text('plex:\n  token: secret\n', encoding='utf-8')
+        with pytest.raises(FileNotFoundError):
+            read_log_tail(str(tmp_path), 'config.yml')
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        outside = tmp_path / 'outside'
+        outside.mkdir()
+        (outside / 'secret.log').write_text('TOP SECRET', encoding='utf-8')
+        logs_dir = tmp_path / 'logs'
+        logs_dir.mkdir()
+        try:
+            os.symlink(str(outside / 'secret.log'), str(logs_dir / 'escape.log'))
+        except (OSError, NotImplementedError):
+            pytest.skip('symlinks not supported in this environment')
+        with pytest.raises(FileNotFoundError):
+            read_log_tail(str(logs_dir), 'escape.log')
+
 
 class TestDisplayNameSafeSlug:
     """Tests for display_name_safe_slug()"""

--- a/web/app.py
+++ b/web/app.py
@@ -11,10 +11,19 @@ Design notes:
   multi-tenant refactor of the utils layer carries the web UI with it.
 - This module does not alter any existing recommender/CLI behavior; it
   only shells out to it.
+- Every request is guarded by web.security.register_origin_host_guard:
+  the Host header must be 127.0.0.1/localhost (blocks DNS rebinding),
+  and every state-changing request's Origin/Referer must be too (blocks
+  a page on any other origin from driving /run or /config/* - this app
+  has no other session/auth boundary to rely on).
 """
 
+import atexit
 import os
+import queue
+import signal
 import socket
+import sys
 import threading
 import time
 import webbrowser
@@ -24,15 +33,61 @@ from flask import (
     Flask, Response, abort, jsonify, redirect, render_template,
     request, send_from_directory, stream_with_context, url_for,
 )
+from flask.testing import FlaskClient
+from werkzeug.datastructures import Headers
 
 from utils import get_project_root, get_users_from_config, load_config
 
 from .config_app import register_config_routes
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
-from .security import redact
+from .security import redact, register_origin_host_guard
 from .status import find_user_watchlist, get_last_run_status, list_log_files, read_log_tail
 
 DEFAULT_PORT = 8787
+
+# How long the SSE stream waits for a new line before sending a
+# keepalive comment - see run_stream()'s generate().
+SSE_HEARTBEAT_SECONDS = 15.0
+
+# Applied to served watchlist HTML (see results_watchlist()). Primary
+# XSS defense is escaping at generation time (recommenders/
+# external_output.py); this is defense-in-depth so that even a gap
+# there can't turn into a same-origin script able to reach this app's
+# own state-changing endpoints via object embeds / cross-frame tricks.
+# script-src still needs 'unsafe-inline' since the watchlist page's own
+# sort/filter/export UI is inline <script> - that's an existing,
+# intentional part of the page, not something this CSP is meant to
+# block.
+WATCHLIST_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src https://fonts.gstatic.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'none'; "
+    "frame-ancestors 'none'"
+)
+
+
+class _BrowserLikeTestClient(FlaskClient):
+    """Flask's default test client sends bare requests (Host: localhost,
+    no Origin header) that don't look like a browser hitting the UI's
+    own origin - register_origin_host_guard would 403 every test POST
+    as cross-origin otherwise. Stamp a same-origin Origin header by
+    default so the existing test suite keeps modeling "the browser
+    talking to the app it was served from"; a test that wants to
+    exercise the guard's rejection path passes its own Origin/Host
+    header, which takes precedence over this default.
+    """
+
+    def open(self, *args, **kwargs):
+        headers = Headers(kwargs.pop('headers', None))
+        if 'Origin' not in headers:
+            headers['Origin'] = 'http://localhost'
+        kwargs['headers'] = headers
+        return super().open(*args, **kwargs)
 
 
 def create_app(project_root: str = None) -> Flask:
@@ -48,7 +103,9 @@ def create_app(project_root: str = None) -> Flask:
     app.config['LOGS_DIR'] = logs_dir
     app.config['EXTERNAL_DIR'] = external_dir
     app.job_manager = JobManager(project_root, logs_dir)
+    app.test_client_class = _BrowserLikeTestClient
 
+    register_origin_host_guard(app)
     register_config_routes(app)
 
     def _load_config():
@@ -107,7 +164,21 @@ def create_app(project_root: str = None) -> Flask:
             q = job.subscribe()
             try:
                 while True:
-                    item = q.get()
+                    try:
+                        item = q.get(timeout=SSE_HEARTBEAT_SECONDS)
+                    except queue.Empty:
+                        # No new output in a while - send a keepalive
+                        # comment instead of blocking forever. A closed
+                        # browser socket makes the yield below raise
+                        # (Werkzeug detects the write failure), which
+                        # unwinds into the finally clause and
+                        # unsubscribes - without this, a client that
+                        # vanished mid-run (closed tab, dead wifi) would
+                        # never unsubscribe and its queue would sit
+                        # subscribed (bounded, but pointlessly) for the
+                        # rest of the run.
+                        yield ": keepalive\n\n"
+                        continue
                     if item is DONE_SENTINEL:
                         yield f"event: done\ndata: {job.returncode}\n\n"
                         break
@@ -145,7 +216,16 @@ def create_app(project_root: str = None) -> Flask:
         # send_from_directory refuses path traversal on its own; the
         # extension check above is belt-and-suspenders since this only
         # ever serves generated watchlist output, not arbitrary files.
-        return send_from_directory(external_dir, filename)
+        response = send_from_directory(external_dir, filename)
+        if filename.endswith('.html'):
+            # Defense-in-depth on top of the escaping fix in
+            # recommenders/external_output.py (TMDB-derived fields are
+            # HTML-escaped at generation time now) - even a future gap
+            # there shouldn't be able to turn into a script that can
+            # drive this app's own state-changing endpoints.
+            response.headers['Content-Security-Policy'] = WATCHLIST_CSP
+            response.headers['X-Content-Type-Options'] = 'nosniff'
+        return response
 
     @app.get('/results/log/<path:filename>')
     def results_log(filename):
@@ -178,6 +258,28 @@ def main():
     """
     port = int(os.environ.get('CURATARR_UI_PORT', DEFAULT_PORT))
     app = create_app()
+
+    # H3: a server shutdown (Ctrl+C, SIGTERM from a process manager, or
+    # a clean interpreter exit) must never leave an orphaned recommender
+    # subprocess running in the background - it would keep mutating
+    # caches/Plex collections while a freshly-started server could try
+    # to launch a new run at the same time. Covers both a graceful exit
+    # (atexit) and a signal-driven one; JobManager.terminate_running()
+    # is a no-op if nothing is running.
+    atexit.register(app.job_manager.terminate_running)
+
+    def _handle_shutdown_signal(signum, frame):
+        app.job_manager.terminate_running()
+        sys.exit(0)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handle_shutdown_signal)
+        except (ValueError, OSError):
+            # signal.signal() only works on the main thread, and not
+            # every signal is available on every platform - atexit above
+            # still covers a normal interpreter shutdown either way.
+            pass
 
     def _open_when_ready():
         if _wait_for_listening(port):

--- a/web/config_app.py
+++ b/web/config_app.py
@@ -31,10 +31,10 @@ from typing import Dict, Optional
 from flask import jsonify, redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
 
-from utils import load_config
 from utils.plex import MOVIE_RATING_HIERARCHY, TV_RATING_HIERARCHY
 
 from .config_io import (
+    ensure_section,
     format_csv_list,
     load_module,
     merge_secret,
@@ -42,6 +42,7 @@ from .config_io import (
     parse_csv_list,
     save_module,
     secret_status,
+    validate_merge,
 )
 from .config_test_connection import TESTERS
 from .security import redact
@@ -61,23 +62,28 @@ LOG_LEVEL_CHOICES = ('DEBUG', 'INFO', 'WARNING', 'ERROR')
 RATING_CHOICES = MOVIE_RATING_HIERARCHY + TV_RATING_HIERARCHY
 
 
-def _reload_error(project_root: str) -> Optional[str]:
-    """Post-write sanity check: reload everything just written through the
-    same utils.load_config merge path the recommenders use at run time.
+def _commit_modules(project_root: str, modules: Dict[str, CommentedMap]) -> Optional[str]:
+    """Validate *modules* (module-file-name -> CommentedMap to write) via
+    a dry-run merge (config_io.validate_merge) BEFORE writing anything
+    for real, then save every module. Field-level validation (weights
+    sum, URLs, choices - see config_validate.py) happens even earlier,
+    before this is ever called, which is what actually prevents most
+    bad input from being considered at all. This is the second,
+    defense-in-depth check: it catches a value that's individually
+    well-typed but still breaks utils.load_config's merge some other
+    way - and catches it on a throwaway temp copy, so a bad save can
+    never reach the real config files (nor leave some of a multi-file
+    save applied and others not).
 
-    Field-level validation (weights sum, URLs, choices - see
-    config_validate.py) happens *before* any file is touched, which is
-    what actually prevents bad input from ever reaching disk. This is a
-    second, defense-in-depth check that the files we just wrote still
-    parse and merge cleanly - it should never fire given the writers
-    above only ever set well-typed values, but if it does, the operator
-    finds out immediately instead of on the next scheduled run.
+    Returns an error message (and writes nothing) if the dry-run merge
+    fails, else None once every module in *modules* has been saved.
     """
-    try:
-        load_config(module_path(project_root, 'config'))
-    except Exception as exc:
-        logger.error(f"Post-write config reload check failed: {exc}")
-        return str(exc)
+    error = validate_merge(project_root, modules)
+    if error:
+        logger.error(f"Config merge validation failed - nothing saved: {error}")
+        return error
+    for name, data in modules.items():
+        save_module(module_path(project_root, name), data)
     return None
 
 
@@ -112,13 +118,13 @@ def register_config_routes(app) -> None:
                 **_connections_view(data, overrides=parsed),
             ), 400
 
-        _apply_connections(project_root, data, parsed)
-        reload_error = _reload_error(project_root)
-        if reload_error:
+        modules = _apply_connections(project_root, data, parsed)
+        commit_error = _commit_modules(project_root, modules)
+        if commit_error:
             return render_template(
                 'config_connections.html',
                 saved=False,
-                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                errors={'_global': f'Could not save: {commit_error}'},
                 **_connections_view(_load_connections(project_root)),
             ), 500
         return redirect(url_for('config_connections', saved='1'), code=303)
@@ -134,10 +140,20 @@ def register_config_routes(app) -> None:
 
         # Secret fields: an empty submission means "use the already-saved
         # value" so Test Connection works without retyping a token that
-        # was configured on a previous save.
+        # was configured on a previous save - but ONLY when the URL being
+        # tested is the same URL that secret was saved against. Without
+        # this check, submitting a blank token/api_key alongside an
+        # attacker-supplied `url` would make this endpoint fetch the real
+        # stored secret and send it straight to that URL - an
+        # exfiltration path, not just a UX convenience. If the URL has
+        # changed, a blank secret field stays blank and the tester below
+        # fails fast with its own "required" message instead.
         existing = _existing_secret_lookup(data, service)
-        for key, existing_value in existing.items():
-            form[key] = merge_secret(existing_value, form.get(key, ''))
+        saved_url = _existing_url_lookup(data, service)
+        url_unchanged = saved_url is None or form.get('url', '').strip() == saved_url.strip()
+        if url_unchanged:
+            for key, existing_value in existing.items():
+                form[key] = merge_secret(existing_value, form.get(key, ''))
 
         result = tester(form)
         # Defense in depth: an underlying client's exception message could
@@ -175,13 +191,13 @@ def register_config_routes(app) -> None:
                 **_users_view(core, overrides=parsed),
             ), 400
 
-        _apply_users(project_root, core, parsed)
-        reload_error = _reload_error(project_root)
-        if reload_error:
+        modules = _apply_users(project_root, core, parsed)
+        commit_error = _commit_modules(project_root, modules)
+        if commit_error:
             return render_template(
                 'config_users.html',
                 saved=False,
-                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                errors={'_global': f'Could not save: {commit_error}'},
                 **_users_view(load_module(module_path(project_root, 'config'))),
             ), 500
         return redirect(url_for('config_users', saved='1'), code=303)
@@ -223,13 +239,13 @@ def register_config_routes(app) -> None:
                 **_settings_view(tuning, core, sonarr, radarr, trakt, overrides=parsed),
             ), 400
 
-        _apply_settings(project_root, tuning, core, sonarr, radarr, trakt, parsed)
-        reload_error = _reload_error(project_root)
-        if reload_error:
+        modules = _apply_settings(project_root, tuning, core, sonarr, radarr, trakt, parsed)
+        commit_error = _commit_modules(project_root, modules)
+        if commit_error:
             return render_template(
                 'config_settings.html',
                 saved=False,
-                errors={'_global': f'Saved, but the config failed to reload: {reload_error}'},
+                errors={'_global': f'Could not save: {commit_error}'},
                 **_settings_view(
                     load_module(module_path(project_root, 'tuning')),
                     load_module(module_path(project_root, 'config')),
@@ -252,6 +268,22 @@ def _load_connections(project_root: str) -> Dict[str, CommentedMap]:
         'radarr': load_module(module_path(project_root, 'radarr')),
         'trakt': load_module(module_path(project_root, 'trakt')),
     }
+
+
+def _existing_url_lookup(data: Dict[str, CommentedMap], service: str) -> Optional[str]:
+    """The already-saved URL for *service*, or None for services with no
+    user-suppliable destination URL (tmdb/trakt always talk to their
+    fixed real API, so there's no URL for a submission to redirect a
+    stored secret to). Used by config_test_connection to gate the
+    saved-secret auto-fill on 'is this actually still the saved URL'."""
+    core = data['core']
+    if service == 'plex':
+        return (core.get('plex') or {}).get('url', '') or ''
+    if service == 'tautulli':
+        return (core.get('tautulli') or {}).get('url', '') or ''
+    if service in ('sonarr', 'radarr'):
+        return (data[service] or {}).get('url', '') or ''
+    return None
 
 
 def _existing_secret_lookup(data: Dict[str, CommentedMap], service: str) -> Dict[str, str]:
@@ -430,24 +462,27 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
     }
 
 
-def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed: Dict) -> None:
+def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed: Dict) -> Dict[str, CommentedMap]:
+    """Mutate the in-memory CommentedMaps for this screen and return them
+    keyed by module name, WITHOUT writing anything to disk - the caller
+    (config_connections_save) commits them via _commit_modules, which
+    validates the full merge on a temp copy first (see M4 in the audit).
+    """
     core = data['core']
 
-    core.setdefault('plex', CommentedMap())
-    core['plex']['url'] = parsed['plex']['url']
-    core['plex']['movie_library'] = parsed['plex']['movie_library']
-    core['plex']['tv_library'] = parsed['plex']['tv_library']
-    core['plex']['token'] = merge_secret(core['plex'].get('token'), parsed['plex']['token_submitted'])
+    plex_section = ensure_section(core, 'plex')
+    plex_section['url'] = parsed['plex']['url']
+    plex_section['movie_library'] = parsed['plex']['movie_library']
+    plex_section['tv_library'] = parsed['plex']['tv_library']
+    plex_section['token'] = merge_secret(plex_section.get('token'), parsed['plex']['token_submitted'])
 
-    core.setdefault('tmdb', CommentedMap())
-    core['tmdb']['api_key'] = merge_secret(core['tmdb'].get('api_key'), parsed['tmdb']['api_key_submitted'])
+    tmdb_section = ensure_section(core, 'tmdb')
+    tmdb_section['api_key'] = merge_secret(tmdb_section.get('api_key'), parsed['tmdb']['api_key_submitted'])
 
-    core.setdefault('tautulli', CommentedMap())
-    core['tautulli']['enabled'] = parsed['tautulli']['enabled']
-    core['tautulli']['url'] = parsed['tautulli']['url']
-    core['tautulli']['api_key'] = merge_secret(core['tautulli'].get('api_key'), parsed['tautulli']['api_key_submitted'])
-
-    save_module(module_path(project_root, 'config'), core)
+    tautulli_section = ensure_section(core, 'tautulli')
+    tautulli_section['enabled'] = parsed['tautulli']['enabled']
+    tautulli_section['url'] = parsed['tautulli']['url']
+    tautulli_section['api_key'] = merge_secret(tautulli_section.get('api_key'), parsed['tautulli']['api_key_submitted'])
 
     sonarr = data['sonarr']
     sonarr['enabled'] = parsed['sonarr']['enabled']
@@ -456,7 +491,6 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
     sonarr['auto_sync'] = parsed['sonarr']['auto_sync']
     sonarr['user_mode'] = parsed['sonarr']['user_mode']
     sonarr['plex_users'] = parse_csv_list(parsed['sonarr']['plex_users'])
-    save_module(module_path(project_root, 'sonarr'), sonarr)
 
     radarr = data['radarr']
     radarr['enabled'] = parsed['radarr']['enabled']
@@ -465,7 +499,6 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
     radarr['auto_sync'] = parsed['radarr']['auto_sync']
     radarr['user_mode'] = parsed['radarr']['user_mode']
     radarr['plex_users'] = parse_csv_list(parsed['radarr']['plex_users'])
-    save_module(module_path(project_root, 'radarr'), radarr)
 
     trakt = data['trakt']
     trakt['enabled'] = parsed['trakt']['enabled']
@@ -476,7 +509,8 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
     export['user_mode'] = parsed['trakt']['user_mode']
     export['plex_users'] = parse_csv_list(parsed['trakt']['plex_users'])
     trakt['export'] = export
-    save_module(module_path(project_root, 'trakt'), trakt)
+
+    return {'config': core, 'sonarr': sonarr, 'radarr': radarr, 'trakt': trakt}
 
 
 # =========================================================================
@@ -556,16 +590,15 @@ def _parse_users_form(form, errors: Dict[str, str]) -> Dict:
     return {'users': rows, 'new_username': ''}
 
 
-def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> None:
-    core.setdefault('users', CommentedMap())
+def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> Dict[str, CommentedMap]:
+    """Mutate *core* in place and return it keyed by module name, WITHOUT
+    writing to disk - see _apply_connections' docstring for why."""
+    users_section = ensure_section(core, 'users')
     kept = [row for row in parsed['users'] if not row['remove']]
 
-    core['users']['list'] = ', '.join(row['username'] for row in kept)
+    users_section['list'] = ', '.join(row['username'] for row in kept)
 
-    preferences = core['users'].get('preferences')
-    if preferences is None:
-        preferences = CommentedMap()
-        core['users']['preferences'] = preferences
+    preferences = ensure_section(users_section, 'preferences')
 
     # Drop removed users' preferences entirely.
     for row in parsed['users']:
@@ -593,7 +626,7 @@ def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> None:
         else:
             entry.pop('streaming_services', None)
 
-    save_module(module_path(project_root, 'config'), core)
+    return {'config': core}
 
 
 # =========================================================================
@@ -832,74 +865,66 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
 
 def _apply_settings(project_root: str, tuning: CommentedMap, core: CommentedMap,
                      sonarr: CommentedMap, radarr: CommentedMap, trakt: CommentedMap,
-                     parsed: Dict) -> None:
-    tuning.setdefault('movies', CommentedMap())
-    tuning['movies']['limit_results'] = parsed['movies']['limit_results']
-    tuning['movies'].setdefault('weights', CommentedMap())
-    tuning['movies']['weights'].update(parsed['movies']['weights'])
-    tuning['movies'].setdefault('quality_filters', CommentedMap())
-    tuning['movies']['quality_filters']['min_rating'] = parsed['movies']['min_rating']
-    tuning['movies']['quality_filters']['min_vote_count'] = parsed['movies']['min_vote_count']
+                     parsed: Dict) -> Dict[str, CommentedMap]:
+    """Mutate the in-memory CommentedMaps for this screen and return them
+    keyed by module name, WITHOUT writing to disk - see
+    _apply_connections' docstring for why."""
+    movies_section = ensure_section(tuning, 'movies')
+    movies_section['limit_results'] = parsed['movies']['limit_results']
+    ensure_section(movies_section, 'weights').update(parsed['movies']['weights'])
+    movies_quality = ensure_section(movies_section, 'quality_filters')
+    movies_quality['min_rating'] = parsed['movies']['min_rating']
+    movies_quality['min_vote_count'] = parsed['movies']['min_vote_count']
 
-    tuning.setdefault('tv', CommentedMap())
-    tuning['tv']['limit_results'] = parsed['tv']['limit_results']
-    tuning['tv'].setdefault('weights', CommentedMap())
-    tuning['tv']['weights'].update(parsed['tv']['weights'])
-    tuning['tv'].setdefault('quality_filters', CommentedMap())
-    tuning['tv']['quality_filters']['min_rating'] = parsed['tv']['min_rating']
-    tuning['tv']['quality_filters']['min_vote_count'] = parsed['tv']['min_vote_count']
+    tv_section = ensure_section(tuning, 'tv')
+    tv_section['limit_results'] = parsed['tv']['limit_results']
+    ensure_section(tv_section, 'weights').update(parsed['tv']['weights'])
+    tv_quality = ensure_section(tv_section, 'quality_filters')
+    tv_quality['min_rating'] = parsed['tv']['min_rating']
+    tv_quality['min_vote_count'] = parsed['tv']['min_vote_count']
 
-    tuning.setdefault('recency_decay', CommentedMap())
-    tuning['recency_decay'].update(parsed['recency'])
-
-    tuning.setdefault('rating_multipliers', CommentedMap())
-    tuning['rating_multipliers'].update(parsed['rating_multipliers'])
+    ensure_section(tuning, 'recency_decay').update(parsed['recency'])
+    ensure_section(tuning, 'rating_multipliers').update(parsed['rating_multipliers'])
 
     ns = parsed['negative_signals']
-    tuning.setdefault('negative_signals', CommentedMap())
-    tuning['negative_signals']['enabled'] = ns['enabled']
-    tuning['negative_signals'].setdefault('bad_ratings', CommentedMap())
-    tuning['negative_signals']['bad_ratings']['enabled'] = ns['bad_ratings_enabled']
-    tuning['negative_signals']['bad_ratings']['threshold'] = ns['bad_ratings_threshold']
-    tuning['negative_signals']['bad_ratings']['cap_penalty'] = ns['bad_ratings_cap_penalty']
-    tuning['negative_signals'].setdefault('dropped_shows', CommentedMap())
-    tuning['negative_signals']['dropped_shows']['enabled'] = ns['dropped_enabled']
-    tuning['negative_signals']['dropped_shows']['min_episodes_watched'] = ns['dropped_min_episodes']
-    tuning['negative_signals']['dropped_shows']['max_completion_percent'] = ns['dropped_max_completion']
-    tuning['negative_signals']['dropped_shows']['penalty_multiplier'] = ns['dropped_penalty_multiplier']
+    negsig = ensure_section(tuning, 'negative_signals')
+    negsig['enabled'] = ns['enabled']
+    bad_ratings = ensure_section(negsig, 'bad_ratings')
+    bad_ratings['enabled'] = ns['bad_ratings_enabled']
+    bad_ratings['threshold'] = ns['bad_ratings_threshold']
+    bad_ratings['cap_penalty'] = ns['bad_ratings_cap_penalty']
+    dropped_shows = ensure_section(negsig, 'dropped_shows')
+    dropped_shows['enabled'] = ns['dropped_enabled']
+    dropped_shows['min_episodes_watched'] = ns['dropped_min_episodes']
+    dropped_shows['max_completion_percent'] = ns['dropped_max_completion']
+    dropped_shows['penalty_multiplier'] = ns['dropped_penalty_multiplier']
 
     ext = parsed['external']
-    tuning.setdefault('external_recommendations', CommentedMap())
-    tuning['external_recommendations']['enabled'] = ext['enabled']
-    tuning['external_recommendations']['movie_limit'] = ext['movie_limit']
-    tuning['external_recommendations']['show_limit'] = ext['show_limit']
-    tuning['external_recommendations']['min_relevance_score'] = ext['min_relevance_score']
-    tuning['external_recommendations']['min_votes'] = ext['min_votes']
-    tuning['external_recommendations']['max_iterations'] = ext['max_iterations']
-    tuning['external_recommendations']['language'] = ext['language'] or None
-    tuning['external_recommendations']['auto_open_html'] = ext['auto_open_html']
+    ext_section = ensure_section(tuning, 'external_recommendations')
+    ext_section['enabled'] = ext['enabled']
+    ext_section['movie_limit'] = ext['movie_limit']
+    ext_section['show_limit'] = ext['show_limit']
+    ext_section['min_relevance_score'] = ext['min_relevance_score']
+    ext_section['min_votes'] = ext['min_votes']
+    ext_section['max_iterations'] = ext['max_iterations']
+    ext_section['language'] = ext['language'] or None
+    ext_section['auto_open_html'] = ext['auto_open_html']
 
-    save_module(module_path(project_root, 'tuning'), tuning)
-
-    core.setdefault('general', CommentedMap())
-    core['general'].update(parsed['general'])
-    core.setdefault('logging', CommentedMap())
-    core['logging']['level'] = parsed['logging']['level']
-    save_module(module_path(project_root, 'config'), core)
+    ensure_section(core, 'general').update(parsed['general'])
+    ensure_section(core, 'logging')['level'] = parsed['logging']['level']
 
     sonarr['auto_sync'] = parsed['sync_safety']['sonarr']['auto_sync']
     sonarr['user_mode'] = parsed['sync_safety']['sonarr']['user_mode']
     sonarr['plex_users'] = parse_csv_list(parsed['sync_safety']['sonarr']['plex_users'])
-    save_module(module_path(project_root, 'sonarr'), sonarr)
 
     radarr['auto_sync'] = parsed['sync_safety']['radarr']['auto_sync']
     radarr['user_mode'] = parsed['sync_safety']['radarr']['user_mode']
     radarr['plex_users'] = parse_csv_list(parsed['sync_safety']['radarr']['plex_users'])
-    save_module(module_path(project_root, 'radarr'), radarr)
 
     trakt_export = trakt.get('export') or CommentedMap()
     trakt_export['auto_sync'] = parsed['sync_safety']['trakt']['auto_sync']
     trakt_export['user_mode'] = parsed['sync_safety']['trakt']['user_mode']
     trakt_export['plex_users'] = parse_csv_list(parsed['sync_safety']['trakt']['plex_users'])
     trakt['export'] = trakt_export
-    save_module(module_path(project_root, 'trakt'), trakt)
+
+    return {'tuning': tuning, 'config': core, 'sonarr': sonarr, 'radarr': radarr, 'trakt': trakt}

--- a/web/config_io.py
+++ b/web/config_io.py
@@ -14,8 +14,9 @@ bug that slips through) never leaves a half-written config file behind.
 """
 
 import os
+import shutil
 import tempfile
-from typing import Optional
+from typing import Dict, Optional
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
@@ -85,6 +86,69 @@ def save_module(path: str, data: CommentedMap) -> None:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
         raise
+
+
+def ensure_section(parent: CommentedMap, key: str) -> CommentedMap:
+    """Return parent[key] as a CommentedMap, creating one if the key is
+    missing OR present-but-null.
+
+    A bare ``plex:`` / ``general:`` / ``movies:`` line (no nested keys)
+    parses through ruamel/pyyaml as key -> None, not key -> {}. Plain
+    ``parent.setdefault(key, CommentedMap())`` doesn't help in that case
+    since the key already exists (with a None value) - the very next
+    ``parent[key]['field'] = ...`` would then raise TypeError on the
+    None. Any hand-edited or partially-migrated config file can produce
+    this shape, so every _apply_* writer in web/config_app.py goes
+    through this helper instead of setdefault() before mutating a
+    sub-section, so a null section becomes an empty mapping instead of
+    a 500 (and a half-written save, since sibling sections already
+    written to their own module file before the crash would otherwise
+    stay saved while this one - and everything after it - never runs).
+    """
+    section = parent.get(key)
+    if not isinstance(section, CommentedMap):
+        section = CommentedMap()
+        parent[key] = section
+    return section
+
+
+def validate_merge(project_root: str, modules: Dict[str, CommentedMap]) -> Optional[str]:
+    """Dry-run utils.load_config's full merge against a throwaway temp
+    copy of config/ with *modules* substituted in, so a value that
+    passes this screen's own field validation (config_validate.py) but
+    still breaks the merge some other way (e.g. utils.config's own
+    parsing) is caught BEFORE any real file on disk is touched.
+
+    This closes the gap in the old post-write-only reload check, which
+    could only report a broken merge *after* save_module had already
+    replaced the real files - too late for the operator whose next
+    scheduled run would already be reading the broken config.
+
+    *modules* maps MODULE_FILES names ('config', 'tuning', 'sonarr',
+    'radarr', 'trakt') to the CommentedMap that would be written for
+    that module; every module file not being changed by this save is
+    copied through unchanged from the real config dir, so the merge is
+    evaluated against the actual resulting config, not just the files
+    one screen owns.
+
+    Returns None if the merge is clean, or an error message otherwise.
+    """
+    from utils import load_config as _load_config
+
+    src_dir = config_dir(project_root)
+    with tempfile.TemporaryDirectory(prefix='curatarr-config-validate-') as tmp_dir:
+        if os.path.isdir(src_dir):
+            for name in os.listdir(src_dir):
+                src_path = os.path.join(src_dir, name)
+                if os.path.isfile(src_path):
+                    shutil.copy2(src_path, os.path.join(tmp_dir, name))
+        for name, data in modules.items():
+            save_module(os.path.join(tmp_dir, f'{name}.yml'), data)
+        try:
+            _load_config(os.path.join(tmp_dir, 'config.yml'))
+        except Exception as exc:
+            return str(exc)
+    return None
 
 
 def is_secret_field(key: str) -> bool:

--- a/web/config_test_connection.py
+++ b/web/config_test_connection.py
@@ -100,8 +100,16 @@ def test_trakt(client_id: str, client_secret: str, access_token: str, refresh_to
             'ok': False,
             'message': "Not authenticated yet - run 'python3 -m utils.trakt_auth' to link your Trakt account",
         }
-    client = TraktClient(client_id, client_secret, access_token, refresh_token)
-    username = client.get_username()
+    try:
+        client = TraktClient(client_id, client_secret, access_token, refresh_token)
+        username = client.get_username()
+    except Exception as exc:
+        # Matches every other tester in this module: a raw requests/API
+        # error (network failure, unexpected response shape, etc.) must
+        # never bubble up as an unhandled 500 with an unredacted
+        # traceback - it gets the same {ok, message} shape as an
+        # ordinary "connection failed" result instead.
+        return _connection_failed(exc, 'Trakt')
     if username:
         return {'ok': True, 'message': f'Connected as {username}'}
     return {

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -7,11 +7,24 @@ sys.stdout with a TeeLogger and call sys.exit() - fine for a
 short-lived CLI invocation, unsafe inside a long-running Flask process.
 
 Only one job may run at a time (a run mutates shared caches under
-cache/ and Plex collections), enforced by JobManager's lock.
+cache/ and Plex collections), enforced by JobManager's lock (in-process)
+and a PID lockfile (cross-process - see _foreign_run_in_progress).
+
+Frozen (PyInstaller onefile) binary note: `sys.executable
+recommenders/<x>.py` doesn't exist once packaged - there is no
+`recommenders/` directory alongside the exe, and re-invoking
+`sys.executable` just relaunches the UI. When running frozen,
+_build_command instead re-invokes the packaged exe itself with
+`--run-recommender <engine> [user]`, which curatarr_app.py's dispatcher
+(see that module's docstring) recognizes and runs the requested
+recommender in-process, in that *separate* subprocess - never inside
+this long-lived Flask server process itself, so the stdout-hijacking/
+sys.exit() behavior above stays safe.
 """
 
 import os
 import queue
+import signal
 import subprocess
 import sys
 import threading
@@ -24,6 +37,24 @@ ENGINES = ('full', 'movie', 'tv', 'external')
 # consumers know to stop waiting for more output.
 DONE_SENTINEL = object()
 
+# Caps how many items a single SSE subscriber's queue can hold. Without
+# a bound, a subscriber whose browser tab closed (or whose socket died)
+# without its generator's `finally: unsubscribe()` running yet - see
+# web/app.py's run_stream() - could have _append_line() pile lines into
+# its queue for the rest of a long run with nothing ever reading them
+# back out, growing without limit. Once full, the oldest queued item is
+# dropped to make room for the newest (see _safe_queue_put).
+SUBSCRIBER_QUEUE_MAXSIZE = 2000
+
+# PID lockfile written for the duration of a run (in logs_dir, next to
+# the run's own log file). Exists so a *different* curatarr process -
+# e.g. a fresh server started after the previous one was killed without
+# a clean shutdown - can detect and refuse to race an in-flight run it
+# has no in-memory record of. The in-process JobManager._lock/_current
+# state is authoritative for this process; the lockfile is the
+# cross-process backstop.
+LOCK_FILENAME = 'webui_job.lock'
+
 
 class JobError(Exception):
     """Raised for invalid job requests (bad engine/user, etc)."""
@@ -31,6 +62,51 @@ class JobError(Exception):
 
 class JobAlreadyRunningError(JobError):
     """Raised when a run is requested while another run is in progress."""
+
+
+def _safe_queue_put(q: "queue.Queue", item) -> None:
+    """put() onto a bounded subscriber queue without ever blocking the
+    pump thread or growing without bound. Drops the oldest queued item
+    to make room if full - a slow or disconnected SSE subscriber must
+    never be able to stall a run or leak memory (see
+    SUBSCRIBER_QUEUE_MAXSIZE)."""
+    try:
+        q.put_nowait(item)
+    except queue.Full:
+        try:
+            q.get_nowait()
+        except queue.Empty:
+            pass
+        try:
+            q.put_nowait(item)
+        except queue.Full:
+            pass  # pathological race under concurrent producers - drop it
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe for a PID recorded in the lockfile."""
+    if pid <= 0:
+        return False
+    if os.name == 'nt':
+        try:
+            result = subprocess.run(
+                ['tasklist', '/FI', f'PID eq {pid}'],
+                capture_output=True, text=True, timeout=3,
+            )
+            return str(pid) in result.stdout
+        except Exception:
+            # Can't confirm either way - fail toward "still running" so
+            # we serialize a possible in-flight run rather than race it.
+            return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just owned by someone else
+    except OSError:
+        return False
 
 
 class Job:
@@ -60,14 +136,14 @@ class Job:
         with self._data_lock:
             self.lines.append(line)
             for q in self._subscribers:
-                q.put(line)
+                _safe_queue_put(q, line)
 
     def _finish(self, returncode: int) -> None:
         with self._data_lock:
             self.returncode = returncode
             self.finished_at = datetime.now()
             for q in self._subscribers:
-                q.put(DONE_SENTINEL)
+                _safe_queue_put(q, DONE_SENTINEL)
 
     def subscribe(self) -> "queue.Queue":
         """Register a new SSE listener.
@@ -76,12 +152,12 @@ class Job:
         a browser tab that connects mid-run still sees the backlog
         before live lines start arriving.
         """
-        q: "queue.Queue" = queue.Queue()
+        q: "queue.Queue" = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
         with self._data_lock:
             for line in self.lines:
-                q.put(line)
+                _safe_queue_put(q, line)
             if self.returncode is not None:
-                q.put(DONE_SENTINEL)
+                _safe_queue_put(q, DONE_SENTINEL)
             else:
                 self._subscribers.append(q)
         return q
@@ -123,6 +199,40 @@ class JobManager:
         job = self._current
         return job is not None and job.state == 'running'
 
+    def _lock_path(self) -> str:
+        return os.path.join(self.logs_dir, LOCK_FILENAME)
+
+    def _write_lock(self, pid: int) -> None:
+        try:
+            os.makedirs(self.logs_dir, exist_ok=True)
+            with open(self._lock_path(), 'w', encoding='utf-8') as f:
+                f.write(str(pid))
+        except OSError:
+            pass  # best-effort - in-process state is still authoritative here
+
+    def _remove_lock(self) -> None:
+        try:
+            os.remove(self._lock_path())
+        except OSError:
+            pass
+
+    def _foreign_run_in_progress(self) -> bool:
+        """True if a lockfile left by a *different* process points at a
+        PID that's still alive - i.e. a run this JobManager instance has
+        no in-memory record of (its own server process was restarted
+        without a clean shutdown) but that's still actually executing."""
+        try:
+            with open(self._lock_path(), 'r', encoding='utf-8') as f:
+                pid = int(f.read().strip())
+        except (OSError, ValueError):
+            return False
+        if pid == os.getpid():
+            return False
+        if _pid_alive(pid):
+            return True
+        self._remove_lock()  # stale - that process/child is gone
+        return False
+
     def start(self, engine: str, user: str, allowed_users: List[str]) -> Job:
         """Validate and launch a run. Raises JobError/JobAlreadyRunningError."""
         if engine not in ENGINES:
@@ -135,23 +245,45 @@ class JobManager:
         with self._lock:
             if self.is_running():
                 raise JobAlreadyRunningError("A run is already in progress")
+            if self._foreign_run_in_progress():
+                raise JobAlreadyRunningError(
+                    "A run started by a previous server process is still in progress"
+                )
 
             cmd, env, log_name = self._build_command(engine, user)
             os.makedirs(self.logs_dir, exist_ok=True)
             log_path = os.path.join(self.logs_dir, log_name)
 
             job = Job(engine, user, cmd, log_path)
-            process = subprocess.Popen(
-                cmd,
+            popen_kwargs = dict(
                 cwd=self.project_root,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                text=True,
+                encoding='utf-8',
+                errors='replace',
                 bufsize=1,
                 env=env,
             )
+            if os.name != 'nt':
+                # Own session/process group so a server shutdown (see
+                # JobManager.terminate_running) can kill the whole tree
+                # in one shot - matters for the 'full' engine, whose
+                # run.sh itself spawns movie.py/tv.py/external.py as
+                # further children, not just the immediate bash process.
+                popen_kwargs['start_new_session'] = True
+            try:
+                process = subprocess.Popen(cmd, **popen_kwargs)
+            except OSError as exc:
+                # M3: a missing interpreter/shell (bash, powershell, or
+                # even sys.executable itself in some broken install) must
+                # surface as a normal, friendly JobError - the /run route
+                # already turns that into a redirect with an error
+                # message - not an unhandled 500.
+                raise JobError(f"Could not start the {engine} run: {exc}") from exc
+
             job.process = process
             self._current = job
+            self._write_lock(process.pid)
 
             thread = threading.Thread(target=self._pump, args=(job,), daemon=True)
             thread.start()
@@ -160,15 +292,23 @@ class JobManager:
     def _build_command(self, engine: str, user: str):
         """Build the subprocess argv, environment, and job log filename.
 
-        Mirrors run.sh's own invocations (python3 recommenders/<x>.py
-        [username] [--debug]) so the UI-triggered run behaves exactly
-        like a normal cron/manual run.
+        Source install: mirrors run.sh's own invocations (python3
+        recommenders/<x>.py [username] [--debug]) so the UI-triggered
+        run behaves exactly like a normal cron/manual run.
+
+        Frozen (PyInstaller) binary: recommenders/<x>.py doesn't exist
+        on disk, so this re-invokes the packaged exe itself with
+        `--run-recommender <engine> [user]` - see curatarr_app.py's
+        dispatcher and this module's docstring.
         """
         env = dict(os.environ)
         ts = datetime.now().strftime('%Y%m%d_%H%M%S')
+        frozen = getattr(sys, 'frozen', False)
 
         if engine == 'full':
-            if os.name == 'nt':
+            if frozen:
+                cmd = [sys.executable, '--run-recommender', 'full']
+            elif os.name == 'nt':
                 cmd = ['powershell', '-ExecutionPolicy', 'Bypass', '-File',
                        os.path.join(self.project_root, 'run.ps1')]
             else:
@@ -179,14 +319,20 @@ class JobManager:
             env['RUNNING_IN_DOCKER'] = 'true'
             target = 'all'
         elif engine in ('movie', 'tv'):
-            script = os.path.join(self.project_root, 'recommenders', f'{engine}.py')
-            cmd = [sys.executable, script]
+            if frozen:
+                cmd = [sys.executable, '--run-recommender', engine]
+            else:
+                script = os.path.join(self.project_root, 'recommenders', f'{engine}.py')
+                cmd = [sys.executable, script]
             if user != 'all':
                 cmd.append(user)
             target = user
         elif engine == 'external':
-            script = os.path.join(self.project_root, 'recommenders', 'external.py')
-            cmd = [sys.executable, script]
+            if frozen:
+                cmd = [sys.executable, '--run-recommender', 'external']
+            else:
+                script = os.path.join(self.project_root, 'recommenders', 'external.py')
+                cmd = [sys.executable, script]
             target = 'all'
         else:  # pragma: no cover - guarded by start()'s validation above
             raise JobError(f"Unknown engine: {engine}")
@@ -196,10 +342,23 @@ class JobManager:
 
     def _pump(self, job: Job) -> None:
         """Background thread: read subprocess output, tee to a log file
-        and to every SSE subscriber, then record the exit code."""
-        log_file = open(job.log_path, 'w', encoding='utf-8')
-        returncode = -1
+        and to every SSE subscriber, then record the exit code.
+
+        returncode stays None until the read loop finishes normally and
+        Popen.wait() returns the real exit code. If anything above
+        raises first (the log file couldn't be opened, the read loop
+        itself raised, etc.) returncode is never set to a real value, so
+        job._finish() below reports a synthetic failure (-1) rather than
+        "succeeded" - a pump-level failure means the run's output/log
+        wasn't reliably captured either way, and (this is what actually
+        matters operationally) job._finish() is now *always* reached
+        even on that path, so the job never gets stuck "running"
+        forever and the single-run lock is always released.
+        """
+        log_file = None
+        returncode: Optional[int] = None
         try:
+            log_file = open(job.log_path, 'w', encoding='utf-8')
             assert job.process is not None and job.process.stdout is not None
             for line in job.process.stdout:
                 log_file.write(line)
@@ -207,9 +366,47 @@ class JobManager:
                 job._append_line(line.rstrip('\n'))
             returncode = job.process.wait()
         except Exception as exc:
-            # Subprocess plumbing failure (e.g. couldn't read pipe), not
-            # a recommender-level error - surface it in the live output.
+            # Subprocess plumbing failure (e.g. couldn't open the log
+            # file, couldn't read the pipe), not a recommender-level
+            # error - surface it in the live output.
             job._append_line(f'[web UI] job runner error: {exc}')
         finally:
-            log_file.close()
-            job._finish(returncode)
+            if log_file is not None:
+                try:
+                    log_file.close()
+                except Exception:
+                    pass
+            # Always reap the child, even on the failure path above -
+            # otherwise a log-open failure (or any other exception
+            # raised before Popen.wait() ran) leaves it a zombie.
+            if job.process is not None and job.process.poll() is None:
+                try:
+                    job.process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    job.process.kill()
+                    job.process.wait()
+            self._remove_lock()
+            job._finish(returncode if returncode is not None else -1)
+
+    def terminate_running(self) -> None:
+        """Best-effort: terminate the in-flight subprocess (and its
+        whole process group on POSIX, since it's launched with
+        start_new_session=True) so a server shutdown never leaves an
+        orphaned recommender run mutating caches/Plex collections in
+        the background while a fresh server process might start a new
+        one. Safe to call with no run in progress; see web/app.py's
+        atexit/SIGTERM/SIGINT registration in main().
+        """
+        job = self._current
+        if job is None or job.process is None:
+            return
+        if job.process.poll() is not None:
+            return
+        try:
+            if os.name == 'nt':
+                job.process.terminate()
+            else:
+                os.killpg(os.getpgid(job.process.pid), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+        self._remove_lock()

--- a/web/security.py
+++ b/web/security.py
@@ -26,15 +26,41 @@ _SECRET_KEY_NAMES = (
 
 _KEY_ALTERNATION = "|".join(re.escape(name) for name in _SECRET_KEY_NAMES)
 
-# Matches key=value / key: value / key="value" style occurrences.
+# Matches key=value / key: value / key="value" style occurrences. The
+# value class deliberately allows any non-whitespace, non-quote
+# character (not just alnum/._-+/) so a value that happens to start
+# with (or contain) a special char - `token: "$ecretValue"`,
+# `api_key=#deadbeef!`, a base64 value with a leading `/` or `+`, etc. -
+# still gets masked instead of silently passing through because the
+# old, narrower character class didn't match at that position at all.
 # The key name is kept (so redaction is still informative); only the
 # value is masked.
 _SECRET_PATTERN = re.compile(
-    r'(?i)\b(' + _KEY_ALTERNATION + r')\b\s*[:=]\s*["\']?([A-Za-z0-9._\-+/]{4,})["\']?'
+    r'(?i)\b(' + _KEY_ALTERNATION + r')\b\s*[:=]\s*["\']?([^\s"\']{4,})["\']?'
 )
 
 # "Authorization: Bearer <token>" style headers.
 _BEARER_PATTERN = re.compile(r'(?i)\bBearer\s+([A-Za-z0-9._\-]{8,})')
+
+# Bare high-entropy tokens that don't follow a recognizable key=value
+# shape but are still unambiguously a secret by their vendor-specific
+# prefix (GitHub PATs, Stripe/OpenAI-style sk- keys, Slack tokens, AWS
+# access key IDs, GitLab PATs, npm tokens, Google API keys, etc.) - a
+# recommender/client error message that echoes one of these raw (e.g.
+# in a stack trace argument) wouldn't otherwise be caught by
+# _SECRET_PATTERN since there's no "key: " / "key=" prefix at all.
+# Deliberately prefix-anchored rather than a generic
+# "any long mixed-case alnum run" heuristic, which would also catch
+# harmless things like git commit SHAs and cache/session IDs.
+_KNOWN_TOKEN_PREFIXES = (
+    "github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_",
+    "sk-live-", "sk-test-", "sk_live_", "sk_test_", "sk-",
+    "rk_live_", "rk_test_",
+    "xoxb-", "xoxp-", "xoxa-", "xoxr-",
+    "glpat-", "npm_", "AIza", "AKIA", "ASIA",
+)
+_PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in _KNOWN_TOKEN_PREFIXES)
+_BARE_TOKEN_PATTERN = re.compile(r'\b(' + _PREFIX_ALTERNATION + r')[A-Za-z0-9_\-]{8,}')
 
 REDACTED = "***REDACTED***"
 
@@ -45,6 +71,7 @@ def redact(text: str) -> str:
         return text
     text = _SECRET_PATTERN.sub(lambda m: f"{m.group(1)}={REDACTED}", text)
     text = _BEARER_PATTERN.sub(lambda m: f"Bearer {REDACTED}", text)
+    text = _BARE_TOKEN_PATTERN.sub(lambda m: f"{m.group(1)}{REDACTED}", text)
     return text
 
 
@@ -57,12 +84,77 @@ def safe_join(base_dir: str, filename: str) -> str:
     """Join *filename* onto *base_dir*, refusing path traversal.
 
     Raises FileNotFoundError if the resolved path would escape base_dir
-    (e.g. via ``..`` segments or an absolute path).
+    (e.g. via ``..`` segments, an absolute path, or a symlink inside
+    base_dir that points back out of it). Uses realpath (not just
+    abspath) specifically so a symlink can't be used to escape the
+    containment check - abspath only normalizes ``..``/``.`` segments
+    textually, it doesn't follow symlinks, so a symlink placed inside
+    base_dir pointing outside of it would otherwise sail through.
     """
     import os
 
-    base_dir = os.path.abspath(base_dir)
-    candidate = os.path.abspath(os.path.join(base_dir, filename))
+    base_dir = os.path.realpath(base_dir)
+    candidate = os.path.realpath(os.path.join(base_dir, filename))
     if os.path.commonpath([base_dir, candidate]) != base_dir:
         raise FileNotFoundError(filename)
     return candidate
+
+
+# Hosts the web UI's own origin is allowed to be - 127.0.0.1/localhost,
+# with or without a port. app.run() only ever binds 127.0.0.1 (see
+# web/app.py), so anything else in the Host header means either a
+# misconfigured reverse proxy or a DNS-rebinding attempt.
+_ALLOWED_HOST_RE = re.compile(r'^(127\.0\.0\.1|localhost)(:\d+)?$', re.IGNORECASE)
+
+# Methods that mutate server state - every route using one of these is
+# a save/trigger/test-connection endpoint, never a plain page view.
+STATE_CHANGING_METHODS = frozenset({'POST', 'PUT', 'PATCH', 'DELETE'})
+
+
+def is_allowed_host(netloc: str) -> bool:
+    """True if *netloc* (a bare ``host`` or ``host:port`` string, e.g.
+    from ``request.host`` or ``urlsplit(...).netloc``) is this app's own
+    origin."""
+    return bool(netloc) and bool(_ALLOWED_HOST_RE.match(netloc))
+
+
+def register_origin_host_guard(app) -> None:
+    """Register a before_request hook that:
+
+    1. Rejects (400) ANY request whose Host header isn't 127.0.0.1[:port]
+       or localhost[:port] - blocks DNS-rebinding attacks, where a
+       victim's browser is tricked into resolving an attacker-controlled
+       domain to 127.0.0.1 and then sending it real requests (the
+       Origin/Referer check below can't catch this on its own, since the
+       attacker page's Origin genuinely differs, but a rebinding attack
+       specifically relies on the Host header looking legitimate to a
+       naive server that only binds to localhost and assumes that's
+       enough).
+    2. Rejects (403) any state-changing request (POST/PUT/PATCH/DELETE)
+       whose Origin (falling back to Referer) doesn't also resolve to
+       127.0.0.1[:port]/localhost[:port] - blocks a page on any other
+       origin from driving /run, /config/*, or /config/test/<service>
+       via a cross-site form POST or fetch() (this app has no other
+       session/auth boundary to rely on, since it's designed to run
+       trusted-user-only on localhost).
+
+    A request with neither Origin nor Referer set is rejected too - a
+    real browser always sends at least one of these on a state-changing
+    request; their total absence is what a simple script/curl call
+    (or a non-browser attacker) looks like, not a legitimate UI
+    interaction.
+    """
+    from urllib.parse import urlsplit
+
+    from flask import abort, request
+
+    @app.before_request
+    def _origin_host_guard():
+        if not is_allowed_host(request.host):
+            abort(400)
+        if request.method in STATE_CHANGING_METHODS:
+            source = request.headers.get('Origin') or request.headers.get('Referer')
+            if not source:
+                abort(403)
+            if not is_allowed_host(urlsplit(source).netloc):
+                abort(403)

--- a/web/status.py
+++ b/web/status.py
@@ -57,7 +57,12 @@ def latest_user_log(logs_dir: str, username: str) -> Optional[str]:
     so "latest" reflects whichever of the two most recently ran for
     this user, not necessarily a single combined run.
     """
-    pattern = os.path.join(logs_dir, f'recommendations_{username}_*.log')
+    # glob.escape the username so a name containing glob special chars
+    # (*, ?, [...]) can't turn this into an unintended wildcard match -
+    # e.g. a Plex username of "*" would otherwise match every user's
+    # log files instead of just this one, leaking other users' run
+    # status onto this user's dashboard row.
+    pattern = os.path.join(logs_dir, f'recommendations_{glob.escape(username)}_*.log')
     candidates = glob.glob(pattern)
     if not candidates:
         return None
@@ -79,7 +84,13 @@ def get_last_run_status(logs_dir: str, username: str) -> Dict:
     basename = os.path.basename(log_path)
     timestamp = _parse_timestamp(basename)
     if timestamp is None:
-        timestamp = datetime.fromtimestamp(os.path.getmtime(log_path))
+        try:
+            timestamp = datetime.fromtimestamp(os.path.getmtime(log_path))
+        except OSError:
+            # Log was removed (e.g. log-retention cleanup) between the
+            # glob() in latest_user_log() and here - fall back to no
+            # timestamp rather than 500ing the dashboard.
+            timestamp = None
 
     content = _read_tail(log_path)
     if not content.strip():
@@ -103,11 +114,14 @@ def list_log_files(logs_dir: str) -> List[Dict]:
         path = os.path.join(logs_dir, name)
         if not os.path.isfile(path):
             continue
-        entries.append({
-            'name': name,
-            'size': os.path.getsize(path),
-            'mtime': datetime.fromtimestamp(os.path.getmtime(path)),
-        })
+        try:
+            size = os.path.getsize(path)
+            mtime = datetime.fromtimestamp(os.path.getmtime(path))
+        except OSError:
+            # Deleted between listdir() and here (e.g. concurrent log
+            # rotation/cleanup) - skip it rather than 500ing /results.
+            continue
+        entries.append({'name': name, 'size': size, 'mtime': mtime})
     entries.sort(key=lambda e: e['mtime'], reverse=True)
     return entries
 
@@ -145,9 +159,11 @@ def find_user_watchlist(external_dir: str, config: Dict, username: str) -> Optio
 def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> str:
     """Read the last max_lines of logs_dir/filename, secrets redacted.
 
-    Raises FileNotFoundError if filename escapes logs_dir or doesn't
-    resolve to a real file.
+    Raises FileNotFoundError if filename escapes logs_dir, isn't a
+    *.log file, or doesn't resolve to a real file.
     """
+    if not filename.endswith('.log'):
+        raise FileNotFoundError(filename)
     path = safe_join(logs_dir, filename)
     if not os.path.isfile(path):
         raise FileNotFoundError(filename)


### PR DESCRIPTION
## Summary

Fixes the confirmed findings from the web-UI security + correctness audits, makes the Run button work in the frozen (PyInstaller onefile) binary, and adds the missing tests.

### Security
- **CSRF/Origin/Host guard** (`web/security.py::register_origin_host_guard`, wired in `web/app.py`): every request must have `Host: 127.0.0.1[:port]`/`localhost[:port]` (400 otherwise, blocks DNS rebinding); every state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) must also have an `Origin`/`Referer` resolving to the same allow-list (403 otherwise). Applies to `/run`, `/config/connections`, `/config/users`, `/config/settings`, `/config/test/<service>`.
- **Test-Connection secret leak** (`web/config_app.py`): a blank submitted secret is only auto-filled from the saved value when the submitted `url` matches the already-saved `url`. A differing URL (attacker-supplied) never gets the real stored token/api_key.
- **Watchlist XSS** (`recommenders/external_output.py`): confirmed - TMDB-derived fields (title, collection name, status, etc.) were interpolated into `watchlist.html` unescaped. Fixed with `html.escape()` at generation time. `/results/watchlist/<file>` also gets a restrictive CSP header as defense-in-depth.
- `web/security.py::redact()` broadened to catch values with a leading special char and bare vendor-prefixed tokens (ghp_, sk-, AKIA, etc.).
- `config_test_connection.py::test_trakt` now has the same blanket `except Exception` as every other tester.
- `web/status.py`: `os.path.getmtime`/`getsize` guarded against `OSError` (log deleted mid-scan); usernames are `glob.escape()`d so a `*`/`?`/`[...]` username can't match other users' logs.
- `safe_join`/`read_log_tail`: resolves symlinks (`os.path.realpath`) before the containment check, restricted to `*.log`.

### Correctness (`web/job_runner.py`, `web/config_app.py`)
- `_pump()`'s `open()` is now inside the `try`, and `job._finish()` is always reached in `finally` - a bad log path can no longer wedge the run lock forever.
- SSE `generate()` (`web/app.py`) uses `q.get(timeout=15s)` with a keepalive comment on `Empty`, so a dead client's disconnect is detected and `unsubscribe()` runs; subscriber queues are bounded (drop-oldest) so a dead client can't grow memory unbounded.
- Server shutdown (`atexit` + `SIGINT`/`SIGTERM`) terminates the in-flight subprocess (whole process group on POSIX via `start_new_session=True`); a cross-process PID lockfile detects/serializes a run left behind by a killed server process.
- `Popen(..., encoding='utf-8', errors='replace')`; the child is always reaped in `finally` even if the read loop raises.
- A missing `bash`/`powershell`/interpreter (`FileNotFoundError` from `Popen`) is now a friendly `JobError`, not a 500.
- `config_app.py`: a present-but-null config section (bare `plex:`/`general:` in hand-edited YAML) no longer 500s or half-saves (`config_io.ensure_section`). Every save now dry-run validates the full merge on a temp copy of `config/` before writing any real file (`config_io.validate_merge` + `config_app._commit_modules`).

### Binary Run button (frozen PyInstaller build)
`curatarr_app.py` is now a dispatcher: `curatarr --run-recommender <engine> [user]` runs that recommender's own `main()` in-process, inside the fresh short-lived subprocess the UI just spawned (never inside the long-lived server process). `web/job_runner.py` builds that command when `sys.frozen`. Also fixed `recommenders/external.py` resolving its project root from `__file__` (breaks under a frozen exe's temp extraction dir) instead of `get_project_root()`.

Verified end-to-end against an actual `pyinstaller --clean --noconfirm curatarr.spec` build on the Mac: started the binary's UI server, configured Plex/users through the browser-facing routes, POSTed `/run` for the movie/external engines, and confirmed the SSE stream shows the real recommender output (config load, Plex connection attempt, clean failure/exit) with the job ending in `failed`/lock released - not a 500 or a wedge. Also confirmed the Origin/Host guard rejects a cross-origin POST (403) and a bad `Host` header (400) against the live running binary.

### Tests
76 new test functions added across `tests/test_web_job_runner.py`, `tests/test_web_routes.py`, `tests/test_web_security.py`, `tests/test_web_status.py`, `tests/test_web_config_io.py`, `tests/test_web_config_connections.py`, `tests/test_web_config_users.py`, `tests/test_web_config_settings.py`, `tests/test_web_config_test_connection.py`, `tests/test_external_output.py`, `tests/test_curatarr_app.py`. Full suite: 1423 passed, 88% coverage.

## Test plan
- [x] `pytest tests/ -q` - 1423 passed
- [x] `pytest tests/ --cov=. --cov-report=term-missing` - 88% coverage (≥85% required)
- [x] `pyinstaller --clean --noconfirm curatarr.spec` builds successfully
- [x] Frozen binary: `--run-recommender movie/tv/external` all resolve and run the correct recommender logic
- [x] Frozen binary: live UI server, real `/config/connections` + `/config/users` + `/run` POSTs, SSE stream confirmed
- [x] Frozen binary: cross-origin POST → 403, bad Host header → 400, confirmed live
