### PR TITLE
Add gitleaks secret-scanning gate (pre-push + CI)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,50 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=85
+
+  secret-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks (checksum-verified)
+        run: |
+          set -euo pipefail
+          VERSION="8.30.1"
+          SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+          curl -sSL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          echo "${SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      # Scans only the commits introduced by this push/PR, not full history --
+      # so this job can never go permanently red over something already on
+      # main. The one-time full-history baseline scan is run manually (see
+      # the secret-scanning rollout PR), not in CI.
+      - name: Determine commit range
+        id: range
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+            echo "range=origin/${{ github.event.pull_request.base.ref }}..HEAD" >> "$GITHUB_OUTPUT"
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              echo "range=HEAD" >> "$GITHUB_OUTPUT"
+            else
+              echo "range=${BEFORE}..${{ github.event.after }}" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Run gitleaks
+        run: |
+          gitleaks detect --source . \
+            --log-opts="${{ steps.range.outputs.range }}" \
+            --config .gitleaks.toml \
+            --redact \
+            --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,109 @@
+title = "OrchestratedChaos gitleaks config"
+
+# Start from gitleaks' built-in ruleset (AWS keys, generic private keys,
+# common vendor tokens, etc.) and layer this user's own secret shapes on
+# top -- see custom rules below.
+[extend]
+useDefault = true
+
+# -- Plex --------------------------------------------------------------------
+[[rules]]
+id = "plex-token"
+description = "Plex API token (X-Plex-Token header / plexToken / PLEX_TOKEN)"
+regex = '''(?i)(x-plex-token|plex[_-]?token)[\s"'\]]{0,3}[:=][\s"']{0,3}([a-zA-Z0-9_-]{19,25})(?:["'\s]|$)'''
+secretGroup = 2
+keywords = ["x-plex-token", "plextoken", "plex_token"]
+
+# -- TMDB ----------------------------------------------------------------------
+[[rules]]
+id = "tmdb-api-key"
+description = "TMDB API key"
+regex = '''(?i)tmdb[_-]?api[_-]?key[\s"'\]]{0,3}[:=][\s"']{0,3}([a-f0-9]{32})(?:["'\s]|$)'''
+secretGroup = 1
+keywords = ["tmdb_api_key", "tmdbapikey"]
+
+# -- Tautulli ------------------------------------------------------------------
+[[rules]]
+id = "tautulli-api-key"
+description = "Tautulli API key"
+regex = '''(?i)tautulli[_-]?api[_-]?key[\s"'\]]{0,3}[:=][\s"']{0,3}([a-f0-9]{32})(?:["'\s]|$)'''
+secretGroup = 1
+keywords = ["tautulli_api_key", "tautulliapikey"]
+
+# -- Sonarr / Radarr -------------------------------------------------------------
+[[rules]]
+id = "arr-api-key"
+description = "Sonarr/Radarr API key (X-Api-Key header or api_key config value)"
+regex = '''(?i)(x-api-key|(?:sonarr|radarr)[_-]?api[_-]?key)[\s"'\]]{0,3}[:=][\s"']{0,3}([a-f0-9]{32})(?:["'\s]|$)'''
+secretGroup = 2
+keywords = ["x-api-key", "sonarr_api_key", "radarr_api_key"]
+
+# -- Trakt -----------------------------------------------------------------------
+[[rules]]
+id = "trakt-credentials"
+description = "Trakt client_id/client_secret/access_token/refresh_token"
+regex = '''(?i)trakt[_-]?(?:client[_-]?id|client[_-]?secret|access[_-]?token|refresh[_-]?token)[\s"'\]]{0,3}[:=][\s"']{0,3}([a-zA-Z0-9_-]{20,64})(?:["'\s]|$)'''
+secretGroup = 1
+keywords = ["trakt_client_id", "trakt_client_secret", "trakt_access_token", "trakt_refresh_token"]
+
+# -- MDBList -----------------------------------------------------------------------
+[[rules]]
+id = "mdblist-api-key"
+description = "MDBList API key"
+regex = '''(?i)mdblist[_-]?api[_-]?key[\s"'\]]{0,3}[:=][\s"']{0,3}([a-zA-Z0-9]{20,40})(?:["'\s]|$)'''
+secretGroup = 1
+keywords = ["mdblist_api_key", "mdblistapikey"]
+
+# -- Simkl -----------------------------------------------------------------------
+[[rules]]
+id = "simkl-credentials"
+description = "Simkl API key / client secret"
+regex = '''(?i)simkl[_-]?(?:api[_-]?key|client[_-]?secret)[\s"'\]]{0,3}[:=][\s"']{0,3}([a-zA-Z0-9]{20,64})(?:["'\s]|$)'''
+secretGroup = 1
+keywords = ["simkl_api_key", "simkl_client_secret"]
+
+# -- ntfy ------------------------------------------------------------------------
+[[rules]]
+id = "ntfy-topic-url"
+description = "ntfy.sh topic URL (anyone with this URL can read/publish to the topic)"
+regex = '''https?://ntfy\.sh/[A-Za-z0-9_-]{6,64}'''
+keywords = ["ntfy.sh"]
+
+# -- Generic ------------------------------------------------------------------------
+# Catches bare `token:`/`api_key:` style values too -- this codebase's YAML
+# configs nest per-service keys (plex: -> token:, sonarr: -> api_key:)
+# rather than prefixing them with the service name, so the service-specific
+# rules above miss the real on-disk shape; this is the backstop for those.
+[[rules]]
+id = "generic-high-entropy-secret"
+description = "Generic password/secret/token/api-key assignment with a high-entropy value"
+regex = '''(?i)(?:password|passwd|secret|token|api[_-]?key)[\s"'\]]{0,3}[:=][\s"']{1,3}([a-zA-Z0-9_\-!@#$%^&*]{16,64})["']?'''
+secretGroup = 1
+entropy = 3.5
+keywords = ["password", "passwd", "secret", "token", "api_key", "apikey", "api-key"]
+
+[allowlist]
+description = "Known-safe placeholders, examples, and generated/vendored files"
+regexTarget = "match"
+regexes = [
+  '''(?i)YOUR[_-][A-Z0-9_-]*(KEY|TOKEN|SECRET)''',
+  '''(?i)<[A-Z0-9_-]*(KEY|TOKEN|SECRET)>''',
+  '''(?i)\{\{[^}]*(key|token|secret)[^}]*\}\}''',
+  '''(?i)\bchangeme\b''',
+  '''(?i)\bexample\b''',
+  '''(?i)\bplaceholder\b''',
+  '''x{16,}''',
+  '''0{16,}''',
+]
+paths = [
+  '''(^|/)\.git/''',
+  '''(^|/)node_modules/''',
+  '''(^|/)(dist|build)/''',
+  '''(^|/)(cache|logs)/''',
+  '''\.(lock|svg|png|jpg|jpeg|gif|ico|woff2?|ttf|eot)$''',
+  '''(^|/).*\.example\.(ya?ml|json|env)$''',
+  '''(^|/)\.env\.example$''',
+  '''(^|/)\.env\.template$''',
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)requirements(-[a-z]+)?\.lock$''',
+]

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Pre-push hook -- runs scripts/hooks/pre-push-checks.sh
+# Installed via: bash scripts/setup-hooks.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+bash scripts/hooks/pre-push-checks.sh < /dev/null

--- a/scripts/hooks/pre-push-checks.sh
+++ b/scripts/hooks/pre-push-checks.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Pre-push checks.
+# Currently just the secret-scan gate; add more checks here as the repo
+# grows local pre-push tooling (see hooks/pre-push for the git-hook entry
+# point and how it's wired up).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+    echo "FAILED: gitleaks not found -- run scripts/setup-hooks.sh for install instructions"
+    exit 1
+fi
+
+echo "-- Secret scan --"
+
+# Scans only the commits about to be pushed (not full history), so it can
+# never be permanently red over something already on main. Mirrors the CI
+# `secret-scan` job's range logic (.github/workflows/tests.yml).
+RANGE="HEAD"
+git rev-parse --verify origin/main >/dev/null 2>&1 && RANGE="origin/main..HEAD"
+
+if ! gitleaks detect --source . --log-opts="$RANGE" --config .gitleaks.toml --redact --exit-code 1; then
+    echo ""
+    echo "FAILED: secret(s) detected above (file:line + rule) -- remove them,"
+    echo "move the value into config/*.yml (gitignored) or an environment"
+    echo "variable, and amend the commit before pushing."
+    exit 1
+fi
+
+echo "Secret scan OK"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# One-time setup for local git hooks (currently: secret-scan pre-push gate).
+# Run: bash scripts/setup-hooks.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Curatarr Local Hooks Setup ==="
+
+# 1. Set git hooks path to hooks/ directory (tracked in repo)
+git config core.hooksPath hooks
+echo "Git hooks path set to hooks/"
+
+# 2. Make hook scripts executable
+chmod +x hooks/pre-push
+chmod +x scripts/hooks/*.sh
+echo "Hook scripts made executable"
+
+# 3. Check gitleaks
+if command -v gitleaks &>/dev/null; then
+    echo "gitleaks $(gitleaks version 2>&1 | awk '{print $NF}')"
+else
+    echo "ERROR: Install gitleaks:"
+    echo "  macOS:   brew install gitleaks"
+    echo "  Linux:   see https://github.com/gitleaks/gitleaks#installing"
+    echo "  Windows: scoop install gitleaks  (or download from the releases page)"
+    exit 1
+fi
+
+echo ""
+echo "Setup complete! Hooks are active."
+echo ""
+echo "Usage:"
+echo "  git push -> runs the secret-scan gate (gitleaks) against the commits"
+echo "              about to be pushed"


### PR DESCRIPTION
## Summary
- Adds .gitleaks.toml: gitleaks' default ruleset plus custom rules for this project's secret shapes (Plex token, TMDB/Tautulli/Sonarr/Radarr/Trakt/MDBList/Simkl keys, ntfy topic URLs) and a generic high-entropy password/secret/token/api-key backstop for the YAML-nested config format actually used in config/*.yml.
- New 'secret-scan' job in .github/workflows/tests.yml, triggered by the same push/pull_request events as the existing test job. Scoped to only the commits being introduced (not full history), so it can't go permanently red over something already on main. gitleaks is installed in CI from a checksum-verified release binary (v8.30.1), not a third-party Action.
- First git-hooks setup in this repo: hooks/pre-push, scripts/hooks/pre-push-checks.sh, scripts/setup-hooks.sh -- runs the identical scan locally before a push ever reaches GitHub. Install with: bash scripts/setup-hooks.sh

## Verify
- Planted a fake X-Plex-Token + Sonarr api_key in a throwaway commit and confirmed both the local pre-push hook and gitleaks itself flag and block it (exit 1); throwaway commit removed before push, never left the machine.
- Baseline scan (working tree + full git history, --log-opts=--all): 16 findings total, all confirmed false positives -- test fixtures for the app's own redact() log-sanitization function (dummy AWS/GitHub/Plex/generic tokens) plus one public SSH key fingerprint in RELEASING.md. No real credentials found in history or working tree.

## Test plan
- [ ] CI (test + secret-scan jobs) green on this PR
- [ ] bash scripts/setup-hooks.sh installs cleanly