### PR TITLE
feat(#157) Phase 4: Libraries config screen

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,22 @@ users:
   preferences:
     alice:
       display_name: "Alice A"
+libraries:
+  - id: movies
+    name: Movies
+    section: Movies
+    media_type: movie
+    arr:
+      root_folder: /data/movies
+      quality_profile: HD-1080p
+      minimum_availability: released
+      instance:
+        url: "http://localhost:7878"
+        api_key: "not-a-real-radarr-key"
+  - id: tv-shows
+    name: TV Shows
+    section: TV Shows
+    media_type: tv
 '''
 
 

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -33,8 +33,6 @@ def _read_yaml(root, name):
 VALID_FORM = {
     'plex_url': 'http://localhost:32400',
     'plex_token': '',
-    'plex_movie_library': 'Movies',
-    'plex_tv_library': 'TV Shows',
     'tmdb_api_key': '',
     'tautulli_url': '',
     'tautulli_api_key': '',
@@ -75,8 +73,6 @@ class TestSave:
 
         core = _read_yaml(root, 'config')
         assert core['plex']['url'] == 'http://localhost:32400'
-        assert core['plex']['movie_library'] == 'Movies'
-        assert core['plex']['tv_library'] == 'TV Shows'
 
     def test_saves_sonarr_radarr_trakt_to_their_own_files(self, client):
         c, app, root = client
@@ -168,13 +164,6 @@ class TestValidation:
 
         after = _read_yaml(root, 'config')
         assert after == before
-
-    def test_missing_required_movie_library_rejected(self, client):
-        c, app, root = client
-        bad = dict(VALID_FORM)
-        bad['plex_movie_library'] = ''
-        resp = c.post('/config/connections', data=bad)
-        assert resp.status_code == 400
 
     def test_invalid_user_mode_rejected(self, client):
         c, app, root = client

--- a/tests/test_web_config_libraries.py
+++ b/tests/test_web_config_libraries.py
@@ -1,0 +1,244 @@
+"""Tests for the /config/libraries screen (#157 Phase 4): render existing
+libraries, edit/add/remove repeatable rows, per-library *arr routing +
+instance connection fields, validation (media_type/required/duplicate/
+at-least-one), instance api_key masking/blank-keeps-existing, and
+round-trip of unrelated config.yml keys (plex/users)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import yaml
+
+from web.app import create_app
+from web.config_io import module_path
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _read_config(root):
+    with open(module_path(root, 'config'), encoding='utf-8') as f:
+        return yaml.safe_load(f) or {}
+
+
+def _lib(libs, lib_id):
+    return next(l for l in libs if l['id'] == lib_id)
+
+
+# Base form for the two libraries seeded by tests/conftest.py's
+# curatarr_web_root fixture: 'movies' (movie, with an instance override
+# + api_key) and 'tv-shows' (tv, no overrides at all).
+def _base_form(**overrides):
+    form = {
+        'library_count': '2',
+        'library_id_0': 'movies',
+        'name_0': 'Movies',
+        'section_0': 'Movies',
+        'media_type_0': 'movie',
+        'arr_0_root_folder': '/data/movies',
+        'arr_0_quality_profile': 'HD-1080p',
+        'arr_0_tag': '',
+        'arr_0_minimum_availability': 'released',
+        'arr_0_series_type': '',
+        'instance_url_0': 'http://localhost:7878',
+        'instance_api_key_0': '',
+        'library_id_1': 'tv-shows',
+        'name_1': 'TV Shows',
+        'section_1': 'TV Shows',
+        'media_type_1': 'tv',
+        'arr_1_root_folder': '',
+        'arr_1_quality_profile': '',
+        'arr_1_tag': '',
+        'arr_1_minimum_availability': '',
+        'arr_1_series_type': '',
+        'instance_url_1': '',
+        'instance_api_key_1': '',
+        'new_name': '',
+        'new_section': '',
+        'new_media_type': 'movie',
+    }
+    form.update(overrides)
+    return form
+
+
+class TestGet:
+    def test_renders_existing_libraries_from_fixture(self, client):
+        c, app, root = client
+        resp = c.get('/config/libraries')
+        assert resp.status_code == 200
+        assert b'Movies' in resp.data
+        assert b'TV Shows' in resp.data
+
+    def test_shows_masked_secret_status_not_raw_value(self, client):
+        c, app, root = client
+        resp = c.get('/config/libraries')
+        assert b'not-a-real-radarr-key' not in resp.data
+        assert b'configured' in resp.data
+        assert b'not set' in resp.data  # tv-shows has no instance api_key
+
+    def test_no_libraries_block_shows_zero_rows_not_synthesized(self, tmp_path):
+        """The screen reads core.get('libraries') directly, NOT through
+        utils.config.get_libraries()'s legacy plex.movie_library/
+        tv_library synthesis fallback - an editor screen must never
+        silently materialize a synthesized pair into config.yml just
+        because someone opened it."""
+        root = tmp_path
+        (root / 'config').mkdir()
+        (root / 'config' / 'config.yml').write_text(
+            'plex:\n  url: "http://localhost:32400"\n  movie_library: Movies\n  tv_library: "TV Shows"\n',
+            encoding='utf-8',
+        )
+        (root / 'logs').mkdir()
+        app = create_app(project_root=str(root))
+        app.testing = True
+        c = app.test_client()
+
+        resp = c.get('/config/libraries')
+        assert resp.status_code == 200
+        assert b'No libraries configured yet' in resp.data
+
+
+class TestSave:
+    def test_edits_existing_library_routing(self, client):
+        c, app, root = client
+        form = _base_form(**{'arr_0_root_folder': '/data/movies-edited'})
+        resp = c.post('/config/libraries', data=form)
+        assert resp.status_code == 303
+
+        core = _read_config(root)
+        movies = _lib(core['libraries'], 'movies')
+        assert movies['arr']['root_folder'] == '/data/movies-edited'
+        assert movies['arr']['quality_profile'] == 'HD-1080p'
+
+    def test_edit_preserves_immutable_id_across_rename(self, client):
+        c, app, root = client
+        form = _base_form(**{'name_0': 'Feature Films', 'section_0': 'Feature Films'})
+        c.post('/config/libraries', data=form)
+
+        core = _read_config(root)
+        assert any(l['id'] == 'movies' and l['name'] == 'Feature Films' for l in core['libraries'])
+
+    def test_adds_new_library(self, client):
+        c, app, root = client
+        form = _base_form(**{'new_name': 'Anime', 'new_section': 'Anime', 'new_media_type': 'tv'})
+        c.post('/config/libraries', data=form)
+
+        core = _read_config(root)
+        assert len(core['libraries']) == 3
+        anime = _lib(core['libraries'], 'anime')
+        assert anime['name'] == 'Anime'
+        assert anime['media_type'] == 'tv'
+
+    def test_removes_a_library(self, client):
+        c, app, root = client
+        form = _base_form(**{'remove_1': 'on'})
+        resp = c.post('/config/libraries', data=form)
+        assert resp.status_code == 303
+
+        core = _read_config(root)
+        assert len(core['libraries']) == 1
+        assert core['libraries'][0]['id'] == 'movies'
+
+    def test_round_trip_preserves_unrelated_config_keys(self, client):
+        c, app, root = client
+        c.post('/config/libraries', data=_base_form(**{'arr_0_tag': 'Curatarr'}))
+
+        core = _read_config(root)
+        assert core['plex']['url'] == 'http://localhost:32400'
+        assert core['users']['list'] == 'alice, bob'
+        assert core['users']['preferences']['alice']['display_name'] == 'Alice A'
+
+
+class TestInstanceSecret:
+    def test_blank_api_key_on_resave_keeps_existing_value(self, client):
+        c, app, root = client
+        c.post('/config/libraries', data=_base_form(**{'instance_url_0': 'http://localhost:9999'}))
+
+        core = _read_config(root)
+        movies = _lib(core['libraries'], 'movies')
+        assert movies['arr']['instance']['api_key'] == 'not-a-real-radarr-key'
+        assert movies['arr']['instance']['url'] == 'http://localhost:9999'
+
+    def test_nonblank_api_key_overwrites(self, client):
+        c, app, root = client
+        c.post('/config/libraries', data=_base_form(**{'instance_api_key_0': 'brand-new-key'}))
+
+        core = _read_config(root)
+        movies = _lib(core['libraries'], 'movies')
+        assert movies['arr']['instance']['api_key'] == 'brand-new-key'
+
+    def test_new_library_api_key_not_leaked_from_another_row(self, client):
+        """A brand new row's id doesn't match any on-disk library, so a
+        blank instance_api_key on it must NOT pick up 'movies'' saved key."""
+        c, app, root = client
+        form = _base_form(**{
+            'new_name': 'Anime', 'new_section': 'Anime', 'new_media_type': 'tv',
+            'new_instance_url': 'http://localhost:8990',
+            'new_instance_api_key': '',
+        })
+        c.post('/config/libraries', data=form)
+
+        core = _read_config(root)
+        anime = _lib(core['libraries'], 'anime')
+        assert 'instance' not in anime.get('arr', {}) or 'api_key' not in anime['arr'].get('instance', {})
+
+    def test_never_renders_secret_after_save(self, client):
+        c, app, root = client
+        c.post('/config/libraries', data=_base_form(**{'instance_api_key_0': 'brand-new-key'}))
+        resp = c.get('/config/libraries')
+        assert b'brand-new-key' not in resp.data
+
+
+class TestValidation:
+    def test_invalid_media_type_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'media_type_0': 'not-a-type'}))
+        assert resp.status_code == 400
+
+    def test_missing_name_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'name_0': ''}))
+        assert resp.status_code == 400
+
+    def test_missing_section_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'section_0': ''}))
+        assert resp.status_code == 400
+
+    def test_invalid_instance_url_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'instance_url_0': 'not-a-url'}))
+        assert resp.status_code == 400
+
+    def test_duplicate_new_name_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{
+            'new_name': 'Movies', 'new_section': 'Movies 2', 'new_media_type': 'movie',
+        }))
+        assert resp.status_code == 400
+
+    def test_duplicate_rename_rejected(self, client):
+        """Renaming an existing row to collide with another existing
+        row's name must also be rejected, not just the add-fieldset case."""
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'name_1': 'Movies'}))
+        assert resp.status_code == 400
+
+    def test_removing_all_libraries_rejected(self, client):
+        c, app, root = client
+        resp = c.post('/config/libraries', data=_base_form(**{'remove_0': 'on', 'remove_1': 'on'}))
+        assert resp.status_code == 400
+
+    def test_invalid_input_does_not_corrupt_existing_file(self, client):
+        c, app, root = client
+        before = _read_config(root)
+        c.post('/config/libraries', data=_base_form(**{'media_type_0': 'not-a-type'}))
+        after = _read_config(root)
+        assert after == before

--- a/web/config_app.py
+++ b/web/config_app.py
@@ -26,15 +26,17 @@ it's left as a follow-up rather than bundled into this UI-only PR.
 """
 
 import logging
+import re
 from typing import Dict, Optional
 
 from flask import jsonify, redirect, render_template, request, url_for
-from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from utils.plex import MOVIE_RATING_HIERARCHY, TV_RATING_HIERARCHY
 
 from .config_io import (
     ensure_section,
+    existing_library_secret,
     format_csv_list,
     load_module,
     merge_secret,
@@ -50,6 +52,7 @@ from .config_validate import (
     validate_choice,
     validate_float,
     validate_int,
+    validate_media_type,
     validate_required,
     validate_url,
     validate_weights_sum,
@@ -60,6 +63,7 @@ logger = logging.getLogger('curatarr')
 USER_MODE_CHOICES = ('mapping', 'per_user', 'combined')
 LOG_LEVEL_CHOICES = ('DEBUG', 'INFO', 'WARNING', 'ERROR')
 RATING_CHOICES = MOVIE_RATING_HIERARCHY + TV_RATING_HIERARCHY
+MEDIA_TYPE_CHOICES = ('movie', 'tv')
 
 
 def _commit_modules(project_root: str, modules: Dict[str, CommentedMap]) -> Optional[str]:
@@ -203,6 +207,45 @@ def register_config_routes(app) -> None:
         return redirect(url_for('config_users', saved='1'), code=303)
 
     # -------------------------------------------------------------------
+    # Libraries (#157 Phase 4)
+    # -------------------------------------------------------------------
+
+    @app.get('/config/libraries')
+    def config_libraries():
+        core = load_module(module_path(project_root, 'config'))
+        return render_template(
+            'config_libraries.html',
+            saved=request.args.get('saved') == '1',
+            errors={},
+            **_libraries_view(core),
+        )
+
+    @app.post('/config/libraries')
+    def config_libraries_save():
+        core = load_module(module_path(project_root, 'config'))
+        errors: Dict[str, str] = {}
+        parsed = _parse_libraries_form(request.form, errors)
+
+        if errors:
+            return render_template(
+                'config_libraries.html',
+                saved=False,
+                errors=errors,
+                **_libraries_view(core, overrides=parsed),
+            ), 400
+
+        modules = _apply_libraries(project_root, core, parsed)
+        commit_error = _commit_modules(project_root, modules)
+        if commit_error:
+            return render_template(
+                'config_libraries.html',
+                saved=False,
+                errors={'_global': f'Could not save: {commit_error}'},
+                **_libraries_view(load_module(module_path(project_root, 'config'))),
+            ), 500
+        return redirect(url_for('config_libraries', saved='1'), code=303)
+
+    # -------------------------------------------------------------------
     # Settings / Tuning
     # -------------------------------------------------------------------
 
@@ -260,6 +303,14 @@ def register_config_routes(app) -> None:
 # =========================================================================
 # Connections screen
 # =========================================================================
+#
+# plex.movie_library/plex.tv_library are deliberately NOT fields on this
+# screen (#157 Phase 4 de-scope) - the Libraries screen (below) is now the
+# source of truth for repeatable library entries, including the movie/tv
+# split. utils.config.get_libraries()'s legacy-synthesis fallback still
+# reads plex.movie_library/tv_library for any hand-written config.yml that
+# predates the 'libraries:' block, so existing installs keep working
+# without this screen ever writing those two fields again.
 
 def _load_connections(project_root: str) -> Dict[str, CommentedMap]:
     return {
@@ -324,8 +375,6 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
     return {
         'plex': {
             'url': pick('plex', 'url', plex.get('url', '')),
-            'movie_library': pick('plex', 'movie_library', plex.get('movie_library', '')),
-            'tv_library': pick('plex', 'tv_library', plex.get('tv_library', '')),
             'token_status': secret_status(
                 merge_secret(plex.get('token'), o.get('plex', {}).get('token_submitted', ''))
                 if 'plex' in o else plex.get('token')
@@ -389,10 +438,6 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
 
     plex_url = form.get('plex_url', '').strip()
     validate_url(plex_url, 'plex_url', errors, required=True)
-    plex_movie_library = form.get('plex_movie_library', '').strip()
-    validate_required(plex_movie_library, 'plex_movie_library', errors, 'Movie library')
-    plex_tv_library = form.get('plex_tv_library', '').strip()
-    validate_required(plex_tv_library, 'plex_tv_library', errors, 'TV library')
 
     tautulli_enabled = flag('tautulli_enabled')
     tautulli_url = form.get('tautulli_url', '').strip()
@@ -423,8 +468,6 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
     return {
         'plex': {
             'url': plex_url,
-            'movie_library': plex_movie_library,
-            'tv_library': plex_tv_library,
             'token_submitted': form.get('plex_token', ''),
         },
         'tmdb': {
@@ -472,8 +515,6 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
 
     plex_section = ensure_section(core, 'plex')
     plex_section['url'] = parsed['plex']['url']
-    plex_section['movie_library'] = parsed['plex']['movie_library']
-    plex_section['tv_library'] = parsed['plex']['tv_library']
     plex_section['token'] = merge_secret(plex_section.get('token'), parsed['plex']['token_submitted'])
 
     tmdb_section = ensure_section(core, 'tmdb')
@@ -626,6 +667,272 @@ def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> Dict[st
         else:
             entry.pop('streaming_services', None)
 
+    return {'config': core}
+
+
+# =========================================================================
+# Libraries screen (#157 Phase 4)
+# =========================================================================
+#
+# Repeatable multi-library entries, matching utils.config.get_libraries's
+# 'libraries:' schema (see the block comment above it in utils/config.py):
+#
+#   libraries:
+#     - id: movies            # stable, immutable once created - see below
+#       name: Movies
+#       section: Movies
+#       media_type: movie
+#       arr:
+#         root_folder: /data/movies
+#         quality_profile: HD-1080p
+#         tag: Curatarr
+#         monitor: false
+#         search: false
+#         minimum_availability: released   # movie libraries only
+#         series_type: standard            # tv libraries only
+#         season_folder: true              # tv libraries only
+#         instance:
+#           url: http://localhost:7878
+#           api_key: KEY
+#
+# This screen reads/writes core.get('libraries') directly - NOT through
+# get_libraries() - because get_libraries()'s legacy-synthesis fallback
+# (plex.movie_library/tv_library -> two library entries) exists purely to
+# keep pre-#157 configs working at *run* time; materializing that
+# synthesized pair into config.yml just because someone opened this
+# *editor* screen would silently change what a hand-written config means.
+# An empty/missing 'libraries:' block here means exactly that: no
+# libraries defined yet, filled in via "Add a library" below.
+#
+# `id` is a stable identity used elsewhere (recommenders/base.py's
+# self.library_id, the movie/tv recommendation cache keys in
+# recommenders/external.py, utils.cli's --library-id) - editing a
+# library's display name must never change its id, or a rename would
+# silently orphan that library's cache/provenance history. So: existing
+# rows keep whatever id load from disk (round-tripped through a hidden
+# form field, immutable in this UI), and only a brand new row gets a
+# fresh id, derived from its name via _derive_library_id (mirroring
+# utils.config._slugify_library_id's derivation without importing that
+# module's private helper across a package boundary).
+
+def _derive_library_id(name: str) -> str:
+    slug = re.sub(r'[^a-z0-9]+', '-', (name or '').strip().lower()).strip('-')
+    return slug or 'library'
+
+
+def _arr_form_fields(prefix: str, form) -> Dict:
+    def flag(name: str) -> bool:
+        return form.get(name) in ('on', 'true', '1')
+
+    return {
+        'root_folder': form.get(f'{prefix}_root_folder', '').strip(),
+        'quality_profile': form.get(f'{prefix}_quality_profile', '').strip(),
+        'tag': form.get(f'{prefix}_tag', '').strip(),
+        'monitor': flag(f'{prefix}_monitor'),
+        'search': flag(f'{prefix}_search'),
+        'minimum_availability': form.get(f'{prefix}_minimum_availability', '').strip(),
+        'series_type': form.get(f'{prefix}_series_type', '').strip(),
+        'season_folder': flag(f'{prefix}_season_folder'),
+    }
+
+
+def _disk_library_row(entry: Dict) -> Dict:
+    entry = entry or {}
+    arr = entry.get('arr') or {}
+    instance = arr.get('instance') or {}
+    name = entry.get('name') or entry.get('id') or ''
+    return {
+        'id': entry.get('id') or _derive_library_id(name),
+        'name': name,
+        'section': entry.get('section') or name,
+        'media_type': entry.get('media_type') or 'movie',
+        'arr': {
+            'root_folder': arr.get('root_folder') or '',
+            'quality_profile': arr.get('quality_profile') or '',
+            'tag': arr.get('tag') or '',
+            'monitor': bool(arr.get('monitor', False)),
+            'search': bool(arr.get('search', False)),
+            'minimum_availability': arr.get('minimum_availability') or '',
+            'series_type': arr.get('series_type') or '',
+            'season_folder': bool(arr.get('season_folder', False)),
+        },
+        'instance_url': instance.get('url') or '',
+        'instance_api_key_status': secret_status(instance.get('api_key')),
+        'remove': False,
+    }
+
+
+def _libraries_view(core: CommentedMap, overrides: Optional[Dict] = None) -> Dict:
+    if overrides is None:
+        rows = [_disk_library_row(entry) for entry in (core.get('libraries') or [])]
+        return {
+            'libraries': rows,
+            'new_name': '',
+            'new_section': '',
+            'new_media_type': 'movie',
+            'media_type_choices': MEDIA_TYPE_CHOICES,
+        }
+
+    # Redisplay after a validation error: overrides['libraries'] already
+    # has the shape _parse_libraries_form produced below. Recompute each
+    # row's masked secret status the same way _connections_view does for
+    # 'token_status' - merging the on-disk secret (looked up by the
+    # row's immutable id) with whatever was just submitted - so the
+    # redisplay never echoes the raw submitted api_key and still shows
+    # what WOULD be saved if the errors were fixed and resubmitted.
+    rows = []
+    for row in overrides['libraries']:
+        status = secret_status(merge_secret(
+            existing_library_secret(core, row['id']),
+            row.get('instance_api_key_submitted', ''),
+        ))
+        rows.append({
+            'id': row['id'],
+            'name': row['name'],
+            'section': row['section'],
+            'media_type': row['media_type'],
+            'arr': row['arr'],
+            'instance_url': row['instance_url'],
+            'instance_api_key_status': status,
+            'remove': row['remove'],
+        })
+    return {
+        'libraries': rows,
+        'new_name': overrides.get('new_name', ''),
+        'new_section': overrides.get('new_section', ''),
+        'new_media_type': overrides.get('new_media_type', 'movie'),
+        'media_type_choices': MEDIA_TYPE_CHOICES,
+    }
+
+
+def _parse_libraries_form(form, errors: Dict[str, str]) -> Dict:
+    def flag(name: str) -> bool:
+        return form.get(name) in ('on', 'true', '1')
+
+    rows = []
+    count = int(form.get('library_count', '0') or '0')
+    for i in range(count):
+        library_id = form.get(f'library_id_{i}', '').strip()
+        name = form.get(f'name_{i}', '').strip()
+        section = form.get(f'section_{i}', '').strip()
+        media_type = form.get(f'media_type_{i}', 'movie')
+        instance_url = form.get(f'instance_url_{i}', '').strip()
+        remove = flag(f'remove_{i}')
+
+        validate_required(name, f'name_{i}', errors, 'Library name')
+        validate_required(section, f'section_{i}', errors, 'Plex section')
+        validate_media_type(media_type, f'media_type_{i}', errors)
+        validate_url(instance_url, f'instance_url_{i}', errors, required=False)
+
+        rows.append({
+            'id': library_id,
+            'name': name,
+            'section': section,
+            'media_type': media_type,
+            'arr': _arr_form_fields(f'arr_{i}', form),
+            'instance_url': instance_url,
+            'instance_api_key_submitted': form.get(f'instance_api_key_{i}', ''),
+            'remove': remove,
+        })
+
+    # Add a library: mirrors _parse_users_form's 'new_username' - a
+    # single always-blank-on-redisplay field, not part of the indexed
+    # loop above. A non-blank name here becomes a new row (arr/instance
+    # left blank, editable on a follow-up visit once it exists), same
+    # as a new user only gets a username until edited again.
+    new_name = form.get('new_name', '').strip()
+    if new_name:
+        new_section = form.get('new_section', '').strip()
+        new_media_type = form.get('new_media_type', 'movie')
+        validate_required(new_section, 'new_section', errors, 'Plex section')
+        validate_media_type(new_media_type, 'new_media_type', errors)
+
+        if any(r['name'] == new_name for r in rows if not r['remove']):
+            errors['new_name'] = f'{new_name} is already in the library list'
+
+        rows.append({
+            'id': None,
+            'name': new_name,
+            'section': new_section,
+            'media_type': new_media_type,
+            'arr': _arr_form_fields('new_arr', form),
+            'instance_url': form.get('new_instance_url', '').strip(),
+            'instance_api_key_submitted': form.get('new_instance_api_key', ''),
+            'remove': False,
+        })
+
+    # Duplicate name/derived-id check across every row that will
+    # actually be kept (post-remove). Existing rows keep their stable
+    # on-disk id; a brand new row (id is None here) previews the id
+    # _apply_libraries will assign it at save time, so a rename/add that
+    # collides with another library is caught before anything is
+    # written - not just a duplicate 'new_name' against the existing
+    # list, but any two kept rows colliding with each other.
+    seen_names, seen_ids = set(), set()
+    for i, row in enumerate(rows):
+        if row['remove'] or not row['name']:
+            continue
+        derived_id = row['id'] or _derive_library_id(row['name'])
+        if row['name'] in seen_names or derived_id in seen_ids:
+            key = 'new_name' if row['id'] is None else f'name_{i}'
+            errors.setdefault(key, f'"{row["name"]}" duplicates another library (name or id already in use)')
+        seen_names.add(row['name'])
+        seen_ids.add(derived_id)
+
+    if not any(not row['remove'] for row in rows):
+        errors['_global'] = 'At least one library is required.'
+
+    return {'libraries': rows, 'new_name': '', 'new_section': '', 'new_media_type': 'movie'}
+
+
+def _apply_libraries(project_root: str, core: CommentedMap, parsed: Dict) -> Dict[str, CommentedMap]:
+    """Mutate *core* in place and return it keyed by module name, WITHOUT
+    writing to disk - see _apply_connections' docstring for why."""
+    kept = [row for row in parsed['libraries'] if not row['remove']]
+
+    seq = CommentedSeq()
+    for row in kept:
+        library_id = row['id'] or _derive_library_id(row['name'])
+
+        entry = CommentedMap()
+        entry['id'] = library_id
+        entry['name'] = row['name']
+        entry['section'] = row['section']
+        entry['media_type'] = row['media_type']
+
+        arr_in = row['arr']
+        arr = CommentedMap()
+        if arr_in['root_folder']:
+            arr['root_folder'] = arr_in['root_folder']
+        if arr_in['quality_profile']:
+            arr['quality_profile'] = arr_in['quality_profile']
+        if arr_in['tag']:
+            arr['tag'] = arr_in['tag']
+        if arr_in['monitor']:
+            arr['monitor'] = arr_in['monitor']
+        if arr_in['search']:
+            arr['search'] = arr_in['search']
+        if row['media_type'] == 'movie' and arr_in['minimum_availability']:
+            arr['minimum_availability'] = arr_in['minimum_availability']
+        if row['media_type'] == 'tv' and arr_in['series_type']:
+            arr['series_type'] = arr_in['series_type']
+        if row['media_type'] == 'tv' and arr_in['season_folder']:
+            arr['season_folder'] = arr_in['season_folder']
+
+        instance = CommentedMap()
+        if row['instance_url']:
+            instance['url'] = row['instance_url']
+        api_key = merge_secret(existing_library_secret(core, library_id), row['instance_api_key_submitted'])
+        if api_key:
+            instance['api_key'] = api_key
+        if instance:
+            arr['instance'] = instance
+
+        if arr:
+            entry['arr'] = arr
+        seq.append(entry)
+
+    core['libraries'] = seq
     return {'config': core}
 
 

--- a/web/config_io.py
+++ b/web/config_io.py
@@ -181,6 +181,29 @@ def parse_csv_list(value: Optional[str]) -> list:
     return [item.strip() for item in value.split(',') if item.strip()]
 
 
+def existing_library_secret(core: CommentedMap, library_id: Optional[str]) -> str:
+    """Current arr.instance.api_key for the on-disk library whose id is
+    *library_id*, or '' if that id doesn't match any existing entry (a
+    brand new library row being added this submission) or has no
+    instance api_key configured.
+
+    Used by web.config_app's Libraries screen (_apply_libraries /
+    _libraries_view) so a blank instance_api_key submission keeps
+    whatever secret was already saved for that specific library row -
+    matched by its immutable id, not by list position, since rows can
+    be reordered/added/removed within the same submission.
+    """
+    if not library_id:
+        return ''
+    for entry in core.get('libraries') or []:
+        entry = entry or {}
+        if entry.get('id') == library_id:
+            arr = entry.get('arr') or {}
+            instance = arr.get('instance') or {}
+            return instance.get('api_key', '') or ''
+    return ''
+
+
 def format_csv_list(value) -> str:
     """Inverse of parse_csv_list, for pre-filling a text input from a
     YAML list (or a legacy comma-string) on GET."""

--- a/web/config_validate.py
+++ b/web/config_validate.py
@@ -47,6 +47,13 @@ def validate_choice(value: str, field: str, errors: Dict[str, str], choices) -> 
         errors[field] = f'Must be one of: {", ".join(choices)}'
 
 
+def validate_media_type(value: str, field: str, errors: Dict[str, str]) -> None:
+    """Thin wrapper over validate_choice for the Libraries screen's
+    media_type field (#157 Phase 4) - kept separate from the generic
+    helper so the ('movie', 'tv') choice set has one place to change."""
+    validate_choice(value, field, errors, ('movie', 'tv'))
+
+
 def validate_float(value, field: str, errors: Dict[str, str], lo: float = None,
                     hi: float = None, label: str = None) -> Optional[float]:
     """Parse *value* as a float, recording an error and returning None on

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -14,6 +14,7 @@
       <a href="{{ url_for('run_form') }}">Run</a>
       <a href="{{ url_for('results') }}">Results</a>
       <a href="{{ url_for('config_connections') }}">Connections</a>
+      <a href="{{ url_for('config_libraries') }}">Libraries</a>
       <a href="{{ url_for('config_users') }}">Users</a>
       <a href="{{ url_for('config_settings') }}">Settings</a>
     </nav>

--- a/web/templates/config_connections.html
+++ b/web/templates/config_connections.html
@@ -23,15 +23,10 @@
       <input type="password" name="plex_token" placeholder="Leave blank to keep existing" autocomplete="off">
     </label>
 
-    <label>Movie library
-      <input type="text" name="plex_movie_library" value="{{ plex.movie_library }}">
-    </label>
-    {% if errors.plex_movie_library %}<p class="field-error">{{ errors.plex_movie_library }}</p>{% endif %}
-
-    <label>TV library
-      <input type="text" name="plex_tv_library" value="{{ plex.tv_library }}">
-    </label>
-    {% if errors.plex_tv_library %}<p class="field-error">{{ errors.plex_tv_library }}</p>{% endif %}
+    <p class="muted">
+      Movie/TV libraries are now configured on the
+      <a href="{{ url_for('config_libraries') }}">Libraries</a> screen.
+    </p>
 
     <button type="button" class="test-connection" data-service="plex"
             data-field-map='{"url": "plex_url", "token": "plex_token"}'>Test Connection</button>

--- a/web/templates/config_libraries.html
+++ b/web/templates/config_libraries.html
@@ -1,0 +1,109 @@
+{% extends 'base.html' %}
+{% block title %}Libraries - Curatarr{% endblock %}
+{% block content %}
+<h1>Libraries</h1>
+
+{% if saved %}
+<p class="banner running">Saved.</p>
+{% endif %}
+{% if errors['_global'] %}
+<p class="banner error">{{ errors['_global'] }}</p>
+{% endif %}
+
+<p class="muted">
+  Each Plex library (movies or TV) curatarr scans and generates recommendations for. Every
+  library can route to its own Radarr/Sonarr instance and folder/quality/tag settings here -
+  any field left blank falls back to the global Sonarr/Radarr connection on the
+  <a href="{{ url_for('config_connections') }}">Connections</a> screen.
+</p>
+
+<form method="post" action="{{ url_for('config_libraries_save') }}" class="config-form">
+  <input type="hidden" name="library_count" value="{{ libraries|length }}">
+
+  <table class="status-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Plex section</th>
+        <th>Media type</th>
+        <th>Root folder</th>
+        <th>Quality profile</th>
+        <th>Tag</th>
+        <th>Monitor</th>
+        <th>Search</th>
+        <th>Min. availability (movie)</th>
+        <th>Series type (tv)</th>
+        <th>Season folders (tv)</th>
+        <th>Instance URL</th>
+        <th>Instance API key</th>
+        <th>Remove</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for lib in libraries %}
+      <tr>
+        <td>
+          <input type="hidden" name="library_id_{{ loop.index0 }}" value="{{ lib.id }}">
+          <input type="text" name="name_{{ loop.index0 }}" value="{{ lib.name }}">
+          {% if errors['name_' ~ loop.index0] %}<p class="field-error">{{ errors['name_' ~ loop.index0] }}</p>{% endif %}
+        </td>
+        <td>
+          <input type="text" name="section_{{ loop.index0 }}" value="{{ lib.section }}">
+          {% if errors['section_' ~ loop.index0] %}<p class="field-error">{{ errors['section_' ~ loop.index0] }}</p>{% endif %}
+        </td>
+        <td>
+          <select name="media_type_{{ loop.index0 }}">
+            {% for choice in media_type_choices %}
+            <option value="{{ choice }}" {% if lib.media_type == choice %}selected{% endif %}>{{ choice }}</option>
+            {% endfor %}
+          </select>
+          {% if errors['media_type_' ~ loop.index0] %}<p class="field-error">{{ errors['media_type_' ~ loop.index0] }}</p>{% endif %}
+        </td>
+        <td><input type="text" name="arr_{{ loop.index0 }}_root_folder" value="{{ lib.arr.root_folder }}" placeholder="(use global)"></td>
+        <td><input type="text" name="arr_{{ loop.index0 }}_quality_profile" value="{{ lib.arr.quality_profile }}" placeholder="(use global)"></td>
+        <td><input type="text" name="arr_{{ loop.index0 }}_tag" value="{{ lib.arr.tag }}" placeholder="(use global)"></td>
+        <td><input type="checkbox" name="arr_{{ loop.index0 }}_monitor" {% if lib.arr.monitor %}checked{% endif %}></td>
+        <td><input type="checkbox" name="arr_{{ loop.index0 }}_search" {% if lib.arr.search %}checked{% endif %}></td>
+        <td><input type="text" name="arr_{{ loop.index0 }}_minimum_availability" value="{{ lib.arr.minimum_availability }}" placeholder="(use global)"></td>
+        <td><input type="text" name="arr_{{ loop.index0 }}_series_type" value="{{ lib.arr.series_type }}" placeholder="(use global)"></td>
+        <td><input type="checkbox" name="arr_{{ loop.index0 }}_season_folder" {% if lib.arr.season_folder %}checked{% endif %}></td>
+        <td>
+          <input type="text" name="instance_url_{{ loop.index0 }}" value="{{ lib.instance_url }}" placeholder="(use global Sonarr/Radarr)">
+          {% if errors['instance_url_' ~ loop.index0] %}<p class="field-error">{{ errors['instance_url_' ~ loop.index0] }}</p>{% endif %}
+        </td>
+        <td>
+          <span class="muted">{{ lib.instance_api_key_status }}</span>
+          <input type="password" name="instance_api_key_{{ loop.index0 }}" placeholder="Leave blank to keep existing" autocomplete="off">
+        </td>
+        <td><label><input type="checkbox" name="remove_{{ loop.index0 }}"> remove</label></td>
+      </tr>
+      {% else %}
+      <tr><td colspan="14">No libraries configured yet - add one below.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <fieldset>
+    <legend>Add a library</legend>
+    <label>Name
+      <input type="text" name="new_name" value="{{ new_name }}" placeholder="Kids Movies">
+    </label>
+    {% if errors.new_name %}<p class="field-error">{{ errors.new_name }}</p>{% endif %}
+    <label>Plex section
+      <input type="text" name="new_section" value="{{ new_section }}" placeholder="Kids Movies">
+    </label>
+    {% if errors.new_section %}<p class="field-error">{{ errors.new_section }}</p>{% endif %}
+    <label>Media type
+      <select name="new_media_type">
+        {% for choice in media_type_choices %}
+        <option value="{{ choice }}" {% if new_media_type == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if errors.new_media_type %}<p class="field-error">{{ errors.new_media_type }}</p>{% endif %}
+    <p class="muted">Routing (folder/quality/tag/instance) and monitor/search can be filled in after adding.</p>
+  </fieldset>
+
+  <button type="submit">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds /config/libraries: add/edit/remove repeatable library rows (name, Plex section, media_type, per-library Radarr/Sonarr routing, optional per-library *arr instance override), mirroring the Users screen's repeatable-row pattern.
- Reads/writes config.yml's libraries: block directly (not through get_libraries()'s legacy plex.movie_library/tv_library synthesis fallback), so opening the editor never silently materializes a synthesized pair for a hand-written config.
- Library id (used elsewhere for cache/provenance) is immutable once created - a rename never orphans history; duplicate name/id checks run across the full kept row set before anything is written.
- De-scopes plex.movie_library/tv_library from the Connections screen.

## Test plan
- [x] New tests/test_web_config_libraries.py (20 tests): GET render, edit/add/remove, media_type + required-field validation (400 + redisplay, file untouched), instance api_key blank-keeps-existing (matched by id, not leaked across rows), round-trip of unrelated config.yml keys, duplicate-name/rename rejection, >=1-library rule, secret masking, no-libraries-block shows zero rows (not synthesized).
- [x] tests/conftest.py fixture updated with a libraries: block; tests/test_web_config_connections.py updated for the removed movie/tv-library fields.
- [x] Full suite: 1530 passed, 89.82% coverage (>=85% gate).
- [x] gitleaks clean on the branch diff.