### PR TITLE
feat(#157) Phase 2: per-library export routing

### DIFF
--- a/recommenders/external_exports.py
+++ b/recommenders/external_exports.py
@@ -14,10 +14,12 @@ from utils import (
     CYAN, GREEN, RESET,
     print_status, log_warning, log_error, clickable_link,
     get_authenticated_trakt_client, TraktAPIError, TraktAuthError,
-    create_sonarr_client, SonarrAPIError,
-    create_radarr_client, RadarrAPIError,
+    create_sonarr_client, create_sonarr_client_from, SonarrAPIError,
+    create_radarr_client, create_radarr_client_from, RadarrAPIError,
     create_mdblist_client, MDBListAPIError,
     create_simkl_client, SimklAPIError, SimklAuthError,
+    MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV,
+    get_libraries, get_libraries_for_media_type, get_effective_arr_config,
 )
 
 logger = logging.getLogger('curatarr')
@@ -294,6 +296,60 @@ def export_to_trakt(config: Dict, all_users_data: List[Dict], tmdb_api_key: str)
             log_error(f"Failed to export {display_name} to Trakt: {e}")
 
 
+def _resolve_library_groups(
+    config: Dict, users_to_export: List[Dict], media_type: str
+) -> List[Any]:
+    """
+    Group users_to_export by library_id and resolve each group's library.
+
+    #157 Phase 2: per-library *arr export routing. Recommendations don't
+    carry library_id until Phase 3, so users without one fall back to the
+    media-type's library (get_libraries_for_media_type) - currently a single
+    synthesized/configured library - and the whole group routes to it. This
+    keeps single-library installs routing identically to the pre-Phase-2
+    flow while the plumbing is ready for Phase 3.
+
+    Args:
+        config: Root configuration dictionary
+        users_to_export: Filtered per-user recommendation payloads
+        media_type: MEDIA_TYPE_MOVIE or MEDIA_TYPE_TV
+
+    Returns:
+        List of (library, group_users) tuples for groups whose library
+        could be resolved. Unresolvable groups are logged and dropped.
+    """
+    groups: Dict[Optional[str], List[Dict]] = {}
+    for user_data in users_to_export:
+        groups.setdefault(user_data.get('library_id'), []).append(user_data)
+
+    resolved = []
+    for library_id, group_users in groups.items():
+        if library_id is None:
+            candidates = get_libraries_for_media_type(config, media_type)
+            if not candidates:
+                log_warning(
+                    f"Export: no '{media_type}' library configured - skipping "
+                    f"{len(group_users)} user(s) with no library_id"
+                )
+                continue
+            library = candidates[0]
+        else:
+            library = next(
+                (lib for lib in get_libraries(config) if lib.get('id') == library_id),
+                None
+            )
+            if library is None:
+                log_warning(
+                    f"Export: library_id '{library_id}' not found in config - "
+                    f"skipping {len(group_users)} user(s)' recommendations"
+                )
+                continue
+
+        resolved.append((library, group_users))
+
+    return resolved
+
+
 def export_to_sonarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str) -> None:
     """
     Export TV recommendations to Sonarr.
@@ -365,147 +421,172 @@ def export_to_sonarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str
     else:
         users_to_export = all_users_data
 
-    # Get Sonarr settings from config
-    root_folder = sonarr_config.get('root_folder', '/tv')
-    quality_profile_name = sonarr_config.get('quality_profile', 'HD-1080p')
-    tag_name = sonarr_config.get('tag', 'Curatarr')
+    # Sonarr settings not yet part of the per-library arr schema (Phase 1
+    # doesn't cover these - see utils/config.py _ARR_ROUTING_FIELDS); stay
+    # global for all libraries until a future phase adds them.
     append_usernames = sonarr_config.get('append_usernames', False)
-    monitored = sonarr_config.get('monitor', False)
-    search_for_series = sonarr_config.get('search_for_series', False)
-    series_type = sonarr_config.get('series_type', 'standard')
     season_folder = sonarr_config.get('season_folder', True)
 
-    # Get quality profile ID
-    quality_profile_id = sonarr_client.get_quality_profile_id(quality_profile_name)
-    if not quality_profile_id:
-        available = [p['name'] for p in sonarr_client.get_quality_profiles()]
-        log_error(f"Quality profile '{quality_profile_name}' not found. Available: {available}")
-        return
+    # Per-library routing (#157 Phase 2): group users by library_id,
+    # resolve each group's effective Sonarr instance/routing, and process
+    # groups independently.
+    library_groups = _resolve_library_groups(config, users_to_export, MEDIA_TYPE_TV)
 
-    # Validate root folder
-    valid_root = sonarr_client.get_root_folder_path(root_folder)
-    if not valid_root:
-        available = [f['path'] for f in sonarr_client.get_root_folders()]
-        log_error(f"Root folder '{root_folder}' not found. Available: {available}")
-        return
-
-    # Collect all shows to add (handle combined mode)
-    if user_mode == 'combined':
-        all_show_tvdb_ids = []
-        for user_data in users_to_export:
-            # Collect TVDB IDs (flatten nested structure)
-            for show in flatten_categorized(user_data['shows_categorized']):
-                tvdb_id = show.get('tvdb_id')
-                if tvdb_id:
-                    all_show_tvdb_ids.append(tvdb_id)
-        # Deduplicate
-        all_show_tvdb_ids = list(dict.fromkeys(all_show_tvdb_ids))
-
-        if not all_show_tvdb_ids:
-            print_status("  No show recommendations to add", "info")
-            return
-
-        print(f"  Combined mode: Processing {len(all_show_tvdb_ids)} show recommendations...")
-
-        # Get or create tag
-        tag_id = sonarr_client.get_or_create_tag(tag_name)
-
-        added = 0
-        skipped = 0
-        failed = 0
-
-        for tvdb_id in all_show_tvdb_ids:
-            if sonarr_client.series_exists(tvdb_id):
-                skipped += 1
-                continue
-
-            # Look up series
-            series_data = sonarr_client.lookup_series(tvdb_id)
-            if not series_data:
-                logger.debug(f"Could not find series for TVDB ID: {tvdb_id}")
-                failed += 1
-                continue
-
-            try:
-                sonarr_client.add_series(
-                    tvdb_id=tvdb_id,
-                    title=series_data['title'],
-                    root_folder_path=valid_root,
-                    quality_profile_id=quality_profile_id,
-                    monitored=monitored,
-                    season_folder=season_folder,
-                    series_type=series_type,
-                    tag_ids=[tag_id],
-                    search_for_missing_episodes=search_for_series
-                )
-                added += 1
-                print(f"  {GREEN}Added: {series_data['title']}{RESET}")
-            except SonarrAPIError as e:
-                logger.debug(f"Failed to add {series_data['title']}: {e}")
-                failed += 1
-
-        print_status(f"  Combined: {added} added, {skipped} already exist, {failed} failed", "success")
-        return
-
-    # Per-user or mapping mode
-    for user_data in users_to_export:
-        display_name = user_data['display_name']
-        shows_categorized = user_data['shows_categorized']
-
-        # Collect TVDB IDs for shows (flatten nested structure)
-        show_tvdb_ids = []
-        for show in flatten_categorized(shows_categorized):
-            tvdb_id = show.get('tvdb_id')
-            if tvdb_id:
-                show_tvdb_ids.append(tvdb_id)
-        # Deduplicate
-        show_tvdb_ids = list(dict.fromkeys(show_tvdb_ids))
-
-        if not show_tvdb_ids:
-            print_status(f"  {display_name}: No show recommendations to add", "info")
+    for library, group_users in library_groups:
+        eff = get_effective_arr_config(config, library)
+        arr_client = create_sonarr_client_from(eff.get('url'), eff.get('api_key'))
+        if not arr_client:
+            log_warning(
+                f"Sonarr export: library '{library['name']}' has no Sonarr instance "
+                "configured - skipping"
+            )
             continue
 
-        print(f"  {display_name}: Processing {len(show_tvdb_ids)} show recommendations...")
+        # Get Sonarr settings for this library
+        root_folder = eff.get('root_folder') or '/tv'
+        quality_profile_name = eff.get('quality_profile') or 'HD-1080p'
+        tag_name = eff.get('tag') or 'Curatarr'
+        monitored = eff.get('monitor', False)
+        search_for_series = eff.get('search', False)
+        series_type = eff.get('series_type') or 'standard'
 
-        # Get or create tag (optionally with username)
-        user_tag = f"{tag_name}-{display_name}" if append_usernames else tag_name
-        tag_id = sonarr_client.get_or_create_tag(user_tag)
+        # Get quality profile ID
+        quality_profile_id = arr_client.get_quality_profile_id(quality_profile_name)
+        if not quality_profile_id:
+            available = [p['name'] for p in arr_client.get_quality_profiles()]
+            log_error(
+                f"Quality profile '{quality_profile_name}' not found for library "
+                f"'{library['name']}'. Available: {available}"
+            )
+            continue
 
-        added = 0
-        skipped = 0
-        failed = 0
+        # Validate root folder
+        valid_root = arr_client.get_root_folder_path(root_folder)
+        if not valid_root:
+            available = [f['path'] for f in arr_client.get_root_folders()]
+            log_error(
+                f"Root folder '{root_folder}' not found for library "
+                f"'{library['name']}'. Available: {available}"
+            )
+            continue
 
-        for tvdb_id in show_tvdb_ids:
-            if sonarr_client.series_exists(tvdb_id):
-                skipped += 1
+        # Collect all shows to add (handle combined mode)
+        if user_mode == 'combined':
+            all_show_tvdb_ids = []
+            for user_data in group_users:
+                # Collect TVDB IDs (flatten nested structure)
+                for show in flatten_categorized(user_data['shows_categorized']):
+                    tvdb_id = show.get('tvdb_id')
+                    if tvdb_id:
+                        all_show_tvdb_ids.append(tvdb_id)
+            # Deduplicate
+            all_show_tvdb_ids = list(dict.fromkeys(all_show_tvdb_ids))
+
+            if not all_show_tvdb_ids:
+                print_status("  No show recommendations to add", "info")
                 continue
 
-            # Look up series
-            series_data = sonarr_client.lookup_series(tvdb_id)
-            if not series_data:
-                logger.debug(f"Could not find series for TVDB ID: {tvdb_id}")
-                failed += 1
+            print(f"  Combined mode: Processing {len(all_show_tvdb_ids)} show recommendations...")
+
+            # Get or create tag
+            tag_id = arr_client.get_or_create_tag(tag_name)
+
+            added = 0
+            skipped = 0
+            failed = 0
+
+            for tvdb_id in all_show_tvdb_ids:
+                if arr_client.series_exists(tvdb_id):
+                    skipped += 1
+                    continue
+
+                # Look up series
+                series_data = arr_client.lookup_series(tvdb_id)
+                if not series_data:
+                    logger.debug(f"Could not find series for TVDB ID: {tvdb_id}")
+                    failed += 1
+                    continue
+
+                try:
+                    arr_client.add_series(
+                        tvdb_id=tvdb_id,
+                        title=series_data['title'],
+                        root_folder_path=valid_root,
+                        quality_profile_id=quality_profile_id,
+                        monitored=monitored,
+                        season_folder=season_folder,
+                        series_type=series_type,
+                        tag_ids=[tag_id],
+                        search_for_missing_episodes=search_for_series
+                    )
+                    added += 1
+                    print(f"  {GREEN}Added: {series_data['title']}{RESET}")
+                except SonarrAPIError as e:
+                    logger.debug(f"Failed to add {series_data['title']}: {e}")
+                    failed += 1
+
+            print_status(f"  Combined: {added} added, {skipped} already exist, {failed} failed", "success")
+            continue
+
+        # Per-user or mapping mode
+        for user_data in group_users:
+            display_name = user_data['display_name']
+            shows_categorized = user_data['shows_categorized']
+
+            # Collect TVDB IDs for shows (flatten nested structure)
+            show_tvdb_ids = []
+            for show in flatten_categorized(shows_categorized):
+                tvdb_id = show.get('tvdb_id')
+                if tvdb_id:
+                    show_tvdb_ids.append(tvdb_id)
+            # Deduplicate
+            show_tvdb_ids = list(dict.fromkeys(show_tvdb_ids))
+
+            if not show_tvdb_ids:
+                print_status(f"  {display_name}: No show recommendations to add", "info")
                 continue
 
-            try:
-                sonarr_client.add_series(
-                    tvdb_id=tvdb_id,
-                    title=series_data['title'],
-                    root_folder_path=valid_root,
-                    quality_profile_id=quality_profile_id,
-                    monitored=monitored,
-                    season_folder=season_folder,
-                    series_type=series_type,
-                    tag_ids=[tag_id],
-                    search_for_missing_episodes=search_for_series
-                )
-                added += 1
-                print(f"    {GREEN}Added: {series_data['title']}{RESET}")
-            except SonarrAPIError as e:
-                logger.debug(f"Failed to add {series_data['title']}: {e}")
-                failed += 1
+            print(f"  {display_name}: Processing {len(show_tvdb_ids)} show recommendations...")
 
-        print_status(f"  {display_name}: {added} added, {skipped} already exist, {failed} failed", "success")
+            # Get or create tag (optionally with username)
+            user_tag = f"{tag_name}-{display_name}" if append_usernames else tag_name
+            tag_id = arr_client.get_or_create_tag(user_tag)
+
+            added = 0
+            skipped = 0
+            failed = 0
+
+            for tvdb_id in show_tvdb_ids:
+                if arr_client.series_exists(tvdb_id):
+                    skipped += 1
+                    continue
+
+                # Look up series
+                series_data = arr_client.lookup_series(tvdb_id)
+                if not series_data:
+                    logger.debug(f"Could not find series for TVDB ID: {tvdb_id}")
+                    failed += 1
+                    continue
+
+                try:
+                    arr_client.add_series(
+                        tvdb_id=tvdb_id,
+                        title=series_data['title'],
+                        root_folder_path=valid_root,
+                        quality_profile_id=quality_profile_id,
+                        monitored=monitored,
+                        season_folder=season_folder,
+                        series_type=series_type,
+                        tag_ids=[tag_id],
+                        search_for_missing_episodes=search_for_series
+                    )
+                    added += 1
+                    print(f"    {GREEN}Added: {series_data['title']}{RESET}")
+                except SonarrAPIError as e:
+                    logger.debug(f"Failed to add {series_data['title']}: {e}")
+                    failed += 1
+
+            print_status(f"  {display_name}: {added} added, {skipped} already exist, {failed} failed", "success")
 
 
 def export_to_radarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str) -> None:
@@ -579,144 +660,169 @@ def export_to_radarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str
     else:
         users_to_export = all_users_data
 
-    # Get Radarr settings from config
-    root_folder = radarr_config.get('root_folder', '/movies')
-    quality_profile_name = radarr_config.get('quality_profile', 'HD-1080p')
-    minimum_availability = radarr_config.get('minimum_availability', 'released')
-    tag_name = radarr_config.get('tag', 'Curatarr')
+    # Radarr settings not yet part of the per-library arr schema (Phase 1
+    # doesn't cover these - see utils/config.py _ARR_ROUTING_FIELDS); stay
+    # global for all libraries until a future phase adds them.
     append_usernames = radarr_config.get('append_usernames', False)
-    monitored = radarr_config.get('monitor', False)
-    search_for_movie = radarr_config.get('search_for_movie', False)
 
-    # Get quality profile ID
-    quality_profile_id = radarr_client.get_quality_profile_id(quality_profile_name)
-    if not quality_profile_id:
-        available = [p['name'] for p in radarr_client.get_quality_profiles()]
-        log_error(f"Quality profile '{quality_profile_name}' not found. Available: {available}")
-        return
+    # Per-library routing (#157 Phase 2): group users by library_id,
+    # resolve each group's effective Radarr instance/routing, and process
+    # groups independently.
+    library_groups = _resolve_library_groups(config, users_to_export, MEDIA_TYPE_MOVIE)
 
-    # Validate root folder
-    valid_root = radarr_client.get_root_folder_path(root_folder)
-    if not valid_root:
-        available = [f['path'] for f in radarr_client.get_root_folders()]
-        log_error(f"Root folder '{root_folder}' not found. Available: {available}")
-        return
-
-    # Collect all movies to add (handle combined mode)
-    if user_mode == 'combined':
-        all_movie_tmdb_ids = []
-        for user_data in users_to_export:
-            # Collect TMDB IDs (flatten nested structure)
-            for movie in flatten_categorized(user_data['movies_categorized']):
-                tmdb_id = movie.get('tmdb_id')
-                if tmdb_id:
-                    all_movie_tmdb_ids.append(tmdb_id)
-        # Deduplicate
-        all_movie_tmdb_ids = list(dict.fromkeys(all_movie_tmdb_ids))
-
-        if not all_movie_tmdb_ids:
-            print_status("  No movie recommendations to add", "info")
-            return
-
-        print(f"  Combined mode: Processing {len(all_movie_tmdb_ids)} movie recommendations...")
-
-        # Get or create tag
-        tag_id = radarr_client.get_or_create_tag(tag_name)
-
-        added = 0
-        skipped = 0
-        failed = 0
-
-        for tmdb_id in all_movie_tmdb_ids:
-            if radarr_client.movie_exists(tmdb_id):
-                skipped += 1
-                continue
-
-            # Look up movie
-            movie_data = radarr_client.lookup_movie(tmdb_id)
-            if not movie_data:
-                logger.debug(f"Could not find movie for TMDB ID: {tmdb_id}")
-                failed += 1
-                continue
-
-            try:
-                radarr_client.add_movie(
-                    tmdb_id=tmdb_id,
-                    title=movie_data['title'],
-                    root_folder_path=valid_root,
-                    quality_profile_id=quality_profile_id,
-                    monitored=monitored,
-                    minimum_availability=minimum_availability,
-                    tag_ids=[tag_id],
-                    search_for_movie=search_for_movie
-                )
-                added += 1
-                print(f"  {GREEN}Added: {movie_data['title']}{RESET}")
-            except RadarrAPIError as e:
-                logger.debug(f"Failed to add {movie_data['title']}: {e}")
-                failed += 1
-
-        print_status(f"  Combined: {added} added, {skipped} already exist, {failed} failed", "success")
-        return
-
-    # Per-user or mapping mode
-    for user_data in users_to_export:
-        display_name = user_data['display_name']
-        movies_categorized = user_data['movies_categorized']
-
-        # Collect TMDB IDs for movies (flatten nested structure)
-        movie_tmdb_ids = []
-        for movie in flatten_categorized(movies_categorized):
-            tmdb_id = movie.get('tmdb_id')
-            if tmdb_id:
-                movie_tmdb_ids.append(tmdb_id)
-        # Deduplicate
-        movie_tmdb_ids = list(dict.fromkeys(movie_tmdb_ids))
-
-        if not movie_tmdb_ids:
-            print_status(f"  {display_name}: No movie recommendations to add", "info")
+    for library, group_users in library_groups:
+        eff = get_effective_arr_config(config, library)
+        arr_client = create_radarr_client_from(eff.get('url'), eff.get('api_key'))
+        if not arr_client:
+            log_warning(
+                f"Radarr export: library '{library['name']}' has no Radarr instance "
+                "configured - skipping"
+            )
             continue
 
-        print(f"  {display_name}: Processing {len(movie_tmdb_ids)} movie recommendations...")
+        # Get Radarr settings for this library
+        root_folder = eff.get('root_folder') or '/movies'
+        quality_profile_name = eff.get('quality_profile') or 'HD-1080p'
+        minimum_availability = eff.get('minimum_availability') or 'released'
+        tag_name = eff.get('tag') or 'Curatarr'
+        monitored = eff.get('monitor', False)
+        search_for_movie = eff.get('search', False)
 
-        # Get or create tag (optionally with username)
-        user_tag = f"{tag_name}-{display_name}" if append_usernames else tag_name
-        tag_id = radarr_client.get_or_create_tag(user_tag)
+        # Get quality profile ID
+        quality_profile_id = arr_client.get_quality_profile_id(quality_profile_name)
+        if not quality_profile_id:
+            available = [p['name'] for p in arr_client.get_quality_profiles()]
+            log_error(
+                f"Quality profile '{quality_profile_name}' not found for library "
+                f"'{library['name']}'. Available: {available}"
+            )
+            continue
 
-        added = 0
-        skipped = 0
-        failed = 0
+        # Validate root folder
+        valid_root = arr_client.get_root_folder_path(root_folder)
+        if not valid_root:
+            available = [f['path'] for f in arr_client.get_root_folders()]
+            log_error(
+                f"Root folder '{root_folder}' not found for library "
+                f"'{library['name']}'. Available: {available}"
+            )
+            continue
 
-        for tmdb_id in movie_tmdb_ids:
-            if radarr_client.movie_exists(tmdb_id):
-                skipped += 1
+        # Collect all movies to add (handle combined mode)
+        if user_mode == 'combined':
+            all_movie_tmdb_ids = []
+            for user_data in group_users:
+                # Collect TMDB IDs (flatten nested structure)
+                for movie in flatten_categorized(user_data['movies_categorized']):
+                    tmdb_id = movie.get('tmdb_id')
+                    if tmdb_id:
+                        all_movie_tmdb_ids.append(tmdb_id)
+            # Deduplicate
+            all_movie_tmdb_ids = list(dict.fromkeys(all_movie_tmdb_ids))
+
+            if not all_movie_tmdb_ids:
+                print_status("  No movie recommendations to add", "info")
                 continue
 
-            # Look up movie
-            movie_data = radarr_client.lookup_movie(tmdb_id)
-            if not movie_data:
-                logger.debug(f"Could not find movie for TMDB ID: {tmdb_id}")
-                failed += 1
+            print(f"  Combined mode: Processing {len(all_movie_tmdb_ids)} movie recommendations...")
+
+            # Get or create tag
+            tag_id = arr_client.get_or_create_tag(tag_name)
+
+            added = 0
+            skipped = 0
+            failed = 0
+
+            for tmdb_id in all_movie_tmdb_ids:
+                if arr_client.movie_exists(tmdb_id):
+                    skipped += 1
+                    continue
+
+                # Look up movie
+                movie_data = arr_client.lookup_movie(tmdb_id)
+                if not movie_data:
+                    logger.debug(f"Could not find movie for TMDB ID: {tmdb_id}")
+                    failed += 1
+                    continue
+
+                try:
+                    arr_client.add_movie(
+                        tmdb_id=tmdb_id,
+                        title=movie_data['title'],
+                        root_folder_path=valid_root,
+                        quality_profile_id=quality_profile_id,
+                        monitored=monitored,
+                        minimum_availability=minimum_availability,
+                        tag_ids=[tag_id],
+                        search_for_movie=search_for_movie
+                    )
+                    added += 1
+                    print(f"  {GREEN}Added: {movie_data['title']}{RESET}")
+                except RadarrAPIError as e:
+                    logger.debug(f"Failed to add {movie_data['title']}: {e}")
+                    failed += 1
+
+            print_status(f"  Combined: {added} added, {skipped} already exist, {failed} failed", "success")
+            continue
+
+        # Per-user or mapping mode
+        for user_data in group_users:
+            display_name = user_data['display_name']
+            movies_categorized = user_data['movies_categorized']
+
+            # Collect TMDB IDs for movies (flatten nested structure)
+            movie_tmdb_ids = []
+            for movie in flatten_categorized(movies_categorized):
+                tmdb_id = movie.get('tmdb_id')
+                if tmdb_id:
+                    movie_tmdb_ids.append(tmdb_id)
+            # Deduplicate
+            movie_tmdb_ids = list(dict.fromkeys(movie_tmdb_ids))
+
+            if not movie_tmdb_ids:
+                print_status(f"  {display_name}: No movie recommendations to add", "info")
                 continue
 
-            try:
-                radarr_client.add_movie(
-                    tmdb_id=tmdb_id,
-                    title=movie_data['title'],
-                    root_folder_path=valid_root,
-                    quality_profile_id=quality_profile_id,
-                    monitored=monitored,
-                    minimum_availability=minimum_availability,
-                    tag_ids=[tag_id],
-                    search_for_movie=search_for_movie
-                )
-                added += 1
-                print(f"    {GREEN}Added: {movie_data['title']}{RESET}")
-            except RadarrAPIError as e:
-                logger.debug(f"Failed to add {movie_data['title']}: {e}")
-                failed += 1
+            print(f"  {display_name}: Processing {len(movie_tmdb_ids)} movie recommendations...")
 
-        print_status(f"  {display_name}: {added} added, {skipped} already exist, {failed} failed", "success")
+            # Get or create tag (optionally with username)
+            user_tag = f"{tag_name}-{display_name}" if append_usernames else tag_name
+            tag_id = arr_client.get_or_create_tag(user_tag)
+
+            added = 0
+            skipped = 0
+            failed = 0
+
+            for tmdb_id in movie_tmdb_ids:
+                if arr_client.movie_exists(tmdb_id):
+                    skipped += 1
+                    continue
+
+                # Look up movie
+                movie_data = arr_client.lookup_movie(tmdb_id)
+                if not movie_data:
+                    logger.debug(f"Could not find movie for TMDB ID: {tmdb_id}")
+                    failed += 1
+                    continue
+
+                try:
+                    arr_client.add_movie(
+                        tmdb_id=tmdb_id,
+                        title=movie_data['title'],
+                        root_folder_path=valid_root,
+                        quality_profile_id=quality_profile_id,
+                        monitored=monitored,
+                        minimum_availability=minimum_availability,
+                        tag_ids=[tag_id],
+                        search_for_movie=search_for_movie
+                    )
+                    added += 1
+                    print(f"    {GREEN}Added: {movie_data['title']}{RESET}")
+                except RadarrAPIError as e:
+                    logger.debug(f"Failed to add {movie_data['title']}: {e}")
+                    failed += 1
+
+            print_status(f"  {display_name}: {added} added, {skipped} already exist, {failed} failed", "success")
 
 
 def export_to_mdblist(config: Dict, all_users_data: List[Dict], tmdb_api_key: str) -> None:

--- a/tests/test_external_exports.py
+++ b/tests/test_external_exports.py
@@ -315,6 +315,180 @@ class TestExportToRadarr:
         mock_create.assert_called_once()
 
 
+def _mock_radarr_client():
+    """MagicMock RadarrClient that echoes routing args back so tests can
+    assert exactly what each per-library group resolved."""
+    client = MagicMock()
+    client.test_connection.return_value = None
+    client.get_movies.return_value = []
+    client.get_quality_profile_id.side_effect = lambda name: f"qp-{name}"
+    client.get_quality_profiles.return_value = []
+    client.get_root_folder_path.side_effect = lambda path: path
+    client.get_root_folders.return_value = []
+    client.get_or_create_tag.side_effect = lambda name: f"tag-{name}"
+    client.movie_exists.return_value = False
+    client.lookup_movie.side_effect = lambda tmdb_id: {'title': f'Movie {tmdb_id}'}
+    client.add_movie.return_value = {}
+    return client
+
+
+class TestExportToRadarrPerLibraryRouting:
+    """Tests for #157 Phase 2: per-library Radarr export routing"""
+
+    @patch('recommenders.external_exports.create_radarr_client_from')
+    @patch('recommenders.external_exports.create_radarr_client')
+    def test_single_library_no_library_id_matches_legacy_routing(self, mock_create, mock_create_from):
+        """No library_id on recs -> routes via the single synthesized/global library,
+        producing identical routing to the pre-Phase-2 flat-config flow."""
+        client = _mock_radarr_client()
+        mock_create.return_value = client
+        mock_create_from.return_value = client
+
+        config = {
+            'radarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://radarr:7878',
+                'api_key': 'global-key',
+                'root_folder': '/movies',
+                'quality_profile': 'HD-1080p',
+                'tag': 'Curatarr',
+                'monitor': True,
+                'search_for_movie': True,
+                'minimum_availability': 'released',
+            }
+        }
+        all_users_data = [
+            {
+                'username': 'jason',
+                'display_name': 'Jason',
+                'movies_categorized': {'acquire': [{'tmdb_id': 100}], 'user_services': {}, 'other_services': {}},
+            }
+        ]
+
+        export_to_radarr(config, all_users_data, 'tmdb-key')
+
+        # Preflight client still created once from the global block (unchanged safety gate)
+        mock_create.assert_called_once_with(config)
+        # Per-library client resolves to the same global block via the no-library_id fallback
+        mock_create_from.assert_called_once_with('http://radarr:7878', 'global-key')
+
+        client.add_movie.assert_called_once()
+        _, kwargs = client.add_movie.call_args
+        assert kwargs['root_folder_path'] == '/movies'
+        assert kwargs['quality_profile_id'] == 'qp-HD-1080p'
+        assert kwargs['tag_ids'] == ['tag-Curatarr']
+        assert kwargs['monitored'] is True
+        assert kwargs['minimum_availability'] == 'released'
+        assert kwargs['search_for_movie'] is True
+
+    @patch('recommenders.external_exports.create_radarr_client_from')
+    @patch('recommenders.external_exports.create_radarr_client')
+    def test_two_library_ids_build_two_clients_with_own_routing(self, mock_create, mock_create_from):
+        """Recs tagged with two different library_ids route through two independently
+        -resolved clients, each with its own root_folder/quality_profile/tag."""
+        mock_create.return_value = _mock_radarr_client()
+
+        movies_client = _mock_radarr_client()
+        kids_client = _mock_radarr_client()
+        mock_create_from.side_effect = [movies_client, kids_client]
+
+        config = {
+            'radarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://radarr:7878',
+                'api_key': 'global-key',
+            },
+            'libraries': [
+                {
+                    'id': 'movies', 'name': 'Movies', 'media_type': 'movie',
+                    'arr': {'root_folder': '/movies', 'quality_profile': 'HD-1080p', 'tag': 'Curatarr'},
+                },
+                {
+                    'id': 'kids-movies', 'name': 'Kids Movies', 'media_type': 'movie',
+                    'arr': {'root_folder': '/kids-movies', 'quality_profile': 'SD', 'tag': 'Curatarr-Kids'},
+                },
+            ],
+        }
+        all_users_data = [
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'movies',
+                'movies_categorized': {'acquire': [{'tmdb_id': 100}], 'user_services': {}, 'other_services': {}},
+            },
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'kids-movies',
+                'movies_categorized': {'acquire': [{'tmdb_id': 200}], 'user_services': {}, 'other_services': {}},
+            },
+        ]
+
+        export_to_radarr(config, all_users_data, 'tmdb-key')
+
+        assert mock_create_from.call_count == 2
+
+        movies_client.add_movie.assert_called_once()
+        _, movies_kwargs = movies_client.add_movie.call_args
+        assert movies_kwargs['root_folder_path'] == '/movies'
+        assert movies_kwargs['quality_profile_id'] == 'qp-HD-1080p'
+        assert movies_kwargs['tag_ids'] == ['tag-Curatarr']
+
+        kids_client.add_movie.assert_called_once()
+        _, kids_kwargs = kids_client.add_movie.call_args
+        assert kids_kwargs['root_folder_path'] == '/kids-movies'
+        assert kids_kwargs['quality_profile_id'] == 'qp-SD'
+        assert kids_kwargs['tag_ids'] == ['tag-Curatarr-Kids']
+
+    @patch('recommenders.external_exports.create_radarr_client_from')
+    @patch('recommenders.external_exports.create_radarr_client')
+    def test_library_instance_override_with_field_fallback(self, mock_create, mock_create_from):
+        """Per-library arr.instance overrides url/api_key; omitted arr.* fields
+        fall back to the global radarr block."""
+        mock_create.return_value = _mock_radarr_client()
+        library_client = _mock_radarr_client()
+        mock_create_from.return_value = library_client
+
+        config = {
+            'radarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://radarr:7878',
+                'api_key': 'global-key',
+                'root_folder': '/movies',
+                'quality_profile': 'HD-1080p',
+                'tag': 'Curatarr',
+            },
+            'libraries': [
+                {
+                    'id': 'kids-movies', 'name': 'Kids Movies', 'media_type': 'movie',
+                    'arr': {
+                        'root_folder': '/kids-movies',
+                        'instance': {'url': 'http://kids-radarr:7878', 'api_key': 'kids-key'},
+                    },
+                },
+            ],
+        }
+        all_users_data = [
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'kids-movies',
+                'movies_categorized': {'acquire': [{'tmdb_id': 300}], 'user_services': {}, 'other_services': {}},
+            },
+        ]
+
+        export_to_radarr(config, all_users_data, 'tmdb-key')
+
+        # Instance override used to build the per-library client
+        mock_create_from.assert_called_once_with('http://kids-radarr:7878', 'kids-key')
+
+        library_client.add_movie.assert_called_once()
+        _, kwargs = library_client.add_movie.call_args
+        assert kwargs['root_folder_path'] == '/kids-movies'   # library override
+        assert kwargs['quality_profile_id'] == 'qp-HD-1080p'  # falls back to global
+        assert kwargs['tag_ids'] == ['tag-Curatarr']            # falls back to global
+
+
 class TestExportToSonarr:
     """Tests for export_to_sonarr function"""
 
@@ -351,6 +525,182 @@ class TestExportToSonarr:
         export_to_sonarr(config, [], 'api_key')
 
         mock_create.assert_called_once()
+
+
+def _mock_sonarr_client():
+    """MagicMock SonarrClient that echoes routing args back so tests can
+    assert exactly what each per-library group resolved."""
+    client = MagicMock()
+    client.test_connection.return_value = None
+    client.get_series.return_value = []
+    client.get_quality_profile_id.side_effect = lambda name: f"qp-{name}"
+    client.get_quality_profiles.return_value = []
+    client.get_root_folder_path.side_effect = lambda path: path
+    client.get_root_folders.return_value = []
+    client.get_or_create_tag.side_effect = lambda name: f"tag-{name}"
+    client.series_exists.return_value = False
+    client.lookup_series.side_effect = lambda tvdb_id: {'title': f'Show {tvdb_id}'}
+    client.add_series.return_value = {}
+    return client
+
+
+class TestExportToSonarrPerLibraryRouting:
+    """Tests for #157 Phase 2: per-library Sonarr export routing"""
+
+    @patch('recommenders.external_exports.create_sonarr_client_from')
+    @patch('recommenders.external_exports.create_sonarr_client')
+    def test_single_library_no_library_id_matches_legacy_routing(self, mock_create, mock_create_from):
+        """No library_id on recs -> routes via the single synthesized/global library,
+        producing identical routing to the pre-Phase-2 flat-config flow."""
+        client = _mock_sonarr_client()
+        mock_create.return_value = client
+        mock_create_from.return_value = client
+
+        config = {
+            'sonarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://sonarr:8989',
+                'api_key': 'global-key',
+                'root_folder': '/tv',
+                'quality_profile': 'HD-1080p',
+                'tag': 'Curatarr',
+                'monitor': True,
+                'search_for_series': True,
+                'series_type': 'standard',
+                'season_folder': True,
+            }
+        }
+        all_users_data = [
+            {
+                'username': 'jason',
+                'display_name': 'Jason',
+                'shows_categorized': {'acquire': [{'tvdb_id': 100}], 'user_services': {}, 'other_services': {}},
+            }
+        ]
+
+        export_to_sonarr(config, all_users_data, 'tmdb-key')
+
+        # Preflight client still created once from the global block (unchanged safety gate)
+        mock_create.assert_called_once_with(config)
+        # Per-library client resolves to the same global block via the no-library_id fallback
+        mock_create_from.assert_called_once_with('http://sonarr:8989', 'global-key')
+
+        client.add_series.assert_called_once()
+        _, kwargs = client.add_series.call_args
+        assert kwargs['root_folder_path'] == '/tv'
+        assert kwargs['quality_profile_id'] == 'qp-HD-1080p'
+        assert kwargs['tag_ids'] == ['tag-Curatarr']
+        assert kwargs['monitored'] is True
+        assert kwargs['search_for_missing_episodes'] is True
+        assert kwargs['season_folder'] is True
+        assert kwargs['series_type'] == 'standard'
+
+    @patch('recommenders.external_exports.create_sonarr_client_from')
+    @patch('recommenders.external_exports.create_sonarr_client')
+    def test_two_library_ids_build_two_clients_with_own_routing(self, mock_create, mock_create_from):
+        """Recs tagged with two different library_ids route through two independently
+        -resolved clients, each with its own root_folder/quality_profile/tag."""
+        mock_create.return_value = _mock_sonarr_client()
+
+        tv_client = _mock_sonarr_client()
+        anime_client = _mock_sonarr_client()
+        mock_create_from.side_effect = [tv_client, anime_client]
+
+        config = {
+            'sonarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://sonarr:8989',
+                'api_key': 'global-key',
+            },
+            'libraries': [
+                {
+                    'id': 'tv-shows', 'name': 'TV Shows', 'media_type': 'tv',
+                    'arr': {'root_folder': '/tv', 'quality_profile': 'HD-1080p', 'tag': 'Curatarr'},
+                },
+                {
+                    'id': 'anime', 'name': 'Anime', 'media_type': 'tv',
+                    'arr': {'root_folder': '/anime', 'quality_profile': '4K', 'tag': 'Curatarr-Anime'},
+                },
+            ],
+        }
+        all_users_data = [
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'tv-shows',
+                'shows_categorized': {'acquire': [{'tvdb_id': 100}], 'user_services': {}, 'other_services': {}},
+            },
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'anime',
+                'shows_categorized': {'acquire': [{'tvdb_id': 200}], 'user_services': {}, 'other_services': {}},
+            },
+        ]
+
+        export_to_sonarr(config, all_users_data, 'tmdb-key')
+
+        assert mock_create_from.call_count == 2
+
+        tv_client.add_series.assert_called_once()
+        _, tv_kwargs = tv_client.add_series.call_args
+        assert tv_kwargs['root_folder_path'] == '/tv'
+        assert tv_kwargs['quality_profile_id'] == 'qp-HD-1080p'
+        assert tv_kwargs['tag_ids'] == ['tag-Curatarr']
+
+        anime_client.add_series.assert_called_once()
+        _, anime_kwargs = anime_client.add_series.call_args
+        assert anime_kwargs['root_folder_path'] == '/anime'
+        assert anime_kwargs['quality_profile_id'] == 'qp-4K'
+        assert anime_kwargs['tag_ids'] == ['tag-Curatarr-Anime']
+
+    @patch('recommenders.external_exports.create_sonarr_client_from')
+    @patch('recommenders.external_exports.create_sonarr_client')
+    def test_library_instance_override_with_field_fallback(self, mock_create, mock_create_from):
+        """Per-library arr.instance overrides url/api_key; omitted arr.* fields
+        fall back to the global sonarr block."""
+        mock_create.return_value = _mock_sonarr_client()
+        library_client = _mock_sonarr_client()
+        mock_create_from.return_value = library_client
+
+        config = {
+            'sonarr': {
+                'enabled': True,
+                'auto_sync': True,
+                'user_mode': 'combined',
+                'url': 'http://sonarr:8989',
+                'api_key': 'global-key',
+                'root_folder': '/tv',
+                'quality_profile': 'HD-1080p',
+                'tag': 'Curatarr',
+            },
+            'libraries': [
+                {
+                    'id': 'anime', 'name': 'Anime', 'media_type': 'tv',
+                    'arr': {
+                        'root_folder': '/anime',
+                        'instance': {'url': 'http://anime-sonarr:8989', 'api_key': 'anime-key'},
+                    },
+                },
+            ],
+        }
+        all_users_data = [
+            {
+                'username': 'jason', 'display_name': 'Jason', 'library_id': 'anime',
+                'shows_categorized': {'acquire': [{'tvdb_id': 300}], 'user_services': {}, 'other_services': {}},
+            },
+        ]
+
+        export_to_sonarr(config, all_users_data, 'tmdb-key')
+
+        # Instance override used to build the per-library client
+        mock_create_from.assert_called_once_with('http://anime-sonarr:8989', 'anime-key')
+
+        library_client.add_series.assert_called_once()
+        _, kwargs = library_client.add_series.call_args
+        assert kwargs['root_folder_path'] == '/anime'          # library override
+        assert kwargs['quality_profile_id'] == 'qp-HD-1080p'   # falls back to global
+        assert kwargs['tag_ids'] == ['tag-Curatarr']            # falls back to global
 
 
 class TestExportToMdblist:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -224,6 +224,7 @@ from .sonarr import (
     SonarrAPIError,
     SonarrClient,
     create_sonarr_client,
+    create_sonarr_client_from,
 )
 
 # Radarr utilities
@@ -231,6 +232,7 @@ from .radarr import (
     RadarrAPIError,
     RadarrClient,
     create_radarr_client,
+    create_radarr_client_from,
 )
 
 # MDBList utilities
@@ -413,10 +415,12 @@ __all__ = [
     'SonarrAPIError',
     'SonarrClient',
     'create_sonarr_client',
+    'create_sonarr_client_from',
     # Radarr
     'RadarrAPIError',
     'RadarrClient',
     'create_radarr_client',
+    'create_radarr_client_from',
     # MDBList
     'MDBListAPIError',
     'MDBListClient',

--- a/utils/radarr.py
+++ b/utils/radarr.py
@@ -256,6 +256,28 @@ class RadarrClient(BaseAPIClient):
         return self._make_request("POST", "movie", data=data)
 
 
+def create_radarr_client_from(url: Optional[str], api_key: Optional[str]) -> Optional[RadarrClient]:
+    """
+    Create a Radarr client from an explicit URL/API key pair.
+
+    Thin factory used for per-library Radarr instance resolution (see
+    utils.config.get_effective_arr_config, #157 Phase 2). create_radarr_client()
+    wraps this with the legacy global-config lookup.
+
+    Args:
+        url: Radarr base URL
+        api_key: Radarr API key
+
+    Returns:
+        RadarrClient if url/api_key are present and api_key isn't the
+        placeholder, None otherwise
+    """
+    if not url or not api_key or api_key == 'YOUR_RADARR_API_KEY':
+        return None
+
+    return RadarrClient(url, api_key)
+
+
 def create_radarr_client(config: Dict) -> Optional[RadarrClient]:
     """
     Create a Radarr client from config.
@@ -271,10 +293,6 @@ def create_radarr_client(config: Dict) -> Optional[RadarrClient]:
     if not radarr_config.get('enabled', False):
         return None
 
-    url = radarr_config.get('url')
-    api_key = radarr_config.get('api_key')
-
-    if not url or not api_key or api_key == 'YOUR_RADARR_API_KEY':
-        return None
+    return create_radarr_client_from(radarr_config.get('url'), radarr_config.get('api_key'))
 
     return RadarrClient(url, api_key)

--- a/utils/sonarr.py
+++ b/utils/sonarr.py
@@ -262,6 +262,28 @@ class SonarrClient(BaseAPIClient):
         return self._make_request("POST", "series", data=data)
 
 
+def create_sonarr_client_from(url: Optional[str], api_key: Optional[str]) -> Optional[SonarrClient]:
+    """
+    Create a Sonarr client from an explicit URL/API key pair.
+
+    Thin factory used for per-library Sonarr instance resolution (see
+    utils.config.get_effective_arr_config, #157 Phase 2). create_sonarr_client()
+    wraps this with the legacy global-config lookup.
+
+    Args:
+        url: Sonarr base URL
+        api_key: Sonarr API key
+
+    Returns:
+        SonarrClient if url/api_key are present and api_key isn't the
+        placeholder, None otherwise
+    """
+    if not url or not api_key or api_key == 'YOUR_SONARR_API_KEY':
+        return None
+
+    return SonarrClient(url, api_key)
+
+
 def create_sonarr_client(config: Dict) -> Optional[SonarrClient]:
     """
     Create a Sonarr client from config.
@@ -277,10 +299,4 @@ def create_sonarr_client(config: Dict) -> Optional[SonarrClient]:
     if not sonarr_config.get('enabled', False):
         return None
 
-    url = sonarr_config.get('url')
-    api_key = sonarr_config.get('api_key')
-
-    if not url or not api_key or api_key == 'YOUR_SONARR_API_KEY':
-        return None
-
-    return SonarrClient(url, api_key)
+    return create_sonarr_client_from(sonarr_config.get('url'), sonarr_config.get('api_key'))


### PR DESCRIPTION
## Summary
- export_to_sonarr/export_to_radarr now group users_to_export by library_id and resolve each group's client/routing independently via get_libraries + get_effective_arr_config, instead of one global client + one flat routing config.
- Groups without a library_id (recs don't carry it until Phase 3) fall back to the media-type's library via get_libraries_for_media_type, keeping single-library installs routing identically to before.
- Adds create_sonarr_client_from()/create_radarr_client_from() thin url/api_key factories; create_sonarr_client()/create_radarr_client() now wrap them with the legacy global-config lookup.
- season_folder/append_usernames stay global (not part of the Phase 1 per-library arr schema).

## Test plan
- [x] tests/test_external_exports.py: regression (no library_id -> identical routing to pre-Phase-2 flat config), two library_ids -> two independently-built clients with own root_folder/quality_profile/tag, per-library arr.instance override with field-level fallback to global block
- [x] Full suite: pytest tests/ --cov=. --cov-fail-under=85 -> 1474 passed, 88.35% coverage
- [x] Existing export tests pass unchanged (31/31)
- [x] gitleaks secret scan clean (pre-push + CI)