### PR TITLE
feat(#157) Phase 3: per-library recommendation loop + cache/provenance

### DIFF
--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -33,6 +33,7 @@ from utils import (
     init_plex,
     get_configured_users,
     get_tmdb_config,
+    get_libraries_for_media_type,
     check_cache_version,
     load_media_cache,
     save_media_cache,
@@ -373,17 +374,36 @@ class BaseRecommender(ABC):
     library_config_key: str = None  # e.g., 'movie_library_title'
     default_library_name: str = None  # e.g., 'Movies'
 
-    def __init__(self, config_path: str, single_user: str = None):
+    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
         """
         Initialize the recommender.
 
         Args:
             config_path: Path to the config.yml configuration file
             single_user: Optional username for single-user mode
+            library: Optional normalized library dict (see utils.config.get_libraries)
+                for the #157 Phase 3 per-library recommendation loop. When
+                provided, the recommender operates against this library's
+                Plex section. When None, falls back to the legacy
+                library_config_key/default_library_name resolution.
         """
         self.single_user = single_user
         self.config = load_config(config_path)
-        self.library_title = self.config['plex'].get(self.library_config_key, self.default_library_name)
+        self.library = library
+
+        if self.library:
+            self.library_id = self.library['id']
+            self.library_title = self.library['section']
+        else:
+            self.library_id = None
+            self.library_title = self.config['plex'].get(self.library_config_key, self.default_library_name)
+
+        # Sibling libraries of this media type - drives cache filename /
+        # collection naming back-compat: a single library (synthesized or
+        # explicitly configured) keeps today's exact names; only genuine
+        # multi-library installs get library-qualified names (#157 Phase 3).
+        self._sibling_libraries = get_libraries_for_media_type(self.config, self.media_type)
+        self._is_multi_library = bool(self.library) and len(self._sibling_libraries) > 1
 
         # Initialize counters and caches
         self.cached_watched_count = 0
@@ -462,12 +482,42 @@ class BaseRecommender(ABC):
         """
         pass
 
+    def _cache_library_prefix(self) -> str:
+        """
+        Prefix for per-library cache filenames (#157 Phase 3).
+
+        Empty string for a single-library install (back-compat: existing
+        watched-cache files keep their exact legacy names). Only genuine
+        multi-library installs (>1 library of this media type) get a
+        library-id-qualified prefix, so caches don't collide across libraries.
+
+        Returns:
+            "{library_id}_" when multi-library, else ""
+        """
+        if not self._is_multi_library:
+            return ''
+        return f"{self.library_id}_"
+
+    def _library_suffix_for_label(self) -> str:
+        """Plex label suffix - empty unless >1 library shares this media type."""
+        if not self._is_multi_library:
+            return ''
+        return f"_{self.library_id}"
+
+    def _library_suffix_for_collection_name(self) -> str:
+        """Collection display-name suffix - empty unless >1 library shares this media type."""
+        if not self._is_multi_library:
+            return ''
+        name = (self.library or {}).get('name') or self.library_title
+        return f" ({name})"
+
     def _get_user_context(self) -> str:
         """
         Get a safe string representing the current user context for cache filenames.
 
         Returns:
-            Sanitized user context string
+            Sanitized user context string, prefixed with the library id when
+            this install has more than one library of this media type.
         """
         if self.single_user:
             user_ctx = f"plex_{self.single_user}"
@@ -476,7 +526,8 @@ class BaseRecommender(ABC):
         else:
             user_ctx = 'plex_' + '_'.join(self.users['managed_users'])
 
-        return re.sub(r'\W+', '', user_ctx)
+        sanitized = re.sub(r'\W+', '', user_ctx)
+        return f"{self._cache_library_prefix()}{sanitized}"
 
     def _refresh_watched_data(self):
         """Force refresh of watched data from Plex."""
@@ -868,7 +919,7 @@ class BaseRecommender(ABC):
             display_name = username.capitalize()
 
         emoji = "🎬" if self.media_type == 'movie' else "📺"
-        collection_name = f"{emoji} {display_name} - Recommendation"
+        collection_name = f"{emoji} {display_name} - Recommendation{self._library_suffix_for_collection_name()}"
         success = update_plex_collection(section, collection_name, final_items, logger, label_name=label_name)
         if success:
             cleanup_old_collections(section, collection_name, username, emoji, logger)
@@ -900,6 +951,7 @@ class BaseRecommender(ABC):
         try:
             section = self.plex.library.section(self.library_title)
             base_label = self.config.get('collections', {}).get('label_name', 'Recommended')
+            base_label = f"{base_label}{self._library_suffix_for_label()}"
             append_usernames = self.config.get('collections', {}).get('append_usernames', False)
             users = self.users['plex_users'] or self.users['managed_users']
             label_name = build_label_name(base_label, users, self.single_user, append_usernames)

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -34,6 +34,7 @@ from utils import (
     GREEN, YELLOW, CYAN, RESET,
     RATING_MULTIPLIERS,
     TMDB_REQUEST_TIMEOUT, TMDB_TV_MOVIE_GENRE_ID, TMDB_ANIMATION_GENRE_ID,
+    MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV,
     get_plex_account_ids, get_tmdb_config, get_tmdb_keywords,
     fetch_watch_history_with_tmdb,
     log_warning, log_error, load_config, clickable_link,
@@ -46,6 +47,7 @@ from utils import (
     fetch_tmdb_details_for_profile,
     get_project_root,
     get_authenticated_trakt_client,
+    get_libraries_for_media_type,
     smart_open_html,
 )
 
@@ -1871,12 +1873,22 @@ def find_similar_content_with_profile(
     return final_recs
 
 
-def load_cache(display_name: str, media_type: str) -> Dict:
-    """Load existing recommendations cache, filtering out items below quality thresholds"""
+def load_cache(display_name: str, media_type: str, lib_id: Optional[str] = None) -> Dict:
+    """Load existing recommendations cache, filtering out items below quality thresholds
+
+    Args:
+        display_name: User's display name
+        media_type: 'movies' or 'shows'
+        lib_id: Optional library id (#157 Phase 3). When provided, the cache
+            filename is qualified with it so multiple libraries of the same
+            media type don't collide. None (default) keeps the legacy
+            filename - required for single-library back-compat.
+    """
     cache_dir = os.path.join(get_project_root(), 'cache')
     os.makedirs(cache_dir, exist_ok=True)
     safe_name = display_name.lower().replace(' ', '_')
-    cache_file = os.path.join(cache_dir, f'external_recs_{safe_name}_{media_type}.json')
+    lib_prefix = f'{lib_id}_' if lib_id else ''
+    cache_file = os.path.join(cache_dir, f'external_recs_{lib_prefix}{safe_name}_{media_type}.json')
 
     if os.path.exists(cache_file):
         with open(cache_file, 'r') as f:
@@ -1911,12 +1923,20 @@ def load_cache(display_name: str, media_type: str) -> Dict:
             return filtered
     return {}
 
-def save_cache(display_name: str, media_type: str, cache_data: Dict) -> None:
-    """Save recommendations cache with version."""
+def save_cache(display_name: str, media_type: str, cache_data: Dict, lib_id: Optional[str] = None) -> None:
+    """Save recommendations cache with version.
+
+    Args:
+        display_name: User's display name
+        media_type: 'movies' or 'shows'
+        cache_data: Cache payload to persist
+        lib_id: Optional library id (#157 Phase 3) - see load_cache()
+    """
     cache_dir = os.path.join(get_project_root(), 'cache')
     os.makedirs(cache_dir, exist_ok=True)
     safe_name = display_name.lower().replace(' ', '_')
-    cache_file = os.path.join(cache_dir, f'external_recs_{safe_name}_{media_type}.json')
+    lib_prefix = f'{lib_id}_' if lib_id else ''
+    cache_file = os.path.join(cache_dir, f'external_recs_{lib_prefix}{safe_name}_{media_type}.json')
 
     versioned_cache = {
         'version': EXTERNAL_RECS_CACHE_VERSION,
@@ -1924,6 +1944,24 @@ def save_cache(display_name: str, media_type: str, cache_data: Dict) -> None:
     }
     with open(cache_file, 'w') as f:
         json.dump(versioned_cache, f, indent=2)
+
+def _stamp_library_id(categorized: Dict, library_id: Optional[str]) -> None:
+    """Stamp library_id provenance onto every item in a categorized dict (#157 Phase 3).
+
+    Args:
+        categorized: Dict with 'user_services' (dict of service -> items),
+            'other_services' (dict of service -> items), and 'acquire' (list)
+        library_id: The source library's id, or None
+    """
+    for service_items in categorized.get('user_services', {}).values():
+        for item in service_items:
+            item['library_id'] = library_id
+    for service_items in categorized.get('other_services', {}).values():
+        for item in service_items:
+            item['library_id'] = library_id
+    for item in categorized.get('acquire', []):
+        item['library_id'] = library_id
+
 
 def load_ignore_list(display_name: str) -> Set[str]:
     """Load user's manual ignore list"""
@@ -1935,25 +1973,45 @@ def load_ignore_list(display_name: str) -> Set[str]:
             return set(line.strip() for line in f if line.strip())
     return set()
 
-def process_user(config, plex, username):
-    """Process external recommendations for a single user"""
+def process_user(config, plex, username, movie_library=None, tv_library=None):
+    """Process external recommendations for a single user.
+
+    Args:
+        config: Root configuration dictionary
+        plex: Connected PlexServer instance
+        username: Plex username to process
+        movie_library: Optional normalized movie library dict (#157 Phase 3,
+            see utils.config.get_libraries). None keeps the legacy
+            single-library behavior (config['plex'].movie_library).
+        tv_library: Optional normalized tv library dict (#157 Phase 3).
+            None keeps the legacy single-library behavior
+            (config['plex'].tv_library).
+    """
     user_prefs = config.get('users', {}).get('preferences', {}).get(username, {})
     display_name = user_prefs.get('display_name', username)
 
     print(f"\n{GREEN}Processing external recommendations for: {display_name}{RESET}")
 
     # Get current library contents
-    movie_library = config['plex'].get('movie_library', 'Movies')
-    tv_library = config['plex'].get('tv_library', 'TV Shows')
+    movie_library_name = movie_library['section'] if movie_library else config['plex'].get('movie_library', 'Movies')
+    tv_library_name = tv_library['section'] if tv_library else config['plex'].get('tv_library', 'TV Shows')
 
-    library_movies = get_library_items(plex, movie_library, 'movie')
-    library_shows = get_library_items(plex, tv_library, 'show')
+    # Cache filenames stay legacy (unqualified) unless this install has more
+    # than one library of that media type - back-compat for single-library
+    # installs (#157 Phase 3), matching the internal recommenders' rule.
+    movie_is_multi = bool(movie_library) and len(get_libraries_for_media_type(config, MEDIA_TYPE_MOVIE)) > 1
+    tv_is_multi = bool(tv_library) and len(get_libraries_for_media_type(config, MEDIA_TYPE_TV)) > 1
+    movie_cache_lib_id = movie_library['id'] if movie_is_multi else None
+    tv_cache_lib_id = tv_library['id'] if tv_is_multi else None
+
+    library_movies = get_library_items(plex, movie_library_name, 'movie')
+    library_shows = get_library_items(plex, tv_library_name, 'show')
 
     print(f"{CYAN}Library has {len(library_movies['titles'])} movies, {len(library_shows['titles'])} TV shows{RESET}")
 
     # Load existing cache and ignore list
-    movie_cache = load_cache(display_name, 'movies')
-    show_cache = load_cache(display_name, 'shows')
+    movie_cache = load_cache(display_name, 'movies', lib_id=movie_cache_lib_id)
+    show_cache = load_cache(display_name, 'shows', lib_id=tv_cache_lib_id)
     ignore_list = load_ignore_list(display_name)
 
     # Get language filter from config
@@ -2188,8 +2246,8 @@ def process_user(config, plex, username):
         print(f"{YELLOW}Trimmed cache: {trimmed_movies} movies, {trimmed_shows} shows (replaced by better recs){RESET}")
 
     # Save updated caches
-    save_cache(display_name, 'movies', movie_cache)
-    save_cache(display_name, 'shows', show_cache)
+    save_cache(display_name, 'movies', movie_cache, lib_id=movie_cache_lib_id)
+    save_cache(display_name, 'shows', show_cache, lib_id=tv_cache_lib_id)
 
     # Prepare lists for categorization - apply threshold and limits
     all_movies = sorted(movie_cache.values(), key=lambda x: x['score'], reverse=True)
@@ -2231,6 +2289,14 @@ def process_user(config, plex, username):
         'tv'
     )
 
+    # Item provenance (#157 Phase 3): stamp each recommendation with the
+    # library it was sourced from/targets. None when running the legacy
+    # single-library path (movie_library/tv_library not passed).
+    movie_item_library_id = movie_library['id'] if movie_library else None
+    tv_item_library_id = tv_library['id'] if tv_library else None
+    _stamp_library_id(movies_categorized, movie_item_library_id)
+    _stamp_library_id(shows_categorized, tv_item_library_id)
+
     # Generate markdown per user
     project_root = get_project_root()
     output_dir = os.path.join(project_root, 'recommendations', 'external')
@@ -2247,7 +2313,21 @@ def process_user(config, plex, username):
     print(f"{GREEN}Processed: {total_movies} movies, {total_shows} shows{RESET}")
     print(f"\nExternal recommendation process completed for {display_name}!")
 
-    # Return data for combined HTML generation and Trakt sync
+    # Return data for combined HTML generation and Trakt sync.
+    #
+    # library_id (#157 Phase 3 provenance): a single call processes BOTH
+    # movies and shows, which can belong to different libraries (different
+    # ids) once there's more than one library of either media type. Export
+    # routing's _resolve_library_groups() (Phase 2, unchanged) reads this
+    # single field for BOTH Radarr and Sonarr grouping without checking
+    # media_type, so it cannot safely hold two different ids at once -
+    # stamping either one here would misroute the other media type's export
+    # in the common case (one movie library + one TV library, different
+    # ids). We deliberately leave it None so Phase 2's existing per-media-type
+    # fallback (get_libraries_for_media_type(...)[0]) keeps routing
+    # correctly; per-item library_id (see _stamp_library_id above) already
+    # carries the real provenance for anything that inspects individual
+    # recommendations.
     return {
         'username': username,
         'display_name': display_name,
@@ -2255,7 +2335,8 @@ def process_user(config, plex, username):
         'shows_categorized': shows_categorized,
         'movie_profile': movie_profile,
         'show_profile': show_profile,
-        'user_services': user_services
+        'user_services': user_services,
+        'library_id': None
     }
 
 def main():
@@ -2312,9 +2393,28 @@ def main():
     total_users = 0
 
     if run_recommendations:
+        # #157 Phase 3: resolve the primary movie/tv library once up front.
+        # process_user() handles movies and shows together for a user in a
+        # single pass (shared Trakt watchlist fetch, one combined markdown
+        # file per user), so we don't fan this out into a per-library loop -
+        # that would call process_user() N times per user and overwrite each
+        # user's markdown watchlist with partial (movies-only/shows-only)
+        # data. Instead we thread through the first configured library of
+        # each media type, which is exactly today's single library for a
+        # single-library install (byte-identical: one process_user() call
+        # per user, same as before).
+        movie_libraries = get_libraries_for_media_type(config, MEDIA_TYPE_MOVIE)
+        tv_libraries = get_libraries_for_media_type(config, MEDIA_TYPE_TV)
+        primary_movie_library = movie_libraries[0] if movie_libraries else None
+        primary_tv_library = tv_libraries[0] if tv_libraries else None
+
         for username in users:
             try:
-                user_data = process_user(config, plex, username)
+                user_data = process_user(
+                    config, plex, username,
+                    movie_library=primary_movie_library,
+                    tv_library=primary_tv_library
+                )
                 if user_data:
                     all_users_data.append(user_data)
             except Exception as e:

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -122,15 +122,16 @@ class PlexMovieRecommender(BaseRecommender):
             'language': weights_config.get('language', weights_config.get('language_weight', 0.0)),
         }
 
-    def __init__(self, config_path: str, single_user: str = None):
+    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
         """Initialize the movie recommender.
 
         Args:
             config_path: Path to the config.yml configuration file
             single_user: Optional username to generate recommendations for a single user
+            library: Optional normalized library dict (#157 Phase 3 per-library loop)
         """
         # Initialize base class (config, plex, display options, weights, etc.)
-        super().__init__(config_path, single_user)
+        super().__init__(config_path, single_user, library=library)
 
         # Movie-specific initialization
         self.cached_unwatched_count = 0
@@ -562,14 +563,14 @@ def adapt_root_config_to_legacy(root_config):
 # ------------------------------------------------------------------------
 # MAIN
 # ------------------------------------------------------------------------
-def process_recommendations(config, config_path, log_retention_days, single_user=None):
+def process_recommendations(config, config_path, log_retention_days, single_user=None, library=None):
     original_stdout = sys.stdout
     log_dir = os.path.join(get_project_root(), 'logs')
     setup_log_file(log_dir, log_retention_days, single_user, 'recommendations')
 
     try:
         # Create recommender with single user context
-        recommender = PlexMovieRecommender(config_path, single_user=single_user)
+        recommender = PlexMovieRecommender(config_path, single_user=single_user, library=library)
         
         # Check for debug mode
         if config.get('general', {}).get('debug', False):
@@ -621,7 +622,8 @@ def main():
         media_type='Movie',
         description='Movie Recommendations for Plex',
         adapt_config_func=adapt_root_config_to_legacy,
-        process_func=process_recommendations
+        process_func=process_recommendations,
+        media_type_key='movie'
     )
 
 if __name__ == "__main__":

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -106,15 +106,16 @@ class PlexTVRecommender(BaseRecommender):
             'language': weights_config.get('language', weights_config.get('language_weight', 0.05)),
         }
 
-    def __init__(self, config_path: str, single_user: str = None):
+    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
         """Initialize the TV show recommender.
 
         Args:
             config_path: Path to the config.yml configuration file
             single_user: Optional username to generate recommendations for a single user
+            library: Optional normalized library dict (#157 Phase 3 per-library loop)
         """
         # Initialize base class (config, plex, display options, weights, etc.)
-        super().__init__(config_path, single_user)
+        super().__init__(config_path, single_user, library=library)
 
         # TV-specific initialization
         self.cached_unwatched_count = 0
@@ -605,10 +606,11 @@ def main():
         media_type='TV Show',
         description='TV Show Recommendations for Plex',
         adapt_config_func=adapt_root_config_to_legacy,
-        process_func=process_recommendations
+        process_func=process_recommendations,
+        media_type_key='tv'
     )
 
-def process_recommendations(config, config_path, log_retention_days, single_user=None):
+def process_recommendations(config, config_path, log_retention_days, single_user=None, library=None):
     """Process and display TV show recommendations for configured users."""
     original_stdout = sys.stdout
     log_dir = os.path.join(get_project_root(), 'logs')
@@ -616,7 +618,7 @@ def process_recommendations(config, config_path, log_retention_days, single_user
 
     try:
         # Create recommender with single user context
-        recommender = PlexTVRecommender(config_path, single_user)
+        recommender = PlexTVRecommender(config_path, single_user, library=library)
         recommendations = recommender.get_recommendations()
 
         print(f"\n{GREEN}=== Recommended Unwatched Shows in Your Library ==={RESET}")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -794,3 +794,281 @@ class TestBaseCacheTVShowBackfill:
 
         # Should not error - backfill isn't called for TV
         assert result is False  # Cache was up to date
+
+
+# ------------------------------------------------------------------------
+# #157 Phase 3: per-library recommendation loop - library threading,
+# cache-key back-compat, and collection/label naming.
+# ------------------------------------------------------------------------
+
+SINGLE_MOVIE_LIBRARY_CONFIG = {
+    'plex': {'url': 'http://localhost', 'token': 'abc', 'movie_library': 'Movies'},
+    'general': {},
+    'weights': {'genre': 0.5, 'actor': 0.5},
+}
+
+MULTI_MOVIE_LIBRARY_CONFIG = {
+    'plex': {'url': 'http://localhost', 'token': 'abc'},
+    'general': {},
+    'weights': {'genre': 0.5, 'actor': 0.5},
+    'libraries': [
+        {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+        {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'},
+    ],
+}
+
+LIB_MOVIES_4K = {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'}
+LIB_MOVIES = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+
+
+class TestBaseRecommenderLibraryInit:
+    """Tests for BaseRecommender.__init__ library threading (#157 Phase 3)."""
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_no_library_uses_legacy_resolution(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """library=None (default) keeps the legacy library_config_key lookup."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender.library is None
+        assert recommender.library_id is None
+        assert recommender.library_title == 'Movies'
+        assert recommender._is_multi_library is False
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_synthesized_single_library_passed_stays_single(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """Even when the (single, synthesized) library object IS passed
+        through (as the new cli.py matrix loop always does), a single
+        library for this media type must NOT trigger multi-library
+        naming/cache behavior."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        synthesized = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+        recommender = ConcreteRecommender('/path/to/config.yml', library=synthesized)
+
+        assert recommender.library == synthesized
+        assert recommender.library_id == 'movies'
+        assert recommender.library_title == 'Movies'
+        assert recommender._is_multi_library is False
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_multi_library_sets_library_fields(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """When >1 library shares this media type, the given library's
+        section/id are used and multi-library mode is flagged."""
+        mock_load.return_value = MULTI_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES_4K)
+
+        assert recommender.library_id == 'movies-4k'
+        assert recommender.library_title == 'Movies 4K'
+        assert recommender._is_multi_library is True
+
+
+class TestBaseRecommenderCacheLibraryPrefix:
+    """Tests for per-library cache filename back-compat (#157 Phase 3)."""
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_single_library_user_context_unprefixed(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """Single-library install (legacy, no library passed): user context
+        has no library prefix, so watched_cache_{user}.json is unchanged."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': ['jason'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender._get_user_context() == 'plex_jason'
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_synthesized_single_library_passed_stays_unprefixed(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """Same as above but library IS passed (matrix loop always passes
+        one) - still unprefixed because it's the sole library for the
+        media type. This is the single-library byte-identical proof for
+        cache filenames."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': ['jason'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        synthesized = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+        recommender = ConcreteRecommender('/path/to/config.yml', library=synthesized)
+
+        assert recommender._get_user_context() == 'plex_jason'
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_multi_library_user_context_prefixed(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        """Multi-library install: user context gets a library-id prefix, so
+        watched caches for different libraries never collide."""
+        mock_load.return_value = MULTI_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': ['jason'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        movies_recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES)
+        movies_4k_recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES_4K)
+
+        assert movies_recommender._get_user_context() == 'movies_plex_jason'
+        assert movies_4k_recommender._get_user_context() == 'movies-4k_plex_jason'
+        # Distinct filenames - no cross-library cache collision
+        assert movies_recommender._get_user_context() != movies_4k_recommender._get_user_context()
+
+
+class TestBaseRecommenderCollectionNaming:
+    """Tests for per-library collection/label naming (#157 Phase 3)."""
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_single_library_no_suffix(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender._library_suffix_for_collection_name() == ''
+        assert recommender._library_suffix_for_label() == ''
+        assert recommender._cache_library_prefix() == ''
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_multi_library_adds_suffixes(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex):
+        mock_load.return_value = MULTI_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES_4K)
+
+        assert recommender._library_suffix_for_collection_name() == ' (Movies 4K)'
+        assert recommender._library_suffix_for_label() == '_movies-4k'
+        assert recommender._cache_library_prefix() == 'movies-4k_'
+
+    @patch('recommenders.base.cleanup_old_collections')
+    @patch('recommenders.base.update_plex_collection')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_sync_plex_collection_single_library_name_unchanged(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup
+    ):
+        """Single-library install: collection name is byte-identical to
+        pre-Phase-3 (no suffix)."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender('/path/to/config.yml')
+        section = Mock()
+
+        recommender._sync_plex_collection(section, 'Recommended_alice', [Mock()])
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "🎬 Alice - Recommendation"
+        mock_cleanup.assert_called_once()
+        assert mock_cleanup.call_args[0][1] == "🎬 Alice - Recommendation"
+
+    @patch('recommenders.base.cleanup_old_collections')
+    @patch('recommenders.base.update_plex_collection')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_sync_plex_collection_multi_library_adds_suffix(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup
+    ):
+        """Multi-library install: collection name is suffixed with the
+        library name so same-named collections across libraries are
+        distinguishable."""
+        mock_load.return_value = MULTI_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES_4K)
+        section = Mock()
+
+        recommender._sync_plex_collection(section, 'Recommended_alice', [Mock()])
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "🎬 Alice - Recommendation (Movies 4K)"
+
+    @patch('recommenders.base.build_label_name')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_manage_plex_labels_qualifies_label_for_multi_library(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_build_label
+    ):
+        """Multi-library install: the internal Plex label is qualified with
+        the library id so labeling doesn't collide across libraries."""
+        mock_load.return_value = MULTI_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {'plex_users': ['alice'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+        mock_build_label.return_value = 'Recommended_movies-4k_alice'
+
+        recommender = ConcreteRecommender('/path/to/config.yml', library=LIB_MOVIES_4K)
+        recommender.plex = Mock()
+        # Short-circuit deep inside manage_plex_labels right after label_name
+        # is built, by making item-finding raise - we only care about the
+        # base_label passed into build_label_name.
+        recommender._find_plex_items_for_recs = Mock(side_effect=RuntimeError("stop"))
+
+        try:
+            recommender.manage_plex_labels([{'title': 'Test', 'year': 2020}])
+        except Exception:
+            pass
+
+        assert mock_build_label.called
+        base_label_arg = mock_build_label.call_args[0][0]
+        assert base_label_arg == 'Recommended_movies-4k'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -442,7 +442,7 @@ class TestRunRecommenderMain:
         self, mock_setup_log, mock_parse_args, mock_root, mock_open, mock_yaml
     ):
         """Test exits with code 1 if config cannot be loaded."""
-        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_open.side_effect = FileNotFoundError("No config")
 
@@ -467,7 +467,7 @@ class TestRunRecommenderMain:
         mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test exits with code 1 if no users configured."""
-        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {'plex': {'token': 'abc'}}  # No users
         mock_migrate.return_value = {}
@@ -494,7 +494,7 @@ class TestRunRecommenderMain:
         mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test calls process_func for each configured user."""
-        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {
             'plex': {'token': 'abc'},
@@ -528,7 +528,7 @@ class TestRunRecommenderMain:
         mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test processes only specified user in single user mode."""
-        mock_parse_args.return_value = Mock(username='bob', debug=False)
+        mock_parse_args.return_value = Mock(username='bob', debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {
             'plex': {'token': 'abc'},
@@ -562,7 +562,7 @@ class TestRunRecommenderMain:
         mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test enables debug logging when --debug flag is set."""
-        mock_parse_args.return_value = Mock(username=None, debug=True)
+        mock_parse_args.return_value = Mock(username=None, debug=True, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {
             'plex': {'token': 'abc'},
@@ -601,7 +601,7 @@ class TestRunRecommenderMain:
         """Test run_recommender_main invokes rename migration and re-reads
         config.yml when a rename was migrated, so downstream processing
         sees the updated usernames."""
-        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.side_effect = [
             {'plex': {'token': 'abc'}, 'users': {'list': 'oldname'}},
@@ -636,7 +636,7 @@ class TestRunRecommenderMain:
         mock_setup_log, mock_resolve, mock_print, mock_migrate
     ):
         """Test config.yml is only read once when no rename was detected."""
-        mock_parse_args.return_value = Mock(username=None, debug=False)
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
         mock_root.return_value = '/fake/root'
         mock_yaml.return_value = {'plex': {'token': 'abc'}, 'users': {'list': 'alice'}}
         mock_migrate.return_value = {}
@@ -649,3 +649,202 @@ class TestRunRecommenderMain:
         run_recommender_main('Movie', 'Test', mock_adapt, mock_process)
 
         assert mock_yaml.call_count == 1
+
+
+class TestRunRecommenderMainLibraryMatrixLoop:
+    """Tests for the #157 Phase 3 per-library (library x user) matrix loop."""
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_single_library_install_matches_legacy_call_count(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """Regression: no 'libraries:' config (synthesized single library)
+        produces exactly one process_func call per user, with the
+        synthesized library passed as the 5th positional arg - same call
+        count as before Phase 3."""
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
+        mock_root.return_value = '/fake/root'
+        mock_yaml.return_value = {
+            'plex': {'token': 'abc', 'movie_library': 'Movies'},
+            'users': {'list': 'alice, bob'}
+        }
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(return_value={
+            'plex': {'token': 'abc', 'movie_library': 'Movies'},
+            'users': {'list': 'alice, bob'},
+            'general': {}
+        })
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('Movie', 'Test', mock_adapt, mock_process, media_type_key='movie')
+
+        assert mock_process.call_count == 2
+        for call in mock_process.call_args_list:
+            library = call[0][4]
+            assert library is not None
+            assert library['id'] == 'movies'
+            assert library['section'] == 'Movies'
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_two_libraries_two_users_yields_four_calls(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """2 libraries x 2 users = 4 process_func invocations, each with the
+        correct library object."""
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
+        mock_root.return_value = '/fake/root'
+        root_cfg = {
+            'plex': {'token': 'abc'},
+            'users': {'list': 'alice, bob'},
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+                {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'},
+                {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'},
+            ],
+        }
+        mock_yaml.return_value = root_cfg
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('Movie', 'Test', mock_adapt, mock_process, media_type_key='movie')
+
+        assert mock_process.call_count == 4
+        seen = set()
+        for call in mock_process.call_args_list:
+            resolved_user = call[0][3]
+            library = call[0][4]
+            seen.add((library['id'], resolved_user))
+        assert seen == {
+            ('movies', 'alice'), ('movies', 'bob'),
+            ('movies-4k', 'alice'), ('movies-4k', 'bob'),
+        }
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_media_type_key_selects_tv_libraries(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """media_type_key='tv' only loops over tv libraries, not movie ones."""
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
+        mock_root.return_value = '/fake/root'
+        root_cfg = {
+            'plex': {'token': 'abc'},
+            'users': {'list': 'alice'},
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+                {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'},
+                {'id': 'anime', 'name': 'Anime', 'section': 'Anime', 'media_type': 'tv'},
+            ],
+        }
+        mock_yaml.return_value = root_cfg
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('TV Show', 'Test', mock_adapt, mock_process, media_type_key='tv')
+
+        assert mock_process.call_count == 2
+        lib_ids = {call[0][4]['id'] for call in mock_process.call_args_list}
+        assert lib_ids == {'tv-shows', 'anime'}
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_library_flag_filters_to_single_library(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """--library <id> restricts processing to a single library."""
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id='movies-4k')
+        mock_root.return_value = '/fake/root'
+        root_cfg = {
+            'plex': {'token': 'abc'},
+            'users': {'list': 'alice'},
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+                {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'},
+            ],
+        }
+        mock_yaml.return_value = root_cfg
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main('Movie', 'Test', mock_adapt, mock_process, media_type_key='movie')
+
+        assert mock_process.call_count == 1
+        assert mock_process.call_args[0][4]['id'] == 'movies-4k'
+
+    @patch('utils.cli.migrate_renamed_plex_users')
+    @patch('utils.cli.print_runtime')
+    @patch('utils.cli.resolve_admin_username')
+    @patch('utils.cli.setup_logging')
+    @patch('utils.cli.yaml.safe_load')
+    @patch('builtins.open', create=True)
+    @patch('utils.cli.get_project_root')
+    @patch('utils.cli.argparse.ArgumentParser.parse_args')
+    def test_library_flag_unknown_id_exits(
+        self, mock_parse_args, mock_root, mock_open, mock_yaml,
+        mock_setup_log, mock_resolve, mock_print, mock_migrate
+    ):
+        """--library <unknown id> exits with an error instead of silently
+        processing every library."""
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id='nope')
+        mock_root.return_value = '/fake/root'
+        mock_yaml.return_value = {
+            'plex': {'token': 'abc'},
+            'users': {'list': 'alice'}
+        }
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, 'general': {}})
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_recommender_main('Movie', 'Test', mock_adapt, mock_process, media_type_key='movie')
+
+        assert exc_info.value.code == 1
+        mock_process.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,6 +223,32 @@ class TestAdaptConfigForMediaType:
         result = adapt_config_for_media_type(config, 'movies')
         assert result['add_label'] is False
 
+    def test_libraries_passed_through(self):
+        """#157 Phase 3: the adapted config must carry 'libraries' through so
+        utils/cli.py's per-library loop (which calls
+        get_libraries_for_media_type against the adapted config) sees a
+        real multi-library setup instead of always falling back to the
+        synthesized single-library default."""
+        config = {
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'media_type': 'movie'},
+                {'id': 'movies-4k', 'name': 'Movies 4K', 'media_type': 'movie'},
+            ]
+        }
+        result = adapt_config_for_media_type(config, 'movies')
+        assert result['libraries'] == config['libraries']
+
+    def test_libraries_absent_passes_through_none(self):
+        """No 'libraries' key in root config -> adapted config's 'libraries'
+        is None, so get_libraries_for_media_type falls back to synthesis."""
+        config = {'plex': {'movie_library': 'Movies'}}
+        result = adapt_config_for_media_type(config, 'movies')
+        assert result['libraries'] is None
+
+        libs = get_libraries_for_media_type(result, 'movie')
+        assert len(libs) == 1
+        assert libs[0]['section'] == 'Movies'
+
 
 class TestNegativeSignalsConstants:
     """Tests for negative signals constants"""

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -38,6 +38,8 @@ from recommenders.external import (
     is_thin_profile,
     discover_popular_by_genre,
     THIN_PROFILE_THRESHOLD,
+    process_user,
+    _stamp_library_id,
 )
 from utils.trakt import enhance_profile_with_trakt
 from collections import Counter
@@ -1359,6 +1361,282 @@ class TestExternalRecsCacheVersioning:
 
                 assert '12345' in result
                 assert result['12345']['title'] == 'Test Movie'
+
+
+class TestExternalRecsCacheLibraryId:
+    """Tests for per-library external recs cache filenames (#157 Phase 3)."""
+
+    def test_no_lib_id_uses_legacy_filename(self):
+        """lib_id=None (default) keeps the exact legacy filename - single
+        library install byte-identical proof for external recs cache."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
+                save_cache('testuser', 'movies', {'1': {'title': 'A'}})
+
+                expected_path = os.path.join(tmpdir, 'cache', 'external_recs_testuser_movies.json')
+                assert os.path.exists(expected_path)
+
+    def test_lib_id_qualifies_filename(self):
+        """lib_id qualifies the filename so multiple libraries of the same
+        media type don't collide."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
+                save_cache('testuser', 'movies', {'1': {'title': 'A'}}, lib_id='movies-4k')
+
+                expected_path = os.path.join(tmpdir, 'cache', 'external_recs_movies-4k_testuser_movies.json')
+                assert os.path.exists(expected_path)
+
+    def test_distinct_lib_ids_produce_isolated_caches(self):
+        """Two libraries of the same media type get fully isolated caches -
+        writing to one must not affect the other."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
+                save_cache('testuser', 'movies', {'1': {'title': 'Library A movie', 'vote_count': 500}}, lib_id='movies')
+                save_cache('testuser', 'movies', {'2': {'title': 'Library B movie', 'vote_count': 500}}, lib_id='movies-4k')
+
+                cache_a = load_cache('testuser', 'movies', lib_id='movies')
+                cache_b = load_cache('testuser', 'movies', lib_id='movies-4k')
+
+                assert '1' in cache_a and '2' not in cache_a
+                assert '2' in cache_b and '1' not in cache_b
+
+    def test_stamp_library_id_covers_all_categories(self):
+        """_stamp_library_id sets library_id on every item across
+        user_services, other_services, and acquire."""
+        categorized = {
+            'user_services': {'Netflix': [{'tmdb_id': 1}, {'tmdb_id': 2}]},
+            'other_services': {'Hulu': [{'tmdb_id': 3}]},
+            'acquire': [{'tmdb_id': 4}],
+            'all_items': [{'tmdb_id': 1}],  # same objects in real usage
+        }
+
+        _stamp_library_id(categorized, 'movies-4k')
+
+        assert categorized['user_services']['Netflix'][0]['library_id'] == 'movies-4k'
+        assert categorized['user_services']['Netflix'][1]['library_id'] == 'movies-4k'
+        assert categorized['other_services']['Hulu'][0]['library_id'] == 'movies-4k'
+        assert categorized['acquire'][0]['library_id'] == 'movies-4k'
+
+    def test_stamp_library_id_handles_none(self):
+        """_stamp_library_id(None) is valid - legacy/no-library items stay None."""
+        categorized = {'user_services': {}, 'other_services': {}, 'acquire': [{'tmdb_id': 1}]}
+
+        _stamp_library_id(categorized, None)
+
+        assert categorized['acquire'][0]['library_id'] is None
+
+    def test_lib_id_round_trip(self):
+        """save_cache(lib_id=...) then load_cache(lib_id=...) reads back
+        what was written."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('recommenders.external.get_project_root', return_value=tmpdir):
+                cache_data = {'999': {'title': 'Qualified Cache', 'tmdb_id': 999, 'vote_count': 500}}
+                save_cache('testuser', 'movies', cache_data, lib_id='movies-4k')
+
+                result = load_cache('testuser', 'movies', lib_id='movies-4k')
+
+                assert '999' in result
+                assert result['999']['title'] == 'Qualified Cache'
+
+
+def _process_user_load_cache_side_effect(display_name, media_type, lib_id=None):
+    """Shared fixture data for TestProcessUserLibraryProvenance - one
+    already-cached, above-threshold item per media type so discovery
+    (movie_deficit/show_deficit) is skipped and only the caching/
+    categorization/provenance path under test runs."""
+    if media_type == 'movies':
+        return {'100': {
+            'tmdb_id': 100, 'title': 'Cached Movie', 'year': 2020,
+            'rating': 7.5, 'vote_count': 500, 'score': 0.9, 'original_language': 'en'
+        }}
+    return {'200': {
+        'tmdb_id': 200, 'title': 'Cached Show', 'year': 2019,
+        'rating': 8.0, 'vote_count': 300, 'score': 0.9, 'original_language': 'en'
+    }}
+
+
+def _process_user_categorize_side_effect(items, tmdb_api_key, user_services, media_type):
+    """Fixture standing in for categorize_by_streaming_service - returns one
+    item so _stamp_library_id has something to stamp."""
+    item = {'tmdb_id': 999 if media_type == 'movie' else 888, 'title': f'{media_type}-item'}
+    return {'user_services': {}, 'other_services': {'Netflix': [item]}, 'acquire': [], 'all_items': [item]}
+
+
+class TestProcessUserLibraryProvenance:
+    """Tests for process_user library params and item provenance (#157 Phase 3)."""
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_legacy_no_library_params(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile, mock_enhance,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_categorize, mock_markdown
+    ):
+        """No movie_library/tv_library passed (legacy callers): resolves
+        section names from config['plex'], cache lib_id stays None, item
+        library_id stamps are None, and the top-level library_id is None."""
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_enhance.side_effect = lambda profile, *a, **kw: profile
+        mock_load_ignore.return_value = set()
+        mock_load_cache.side_effect = _process_user_load_cache_side_effect
+        mock_categorize.side_effect = _process_user_categorize_side_effect
+
+        config = {
+            'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'users': {'preferences': {}},
+            'external_recommendations': {'movie_limit': 1, 'show_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [],
+            'trakt': {},
+        }
+
+        result = process_user(config, Mock(), 'alice')
+
+        # Section names resolved from legacy config['plex'] keys
+        get_items_calls = mock_get_items.call_args_list
+        assert get_items_calls[0][0][1] == 'Movies'
+        assert get_items_calls[1][0][1] == 'TV Shows'
+
+        # Cache filenames stay legacy (lib_id=None)
+        assert mock_load_cache.call_args_list[0].kwargs['lib_id'] is None
+        assert mock_load_cache.call_args_list[1].kwargs['lib_id'] is None
+        assert mock_save_cache.call_args_list[0].kwargs['lib_id'] is None
+        assert mock_save_cache.call_args_list[1].kwargs['lib_id'] is None
+
+        # Top-level library_id always None (see _stamp_library_id / return docstring)
+        assert result['library_id'] is None
+
+        # Item-level provenance stamps are None (no library resolved)
+        movie_item = result['movies_categorized']['other_services']['Netflix'][0]
+        show_item = result['shows_categorized']['other_services']['Netflix'][0]
+        assert movie_item['library_id'] is None
+        assert show_item['library_id'] is None
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_multi_library_params_qualify_cache_and_stamp_items(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile, mock_enhance,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_categorize, mock_markdown
+    ):
+        """movie_library/tv_library passed with a genuinely multi-library
+        movie config (2 movie libraries) but a single tv library:
+        - movie cache filenames get lib-qualified (movie_is_multi)
+        - tv cache filenames stay legacy (only 1 tv library, despite
+          tv_library being passed) - per-media-type independence
+        - every returned item is stamped with its real library id
+        """
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_enhance.side_effect = lambda profile, *a, **kw: profile
+        mock_load_ignore.return_value = set()
+        mock_load_cache.side_effect = _process_user_load_cache_side_effect
+        mock_categorize.side_effect = _process_user_categorize_side_effect
+
+        movie_library = {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'}
+        tv_library = {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'}
+
+        config = {
+            'plex': {'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'users': {'preferences': {}},
+            'external_recommendations': {'movie_limit': 1, 'show_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [],
+            'trakt': {},
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+                movie_library,
+                tv_library,
+            ],
+        }
+
+        result = process_user(config, Mock(), 'alice', movie_library=movie_library, tv_library=tv_library)
+
+        # Section names resolved from the passed library dicts
+        get_items_calls = mock_get_items.call_args_list
+        assert get_items_calls[0][0][1] == 'Movies 4K'
+        assert get_items_calls[1][0][1] == 'TV Shows'
+
+        # Movie cache qualified (2 movie libraries); tv cache stays legacy (1 tv library)
+        assert mock_load_cache.call_args_list[0].kwargs['lib_id'] == 'movies-4k'
+        assert mock_load_cache.call_args_list[1].kwargs['lib_id'] is None
+        assert mock_save_cache.call_args_list[0].kwargs['lib_id'] == 'movies-4k'
+        assert mock_save_cache.call_args_list[1].kwargs['lib_id'] is None
+
+        # Top-level library_id stays None even in multi-library mode (see
+        # process_user's return docstring: a single call spans both movie
+        # and tv libraries, which can have different ids, and Phase 2's
+        # _resolve_library_groups isn't media-type-aware for non-None ids)
+        assert result['library_id'] is None
+
+        # Item-level provenance carries the real library ids
+        movie_item = result['movies_categorized']['other_services']['Netflix'][0]
+        show_item = result['shows_categorized']['other_services']['Netflix'][0]
+        assert movie_item['library_id'] == 'movies-4k'
+        assert show_item['library_id'] == 'tv-shows'
+
+
+class TestMainLibraryResolution:
+    """Tests for main() resolving primary movie/tv libraries (#157 Phase 3)."""
+
+    @patch('recommenders.external.export_to_simkl')
+    @patch('recommenders.external.export_to_mdblist')
+    @patch('recommenders.external.export_to_radarr')
+    @patch('recommenders.external.export_to_sonarr')
+    @patch('recommenders.external.export_to_trakt')
+    @patch('recommenders.external.generate_combined_html')
+    @patch('recommenders.external.find_horizon_movies')
+    @patch('recommenders.external.find_missing_sequels')
+    @patch('recommenders.external.process_user')
+    @patch('recommenders.external.PlexServer')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.load_config')
+    @patch('recommenders.external.get_project_root')
+    @patch('sys.argv', ['external.py'])
+    def test_single_library_install_calls_process_user_once_per_user(
+        self, mock_root, mock_load_config, mock_get_tmdb, mock_plex_server,
+        mock_process_user, mock_sequels, mock_horizon, mock_html,
+        mock_trakt, mock_sonarr, mock_radarr, mock_mdblist, mock_simkl
+    ):
+        """Single-library install (no 'libraries:' config): process_user is
+        called once per user (same call count as before Phase 3), with the
+        synthesized movie/tv libraries threaded through."""
+        mock_root.return_value = '/fake/root'
+        mock_load_config.return_value = {
+            'plex': {'url': 'http://x', 'token': 'y', 'movie_library': 'Movies', 'tv_library': 'TV Shows'},
+            'users': {'list': 'alice, bob'},
+            'huntarr': {'sequel_huntarr': False, 'horizon_huntarr': False},
+        }
+        mock_get_tmdb.return_value = {'api_key': 'key', 'use_keywords': True}
+        mock_plex_server.return_value = Mock()
+        mock_process_user.return_value = {
+            'username': 'x', 'display_name': 'x',
+            'movies_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []},
+            'shows_categorized': {'user_services': {}, 'other_services': {}, 'acquire': []},
+            'movie_profile': {}, 'show_profile': {}, 'user_services': [], 'library_id': None
+        }
+        mock_html.return_value = None
+
+        from recommenders.external import main
+        main()
+
+        assert mock_process_user.call_count == 2
+        for call in mock_process_user.call_args_list:
+            assert call.kwargs['movie_library']['id'] == 'movies'
+            assert call.kwargs['tv_library']['id'] == 'tv-shows'
 
 
 class TestTVMovieGenreDetection:

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock, patch, MagicMock
 from collections import Counter
 import json
 
-from recommenders.movie import MovieCache, PlexMovieRecommender, format_movie_output, adapt_root_config_to_legacy
+from recommenders.movie import (
+    MovieCache, PlexMovieRecommender, format_movie_output, adapt_root_config_to_legacy,
+    process_recommendations, main,
+)
 
 
 class TestMovieCache:
@@ -125,6 +128,64 @@ class TestPlexMovieRecommenderInit:
         recommender = PlexMovieRecommender('/path/to/config.yml')
 
         mock_cache.assert_called_once()
+
+class TestPlexMovieRecommenderLibraryParam:
+    """Tests for PlexMovieRecommender library threading (#157 Phase 3)."""
+
+    @patch('recommenders.movie.MovieCache')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_library_forwarded_to_base(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test that the library param reaches BaseRecommender and sets
+        library_id/library_title from the library dict, not the legacy
+        movie_library config key."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'movie_library': 'Movies'},
+            'general': {},
+            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2},
+            'libraries': [
+                {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'},
+                {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'},
+            ],
+        }
+        mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+        mock_cache.return_value = Mock(cache={'movies': {}})
+
+        library = {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'}
+        recommender = PlexMovieRecommender('/path/to/config.yml', library=library)
+
+        assert recommender.library_id == 'movies-4k'
+        assert recommender.library_title == 'Movies 4K'
+
+    @patch('recommenders.movie.MovieCache')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_no_library_keeps_legacy_title(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """library=None (default) resolves library_title from the legacy
+        movie_library config key, unchanged from before Phase 3."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'movie_library': 'Movies'},
+            'general': {},
+            'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2},
+        }
+        mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+        mock_cache.return_value = Mock(cache={'movies': {}})
+
+        recommender = PlexMovieRecommender('/path/to/config.yml')
+
+        assert recommender.library_id is None
+        assert recommender.library_title == 'Movies'
+
 
 class TestPlexMovieRecommenderWeights:
     """Tests for PlexMovieRecommender weight loading."""
@@ -376,6 +437,53 @@ class TestAdaptRootConfigToLegacy:
         result = adapt_root_config_to_legacy(config)
 
         assert isinstance(result, dict)
+
+
+class TestProcessRecommendationsLibraryParam:
+    """Tests for process_recommendations library forwarding (#157 Phase 3)."""
+
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_forwards_library_to_recommender(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+        """process_recommendations passes library through to
+        PlexMovieRecommender's constructor unchanged."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        library = {'id': 'movies-4k', 'name': 'Movies 4K', 'section': 'Movies 4K', 'media_type': 'movie'}
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0, single_user='alice', library=library)
+
+        mock_recommender_cls.assert_called_once_with('/path/to/config.yml', single_user='alice', library=library)
+
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+        """process_recommendations defaults library=None (legacy callers)."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0, single_user='alice')
+
+        mock_recommender_cls.assert_called_once_with('/path/to/config.yml', single_user='alice', library=None)
+
+
+class TestMainMediaTypeKey:
+    """Tests for main() passing media_type_key (#157 Phase 3)."""
+
+    @patch('recommenders.movie.run_recommender_main')
+    def test_main_passes_movie_media_type_key(self, mock_run_main):
+        main()
+
+        assert mock_run_main.call_count == 1
+        _, kwargs = mock_run_main.call_args
+        assert kwargs['media_type_key'] == 'movie'
+        assert kwargs['process_func'] is process_recommendations
 
 
 class TestPlexMovieRecommenderWatchedCount:

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock, patch, MagicMock
 from collections import Counter
 import json
 
-from recommenders.tv import ShowCache, PlexTVRecommender, format_show_output, adapt_root_config_to_legacy
+from recommenders.tv import (
+    ShowCache, PlexTVRecommender, format_show_output, adapt_root_config_to_legacy,
+    process_recommendations, main,
+)
 
 
 class TestShowCache:
@@ -189,6 +192,72 @@ class TestPlexTVRecommenderInit:
         recommender = PlexTVRecommender('/path/to/config.yml')
 
         assert recommender.library_title == 'My TV Shows'
+
+
+class TestPlexTVRecommenderLibraryParam:
+    """Tests for PlexTVRecommender library threading (#157 Phase 3)."""
+
+    @patch('recommenders.tv.ShowCache')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_library_forwarded_to_base(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """Test that the library param reaches BaseRecommender and sets
+        library_id/library_title from the library dict, not the legacy
+        tv_library config key."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'tv_library': 'TV Shows'},
+            'general': {},
+            'weights': {},
+            'libraries': [
+                {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'},
+                {'id': 'anime', 'name': 'Anime', 'section': 'Anime', 'media_type': 'tv'},
+            ],
+        }
+        mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_section = Mock()
+        mock_section.all.return_value = []
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+        mock_cache.return_value = Mock(cache={'shows': {}})
+
+        library = {'id': 'anime', 'name': 'Anime', 'section': 'Anime', 'media_type': 'tv'}
+        recommender = PlexTVRecommender('/path/to/config.yml', library=library)
+
+        assert recommender.library_id == 'anime'
+        assert recommender.library_title == 'Anime'
+
+    @patch('recommenders.tv.ShowCache')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_no_library_keeps_legacy_title(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache):
+        """library=None (default) resolves library_title from the legacy
+        tv_library config key, unchanged from before Phase 3."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc', 'tv_library': 'TV Shows'},
+            'general': {},
+            'weights': {}
+        }
+        mock_users.return_value = {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_section = Mock()
+        mock_section.all.return_value = []
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+        mock_cache.return_value = Mock(cache={'shows': {}})
+
+        recommender = PlexTVRecommender('/path/to/config.yml')
+
+        assert recommender.library_id is None
+        assert recommender.library_title == 'TV Shows'
 
 
 class TestPlexTVRecommenderWeights:
@@ -935,3 +1004,50 @@ class TestExtractGenresFromShow:
 
         assert 'drama' in result
         assert 'thriller' in result
+
+
+class TestProcessRecommendationsLibraryParam:
+    """Tests for process_recommendations library forwarding (#157 Phase 3)."""
+
+    @patch('recommenders.tv.PlexTVRecommender')
+    @patch('recommenders.tv.teardown_log_file')
+    @patch('recommenders.tv.setup_log_file')
+    def test_forwards_library_to_recommender(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+        """process_recommendations passes library through to
+        PlexTVRecommender's constructor unchanged."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        library = {'id': 'anime', 'name': 'Anime', 'section': 'Anime', 'media_type': 'tv'}
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0, single_user='alice', library=library)
+
+        mock_recommender_cls.assert_called_once_with('/path/to/config.yml', 'alice', library=library)
+
+    @patch('recommenders.tv.PlexTVRecommender')
+    @patch('recommenders.tv.teardown_log_file')
+    @patch('recommenders.tv.setup_log_file')
+    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+        """process_recommendations defaults library=None (legacy callers)."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0, single_user='alice')
+
+        mock_recommender_cls.assert_called_once_with('/path/to/config.yml', 'alice', library=None)
+
+
+class TestMainMediaTypeKey:
+    """Tests for main() passing media_type_key (#157 Phase 3)."""
+
+    @patch('recommenders.tv.run_recommender_main')
+    def test_main_passes_tv_media_type_key(self, mock_run_main):
+        main()
+
+        assert mock_run_main.call_count == 1
+        _, kwargs = mock_run_main.call_args
+        assert kwargs['media_type_key'] == 'tv'
+        assert kwargs['process_func'] is process_recommendations

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional
 import yaml
 from plexapi.myplex import MyPlexAccount
 
-from .config import __version__
+from .config import __version__, get_libraries_for_media_type
 from .display import (
     CYAN, GREEN, RESET,
     TeeLogger,
@@ -176,16 +176,26 @@ def run_recommender_main(
     media_type: str,
     description: str,
     adapt_config_func: Callable[[Dict], Dict],
-    process_func: Callable[[Dict, str, int, Optional[str]], None]
+    process_func: Callable[[Dict, str, int, Optional[str], Optional[Dict]], None],
+    media_type_key: str = 'movie'
 ):
     """
     Common main entry point for recommenders.
+
+    Loops library-outer, user-inner (#157 Phase 3): for each configured
+    library matching media_type_key, process every user against that
+    library. Single-library installs (no 'libraries:' config, or exactly
+    one library of this media type) synthesize a single library entry, so
+    this collapses back to the original one-loop-per-user behavior.
 
     Args:
         media_type: 'Movie' or 'TV Show' for display
         description: argparse description
         adapt_config_func: Function to adapt root config to media-specific format
-        process_func: Function to process recommendations for a user
+        process_func: Function to process recommendations for a user. Receives
+            (user_config, config_path, log_retention_days, resolved_user, library)
+        media_type_key: 'movie' or 'tv' - selects which libraries to loop over
+            (see utils.config.get_libraries_for_media_type)
     """
     # Ensure UTF-8 output
     if sys.stdout.encoding.lower() != 'utf-8':
@@ -195,6 +205,8 @@ def run_recommender_main(
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('username', nargs='?', help='Process recommendations for only this user')
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
+    parser.add_argument('--library', dest='library_id', default=None,
+                         help='Process recommendations for only this library id')
     args = parser.parse_args()
 
     start_time = datetime.now()
@@ -245,18 +257,37 @@ def run_recommender_main(
         log_error("No users configured. Please configure plex_users or managed_users in config.yml")
         sys.exit(1)
 
-    # Process each user
+    # Resolve libraries for this media type (#157 Phase 3). A single-library
+    # install (no 'libraries:' config, or exactly one explicit library of
+    # this media type) always resolves to exactly one entry here, so the
+    # loop below collapses to the original one-pass-per-user behavior.
+    libraries = get_libraries_for_media_type(base_config, media_type_key)
+
+    if args.library_id:
+        libraries = [lib for lib in libraries if lib.get('id') == args.library_id]
+        if not libraries:
+            log_error(f"Library '{args.library_id}' not found for media type '{media_type_key}'")
+            sys.exit(1)
+
+    multi_library = len(libraries) > 1
+
+    # Process each library x user
     plex_token = base_config.get('plex', {}).get('token', '')
-    for user in all_users:
-        print(f"\n{GREEN}Processing recommendations for user: {user}{RESET}")
-        print("-" * 50)
+    for library in libraries:
+        if multi_library:
+            print(f"\n{CYAN}=== Library: {library['name']} ==={RESET}")
+            print("-" * 50)
 
-        resolved_user = resolve_admin_username(user, plex_token)
-        user_config = update_config_for_user(base_config, resolved_user)
+        for user in all_users:
+            print(f"\n{GREEN}Processing recommendations for user: {user}{RESET}")
+            print("-" * 50)
 
-        process_func(user_config, config_path, log_retention_days, resolved_user)
+            resolved_user = resolve_admin_username(user, plex_token)
+            user_config = update_config_for_user(base_config, resolved_user)
 
-        print(f"\n{GREEN}Completed processing for user: {resolved_user}{RESET}")
-        print("-" * 50)
+            process_func(user_config, config_path, log_retention_days, resolved_user, library)
+
+            print(f"\n{GREEN}Completed processing for user: {resolved_user}{RESET}")
+            print("-" * 50)
 
     print_runtime(start_time)

--- a/utils/config.py
+++ b/utils/config.py
@@ -420,6 +420,12 @@ def adapt_config_for_media_type(root_config: Dict, media_type: str = 'movies') -
         'rating_multipliers': root_config.get('rating_multipliers', {}),
         'general': root_config.get('general', {}),
         'cache_dir': root_config.get('cache_dir', 'cache'),
+        # #157 Phase 3: pass through the raw multi-library config so
+        # get_libraries()/get_libraries_for_media_type() (called against this
+        # adapted config from utils/cli.py's per-library recommendation loop)
+        # see the real 'libraries' block instead of always falling back to
+        # the synthesized single-library default.
+        'libraries': root_config.get('libraries'),
     }
 
     # Add media-specific settings


### PR DESCRIPTION
## Summary
- Matrix loop: `utils/cli.py::run_recommender_main` now takes a `media_type_key` and loops library-outer/user-inner over `get_libraries_for_media_type(base_config, media_type_key)`, calling `process_func(user_config, config_path, log_retention_days, resolved_user, library)`. New optional `--library <id>` CLI flag restricts a run to one library.
- `recommenders/movie.py` / `tv.py`: `process_recommendations(..., library=None)` threads `library` into the recommender constructor; `main()` passes `media_type_key='movie'\'/`'tv'`.
- `recommenders/base.py::BaseRecommender.__init__` accepts `library=None`; when provided sets `self.library`/`self.library_id`/`self.library_title` from the library dict, else keeps the legacy `library_config_key` resolution.
- Cache keys: watched-cache and external-recs-cache filenames get a `{library_id}_` prefix **only** when a media type has more than one library; the shared `all_movies_cache.json`/`all_shows_cache.json` media-metadata cache is untouched (still shared per media type, as designed).
- Collection/label naming: Plex collection display name and internal label get a library-qualifying suffix **only** when >1 library shares that media type.
- `recommenders/external.py::process_user` gains `movie_library`/`tv_library` params, stamps `library_id` on every categorized recommendation item, and `main()` resolves the primary movie/tv library once per run and threads it through (documented deviation from a literal per-library loop - see PR discussion below).

## Single-library byte-identical proof
- `utils/config.py::adapt_config_for_media_type` now passes `libraries` through so the loop sees real multi-library config.
- No `libraries:` config (or exactly one library of a media type) -> `get_libraries_for_media_type` synthesizes exactly one entry -> the matrix loop collapses to one `process_func` call per user, same as before (`tests/test_cli.py::TestRunRecommenderMainLibraryMatrixLoop::test_single_library_install_matches_legacy_call_count`).
- Cache filenames and collection/label names stay unprefixed/unsuffixed even though the (single, synthesized) library object is now always passed through, because the is multi-library check counts sibling libraries for that media type, not whether a library object was passed (`tests/test_base.py::TestBaseRecommenderCacheLibraryPrefix`, `TestBaseRecommenderCollectionNaming`).
- `recommenders/external.py`: single-library install keeps exactly one `process_user()` call per user (`tests/test_external.py::TestMainLibraryResolution`), and cache filenames stay legacy (`TestExternalRecsCacheLibraryId`).

## Known deviation (documented in code)
`external.py::process_user` handles movies and shows together in one call (shared Trakt fetch, one combined markdown file per user). A literal `for library in libraries: for user in users` loop would call it twice per user for a single-library install and overwrite each user's markdown with partial data, or - if the top-level `library_id` were populated with the wrong media type's library id - silently break Sonarr/Radarr export routing in `external_exports.py::_resolve_library_groups` (Phase 2, unchanged), which reads `user_data['library_id']` for both movie and TV grouping without checking media type. Verified this concretely: stamping either the movie or tv library id there causes the *other* media type's export to resolve the wrong `*arr` instance. So `process_user` keeps its single-call-per-user shape, threads the primary movie/tv library through for cache-key/section resolution, stamps real per-item `library_id` provenance, and leaves the top-level `user_data['library_id']` at `None` (Phase 2's existing per-media-type fallback already routes this correctly). Full N-library fan-out for external recs is left to a future phase alongside making `_resolve_library_groups` media-type-aware.

## Untouched
- Export routing (`external_exports.py`) - unchanged.
- Web UI - unchanged.
- Trakt/mdblist/simkl - unchanged.
- Media-metadata cache (`all_movies_cache.json`/`all_shows_cache.json`) - stays shared per media type.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85` - 1511 passed, 89.75% coverage
- [x] `tests/test_cli.py`: single-library regression (call count + library object), 2 libraries x 2 users -> 4 calls, media_type_key selects the right libraries, `--library` filter + unknown-id exit
- [x] `tests/test_base.py`: library init, per-library cache-filename prefixing (incl. synthesized-single-library-passed-through case), collection/label naming
- [x] `tests/test_movie.py` / `tests/test_tv.py`: library forwarded through the recommender constructor and `process_recommendations`/`main()`
- [x] `tests/test_external.py`: per-library external-recs cache isolation, `_stamp_library_id`, `process_user` legacy vs multi-library behavior, `main()` single-library call count
- [x] gitleaks pre-push secret scan: clean