### PR TITLE
docs: multi-library + what's new (v2.8.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.25] - 2026-07-23
+
+### Added
+- **Multiple Plex libraries** (#157): Each Plex library is now a first-class entity with its own Sonarr/Radarr routing - per-library root folder, quality profile, tags, monitor/search, and optionally a separate *arr instance. Recommendations (in-library Plex collections and external -> Sonarr/Radarr suggestions) run per-library, so Movies, TV, Anime, and Kids can each follow their own rules and land in their own destinations from a single instance. Existing single-library configs auto-migrate on first run. Manage via the new **Libraries** screen (`/config/libraries`) or the `libraries:` list in `config.yml`
+- **Web UI**: Run curatarr from the browser (`http://127.0.0.1:8787`) - dashboard, run-with-live-log, results, and config screens for connections/users/settings/libraries. CLI/cron flow is unchanged
+- **One-click binaries for every platform**: Windows (x64), macOS (universal - Intel + Apple Silicon), and Linux (x64 + arm64) downloads, each with a SHA256 checksum - no Python or terminal required
+
+### Changed
+- Auto-update now verifies a signed release tag (fail-closed) before applying
+
+### Security
+- Patched `requests` CVE; dependencies pinned and hash-locked
+- Added secret-scanning (gitleaks) gate on every push
+
 ## [2.8.20] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Your Plex library has thousands of titles. Your users have watched maybe 10% of 
 
 ### For You (Simple & Robust)
 - **One command** — `./run.sh` handles everything
+- **Multi-library support** — Each Plex library gets its own Sonarr/Radarr root folder, quality profile, tags, monitor/search, and optionally its own *arr instance; recommendations run per-library so Movies, TV, Anime, and Kids each follow their own rules
 - **Modular config** — Main settings plus optional integration files
 - **Auto-updates** — Applies SSH-signed release updates from GitHub on each run (optional)
 - **Smart caching** — Auto-clears incompatible caches after updates
@@ -132,6 +133,9 @@ hand-editing YAML:
   decay, rating multipliers, negative signals, external recommendation limits,
   and the Sonarr/Radarr/Trakt auto-sync safety toggles (surfaced with a warning -
   turning auto-sync on starts writing to your download clients on every run).
+- **Libraries** (`/config/libraries`) - manage multiple Plex libraries, each
+  with its own Sonarr/Radarr root folder, quality profile, tags, monitor/search
+  behavior, and optionally its own *arr instance.
 
 Secrets (tokens/API keys) are never shown once saved - fields show a
 "configured" / "not set" status, and you only need to enter a new value to


### PR DESCRIPTION
## Summary
- Add multi-library support to the README Features list and document the new Libraries config screen (`/config/libraries`)
- Add a v2.8.25 CHANGELOG entry covering multi-library routing (#157), the web UI, full-platform binaries, and auto-update/security hardening

## Test plan
- [x] Docs-only change, no code touched
