### PR TITLE
feat(#157) Phase 1: libraries schema, accessors, migration

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -50,6 +50,39 @@ huntarr:
 logging:
   level: INFO  # DEBUG, INFO, WARNING, ERROR
 
+# Optional: Multi-library support
+# Define one entry per Plex library you want Curatarr to manage separately
+# (e.g. "Movies" and "Kids Movies", or "TV Shows" and "Anime"). Each entry's
+# `arr` block is optional - any field left out falls back to the matching
+# global radarr.yml/sonarr.yml setting for that media_type. `instance` is
+# also optional, for routing a specific library to its own *arr instance
+# instead of the default one configured in radarr.yml/sonarr.yml.
+# If this section is omitted entirely, Curatarr falls back to the single
+# movie_library/tv_library above (unchanged legacy behavior).
+# libraries:
+#   - id: movies              # stable slug; auto-derived from name if omitted
+#     name: Movies
+#     section: Movies          # Plex section title
+#     media_type: movie        # movie | tv
+#     arr:                     # optional; each field falls back to global sonarr/radarr
+#       root_folder: /data/movies
+#       quality_profile: HD-1080p
+#       tag: Curatarr
+#       monitor: false
+#       search: false
+#       minimum_availability: released   # movie-only
+#   - id: tv-shows
+#     name: TV Shows
+#     section: TV Shows
+#     media_type: tv
+#     arr:
+#       root_folder: /data/tv
+#       quality_profile: HD-1080p
+#       series_type: standard            # tv-only
+#       instance:               # optional per-library *arr instance; falls back to global block
+#         url: http://localhost:8989
+#         api_key: YOUR_SONARR_API_KEY
+
 # Optional: Tautulli watch-history integration
 # Supplements Plex's own watch history with history from Tautulli, weighted
 # the same way. Mainly useful for shared/external users whose Plex-native

--- a/config/radarr.example.yml
+++ b/config/radarr.example.yml
@@ -1,4 +1,11 @@
 # Curatarr Radarr Configuration
+#
+# NOTE: With multi-library support (config.yml -> libraries), per-library
+# `arr` blocks can override root_folder/quality_profile/tag/monitor/search/
+# minimum_availability/instance individually - any field a library omits
+# still falls back to the values below. This file remains the DEFAULT *arr
+# instance (enabled/url/api_key) and the sync policy (auto_sync/user_mode/
+# plex_users), which are NOT overridable per-library.
 
 enabled: false
 url: http://localhost:7878

--- a/config/sonarr.example.yml
+++ b/config/sonarr.example.yml
@@ -1,5 +1,12 @@
 # Curatarr Sonarr Configuration
 # Auto-add recommended TV shows to Sonarr
+#
+# NOTE: With multi-library support (config.yml -> libraries), per-library
+# `arr` blocks can override root_folder/quality_profile/tag/monitor/search/
+# series_type/instance individually - any field a library omits still falls
+# back to the values below. This file remains the DEFAULT *arr instance
+# (enabled/url/api_key) and the sync policy (auto_sync/user_mode/plex_users),
+# which are NOT overridable per-library.
 
 enabled: false
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,8 @@ import pytest
 
 from utils.config import (
     CACHE_VERSION,
+    MEDIA_TYPE_MOVIE,
+    MEDIA_TYPE_TV,
     DEFAULT_RATING_MULTIPLIERS,
     DEFAULT_NEGATIVE_MULTIPLIERS,
     DEFAULT_NEGATIVE_THRESHOLD,
@@ -18,6 +20,9 @@ from utils.config import (
     get_negative_multiplier,
     adapt_config_for_media_type,
     load_config,
+    get_libraries,
+    get_libraries_for_media_type,
+    get_effective_arr_config,
 )
 
 
@@ -539,3 +544,233 @@ class TestAdaptConfigRadarrSonarr:
         result = adapt_config_for_media_type(config, 'tv')
         assert result['sonarr']['enabled'] is True
         assert result['sonarr']['url'] == 'http://sonarr:8989'
+
+
+class TestGetLibraries:
+    """Tests for get_libraries fallback synthesis and normalization (#157 Phase 1)"""
+
+    def test_no_libraries_key_synthesizes_two_entries(self):
+        config = {'plex': {}}
+        result = get_libraries(config)
+        assert len(result) == 2
+        assert result[0]['media_type'] == MEDIA_TYPE_MOVIE
+        assert result[1]['media_type'] == MEDIA_TYPE_TV
+
+    def test_synthesis_defaults_names_when_plex_library_keys_absent(self):
+        config = {'plex': {}}
+        result = get_libraries(config)
+        assert result[0]['name'] == 'Movies'
+        assert result[1]['name'] == 'TV Shows'
+
+    def test_synthesis_uses_configured_library_names(self):
+        config = {'plex': {'movie_library': 'Films', 'tv_library': 'Shows'}}
+        result = get_libraries(config)
+        assert result[0]['name'] == 'Films'
+        assert result[0]['section'] == 'Films'
+        assert result[1]['name'] == 'Shows'
+        assert result[1]['section'] == 'Shows'
+
+    def test_synthesis_derives_slug_ids(self):
+        config = {'plex': {'movie_library': 'My Movies', 'tv_library': 'TV Shows'}}
+        result = get_libraries(config)
+        assert result[0]['id'] == 'my-movies'
+        assert result[1]['id'] == 'tv-shows'
+
+    def test_empty_libraries_list_also_synthesizes(self):
+        config = {'plex': {}, 'libraries': []}
+        result = get_libraries(config)
+        assert len(result) == 2
+
+    def test_synthesized_arr_merges_from_global_radarr_sonarr(self):
+        config = {
+            'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'radarr': {'enabled': True, 'root_folder': '/data/movies', 'quality_profile': '4K'},
+            'sonarr': {'enabled': True, 'root_folder': '/data/tv', 'series_type': 'anime'},
+        }
+        libraries = get_libraries(config)
+        movie_lib = next(l for l in libraries if l['media_type'] == MEDIA_TYPE_MOVIE)
+        tv_lib = next(l for l in libraries if l['media_type'] == MEDIA_TYPE_TV)
+
+        movie_arr = get_effective_arr_config(config, movie_lib)
+        assert movie_arr['enabled'] is True
+        assert movie_arr['root_folder'] == '/data/movies'
+        assert movie_arr['quality_profile'] == '4K'
+
+        tv_arr = get_effective_arr_config(config, tv_lib)
+        assert tv_arr['enabled'] is True
+        assert tv_arr['root_folder'] == '/data/tv'
+        assert tv_arr['series_type'] == 'anime'
+
+    def test_normalizes_missing_id_from_name_slug(self):
+        config = {'libraries': [{'name': 'Kids Movies', 'media_type': 'movie'}]}
+        result = get_libraries(config)
+        assert result[0]['id'] == 'kids-movies'
+
+    def test_normalizes_missing_media_type_defaults_movie(self):
+        config = {'libraries': [{'name': 'Movies'}]}
+        result = get_libraries(config)
+        assert result[0]['media_type'] == MEDIA_TYPE_MOVIE
+
+    def test_normalizes_missing_section_defaults_to_name(self):
+        config = {'libraries': [{'name': 'Anime', 'media_type': 'tv'}]}
+        result = get_libraries(config)
+        assert result[0]['section'] == 'Anime'
+
+    def test_preserves_explicit_fields(self):
+        config = {
+            'libraries': [
+                {'id': 'custom-id', 'name': 'Movies', 'section': 'Custom Section', 'media_type': 'movie'},
+            ]
+        }
+        result = get_libraries(config)
+        assert result[0]['id'] == 'custom-id'
+        assert result[0]['section'] == 'Custom Section'
+
+    def test_multiple_libraries_of_same_media_type(self):
+        config = {
+            'libraries': [
+                {'name': 'Movies', 'media_type': 'movie'},
+                {'name': 'Kids Movies', 'media_type': 'movie'},
+            ]
+        }
+        result = get_libraries(config)
+        assert len(result) == 2
+        assert result[0]['id'] == 'movies'
+        assert result[1]['id'] == 'kids-movies'
+
+
+class TestGetLibrariesForMediaType:
+    """Tests for get_libraries_for_media_type"""
+
+    def test_filters_to_movie_libraries(self):
+        config = {
+            'libraries': [
+                {'name': 'Movies', 'media_type': 'movie'},
+                {'name': 'TV Shows', 'media_type': 'tv'},
+            ]
+        }
+        result = get_libraries_for_media_type(config, MEDIA_TYPE_MOVIE)
+        assert len(result) == 1
+        assert result[0]['name'] == 'Movies'
+
+    def test_filters_to_tv_libraries(self):
+        config = {
+            'libraries': [
+                {'name': 'Movies', 'media_type': 'movie'},
+                {'name': 'TV Shows', 'media_type': 'tv'},
+                {'name': 'Anime', 'media_type': 'tv'},
+            ]
+        }
+        result = get_libraries_for_media_type(config, MEDIA_TYPE_TV)
+        assert len(result) == 2
+
+    def test_returns_empty_list_when_no_match(self):
+        config = {'libraries': [{'name': 'Movies', 'media_type': 'movie'}]}
+        result = get_libraries_for_media_type(config, MEDIA_TYPE_TV)
+        assert result == []
+
+    def test_falls_back_to_synthesized_libraries(self):
+        config = {'plex': {}}
+        result = get_libraries_for_media_type(config, MEDIA_TYPE_MOVIE)
+        assert len(result) == 1
+        assert result[0]['name'] == 'Movies'
+
+
+class TestGetEffectiveArrConfig:
+    """Tests for get_effective_arr_config merge precedence (#157 Phase 1)"""
+
+    def test_uses_global_when_library_arr_empty(self):
+        config = {'radarr': {'enabled': True, 'url': 'http://radarr:7878', 'api_key': 'globalkey',
+                              'root_folder': '/movies', 'quality_profile': 'HD-1080p'}}
+        library = {'media_type': 'movie', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['enabled'] is True
+        assert result['url'] == 'http://radarr:7878'
+        assert result['api_key'] == 'globalkey'
+        assert result['root_folder'] == '/movies'
+        assert result['quality_profile'] == 'HD-1080p'
+
+    def test_library_arr_overrides_global_routing_field(self):
+        config = {'radarr': {'enabled': True, 'root_folder': '/movies', 'quality_profile': 'HD-1080p'}}
+        library = {'media_type': 'movie', 'arr': {'root_folder': '/kids-movies'}}
+        result = get_effective_arr_config(config, library)
+        # Overridden field
+        assert result['root_folder'] == '/kids-movies'
+        # Fallback field untouched
+        assert result['quality_profile'] == 'HD-1080p'
+
+    def test_instance_overrides_url_and_api_key(self):
+        config = {'radarr': {'enabled': True, 'url': 'http://default:7878', 'api_key': 'default_key'}}
+        library = {
+            'media_type': 'movie',
+            'arr': {'instance': {'url': 'http://custom:7878', 'api_key': 'custom_key'}},
+        }
+        result = get_effective_arr_config(config, library)
+        assert result['url'] == 'http://custom:7878'
+        assert result['api_key'] == 'custom_key'
+
+    def test_instance_partial_override_falls_back_for_omitted_field(self):
+        config = {'radarr': {'enabled': True, 'url': 'http://default:7878', 'api_key': 'default_key'}}
+        library = {
+            'media_type': 'movie',
+            'arr': {'instance': {'url': 'http://custom:7878'}},
+        }
+        result = get_effective_arr_config(config, library)
+        assert result['url'] == 'http://custom:7878'
+        assert result['api_key'] == 'default_key'
+
+    def test_movie_gets_minimum_availability_not_series_type(self):
+        config = {'radarr': {'minimum_availability': 'announced'}}
+        library = {'media_type': 'movie', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['minimum_availability'] == 'announced'
+        assert 'series_type' not in result
+
+    def test_tv_gets_series_type_not_minimum_availability(self):
+        config = {'sonarr': {'series_type': 'anime'}}
+        library = {'media_type': 'tv', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['series_type'] == 'anime'
+        assert 'minimum_availability' not in result
+
+    def test_search_field_falls_back_to_legacy_radarr_search_for_movie(self):
+        config = {'radarr': {'search_for_movie': True}}
+        library = {'media_type': 'movie', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['search'] is True
+
+    def test_search_field_falls_back_to_legacy_sonarr_search_for_series(self):
+        config = {'sonarr': {'search_for_series': True}}
+        library = {'media_type': 'tv', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['search'] is True
+
+    def test_library_arr_search_overrides_legacy_global_search(self):
+        config = {'radarr': {'search_for_movie': False}}
+        library = {'media_type': 'movie', 'arr': {'search': True}}
+        result = get_effective_arr_config(config, library)
+        assert result['search'] is True
+
+    def test_defaults_when_no_global_arr_config_at_all(self):
+        config = {}
+        library = {'media_type': 'movie', 'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['enabled'] is False
+        assert result['monitor'] is False
+        assert result['search'] is False
+        assert result['url'] is None
+        assert result['api_key'] is None
+
+    def test_missing_media_type_defaults_to_movie(self):
+        config = {'radarr': {'root_folder': '/movies'}}
+        library = {'arr': {}}
+        result = get_effective_arr_config(config, library)
+        assert result['root_folder'] == '/movies'
+        assert 'minimum_availability' in result
+
+    def test_missing_arr_key_falls_back_entirely_to_global(self):
+        config = {'sonarr': {'enabled': True, 'root_folder': '/tv'}}
+        library = {'media_type': 'tv'}
+        result = get_effective_arr_config(config, library)
+        assert result['enabled'] is True
+        assert result['root_folder'] == '/tv'

--- a/tests/test_migrate_config.py
+++ b/tests/test_migrate_config.py
@@ -15,6 +15,7 @@ from utils.migrate_config import (
     extract_feature_config,
     build_core_config,
     migrate_config,
+    migrate_to_libraries,
     main,
     TUNING_SECTIONS,
     CORE_SECTIONS,
@@ -57,6 +58,126 @@ class TestNeedsMigration:
             'users': {'list': 'alice'},
         }
         assert needs_migration(config) is False
+
+    def test_returns_true_for_legacy_movie_library_without_libraries(self):
+        """Test returns True if plex.movie_library present but no libraries list (#157)."""
+        config = {'plex': {'movie_library': 'Movies'}}
+        assert needs_migration(config) is True
+
+    def test_returns_true_for_legacy_tv_library_without_libraries(self):
+        """Test returns True if plex.tv_library present but no libraries list (#157)."""
+        config = {'plex': {'tv_library': 'TV Shows'}}
+        assert needs_migration(config) is True
+
+    def test_returns_false_when_libraries_already_present(self):
+        """Test returns False if libraries already migrated, even with legacy keys (idempotent)."""
+        config = {
+            'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'libraries': [{'id': 'movies'}, {'id': 'tv-shows'}],
+        }
+        assert needs_migration(config) is False
+
+    def test_returns_false_when_no_plex_library_keys(self):
+        """Test returns False if plex config has no movie_library/tv_library at all."""
+        config = {'plex': {'url': 'http://localhost:32400'}}
+        assert needs_migration(config) is False
+
+
+class TestCoreSectionsIncludesLibraries:
+    """Test CORE_SECTIONS includes 'libraries' (#157 Phase 1)"""
+
+    def test_libraries_in_core_sections(self):
+        assert 'libraries' in CORE_SECTIONS
+
+
+class TestMigrateToLibraries:
+    """Tests for migrate_to_libraries (#157 Phase 1)"""
+
+    def test_returns_none_if_libraries_already_present(self, tmp_path):
+        config = {'plex': {'movie_library': 'Movies'}, 'libraries': [{'id': 'movies'}]}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert result is None
+
+    def test_returns_none_if_no_legacy_library_keys(self, tmp_path):
+        config = {'plex': {'url': 'http://localhost:32400'}}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert result is None
+
+    def test_builds_two_entries_from_scalar_config(self, tmp_path):
+        config = {'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'}}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert len(result) == 2
+        assert result[0]['id'] == 'movies'
+        assert result[0]['media_type'] == 'movie'
+        assert result[0]['name'] == 'Movies'
+        assert result[1]['id'] == 'tv-shows'
+        assert result[1]['media_type'] == 'tv'
+        assert result[1]['name'] == 'TV Shows'
+
+    def test_defaults_missing_tv_library_name(self, tmp_path):
+        config = {'plex': {'movie_library': 'Movies'}}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert len(result) == 2
+        assert result[1]['name'] == 'TV Shows'
+
+    def test_folds_radarr_routing_from_config_dict(self, tmp_path):
+        config = {
+            'plex': {'movie_library': 'Movies'},
+            'radarr': {
+                'root_folder': '/data/movies',
+                'quality_profile': '4K',
+                'tag': 'Curatarr',
+                'monitor': True,
+                'search_for_movie': True,
+                'minimum_availability': 'announced',
+            },
+        }
+        result = migrate_to_libraries(config, str(tmp_path))
+        movie_arr = result[0]['arr']
+        assert movie_arr['root_folder'] == '/data/movies'
+        assert movie_arr['quality_profile'] == '4K'
+        assert movie_arr['tag'] == 'Curatarr'
+        assert movie_arr['monitor'] is True
+        assert movie_arr['search'] is True
+        assert movie_arr['minimum_availability'] == 'announced'
+
+    def test_folds_sonarr_routing_from_config_dict(self, tmp_path):
+        config = {
+            'plex': {'tv_library': 'TV Shows'},
+            'sonarr': {
+                'root_folder': '/data/tv',
+                'series_type': 'anime',
+                'search_for_series': True,
+            },
+        }
+        result = migrate_to_libraries(config, str(tmp_path))
+        tv_arr = result[1]['arr']
+        assert tv_arr['root_folder'] == '/data/tv'
+        assert tv_arr['series_type'] == 'anime'
+        assert tv_arr['search'] is True
+
+    def test_folds_radarr_routing_from_standalone_module_file(self, tmp_path):
+        """When config.yml is already modular, radarr.yml lives as a separate file."""
+        radarr_path = tmp_path / 'radarr.yml'
+        with open(radarr_path, 'w') as f:
+            yaml.dump({'root_folder': '/data/movies', 'quality_profile': 'HD-1080p'}, f)
+
+        config = {'plex': {'movie_library': 'Movies'}}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert result[0]['arr']['root_folder'] == '/data/movies'
+        assert result[0]['arr']['quality_profile'] == 'HD-1080p'
+
+    def test_only_copies_fields_present_in_legacy_config(self, tmp_path):
+        config = {'plex': {'movie_library': 'Movies'}, 'radarr': {'root_folder': '/data/movies'}}
+        result = migrate_to_libraries(config, str(tmp_path))
+        assert result[0]['arr'] == {'root_folder': '/data/movies'}
+
+    def test_does_not_mutate_plex_library_keys(self, tmp_path):
+        """Additive: migrate_to_libraries doesn't touch plex.movie_library/tv_library."""
+        config = {'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'}}
+        migrate_to_libraries(config, str(tmp_path))
+        assert config['plex']['movie_library'] == 'Movies'
+        assert config['plex']['tv_library'] == 'TV Shows'
 
 
 class TestExtractTuningConfig:
@@ -228,6 +349,84 @@ class TestMigrateConfig:
         assert 'trakt.yml' in result['files_created']
         assert os.path.exists(str(tmp_path / 'tuning.yml'))
         assert os.path.exists(str(tmp_path / 'trakt.yml'))
+
+
+class TestMigrateConfigLibraries:
+    """Tests for the 'libraries' hook inside migrate_config (#157 Phase 1)"""
+
+    def test_scalar_and_arr_config_folds_into_libraries(self, tmp_path):
+        """End-to-end: legacy movie_library/tv_library + radarr/sonarr routing
+        become a 'libraries' list in the migrated config.yml."""
+        config_path = str(tmp_path / 'config.yml')
+        config = {
+            'plex': {'url': 'http://localhost', 'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'tmdb': {'api_key': 'abc'},
+            'radarr': {'enabled': True, 'root_folder': '/data/movies', 'quality_profile': '4K'},
+            'sonarr': {'enabled': True, 'root_folder': '/data/tv', 'series_type': 'anime'},
+        }
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        result = migrate_config(config_path)
+
+        assert result['migrated'] is True
+        with open(config_path, 'r') as f:
+            migrated = yaml.safe_load(f)
+
+        assert 'libraries' in migrated
+        assert len(migrated['libraries']) == 2
+        movie_lib = next(l for l in migrated['libraries'] if l['media_type'] == 'movie')
+        tv_lib = next(l for l in migrated['libraries'] if l['media_type'] == 'tv')
+        assert movie_lib['arr']['root_folder'] == '/data/movies'
+        assert movie_lib['arr']['quality_profile'] == '4K'
+        assert tv_lib['arr']['root_folder'] == '/data/tv'
+        assert tv_lib['arr']['series_type'] == 'anime'
+
+    def test_additive_does_not_delete_legacy_plex_keys(self, tmp_path):
+        """Migration must not remove plex.movie_library/tv_library - additive only."""
+        config_path = str(tmp_path / 'config.yml')
+        config = {
+            'plex': {'url': 'http://localhost', 'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'tmdb': {'api_key': 'abc'},
+        }
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        migrate_config(config_path)
+
+        with open(config_path, 'r') as f:
+            migrated = yaml.safe_load(f)
+
+        assert migrated['plex']['movie_library'] == 'Movies'
+        assert migrated['plex']['tv_library'] == 'TV Shows'
+        assert 'libraries' in migrated
+
+    def test_idempotent_second_run_does_not_remigrate(self, tmp_path):
+        """Running migrate_config again after libraries exist is a no-op."""
+        config_path = str(tmp_path / 'config.yml')
+        config = {
+            'plex': {'url': 'http://localhost', 'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'tmdb': {'api_key': 'abc'},
+        }
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        first = migrate_config(config_path)
+        assert first['migrated'] is True
+
+        second = migrate_config(config_path)
+        assert second['migrated'] is False
+
+    def test_no_migration_needed_when_no_legacy_library_keys_and_already_modular(self, tmp_path):
+        """A config with only core sections and no movie_library/tv_library needs no migration."""
+        config_path = str(tmp_path / 'config.yml')
+        config = {'plex': {'url': 'http://localhost'}, 'tmdb': {'api_key': 'abc'}}
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        result = migrate_config(config_path)
+
+        assert result['migrated'] is False
 
 
 class TestMain:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -51,6 +51,9 @@ from .config import (
     get_negative_signals_config,
     get_negative_multiplier,
     adapt_config_for_media_type,
+    get_libraries,
+    get_libraries_for_media_type,
+    get_effective_arr_config,
 )
 
 # Display utilities
@@ -286,6 +289,9 @@ __all__ = [
     'load_config',
     'get_rating_multipliers',
     'adapt_config_for_media_type',
+    'get_libraries',
+    'get_libraries_for_media_type',
+    'get_effective_arr_config',
     # Display
     'RED',
     'GREEN',

--- a/utils/config.py
+++ b/utils/config.py
@@ -5,8 +5,9 @@ Handles config loading, section access, and rating multipliers.
 
 import os
 import json
+import re
 import yaml
-from typing import Dict
+from typing import Dict, List
 
 # Project version - single source of truth
 __version__ = "2.8.23"
@@ -464,3 +465,215 @@ def adapt_config_for_media_type(root_config: Dict, media_type: str = 'movies') -
     config['negative_signals'] = get_negative_signals_config(root_config)
 
     return config
+
+
+# =============================================================================
+# Multi-library support (#157 Phase 1)
+#
+# `libraries` is a repeatable, first-class entity living inside config.yml:
+#
+#   libraries:
+#     - id: movies
+#       name: Movies
+#       section: Movies
+#       media_type: movie
+#       arr:
+#         root_folder: /data/movies
+#         quality_profile: HD-1080p
+#         instance:
+#           url: http://localhost:7878
+#           api_key: KEY
+#
+# Global sonarr.yml/radarr.yml remain the default *arr instance (enabled/
+# url/api_key), the which-users-sync policy (auto_sync/user_mode/plex_users),
+# and the field-level fallback for any arr.* field a library omits.
+#
+# Nothing in the recommender pipeline consumes these yet (see Phases 2-4) -
+# this is purely additive.
+# =============================================================================
+
+# Legacy global radarr.yml/sonarr.yml field name -> unified library arr.*
+# field name, for the handful of fields whose name differs by media type.
+_ARR_FIELD_ALIASES = {
+    MEDIA_TYPE_MOVIE: {'search': 'search_for_movie'},
+    MEDIA_TYPE_TV: {'search': 'search_for_series'},
+}
+
+# Per-library routing fields eligible for field-level fallback to the global
+# radarr/sonarr block, by media type. minimum_availability is movie-only,
+# series_type is tv-only.
+_ARR_ROUTING_FIELDS = {
+    MEDIA_TYPE_MOVIE: ['root_folder', 'quality_profile', 'tag', 'monitor', 'search', 'minimum_availability'],
+    MEDIA_TYPE_TV: ['root_folder', 'quality_profile', 'tag', 'monitor', 'search', 'series_type'],
+}
+
+# *arr instance/connection fields - overridable per-library via arr.instance
+_ARR_INSTANCE_FIELDS = ['enabled', 'url', 'api_key']
+
+# Sensible boolean defaults for fields that should never resolve to None
+_ARR_FIELD_DEFAULTS = {'enabled': False, 'monitor': False, 'search': False}
+
+
+def _slugify_library_id(name: str) -> str:
+    """
+    Derive a stable slug id from a library name (e.g. "TV Shows" -> "tv-shows").
+
+    Args:
+        name: Library display name
+
+    Returns:
+        Lowercase, hyphenated slug. Falls back to 'library' if name is blank
+        or has no alphanumeric characters.
+    """
+    slug = re.sub(r'[^a-z0-9]+', '-', (name or '').strip().lower()).strip('-')
+    return slug or 'library'
+
+
+def _normalize_library(library: Dict) -> Dict:
+    """
+    Fill in default id/media_type/section for a single library entry.
+
+    Args:
+        library: Raw library dict from config['libraries']
+
+    Returns:
+        A copy of library with id, name, media_type, section, and arr
+        guaranteed to be present.
+    """
+    normalized = dict(library or {})
+    name = normalized.get('name') or normalized.get('id') or 'Library'
+    normalized['name'] = name
+    normalized['id'] = normalized.get('id') or _slugify_library_id(name)
+    normalized['media_type'] = normalized.get('media_type') or MEDIA_TYPE_MOVIE
+    normalized['section'] = normalized.get('section') or name
+    normalized.setdefault('arr', {})
+    return normalized
+
+
+def _synthesize_legacy_libraries(config: Dict) -> List[Dict]:
+    """
+    Back-compat fallback: synthesize a movie + tv library entry from the
+    legacy single-library plex.movie_library/plex.tv_library settings.
+
+    Each synthesized entry's 'arr' override is left empty, so
+    get_effective_arr_config() naturally falls back to the global
+    radarr/sonarr block for that entry's routing - i.e. arr routing is
+    still effectively "pulled from" the global radarr/sonarr config.
+
+    Args:
+        config: Root configuration dictionary
+
+    Returns:
+        Two-entry list: [movie library, tv library]
+    """
+    plex_config = get_config_section(config, 'plex')
+    movie_library = plex_config.get('movie_library', 'Movies')
+    tv_library = plex_config.get('tv_library', 'TV Shows')
+
+    return [
+        {
+            'id': _slugify_library_id(movie_library),
+            'name': movie_library,
+            'section': movie_library,
+            'media_type': MEDIA_TYPE_MOVIE,
+            'arr': {},
+        },
+        {
+            'id': _slugify_library_id(tv_library),
+            'name': tv_library,
+            'section': tv_library,
+            'media_type': MEDIA_TYPE_TV,
+            'arr': {},
+        },
+    ]
+
+
+def get_libraries(config: Dict) -> List[Dict]:
+    """
+    Get the normalized list of libraries from config.
+
+    Reads config['libraries'] (repeatable multi-library entries) and fills
+    in defaults for any omitted fields: id (slug of name), media_type
+    (defaults to 'movie'), section (defaults to name).
+
+    Back-compat fallback: if config has no 'libraries' section (or it's
+    empty), synthesizes a movie entry from plex.movie_library (default
+    'Movies') and a tv entry from plex.tv_library (default 'TV Shows'),
+    so existing single-library installs keep working without a
+    'libraries:' block in config.yml. This is the single back-compat
+    fallback path.
+
+    Args:
+        config: Root configuration dictionary
+
+    Returns:
+        List of normalized library dicts, each with at least:
+        id, name, section, media_type, arr
+    """
+    raw_libraries = config.get('libraries')
+
+    if raw_libraries:
+        return [_normalize_library(lib) for lib in raw_libraries]
+
+    return _synthesize_legacy_libraries(config)
+
+
+def get_libraries_for_media_type(config: Dict, media_type: str) -> List[Dict]:
+    """
+    Get normalized libraries filtered to a specific media type.
+
+    Args:
+        config: Root configuration dictionary
+        media_type: 'movie' or 'tv' (see MEDIA_TYPE_MOVIE / MEDIA_TYPE_TV)
+
+    Returns:
+        List of normalized library dicts matching media_type
+    """
+    return [lib for lib in get_libraries(config) if lib.get('media_type') == media_type]
+
+
+def get_effective_arr_config(config: Dict, library: Dict) -> Dict:
+    """
+    Resolve the effective *arr (Radarr/Sonarr) routing config for a library.
+
+    Deep-merges, in increasing precedence:
+      1. The global sonarr/radarr block (selected by library['media_type'])
+      2. library['arr'] (per-library routing overrides)
+      3. library['arr']['instance'] (per-library *arr instance connection)
+
+    Args:
+        config: Root configuration dictionary
+        library: A library dict (see get_libraries)
+
+    Returns:
+        Dict with effective keys: enabled, url, api_key, root_folder,
+        quality_profile, tag, monitor, search, plus minimum_availability
+        (movie libraries) or series_type (tv libraries).
+    """
+    media_type = library.get('media_type') or MEDIA_TYPE_MOVIE
+    arr_key = 'radarr' if media_type == MEDIA_TYPE_MOVIE else 'sonarr'
+    global_arr = get_config_section(config, arr_key)
+    library_arr = library.get('arr') or {}
+    instance = library_arr.get('instance') or {}
+    aliases = _ARR_FIELD_ALIASES.get(media_type, {})
+
+    effective = {}
+
+    # Instance/connection fields: global -> library.arr -> library.arr.instance
+    for field in _ARR_INSTANCE_FIELDS:
+        value = global_arr.get(field, _ARR_FIELD_DEFAULTS.get(field))
+        if field in library_arr:
+            value = library_arr[field]
+        if field in instance:
+            value = instance[field]
+        effective[field] = value
+
+    # Routing fields: global (legacy field name) -> library.arr (unified name)
+    for field in _ARR_ROUTING_FIELDS.get(media_type, []):
+        global_field = aliases.get(field, field)
+        value = global_arr.get(global_field, _ARR_FIELD_DEFAULTS.get(field))
+        if field in library_arr:
+            value = library_arr[field]
+        effective[field] = value
+
+    return effective

--- a/utils/migrate_config.py
+++ b/utils/migrate_config.py
@@ -13,9 +13,10 @@ Usage:
 """
 
 import os
+import re
 import shutil
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 import yaml
 
@@ -40,10 +41,26 @@ CORE_SECTIONS = [
     'streaming_services',
     'logging',
     'platform',
+    'libraries',
 ]
 
 # Feature modules (each gets its own file)
 FEATURE_MODULES = ['trakt', 'radarr', 'sonarr']
+
+# Legacy global radarr.yml/sonarr.yml routing field -> unified library
+# arr.* field name, for fields whose name differs by media type. Mirrors
+# utils.config._ARR_FIELD_ALIASES (kept local here to avoid a module-level
+# dependency between the two standalone utilities).
+_LEGACY_ARR_FIELD_ALIASES = {
+    'movie': {'search': 'search_for_movie'},
+    'tv': {'search': 'search_for_series'},
+}
+
+# Legacy routing fields to fold into a library's arr block, by media type.
+_LEGACY_ARR_ROUTING_FIELDS = {
+    'movie': ['root_folder', 'quality_profile', 'tag', 'monitor', 'search', 'minimum_availability'],
+    'tv': ['root_folder', 'quality_profile', 'tag', 'monitor', 'search', 'series_type'],
+}
 
 
 def needs_migration(config: dict) -> bool:
@@ -63,6 +80,13 @@ def needs_migration(config: dict) -> bool:
         return True
     if 'tv' in config and 'sonarr' in config.get('tv', {}):
         return True
+
+    # Additive (#157 Phase 1): legacy single-library plex config not yet
+    # folded into a 'libraries' list also needs migration.
+    if not config.get('libraries'):
+        plex_config = config.get('plex', config.get('PLEX', {})) or {}
+        if plex_config.get('movie_library') or plex_config.get('tv_library'):
+            return True
 
     return False
 
@@ -96,6 +120,104 @@ def extract_feature_config(config: dict, feature: str) -> Optional[dict]:
             return config['tv']['sonarr']
 
     return None
+
+
+def _slugify_library_id(name: str) -> str:
+    """Derive a stable slug id from a library name (e.g. "TV Shows" -> "tv-shows")."""
+    slug = re.sub(r'[^a-z0-9]+', '-', (name or '').strip().lower()).strip('-')
+    return slug or 'library'
+
+
+def _fold_legacy_arr_routing(legacy_config: dict, media_type: str) -> dict:
+    """
+    Fold a legacy radarr.yml/sonarr.yml block's routing fields into the
+    unified per-library arr.* schema. Only fields actually present in
+    legacy_config are copied, to keep the migration diff minimal.
+    """
+    field_map = _LEGACY_ARR_FIELD_ALIASES.get(media_type, {})
+    arr = {}
+    for unified_field in _LEGACY_ARR_ROUTING_FIELDS.get(media_type, []):
+        legacy_field = field_map.get(unified_field, unified_field)
+        if legacy_field in legacy_config:
+            arr[unified_field] = legacy_config[legacy_field]
+    return arr
+
+
+def _load_legacy_module(config: dict, config_dir: str, module: str) -> dict:
+    """
+    Get a feature module's config (radarr/sonarr) from the in-memory config
+    dict being migrated, falling back to reading its standalone module file
+    (e.g. radarr.yml) if the config has already been split into modular
+    files (module sections then live outside the root config.yml dict).
+    """
+    if module in config and config[module]:
+        return config[module]
+
+    module_path = os.path.join(config_dir, f'{module}.yml')
+    if os.path.exists(module_path):
+        try:
+            with open(module_path, 'r', encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+                return data or {}
+        except Exception:
+            return {}
+
+    return {}
+
+
+def migrate_to_libraries(config: dict, config_dir: str) -> Optional[List[dict]]:
+    """
+    Build an additive 'libraries' list from legacy single-library plex
+    config, folding in routing fields from radarr.yml/sonarr.yml.
+
+    Purely additive: does NOT remove plex.movie_library/plex.tv_library
+    from config - both the legacy keys and the new 'libraries' list
+    coexist. Idempotent: returns None if config already has a truthy
+    'libraries' section, or if there's no legacy movie_library/tv_library
+    to migrate from.
+
+    Args:
+        config: The config dict being migrated (may still be monolithic,
+            or already split into modular files)
+        config_dir: Directory containing config.yml and module files
+            (radarr.yml, sonarr.yml)
+
+    Returns:
+        Two-entry list [movie library, tv library], or None if not
+        applicable.
+    """
+    if config.get('libraries'):
+        return None
+
+    plex_config = config.get('plex', config.get('PLEX', {})) or {}
+    movie_library = plex_config.get('movie_library')
+    tv_library = plex_config.get('tv_library')
+
+    if not movie_library and not tv_library:
+        return None
+
+    movie_library = movie_library or 'Movies'
+    tv_library = tv_library or 'TV Shows'
+
+    radarr_config = _load_legacy_module(config, config_dir, 'radarr')
+    sonarr_config = _load_legacy_module(config, config_dir, 'sonarr')
+
+    return [
+        {
+            'id': _slugify_library_id(movie_library),
+            'name': movie_library,
+            'section': movie_library,
+            'media_type': 'movie',
+            'arr': _fold_legacy_arr_routing(radarr_config, 'movie'),
+        },
+        {
+            'id': _slugify_library_id(tv_library),
+            'name': tv_library,
+            'section': tv_library,
+            'media_type': 'tv',
+            'arr': _fold_legacy_arr_routing(sonarr_config, 'tv'),
+        },
+    ]
 
 
 def build_core_config(config: dict) -> dict:
@@ -156,6 +278,13 @@ def migrate_config(config_path: str, dry_run: bool = False) -> dict:
         if feature_config:
             feature_configs[feature] = feature_config
 
+    # Additive (#157 Phase 1): fold legacy plex.movie_library/tv_library +
+    # radarr.yml/sonarr.yml routing into a 'libraries' list. Does not
+    # remove the legacy plex keys.
+    libraries = migrate_to_libraries(config, config_dir)
+    if libraries:
+        core_config['libraries'] = libraries
+
     if dry_run:
         print("\n=== Dry Run - Would create these files ===\n")
         print(f"config.yml (slimmed to {len(core_config)} sections)")
@@ -163,6 +292,8 @@ def migrate_config(config_path: str, dry_run: bool = False) -> dict:
             print(f"tuning.yml ({len(tuning_config)} sections)")
         for feature, cfg in feature_configs.items():
             print(f"{feature}.yml")
+        if libraries:
+            print(f"config.yml would gain a 'libraries' section ({len(libraries)} entries)")
         result['migrated'] = True
         return result
 


### PR DESCRIPTION
## Summary
- Additive foundation for #157 multi-library support: no behavior change, nothing consumes this yet (Phases 2-4).
- New accessors in `utils/config.py`: `get_libraries()`, `get_libraries_for_media_type()`, `get_effective_arr_config()`. When `config['libraries']` is absent/empty, synthesizes a movie + tv entry from `plex.movie_library`/`plex.tv_library`, falling back to global `radarr`/`sonarr` blocks for arr routing.
- New migration in `utils/migrate_config.py`: `migrate_to_libraries()`, hooked into `needs_migration`/`migrate_config`, folds legacy `plex.movie_library`/`plex.tv_library` + `radarr.yml`/`sonarr.yml` routing into a `libraries:` list. Purely additive - does not delete the legacy plex keys. Idempotent.
- `config/config.example.yml` gains a commented `libraries:` example block; `radarr.example.yml`/`sonarr.example.yml` get deprecation notes pointing at per-library `arr` overrides while remaining valid defaults.

## Test plan
- [x] New unit tests for `get_libraries` fallback synthesis, normalization, `get_effective_arr_config` merge precedence + instance override + field fallback (`tests/test_config.py`)
- [x] New unit tests for `migrate_to_libraries`, `needs_migration` hook, idempotency, additive non-deletion (`tests/test_migrate_config.py`)
- [x] Full suite: 1468 passed, 88% coverage
- [x] Manual end-to-end smoke test: `load_config` on a legacy single-library config auto-migrates, `libraries:` appears, `plex.movie_library`/`tv_library` retained, `get_effective_arr_config` resolves url/api_key/routing correctly