### PR TITLE
test: include recommenders/ in coverage + cover the #157 rec-engine paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.26] - 2026-07-23
+
+### Changed
+- Coverage measurement now includes `recommenders/` (base/movie/tv/external/external_exports/external_output) - previously the CI `--cov=.` run already collected these modules, but they were the main drag on the 90% total. Added ~120 unit tests covering the core recommendation engine and #157 per-library logic: label/collection management and candidate scoring in `base.py` (61% -> 96%), watched-history collection and rating-tier weighting in `movie.py`/`tv.py` (56%/54% -> 92%/94%), and the `process_user_movie_library`/`process_user_tv_library` per-library fan-out plus `_resolve_library_groups` routing in `external.py`/`external_exports.py`. Overall coverage 90% -> 92%. `external.py`'s HTML/markdown/watchlist generation and `external_exports.py`'s MDBList/Simkl/Trakt-sync exports remain thin (largely untested) - out of scope for this pass, flagged for follow-up
+
 ## [2.8.25] - 2026-07-23
 
 ### Added

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,6 +3,7 @@ Tests for recommenders/base.py - Base cache and recommender classes.
 """
 
 import os
+import copy
 import pytest
 import requests
 import plexapi.exceptions
@@ -333,6 +334,7 @@ class TestBaseCacheGetTmdbData:
 class ConcreteRecommender(BaseRecommender):
     """Concrete implementation of BaseRecommender for testing."""
     media_type = 'movie'
+    media_key = 'movies'
     library_config_key = 'movie_library'
     default_library_name = 'Movies'
 
@@ -1072,3 +1074,810 @@ class TestBaseRecommenderCollectionNaming:
         assert mock_build_label.called
         base_label_arg = mock_build_label.call_args[0][0]
         assert base_label_arg == 'Recommended_movies-4k'
+
+
+# ------------------------------------------------------------------------
+# Core recommendation-engine coverage: label management, candidate scoring,
+# and the TMDB/IMDb id-resolution chain shared by movie.py and tv.py.
+# ------------------------------------------------------------------------
+
+class ConcreteTVRecommender(BaseRecommender):
+    """Concrete TV implementation of BaseRecommender for testing shared logic."""
+    media_type = 'tv'
+    media_key = 'shows'
+    library_config_key = 'tv_library'
+    default_library_name = 'TV Shows'
+
+    def _load_weights(self, weights_config):
+        return {'genre': 0.5, 'actor': 0.5}
+
+    def _get_watched_data(self):
+        return {'genres': Counter(), 'actors': Counter()}
+
+    def _get_watched_count(self):
+        return 0
+
+    def _save_watched_cache(self):
+        pass
+
+    def _get_media_cache(self):
+        return Mock()
+
+    def _find_plex_item(self, section, rec):
+        return None
+
+    def _calculate_similarity_from_cache(self, item_info):
+        return (0.5, {})
+
+    def _print_similarity_breakdown(self, item_info, score, breakdown):
+        pass
+
+
+def _make_recommender(config=None, users=None, library=None, recommender_cls=ConcreteRecommender,
+                       config_path='/path/to/config.yml'):
+    """Build a fully-initialized recommender with Plex/TMDB/config init mocked out.
+
+    Deep-copies the config so tests are free to mutate recommender.config
+    without polluting the shared module-level fixture dicts.
+    """
+    config = copy.deepcopy(config if config is not None else SINGLE_MOVIE_LIBRARY_CONFIG)
+    users = users or {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+    with patch('recommenders.base.load_config', return_value=config), \
+         patch('recommenders.base.get_configured_users', return_value=users), \
+         patch('recommenders.base.get_tmdb_config', return_value={'use_keywords': True, 'api_key': 'key'}), \
+         patch('recommenders.base.init_plex', return_value=Mock()), \
+         patch('os.makedirs'):
+        return recommender_cls(config_path, library=library)
+
+
+class TestGetManagedUsersWatchedData:
+    """Tests for BaseRecommender._get_managed_users_watched_data."""
+
+    def test_returns_cached_data_when_not_single_user(self):
+        recommender = _make_recommender()
+        recommender.watched_data_counters = {'genres': Counter({'a': 1})}
+        result = recommender._get_managed_users_watched_data()
+        assert result == recommender.watched_data_counters
+
+    def test_returns_cached_data_when_single_user(self):
+        recommender = _make_recommender()
+        recommender.single_user = 'alice'
+        recommender.watched_data_counters = {'genres': Counter({'a': 1})}
+        result = recommender._get_managed_users_watched_data()
+        assert result == recommender.watched_data_counters
+
+    @patch('recommenders.base.MyPlexAccount')
+    def test_admin_user_uses_direct_plex_connection(self, mock_account_cls):
+        recommender = _make_recommender(users={'plex_users': [], 'managed_users': ['admin'], 'admin_user': 'admin'})
+        recommender.watched_data_counters = {}
+        recommender.plex = Mock()
+        item = Mock(ratingKey='10')
+        recommender.plex.library.section.return_value.search.return_value = [item]
+        media_cache = Mock()
+        media_cache.cache = {'movies': {'10': {'tmdb_id': 555}}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+
+        result = recommender._get_managed_users_watched_data()
+
+        assert 10 in recommender.watched_ids
+        assert 555 in result['tmdb_ids']
+        mock_account_cls.return_value.user.assert_not_called()
+
+    @patch('recommenders.base.MyPlexAccount')
+    def test_non_admin_user_switches_user(self, mock_account_cls):
+        recommender = _make_recommender(users={'plex_users': [], 'managed_users': ['bob'], 'admin_user': 'admin'})
+        recommender.watched_data_counters = {}
+        recommender.plex = Mock()
+        switched_plex = Mock()
+        recommender.plex.switchUser.return_value = switched_plex
+        switched_plex.library.section.return_value.search.return_value = []
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+
+        recommender._get_managed_users_watched_data()
+
+        recommender.plex.switchUser.assert_called_once()
+
+    @patch('recommenders.base.log_error')
+    @patch('recommenders.base.MyPlexAccount')
+    def test_user_processing_error_continues_to_next_user(self, mock_account_cls, mock_log_error):
+        recommender = _make_recommender(
+            users={'plex_users': [], 'managed_users': ['bob', 'admin'], 'admin_user': 'admin'}
+        )
+        recommender.watched_data_counters = {}
+        recommender.plex = Mock()
+        recommender.plex.switchUser.side_effect = plexapi.exceptions.PlexApiException("fail")
+        recommender.plex.library.section.return_value.search.return_value = []
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+
+        recommender._get_managed_users_watched_data()
+
+        mock_log_error.assert_called()
+
+    @patch('recommenders.base.MyPlexAccount')
+    def test_single_user_admin_alias_uses_admin_user(self, mock_account_cls):
+        recommender = _make_recommender(users={'plex_users': [], 'managed_users': [], 'admin_user': 'admin'})
+        recommender.single_user = 'Administrator'
+        recommender.watched_data_counters = {}
+        recommender.plex = Mock()
+        recommender.plex.library.section.return_value.search.return_value = []
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+
+        recommender._get_managed_users_watched_data()
+
+        recommender.plex.switchUser.assert_not_called()
+
+
+class TestFindPlexItemsForRecs:
+    """Tests for BaseRecommender._find_plex_items_for_recs."""
+
+    def test_finds_by_rating_key(self):
+        recommender = _make_recommender()
+        recommender.plex = Mock()
+        found_item = Mock()
+        recommender.plex.fetchItem.return_value = found_item
+        section = Mock()
+        selected = [{'title': 'A', 'year': 2020, 'plex_rating_key': 123}]
+
+        items_found, skipped = recommender._find_plex_items_for_recs(section, selected)
+
+        assert items_found == [found_item]
+        assert skipped == []
+        found_item.reload.assert_called_once()
+
+    def test_falls_back_to_fuzzy_search_on_fetch_error(self):
+        recommender = _make_recommender()
+        recommender.plex = Mock()
+        recommender.plex.fetchItem.side_effect = Exception("not found")
+        found_item = Mock()
+        recommender._find_plex_item = Mock(return_value=found_item)
+        section = Mock()
+        selected = [{'title': 'A', 'year': 2020, 'plex_rating_key': 123}]
+
+        items_found, skipped = recommender._find_plex_items_for_recs(section, selected)
+
+        assert items_found == [found_item]
+        recommender._find_plex_item.assert_called_once_with(section, selected[0])
+
+    def test_no_rating_key_uses_fuzzy_search(self):
+        recommender = _make_recommender()
+        recommender.plex = Mock()
+        recommender._find_plex_item = Mock(return_value=None)
+        section = Mock()
+        selected = [{'title': 'Missing', 'year': 2019}]
+
+        items_found, skipped = recommender._find_plex_items_for_recs(section, selected)
+
+        assert items_found == []
+        assert skipped == ['Missing (2019)']
+
+
+class TestRemoveOutdatedLabels:
+    """Tests for BaseRecommender._remove_outdated_labels."""
+
+    @patch('recommenders.base.remove_labels_from_items')
+    @patch('recommenders.base.categorize_labeled_items')
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_removes_watched_and_excluded_returns_fresh(self, mock_excl, mock_categorize, mock_remove):
+        recommender = _make_recommender()
+        section = Mock()
+        fresh_item, watched_item, excluded_item = Mock(), Mock(), Mock()
+        section.search.return_value = [fresh_item, watched_item, excluded_item]
+        mock_categorize.return_value = {
+            'fresh': [fresh_item], 'watched': [watched_item], 'excluded': [excluded_item], 'stale': []
+        }
+
+        result = recommender._remove_outdated_labels(section, 'Recommended_alice', 7)
+
+        assert result == [fresh_item]
+        assert mock_remove.call_count == 2
+        reasons = {call.args[3] for call in mock_remove.call_args_list}
+        assert reasons == {'watched', 'excluded genre'}
+
+
+class TestBuildScoredCandidates:
+    """Tests for BaseRecommender._build_scored_candidates."""
+
+    def test_scores_labeled_items_from_cache(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {'1': {'title': 'A'}}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender._calculate_similarity_from_cache = Mock(return_value=(0.8, {}))
+        labeled_item = Mock(ratingKey=1, title='A')
+
+        result = recommender._build_scored_candidates([labeled_item], [], [])
+
+        assert result[1] == (labeled_item, 0.8)
+
+    def test_labeled_item_not_in_cache_gets_zero_score(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        labeled_item = Mock(ratingKey=2, title='B')
+
+        result = recommender._build_scored_candidates([labeled_item], [], [])
+
+        assert result[2] == (labeled_item, 0.0)
+
+    def test_scoring_exception_defaults_to_zero(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {'3': {'title': 'C'}}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender._calculate_similarity_from_cache = Mock(side_effect=Exception("boom"))
+        labeled_item = Mock(ratingKey=3, title='C')
+
+        result = recommender._build_scored_candidates([labeled_item], [], [])
+
+        assert result[3] == (labeled_item, 0.0)
+
+    def test_selected_items_matched_by_rating_key(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = set()
+        plex_item = Mock(ratingKey=5, isPlayed=False)
+        selected = [{'title': 'D', 'year': 2021, 'plex_rating_key': 5, 'similarity_score': 0.6}]
+
+        result = recommender._build_scored_candidates([], selected, [plex_item])
+
+        assert result[5] == (plex_item, 0.6)
+
+    def test_selected_items_fallback_title_year_match(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = set()
+        plex_item = Mock(ratingKey=6, title='E', year=2018, isPlayed=False)
+        selected = [{'title': 'E', 'year': 2018, 'similarity_score': 0.4}]
+
+        result = recommender._build_scored_candidates([], selected, [plex_item])
+
+        assert result[6] == (plex_item, 0.4)
+
+    def test_watched_selected_item_excluded(self):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': {}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = {7}
+        plex_item = Mock(ratingKey=7, isPlayed=False)
+        selected = [{'title': 'F', 'year': 2020, 'plex_rating_key': 7, 'similarity_score': 0.9}]
+
+        result = recommender._build_scored_candidates([], selected, [plex_item])
+
+        assert 7 not in result
+
+
+class TestFilterCandidatesByRating:
+    """Tests for BaseRecommender._filter_candidates_by_rating."""
+
+    def test_no_max_rating_returns_unchanged(self):
+        recommender = _make_recommender()
+        candidates = {1: (Mock(), 0.5)}
+
+        result = recommender._filter_candidates_by_rating(candidates, None)
+
+        assert result is candidates
+
+    @patch('recommenders.base.is_rating_allowed')
+    def test_filters_disallowed_ratings(self, mock_allowed):
+        recommender = _make_recommender()
+        allowed_item = Mock(contentRating='PG-13')
+        blocked_item = Mock(contentRating='R')
+        mock_allowed.side_effect = lambda rating, max_rating, media_type: rating == 'PG-13'
+        candidates = {1: (allowed_item, 0.5), 2: (blocked_item, 0.7)}
+
+        result = recommender._filter_candidates_by_rating(candidates, 'PG-13')
+
+        assert 1 in result
+        assert 2 not in result
+
+
+class TestUpdateLabelsByRank:
+    """Tests for BaseRecommender._update_labels_by_rank."""
+
+    @patch('recommenders.base.add_labels_to_items')
+    @patch('recommenders.base.remove_labels_from_items')
+    def test_keeps_top_scoring_and_evicts_rest(self, mock_remove, mock_add):
+        recommender = _make_recommender()
+        item_high = Mock(ratingKey=1)
+        item_low = Mock(ratingKey=2)
+        item_new = Mock(ratingKey=3)
+        candidates = {1: (item_high, 0.9), 2: (item_low, 0.1), 3: (item_new, 0.8)}
+        unwatched_labeled = [item_high, item_low]
+
+        result = recommender._update_labels_by_rank(candidates, unwatched_labeled, 'Recommended_alice', target_count=2)
+
+        result_keys = {int(i.ratingKey) for i in result}
+        assert result_keys == {1, 3}
+        mock_remove.assert_called_once()
+        mock_add.assert_called_once()
+
+    @patch('recommenders.base.add_labels_to_items')
+    @patch('recommenders.base.remove_labels_from_items')
+    def test_no_changes_when_already_optimal(self, mock_remove, mock_add):
+        recommender = _make_recommender()
+        item = Mock(ratingKey=1)
+        candidates = {1: (item, 0.9)}
+
+        result = recommender._update_labels_by_rank(candidates, [item], 'Recommended_alice', target_count=1)
+
+        mock_remove.assert_not_called()
+        mock_add.assert_not_called()
+        assert result == [item]
+
+
+class TestSyncPlexCollectionEmpty:
+    """Tests for BaseRecommender._sync_plex_collection with no items."""
+
+    @patch('recommenders.base.update_plex_collection')
+    def test_returns_false_when_no_final_items(self, mock_update):
+        recommender = _make_recommender()
+
+        result = recommender._sync_plex_collection(Mock(), 'Recommended_alice', [])
+
+        assert result is False
+        mock_update.assert_not_called()
+
+
+class TestManagePlexLabelsFullFlow:
+    """Tests for BaseRecommender.manage_plex_labels orchestration."""
+
+    def _base_recommender(self, users=None):
+        users = users or {'plex_users': ['alice'], 'managed_users': [], 'admin_user': 'admin'}
+        recommender = _make_recommender(users=users)
+        recommender.plex = Mock()
+        recommender.config['collections'] = {
+            'add_label': True, 'label_name': 'Recommended',
+            'append_usernames': False, 'private_collections': False,
+        }
+        recommender.confirm_operations = False
+        recommender._find_plex_items_for_recs = Mock(return_value=([Mock()], []))
+        recommender._remove_outdated_labels = Mock(return_value=[])
+        recommender._build_scored_candidates = Mock(return_value={1: (Mock(), 0.9)})
+        recommender._update_labels_by_rank = Mock(return_value=[Mock()])
+        recommender._sync_plex_collection = Mock(return_value=True)
+        recommender._save_watched_cache = Mock()
+        return recommender
+
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_happy_path_returns_sync_result(self, mock_build_label):
+        recommender = self._base_recommender()
+
+        result = recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        assert result is True
+        recommender._sync_plex_collection.assert_called_once()
+
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_no_items_found_returns_false(self, mock_build_label):
+        recommender = self._base_recommender()
+        recommender._find_plex_items_for_recs = Mock(return_value=([], ['Skipped Movie (2020)']))
+
+        result = recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        assert result is False
+        recommender._sync_plex_collection.assert_not_called()
+
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_confirm_operations_uses_user_selection(self, mock_build_label):
+        recommender = self._base_recommender()
+        recommender.confirm_operations = True
+        recommender._user_select_recommendations = Mock(return_value=[{'title': 'Movie', 'year': 2020}])
+
+        recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        recommender._user_select_recommendations.assert_called_once()
+
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_confirm_operations_empty_selection_passes_empty_list(self, mock_build_label):
+        recommender = self._base_recommender()
+        recommender.confirm_operations = True
+        recommender._user_select_recommendations = Mock(return_value=[])
+
+        recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        args = recommender._find_plex_items_for_recs.call_args[0]
+        assert args[1] == []
+
+    @patch('recommenders.base.apply_user_label_restrictions')
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_private_collections_applies_restrictions(self, mock_build_label, mock_apply):
+        recommender = self._base_recommender()
+        recommender.config['collections']['private_collections'] = True
+
+        recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        mock_apply.assert_called_once()
+
+    @patch('recommenders.base.get_max_rating_for_user', return_value='PG-13')
+    @patch('recommenders.base.build_label_name', return_value='Recommended_alice')
+    def test_max_rating_filters_candidates(self, mock_build_label, mock_max_rating):
+        recommender = self._base_recommender()
+        recommender._filter_candidates_by_rating = Mock(return_value={1: (Mock(), 0.9)})
+
+        recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        recommender._filter_candidates_by_rating.assert_called_once()
+
+    def test_no_recommendations_returns_false(self):
+        recommender = self._base_recommender()
+
+        result = recommender.manage_plex_labels([])
+
+        assert result is False
+
+    def test_add_label_disabled_returns_false(self):
+        recommender = self._base_recommender()
+        recommender.config['collections']['add_label'] = False
+
+        result = recommender.manage_plex_labels([{'title': 'Movie'}])
+
+        assert result is False
+
+
+class TestManagePlexLabelsExceptionHandling:
+    """Tests for BaseRecommender.manage_plex_labels error handling."""
+
+    def test_plex_exception_returns_false(self):
+        recommender = _make_recommender(users={'plex_users': ['alice'], 'managed_users': [], 'admin_user': 'admin'})
+        recommender.plex = Mock()
+        recommender.plex.library.section.side_effect = plexapi.exceptions.PlexApiException("boom")
+
+        result = recommender.manage_plex_labels([{'title': 'Movie', 'year': 2020}])
+
+        assert result is False
+
+
+class TestGetPlexItemTmdbId:
+    """Tests for BaseRecommender._get_plex_item_tmdb_id cache-miss path."""
+
+    @patch('recommenders.base.get_tmdb_id_for_item')
+    def test_cache_miss_saves_and_returns_id(self, mock_get_id):
+        recommender = _make_recommender()
+        recommender._save_watched_cache = Mock()
+        mock_get_id.return_value = 999
+        plex_item = Mock(ratingKey='42')
+
+        result = recommender._get_plex_item_tmdb_id(plex_item)
+
+        assert result == 999
+        assert recommender.plex_tmdb_cache['42'] == 999
+        recommender._save_watched_cache.assert_called_once()
+
+    @patch('recommenders.base.get_tmdb_id_for_item')
+    def test_cache_miss_no_id_found_does_not_save(self, mock_get_id):
+        recommender = _make_recommender()
+        recommender._save_watched_cache = Mock()
+        mock_get_id.return_value = None
+        plex_item = Mock(ratingKey='42')
+
+        result = recommender._get_plex_item_tmdb_id(plex_item)
+
+        assert result is None
+        recommender._save_watched_cache.assert_not_called()
+
+
+class TestGetPlexItemImdbId:
+    """Tests for BaseRecommender._get_plex_item_imdb_id fallback chain."""
+
+    @patch('recommenders.base.extract_ids_from_guids')
+    def test_returns_imdb_from_guids(self, mock_extract):
+        recommender = _make_recommender()
+        mock_extract.return_value = {'imdb_id': 'tt111', 'tmdb_id': None}
+
+        result = recommender._get_plex_item_imdb_id(Mock())
+
+        assert result == 'tt111'
+
+    @patch('recommenders.base.extract_ids_from_guids')
+    def test_falls_back_to_legacy_guid_attribute(self, mock_extract):
+        recommender = _make_recommender()
+        mock_extract.return_value = {'imdb_id': None, 'tmdb_id': None}
+        plex_item = Mock(guid='imdb://tt222')
+
+        result = recommender._get_plex_item_imdb_id(plex_item)
+
+        assert result == 'tt222'
+
+    @patch('recommenders.base.fetch_tmdb_with_retry')
+    @patch('recommenders.base.extract_ids_from_guids')
+    def test_falls_back_to_tmdb_movie_lookup(self, mock_extract, mock_fetch):
+        recommender = _make_recommender()  # media_type == 'movie'
+        mock_extract.return_value = {'imdb_id': None, 'tmdb_id': None}
+        recommender._get_plex_item_tmdb_id = Mock(return_value=555)
+        mock_fetch.return_value = {'imdb_id': 'tt333'}
+        plex_item = Mock(guid=None)
+
+        result = recommender._get_plex_item_imdb_id(plex_item)
+
+        assert result == 'tt333'
+        assert 'movie/555' in mock_fetch.call_args[0][0]
+
+    @patch('recommenders.base.fetch_tmdb_with_retry')
+    @patch('recommenders.base.extract_ids_from_guids')
+    def test_falls_back_to_tmdb_tv_external_ids(self, mock_extract, mock_fetch):
+        recommender = _make_recommender(recommender_cls=ConcreteTVRecommender)
+        mock_extract.return_value = {'imdb_id': None, 'tmdb_id': None}
+        recommender._get_plex_item_tmdb_id = Mock(return_value=555)
+        mock_fetch.return_value = {'imdb_id': 'tt444'}
+        plex_item = Mock(guid=None)
+
+        result = recommender._get_plex_item_imdb_id(plex_item)
+
+        assert result == 'tt444'
+        assert 'tv/555/external_ids' in mock_fetch.call_args[0][0]
+
+    @patch('recommenders.base.extract_ids_from_guids')
+    def test_returns_none_when_no_tmdb_id_available(self, mock_extract):
+        recommender = _make_recommender()
+        mock_extract.return_value = {'imdb_id': None, 'tmdb_id': None}
+        recommender._get_plex_item_tmdb_id = Mock(return_value=None)
+        plex_item = Mock(guid=None)
+
+        result = recommender._get_plex_item_imdb_id(plex_item)
+
+        assert result is None
+
+
+class TestGetTmdbIdViaImdb:
+    """Tests for BaseRecommender._get_tmdb_id_via_imdb."""
+
+    @patch('recommenders.base.fetch_tmdb_with_retry')
+    def test_returns_tmdb_id_for_movie(self, mock_fetch):
+        recommender = _make_recommender()
+        recommender._get_plex_item_imdb_id = Mock(return_value='tt123')
+        recommender.tmdb_api_key = 'key'
+        mock_fetch.return_value = {'movie_results': [{'id': 42}]}
+
+        result = recommender._get_tmdb_id_via_imdb(Mock())
+
+        assert result == 42
+
+    def test_returns_none_without_imdb_id(self):
+        recommender = _make_recommender()
+        recommender._get_plex_item_imdb_id = Mock(return_value=None)
+
+        result = recommender._get_tmdb_id_via_imdb(Mock())
+
+        assert result is None
+
+    @patch('recommenders.base.fetch_tmdb_with_retry')
+    def test_returns_none_when_no_results(self, mock_fetch):
+        recommender = _make_recommender()
+        recommender._get_plex_item_imdb_id = Mock(return_value='tt123')
+        recommender.tmdb_api_key = 'key'
+        mock_fetch.return_value = {'movie_results': []}
+
+        result = recommender._get_tmdb_id_via_imdb(Mock())
+
+        assert result is None
+
+
+class TestGetTmdbKeywordsForId:
+    """Tests for BaseRecommender._get_tmdb_keywords_for_id."""
+
+    def test_returns_empty_set_without_tmdb_id(self):
+        recommender = _make_recommender()
+
+        assert recommender._get_tmdb_keywords_for_id(None) == set()
+
+    def test_returns_empty_set_when_keywords_disabled(self):
+        recommender = _make_recommender()
+        recommender.use_tmdb_keywords = False
+
+        assert recommender._get_tmdb_keywords_for_id(123) == set()
+
+    @patch('recommenders.base.get_tmdb_keywords')
+    def test_fetches_and_saves_keywords(self, mock_keywords):
+        recommender = _make_recommender()
+        recommender._save_watched_cache = Mock()
+        mock_keywords.return_value = ['a', 'b']
+
+        result = recommender._get_tmdb_keywords_for_id(123)
+
+        assert result == {'a', 'b'}
+        recommender._save_watched_cache.assert_called_once()
+
+
+class TestGetRecommendationsBranches:
+    """Additional branch coverage for BaseRecommender.get_recommendations."""
+
+    def _recommender_with_cache(self, items):
+        recommender = _make_recommender()
+        media_cache = Mock()
+        media_cache.cache = {'movies': items}
+        media_cache._save_cache = Mock()
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = set()
+        recommender.profile_hash = 'hash1'
+        recommender.exclude_genres = []
+        recommender.user_preferences = {}
+        recommender.randomize_recommendations = False
+        return recommender, media_cache
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_quality_filter_excludes_low_rated(self, mock_excl):
+        items = {
+            '1': {'title': 'Good', 'rating': 8.0, 'vote_count': 500, 'genres': []},
+            '2': {'title': 'Bad', 'rating': 2.0, 'vote_count': 5, 'genres': []},
+        }
+        recommender, media_cache = self._recommender_with_cache(items)
+        recommender.config['quality_filters'] = {'min_rating': 5.0, 'min_vote_count': 100}
+
+        result = recommender.get_recommendations()
+
+        titles = [i['title'] for i in result['plex_recommendations']]
+        assert 'Bad' not in titles
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_uses_cached_score_when_profile_hash_matches(self, mock_excl):
+        items = {'1': {'title': 'Cached', 'rating': 8, 'vote_count': 500, 'genres': [],
+                        'profile_hash': 'hash1', 'cached_score': 0.77, 'score_breakdown': {}}}
+        recommender, media_cache = self._recommender_with_cache(items)
+        recommender._calculate_similarity_from_cache = Mock(side_effect=AssertionError("should not recompute"))
+
+        result = recommender.get_recommendations()
+
+        assert result['plex_recommendations'][0]['similarity_score'] == 0.77
+        media_cache._save_cache.assert_not_called()
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_scoring_error_skips_item(self, mock_excl):
+        items = {'1': {'title': 'Bad Score', 'rating': 8, 'vote_count': 500, 'genres': []}}
+        recommender, media_cache = self._recommender_with_cache(items)
+        recommender._calculate_similarity_from_cache = Mock(side_effect=KeyError('boom'))
+
+        result = recommender.get_recommendations()
+
+        assert result['plex_recommendations'] == []
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_no_unwatched_items_returns_empty(self, mock_excl):
+        recommender, media_cache = self._recommender_with_cache({})
+
+        result = recommender.get_recommendations()
+
+        assert result == {'plex_recommendations': []}
+
+    @patch('recommenders.base.select_tiered_recommendations')
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_randomize_recommendations_uses_tiered_selection(self, mock_excl, mock_tiered):
+        items = {'1': {'title': 'A', 'rating': 8, 'vote_count': 500, 'genres': []}}
+        recommender, media_cache = self._recommender_with_cache(items)
+        recommender.randomize_recommendations = True
+        mock_tiered.return_value = [items['1']]
+
+        recommender.get_recommendations()
+
+        mock_tiered.assert_called_once()
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_debug_logging_prints_breakdown(self, mock_excl):
+        items = {'1': {'title': 'A', 'rating': 8, 'vote_count': 500, 'genres': []}}
+        recommender, media_cache = self._recommender_with_cache(items)
+        recommender._print_similarity_breakdown = Mock()
+        with patch('recommenders.base.logger') as mock_logger:
+            mock_logger.isEnabledFor.return_value = True
+            recommender.get_recommendations()
+
+        recommender._print_similarity_breakdown.assert_called()
+
+    @patch('recommenders.base.get_excluded_genres_for_user', return_value=[])
+    def test_refreshes_watched_data_when_ids_missing(self, mock_excl):
+        recommender, media_cache = self._recommender_with_cache({})
+        recommender.cached_watched_count = 5
+        recommender.watched_ids = set()
+        recommender._get_watched_data = Mock(return_value={'genres': {}})
+        recommender._save_watched_cache = Mock()
+
+        recommender.get_recommendations()
+
+        recommender._get_watched_data.assert_called_once()
+        recommender._save_watched_cache.assert_called_once()
+
+    @patch('recommenders.base.get_excluded_genres_for_user')
+    def test_excluded_genres_filtered_and_counted(self, mock_excl):
+        mock_excl.return_value = ['horror']
+        items = {
+            '1': {'title': 'Scary', 'rating': 8, 'vote_count': 500, 'genres': ['Horror']},
+            '2': {'title': 'Fine', 'rating': 8, 'vote_count': 500, 'genres': ['Comedy']},
+        }
+        recommender, media_cache = self._recommender_with_cache(items)
+
+        result = recommender.get_recommendations()
+
+        titles = [i['title'] for i in result['plex_recommendations']]
+        assert titles == ['Fine']
+
+
+class TestLoadWatchedCache:
+    """Tests for BaseRecommender._load_watched_cache."""
+
+    def _recommender_with_cache_path(self, tmp_path):
+        recommender = _make_recommender()
+        recommender.watched_cache_path = str(tmp_path / 'watched_cache.json')
+        return recommender
+
+    @patch('recommenders.base.check_cache_version', return_value=False)
+    def test_invalid_cache_version_returns_empty_without_reading_file(self, mock_valid, tmp_path):
+        recommender = self._recommender_with_cache_path(tmp_path)
+        with open(recommender.watched_cache_path, 'w') as f:
+            f.write('{"watched_count": 3}')
+
+        result = recommender._load_watched_cache()
+
+        assert result == {}
+        assert recommender.cached_watched_count == 0
+
+    @patch('recommenders.base.check_cache_version', return_value=True)
+    def test_loads_valid_cache_fields(self, mock_valid, tmp_path):
+        recommender = self._recommender_with_cache_path(tmp_path)
+        cache_data = {
+            'watched_count': 2,
+            'watched_data_counters': {'genres': {'Action': 2}},
+            'plex_tmdb_cache': {1: 100},
+            'tmdb_keywords_cache': {100: ['x']},
+            'label_dates': {'a': '2024-01-01'},
+            'watched_movie_ids': [1, 2],
+        }
+        import json as _json
+        with open(recommender.watched_cache_path, 'w') as f:
+            _json.dump(cache_data, f)
+
+        result = recommender._load_watched_cache()
+
+        assert recommender.cached_watched_count == 2
+        assert recommender.watched_ids == {1, 2}
+        assert recommender.plex_tmdb_cache == {'1': 100}
+        assert result['watched_count'] == 2
+
+    @patch('recommenders.base.log_warning')
+    @patch('recommenders.base.check_cache_version', return_value=True)
+    def test_invalid_watched_ids_format_warns_and_clears(self, mock_valid, mock_warn, tmp_path):
+        recommender = self._recommender_with_cache_path(tmp_path)
+        cache_data = {'watched_count': 0, 'watched_movie_ids': 'not-a-list'}
+        import json as _json
+        with open(recommender.watched_cache_path, 'w') as f:
+            _json.dump(cache_data, f)
+
+        recommender._load_watched_cache()
+
+        mock_warn.assert_called()
+        assert recommender.watched_ids == set()
+
+    @patch('recommenders.base.check_cache_version', return_value=True)
+    def test_missing_ids_with_positive_count_triggers_refresh(self, mock_valid, tmp_path):
+        recommender = self._recommender_with_cache_path(tmp_path)
+        cache_data = {'watched_count': 5, 'watched_movie_ids': []}
+        import json as _json
+        with open(recommender.watched_cache_path, 'w') as f:
+            _json.dump(cache_data, f)
+        recommender._refresh_watched_data = Mock()
+
+        recommender._load_watched_cache()
+
+        recommender._refresh_watched_data.assert_called_once()
+
+    @patch('recommenders.base.log_warning')
+    @patch('recommenders.base.check_cache_version', return_value=True)
+    def test_corrupt_json_triggers_refresh(self, mock_valid, mock_warn, tmp_path):
+        recommender = self._recommender_with_cache_path(tmp_path)
+        with open(recommender.watched_cache_path, 'w') as f:
+            f.write('{not valid json')
+        recommender._refresh_watched_data = Mock()
+
+        recommender._load_watched_cache()
+
+        mock_warn.assert_called()
+        recommender._refresh_watched_data.assert_called_once()

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -2085,6 +2085,285 @@ class TestProcessUserTvLibrary:
         assert mock_markdown.call_args.kwargs['library_suffix'] == '_anime'
 
 
+class TestProcessUserMovieLibraryBranches:
+    """Additional branch coverage for process_user_movie_library: language
+    filtering, in-library/ignore-list cache pruning, Trakt watchlist
+    exclusion, discovery, and above-limit cache trimming (#157 Phase 3.5)."""
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.find_similar_content_with_profile')
+    @patch('recommenders.external.get_authenticated_trakt_client')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_exercises_filter_discovery_and_trim_branches(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile, mock_enhance,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_get_trakt,
+        mock_find_similar, mock_categorize, mock_markdown
+    ):
+        mock_get_items.return_value = {'titles': {('in library movie', 2018)}, 'tmdb_ids': {777}}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_enhance.side_effect = lambda profile, *a, **kw: profile
+        mock_load_ignore.return_value = {'Ignored Movie'}
+        mock_load_cache.return_value = {
+            '1': {'tmdb_id': 1, 'title': 'Foreign Movie', 'year': 2015, 'rating': 6.0,
+                  'vote_count': 100, 'score': 0.5, 'original_language': 'fr'},
+            '777': {'tmdb_id': 777, 'title': 'in library movie', 'year': 2018, 'rating': 7.0,
+                    'vote_count': 200, 'score': 0.7, 'original_language': 'en'},
+            '2': {'tmdb_id': 2, 'title': 'Ignored Movie', 'year': 2016, 'rating': 6.5,
+                  'vote_count': 150, 'score': 0.6, 'original_language': 'en'},
+            '3': {'tmdb_id': 3, 'title': 'Existing Movie', 'year': 2019, 'rating': 7.2,
+                  'vote_count': 300, 'score': 0.5, 'original_language': 'en'},
+        }
+        mock_get_trakt.return_value = Mock(get_watchlist_imdb_ids=Mock(return_value={'tt999'}))
+        mock_find_similar.return_value = [
+            {'tmdb_id': 3, 'title': 'Existing Movie', 'year': 2019, 'rating': 7.5,
+             'vote_count': 350, 'score': 0.95, 'original_language': 'en'},
+            {'tmdb_id': 4, 'title': 'New Movie', 'year': 2021, 'rating': 8.0,
+             'vote_count': 400, 'score': 0.9, 'original_language': 'en'},
+            {'tmdb_id': 5, 'title': 'Another New Movie', 'year': 2022, 'rating': 8.2,
+             'vote_count': 420, 'score': 0.85, 'original_language': 'en'},
+        ]
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'movie_limit': 2, 'min_relevance_score': 0.65, 'language': 'en'},
+            'streaming_services': [], 'trakt': {'import': {'exclude_watchlist': True}},
+            'libraries': [library],
+        }
+
+        result = process_user_movie_library(config, Mock(), 'alice', library)
+
+        mock_find_similar.assert_called_once()
+        assert mock_find_similar.call_args.kwargs['exclude_imdb_ids'] == {'tt999'}
+        # Cache trimmed back down to movie_limit (2) after discovery added 3 items
+        saved_cache = mock_save_cache.call_args[0][2]
+        assert len(saved_cache) == 2
+        assert result['library_id'] == 'movies'
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.build_user_profile')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_builds_profile_when_no_cached_profile(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_build_profile,
+        mock_categorize, mock_markdown
+    ):
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = None
+        mock_load_ignore.return_value = set()
+        mock_load_cache.return_value = {'100': {
+            'tmdb_id': 100, 'title': 'Cached Movie', 'year': 2020,
+            'rating': 7.5, 'vote_count': 500, 'score': 0.9, 'original_language': 'en'
+        }}
+        mock_build_profile.return_value = {'genres': {}}
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'movie_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [], 'trakt': {},
+            'libraries': [library],
+        }
+
+        process_user_movie_library(config, Mock(), 'alice', library)
+
+        mock_build_profile.assert_called_once()
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_skips_enhance_when_user_not_in_export_mapping(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_enhance,
+        mock_categorize, mock_markdown
+    ):
+        """When export.user_mode='mapping' and plex_users is set but doesn't
+        include this user, Trakt enhancement is skipped for them."""
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_load_ignore.return_value = set()
+        mock_load_cache.return_value = {'100': {
+            'tmdb_id': 100, 'title': 'Cached Movie', 'year': 2020,
+            'rating': 7.5, 'vote_count': 500, 'score': 0.9, 'original_language': 'en'
+        }}
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'movies', 'name': 'Movies', 'section': 'Movies', 'media_type': 'movie'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'movie_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [],
+            'trakt': {'export': {'user_mode': 'mapping', 'plex_users': ['bob']}},
+            'libraries': [library],
+        }
+
+        process_user_movie_library(config, Mock(), 'alice', library)
+
+        mock_enhance.assert_not_called()
+
+
+class TestProcessUserTvLibraryBranches:
+    """Additional branch coverage for process_user_tv_library: language
+    filtering, in-library/ignore-list cache pruning, Trakt watchlist
+    exclusion, discovery, and above-limit cache trimming (#157 Phase 3.5)."""
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.find_similar_content_with_profile')
+    @patch('recommenders.external.get_authenticated_trakt_client')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_exercises_filter_discovery_and_trim_branches(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile, mock_enhance,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_get_trakt,
+        mock_find_similar, mock_categorize, mock_markdown
+    ):
+        mock_get_items.return_value = {'titles': {('in library show', 2018)}, 'tmdb_ids': {777}}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_enhance.side_effect = lambda profile, *a, **kw: profile
+        mock_load_ignore.return_value = {'Ignored Show'}
+        mock_load_cache.return_value = {
+            '1': {'tmdb_id': 1, 'title': 'Foreign Show', 'year': 2015, 'rating': 6.0,
+                  'vote_count': 100, 'score': 0.5, 'original_language': 'fr'},
+            '777': {'tmdb_id': 777, 'title': 'in library show', 'year': 2018, 'rating': 7.0,
+                    'vote_count': 200, 'score': 0.7, 'original_language': 'en'},
+            '2': {'tmdb_id': 2, 'title': 'Ignored Show', 'year': 2016, 'rating': 6.5,
+                  'vote_count': 150, 'score': 0.6, 'original_language': 'en'},
+            '3': {'tmdb_id': 3, 'title': 'Existing Show', 'year': 2019, 'rating': 7.2,
+                  'vote_count': 300, 'score': 0.5, 'original_language': 'en'},
+        }
+        mock_get_trakt.return_value = Mock(get_watchlist_imdb_ids=Mock(return_value={'tt888'}))
+        mock_find_similar.return_value = [
+            {'tmdb_id': 3, 'title': 'Existing Show', 'year': 2019, 'rating': 7.5,
+             'vote_count': 350, 'score': 0.95, 'original_language': 'en'},
+            {'tmdb_id': 4, 'title': 'New Show', 'year': 2021, 'rating': 8.0,
+             'vote_count': 400, 'score': 0.9, 'original_language': 'en'},
+            {'tmdb_id': 5, 'title': 'Another New Show', 'year': 2022, 'rating': 8.2,
+             'vote_count': 420, 'score': 0.85, 'original_language': 'en'},
+        ]
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'show_limit': 2, 'min_relevance_score': 0.65, 'language': 'en'},
+            'streaming_services': [], 'trakt': {'import': {'exclude_watchlist': True}},
+            'libraries': [library],
+        }
+
+        result = process_user_tv_library(config, Mock(), 'alice', library)
+
+        mock_find_similar.assert_called_once()
+        assert mock_find_similar.call_args.kwargs['exclude_imdb_ids'] == {'tt888'}
+        saved_cache = mock_save_cache.call_args[0][2]
+        assert len(saved_cache) == 2
+        assert result['library_id'] == 'tv-shows'
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.build_user_profile')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_builds_profile_when_no_cached_profile(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_build_profile,
+        mock_categorize, mock_markdown
+    ):
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = None
+        mock_load_ignore.return_value = set()
+        mock_load_cache.return_value = {'200': {
+            'tmdb_id': 200, 'title': 'Cached Show', 'year': 2019,
+            'rating': 8.0, 'vote_count': 300, 'score': 0.9, 'original_language': 'en'
+        }}
+        mock_build_profile.return_value = {'genres': {}}
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'show_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [], 'trakt': {},
+            'libraries': [library],
+        }
+
+        process_user_tv_library(config, Mock(), 'alice', library)
+
+        mock_build_profile.assert_called_once()
+
+    @patch('recommenders.external.generate_markdown')
+    @patch('recommenders.external.categorize_by_streaming_service')
+    @patch('recommenders.external.enhance_profile_with_trakt')
+    @patch('recommenders.external.save_cache')
+    @patch('recommenders.external.load_cache')
+    @patch('recommenders.external.load_ignore_list')
+    @patch('recommenders.external.load_user_profile_from_cache')
+    @patch('recommenders.external.get_tmdb_config')
+    @patch('recommenders.external.get_library_items')
+    def test_skips_enhance_when_user_not_in_export_mapping(
+        self, mock_get_items, mock_get_tmdb, mock_load_profile,
+        mock_load_ignore, mock_load_cache, mock_save_cache, mock_enhance,
+        mock_categorize, mock_markdown
+    ):
+        mock_get_items.return_value = {'titles': set(), 'tmdb_ids': set()}
+        mock_get_tmdb.return_value = {'api_key': 'fake_key', 'use_keywords': True}
+        mock_load_profile.return_value = {'genres': {}}
+        mock_load_ignore.return_value = set()
+        mock_load_cache.return_value = {'200': {
+            'tmdb_id': 200, 'title': 'Cached Show', 'year': 2019,
+            'rating': 8.0, 'vote_count': 300, 'score': 0.9, 'original_language': 'en'
+        }}
+        mock_categorize.side_effect = _fanout_categorize_side_effect
+
+        library = {'id': 'tv-shows', 'name': 'TV Shows', 'section': 'TV Shows', 'media_type': 'tv'}
+        config = {
+            'plex': {}, 'users': {'preferences': {}},
+            'external_recommendations': {'show_limit': 1, 'min_relevance_score': 0.65},
+            'streaming_services': [],
+            'trakt': {'export': {'user_mode': 'mapping', 'plex_users': ['bob']}},
+            'libraries': [library],
+        }
+
+        process_user_tv_library(config, Mock(), 'alice', library)
+
+        mock_enhance.assert_not_called()
+
+
 class TestTVMovieGenreDetection:
     """Tests for TV movie (special) genre detection"""
 

--- a/tests/test_external_exports.py
+++ b/tests/test_external_exports.py
@@ -19,6 +19,7 @@ from recommenders.external_exports import (
     export_to_sonarr,
     export_to_mdblist,
     export_to_simkl,
+    _resolve_library_groups,
 )
 
 
@@ -883,3 +884,68 @@ class TestExportToSimkl:
         export_to_simkl(config, [], 'api_key')
 
         mock_create.assert_called_once()
+
+
+class TestResolveLibraryGroupsDirect:
+    """Direct unit tests for _resolve_library_groups (#157 Phase 2/3.5
+    per-library *arr export routing/grouping)."""
+
+    @patch('recommenders.external_exports.get_libraries_for_media_type')
+    def test_no_library_id_uses_first_candidate(self, mock_get_libs):
+        movie_lib = {'id': 'movies', 'name': 'Movies', 'media_type': 'movie'}
+        mock_get_libs.return_value = [movie_lib]
+        users = [{'username': 'alice'}, {'username': 'bob'}]
+
+        result = _resolve_library_groups({}, users, 'movie')
+
+        assert result == [(movie_lib, users)]
+
+    @patch('recommenders.external_exports.log_warning')
+    @patch('recommenders.external_exports.get_libraries_for_media_type', return_value=[])
+    def test_no_library_id_and_no_candidates_drops_group(self, mock_get_libs, mock_warn):
+        users = [{'username': 'alice'}]
+
+        result = _resolve_library_groups({}, users, 'movie')
+
+        assert result == []
+        mock_warn.assert_called_once()
+
+    @patch('recommenders.external_exports.get_libraries_for_media_type')
+    def test_explicit_library_id_resolves_matching_library(self, mock_get_libs):
+        movies = {'id': 'movies', 'name': 'Movies', 'media_type': 'movie'}
+        movies_4k = {'id': 'movies-4k', 'name': 'Movies 4K', 'media_type': 'movie'}
+        mock_get_libs.return_value = [movies, movies_4k]
+        users = [{'username': 'alice', 'library_id': 'movies-4k'}]
+
+        result = _resolve_library_groups({}, users, 'movie')
+
+        assert result == [(movies_4k, users)]
+
+    @patch('recommenders.external_exports.log_warning')
+    @patch('recommenders.external_exports.get_libraries_for_media_type')
+    def test_unknown_library_id_drops_group(self, mock_get_libs, mock_warn):
+        movies = {'id': 'movies', 'name': 'Movies', 'media_type': 'movie'}
+        mock_get_libs.return_value = [movies]
+        users = [{'username': 'alice', 'library_id': 'nonexistent'}]
+
+        result = _resolve_library_groups({}, users, 'movie')
+
+        assert result == []
+        mock_warn.assert_called_once()
+
+    @patch('recommenders.external_exports.get_libraries_for_media_type')
+    def test_multiple_groups_resolved_independently(self, mock_get_libs):
+        movies = {'id': 'movies', 'name': 'Movies', 'media_type': 'movie'}
+        movies_4k = {'id': 'movies-4k', 'name': 'Movies 4K', 'media_type': 'movie'}
+        mock_get_libs.return_value = [movies, movies_4k]
+        users = [
+            {'username': 'alice', 'library_id': 'movies'},
+            {'username': 'bob', 'library_id': 'movies-4k'},
+            {'username': 'carol', 'library_id': 'movies'},
+        ]
+
+        result = _resolve_library_groups({}, users, 'movie')
+
+        result_by_lib = {lib['id']: group for lib, group in result}
+        assert {u['username'] for u in result_by_lib['movies']} == {'alice', 'carol'}
+        assert {u['username'] for u in result_by_lib['movies-4k']} == {'bob'}

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -3,6 +3,7 @@ Tests for recommenders/movie.py - Movie recommendation system.
 """
 
 import os
+import copy
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from collections import Counter
@@ -1010,3 +1011,332 @@ class TestPlexMovieRecommenderLibraryImdbIds:
 
         assert 'tt1234567' in result
         mock_get_ids.assert_called()
+
+
+# ------------------------------------------------------------------------
+# Core recommendation-engine coverage: rating-tier weighting, watched-history
+# collection, movie detail extraction, and the per-user/per-library
+# process_recommendations orchestration entry point (#157).
+# ------------------------------------------------------------------------
+
+MOVIE_TEST_CONFIG = {
+    'plex': {'url': 'http://localhost', 'token': 'abc'},
+    'general': {},
+    'weights': {'genre': 0.3, 'director': 0.2, 'actor': 0.2, 'language': 0.1, 'keyword': 0.2},
+}
+
+
+def _make_movie_recommender(config=None, users=None, movie_cache_data=None, config_path='/path/to/config.yml'):
+    """Build a fully-initialized PlexMovieRecommender with all I/O mocked out.
+
+    Note: __init__ eagerly gathers watched data (real _get_plex_watched_data /
+    _get_managed_users_watched_data call) and touches the library, so the Plex
+    client is a MagicMock (safe default iteration -> []) and the media cache
+    is likewise a MagicMock. Tests that care about the specifics of the
+    watched-history gathering should patch the relevant
+    recommenders.movie.* utility functions *before* calling this helper so
+    construction picks them up.
+    """
+    config = copy.deepcopy(config if config is not None else MOVIE_TEST_CONFIG)
+    users = users or {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+    movie_cache = MagicMock()
+    movie_cache.cache = {'movies': movie_cache_data or {}}
+    with patch('recommenders.movie.MovieCache', return_value=movie_cache), \
+         patch('recommenders.base.init_plex', return_value=MagicMock()), \
+         patch('recommenders.base.get_configured_users', return_value=users), \
+         patch('recommenders.base.get_tmdb_config', return_value={'use_keywords': True, 'api_key': 'key'}), \
+         patch('recommenders.base.load_config', return_value=config), \
+         patch('os.makedirs'):
+        recommender = PlexMovieRecommender(config_path)
+    return recommender
+
+
+class TestCalculateRatingMultiplier:
+    """Tests for PlexMovieRecommender._calculate_rating_multiplier (rating-tier weighting)."""
+
+    def test_none_rating_returns_unrated_default(self):
+        recommender = _make_movie_recommender()
+        assert recommender._calculate_rating_multiplier(None) == 0.6
+
+    def test_zero_rating_returns_unrated_default(self):
+        recommender = _make_movie_recommender()
+        assert recommender._calculate_rating_multiplier(0) == 0.6
+
+    def test_five_star_rating_returns_full_weight(self):
+        recommender = _make_movie_recommender()
+        assert recommender._calculate_rating_multiplier(9.5) == 1.0
+
+    def test_four_star_rating(self):
+        recommender = _make_movie_recommender()
+        assert recommender._calculate_rating_multiplier(7.5) == 0.75
+
+    def test_three_star_rating(self):
+        recommender = _make_movie_recommender()
+        assert recommender._calculate_rating_multiplier(5.5) == 0.5
+
+    def test_two_star_rating_above_threshold(self):
+        recommender = _make_movie_recommender()
+        # threshold defaults to 3, so rating 4 is above threshold - positive tier path
+        assert recommender._calculate_rating_multiplier(4) == 0.25
+
+    def test_low_rating_with_negative_signals_enabled_is_negative(self):
+        recommender = _make_movie_recommender()
+        result = recommender._calculate_rating_multiplier(1.0)
+        assert result < 0
+
+    def test_low_rating_with_negative_signals_globally_disabled(self):
+        recommender = _make_movie_recommender()
+        recommender.config['negative_signals'] = {'enabled': False}
+        result = recommender._calculate_rating_multiplier(1.0)
+        assert result == 0.25
+
+    def test_low_rating_with_bad_ratings_disabled(self):
+        recommender = _make_movie_recommender()
+        recommender.config['negative_signals'] = {'enabled': True, 'bad_ratings': {'enabled': False}}
+        result = recommender._calculate_rating_multiplier(1.0)
+        assert result == 0.25
+
+
+class TestGetPlexWatchedDataMovie:
+    """Tests for PlexMovieRecommender._get_plex_watched_data.
+
+    __init__ eagerly calls this (plex_users installs gather watched data at
+    construction time), so these tests patch the network-touching utilities
+    *before* constructing the recommender and assert on the resulting state.
+    """
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.movie.get_plex_account_ids', return_value=[])
+    @patch('recommenders.movie.get_watched_movie_count', return_value=0)
+    def test_returns_cached_counters_when_not_single_user_and_recalled(self, mock_count, mock_account_ids, mock_exists):
+        recommender = _make_movie_recommender()
+        # __init__ already populated watched_data_counters via a real call;
+        # a direct re-call (not single_user) must short-circuit to the cache.
+        cached = recommender.watched_data_counters
+        assert cached
+
+        result = recommender._get_plex_watched_data()
+
+        assert result is cached
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.movie.process_counters_from_cache')
+    @patch('recommenders.movie.calculate_rewatch_multiplier', return_value=1.0)
+    @patch('recommenders.movie.calculate_recency_multiplier', return_value=1.0)
+    @patch('recommenders.movie.fetch_plex_watch_history_movies')
+    @patch('recommenders.movie.get_plex_account_ids')
+    @patch('recommenders.movie.get_watched_movie_count', return_value=1)
+    def test_processes_watch_history_and_updates_counters(
+        self, mock_count, mock_account_ids, mock_history, mock_recency, mock_rewatch, mock_process_counters, mock_exists
+    ):
+        mock_account_ids.return_value = ['acct1']
+        history_item = Mock(ratingKey=42, viewedAt=None, userRating=None)
+        mock_history.return_value = ([history_item], {})
+
+        recommender = _make_movie_recommender(movie_cache_data={'42': {'title': 'Watched Movie', 'tmdb_id': 999}})
+
+        assert 42 in recommender.watched_ids
+        mock_process_counters.assert_called_once()
+        assert 999 in recommender.watched_data_counters['tmdb_ids']
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.movie.log_error')
+    @patch('recommenders.movie.get_plex_account_ids', return_value=[])
+    @patch('recommenders.movie.get_watched_movie_count', return_value=1)
+    def test_no_account_ids_logs_error(self, mock_count, mock_account_ids, mock_log_error, mock_exists):
+        _make_movie_recommender()
+
+        mock_log_error.assert_called()
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.movie.process_counters_from_cache')
+    @patch('recommenders.movie.calculate_rewatch_multiplier', return_value=1.0)
+    @patch('recommenders.movie.calculate_recency_multiplier', return_value=1.0)
+    @patch('recommenders.movie.merge_movie_history')
+    @patch('recommenders.movie.fetch_tautulli_movie_history')
+    @patch('recommenders.movie.fetch_plex_watch_history_movies')
+    @patch('recommenders.movie.get_plex_account_ids')
+    @patch('recommenders.movie.get_watched_movie_count', return_value=1)
+    def test_merges_tautulli_history_when_enabled(
+        self, mock_count, mock_account_ids, mock_history, mock_tautulli, mock_merge,
+        mock_recency, mock_rewatch, mock_process_counters, mock_exists
+    ):
+        mock_account_ids.return_value = ['acct1']
+        mock_history.return_value = ([], {})
+        mock_tautulli.return_value = [Mock(ratingKey=7)]
+        mock_merge.return_value = [Mock(ratingKey=7, viewedAt=None, userRating=None)]
+
+        config = copy.deepcopy(MOVIE_TEST_CONFIG)
+        config['tautulli'] = {'enabled': True}
+        _make_movie_recommender(config=config, movie_cache_data={})
+
+        mock_merge.assert_called_once()
+
+
+class TestGetMovieDetails:
+    """Tests for PlexMovieRecommender.get_movie_details."""
+
+    @patch('recommenders.movie.extract_genres', return_value=['Action'])
+    @patch('recommenders.movie.extract_rating', return_value=8.0)
+    @patch('recommenders.movie.extract_ids_from_guids', return_value={'imdb_id': 'tt1', 'tmdb_id': 1})
+    def test_extracts_full_details(self, mock_ids, mock_rating, mock_genres):
+        recommender = _make_movie_recommender()
+        recommender.show_rating = True
+        recommender.show_cast = True
+        recommender.use_tmdb_keywords = False
+        director = Mock(tag='Director A')
+        actor = Mock(tag='Actor A')
+        movie = Mock(title='Movie A', year=2020, summary='Summary', directors=[director], roles=[actor])
+
+        result = recommender.get_movie_details(movie)
+
+        assert result['title'] == 'Movie A'
+        assert 'Director A' in result['directors']
+        assert result['ratings']['audience_rating'] == 8.0
+        assert 'Actor A' in result['cast']
+        movie.reload.assert_called_once()
+
+    @patch('recommenders.movie.extract_ids_from_guids', return_value={'imdb_id': None, 'tmdb_id': None})
+    def test_fetches_tmdb_keywords_when_enabled(self, mock_ids):
+        recommender = _make_movie_recommender()
+        recommender.use_tmdb_keywords = True
+        recommender.tmdb_api_key = 'key'
+        recommender._get_plex_item_tmdb_id = Mock(return_value=55)
+        recommender._get_tmdb_keywords_for_id = Mock(return_value={'kw1', 'kw2'})
+        movie = Mock(title='Movie B', year=2021, summary='', directors=[], roles=[])
+
+        result = recommender.get_movie_details(movie)
+
+        assert set(result['tmdb_keywords']) == {'kw1', 'kw2'}
+
+    def test_handles_exception_returns_empty_dict(self):
+        recommender = _make_movie_recommender()
+        movie = Mock()
+        movie.reload.side_effect = Exception("plex error")
+
+        result = recommender.get_movie_details(movie)
+
+        assert result == {}
+
+
+class TestFindPlexItemAndWatchedDataSelectionMovie:
+    """Tests for _find_plex_item delegation and _get_watched_data branch selection."""
+
+    @patch('recommenders.movie.find_plex_movie')
+    def test_find_plex_item_delegates_to_utility(self, mock_find):
+        recommender = _make_movie_recommender()
+        mock_find.return_value = 'found'
+        section = Mock()
+        rec = {'title': 'X', 'year': 2020}
+
+        result = recommender._find_plex_item(section, rec)
+
+        assert result == 'found'
+        mock_find.assert_called_once_with(section, 'X', 2020)
+
+    def test_get_watched_data_uses_plex_history_when_plex_users_configured(self):
+        recommender = _make_movie_recommender(
+            users={'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        )
+        recommender._get_plex_watched_data = Mock(return_value={'genres': {}})
+        recommender._get_managed_users_watched_data = Mock(return_value={'genres': {}})
+
+        recommender._get_watched_data()
+
+        recommender._get_plex_watched_data.assert_called_once()
+        recommender._get_managed_users_watched_data.assert_not_called()
+
+    @patch('recommenders.base.MyPlexAccount')
+    @patch('recommenders.movie.get_watched_movie_count', return_value=0)
+    def test_get_watched_data_uses_managed_users_when_no_plex_users(self, mock_count, mock_account_cls):
+        recommender = _make_movie_recommender(
+            users={'plex_users': [], 'managed_users': ['bob'], 'admin_user': 'admin'}
+        )
+        recommender._get_plex_watched_data = Mock(return_value={'genres': {}})
+        recommender._get_managed_users_watched_data = Mock(return_value={'genres': {}})
+
+        recommender._get_watched_data()
+
+        recommender._get_managed_users_watched_data.assert_called_once()
+        recommender._get_plex_watched_data.assert_not_called()
+
+
+class TestSaveCacheMovie:
+    """Tests for PlexMovieRecommender._save_cache."""
+
+    def test_save_cache_calls_save_watched_cache(self):
+        recommender = _make_movie_recommender()
+        recommender._save_watched_cache = Mock()
+
+        recommender._save_cache()
+
+        recommender._save_watched_cache.assert_called_once()
+
+
+class TestProcessRecommendationsMovie:
+    """Tests for movie.process_recommendations (per-user/per-library orchestration, #157)."""
+
+    @patch('recommenders.movie.format_movie_output', return_value='formatted')
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_happy_path_prints_and_manages_labels(self, mock_setup, mock_teardown, mock_recommender_cls, mock_format):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': [{'title': 'A', 'year': 2020}]}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_instance.manage_plex_labels.assert_called_once()
+        mock_instance._save_cache.assert_called_once()
+
+    @patch('recommenders.movie.log_warning')
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_no_recommendations_warns_and_skips_labels(self, mock_setup, mock_teardown, mock_recommender_cls, mock_warn):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_instance.manage_plex_labels.assert_not_called()
+        mock_warn.assert_called()
+
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_debug_flag_propagated_from_config(self, mock_setup, mock_teardown, mock_recommender_cls):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_instance.config = {'general': {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {'debug': True}}, '/path/to/config.yml', 0)
+
+        assert mock_instance.debug is True
+
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_fatal_error_exits(self, mock_setup, mock_teardown, mock_recommender_cls):
+        mock_recommender_cls.side_effect = RuntimeError("Plex server unreachable")
+
+        with patch('recommenders.movie.sys.exit') as mock_exit:
+            process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_exit.assert_called_once_with(1)
+
+    @patch('recommenders.movie.PlexMovieRecommender')
+    @patch('recommenders.movie.teardown_log_file')
+    @patch('recommenders.movie.setup_log_file')
+    def test_non_fatal_error_does_not_exit(self, mock_setup, mock_teardown, mock_recommender_cls):
+        mock_recommender_cls.side_effect = ValueError("Something else broke")
+
+        with patch('recommenders.movie.sys.exit') as mock_exit:
+            process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_exit.assert_not_called()

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -3,6 +3,7 @@ Tests for recommenders/tv.py - TV show recommendation system.
 """
 
 import os
+import copy
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from collections import Counter
@@ -1051,3 +1052,397 @@ class TestMainMediaTypeKey:
         _, kwargs = mock_run_main.call_args
         assert kwargs['media_type_key'] == 'tv'
         assert kwargs['process_func'] is process_recommendations
+
+
+# ------------------------------------------------------------------------
+# Core recommendation-engine coverage: rating-tier weighting, watched-history
+# collection (incl. dropped-show negative signals), show detail extraction,
+# and the per-user/per-library process_recommendations orchestration entry
+# point (#157).
+# ------------------------------------------------------------------------
+
+TV_TEST_CONFIG = {
+    'plex': {'url': 'http://localhost', 'token': 'abc'},
+    'general': {},
+    'weights': {'genre': 0.2, 'actor': 0.15, 'studio': 0.15, 'keyword': 0.45, 'language': 0.05},
+}
+
+
+def _make_tv_recommender(config=None, users=None, show_cache_data=None, config_path='/path/to/config.yml'):
+    """Build a fully-initialized PlexTVRecommender with all I/O mocked out.
+
+    See _make_movie_recommender in test_movie.py for the rationale (MagicMock
+    Plex client for safe default iteration, __init__ eagerly gathers watched
+    data for plex_users installs).
+    """
+    config = copy.deepcopy(config if config is not None else TV_TEST_CONFIG)
+    users = users or {'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+    show_cache = MagicMock()
+    show_cache.cache = {'shows': show_cache_data or {}}
+    with patch('recommenders.tv.ShowCache', return_value=show_cache), \
+         patch('recommenders.base.init_plex', return_value=MagicMock()), \
+         patch('recommenders.base.get_configured_users', return_value=users), \
+         patch('recommenders.base.get_tmdb_config', return_value={'use_keywords': True, 'api_key': 'key'}), \
+         patch('recommenders.base.load_config', return_value=config), \
+         patch('os.makedirs'):
+        recommender = PlexTVRecommender(config_path)
+    return recommender
+
+
+class TestCalculateRatingMultiplierTV:
+    """Tests for PlexTVRecommender._calculate_rating_multiplier (rating-tier weighting)."""
+
+    def test_none_rating_returns_unrated_default(self):
+        recommender = _make_tv_recommender()
+        assert recommender._calculate_rating_multiplier(None) == 0.6
+
+    def test_five_star_rating_returns_full_weight(self):
+        recommender = _make_tv_recommender()
+        assert recommender._calculate_rating_multiplier(9.5) == 1.0
+
+    def test_four_star_rating(self):
+        recommender = _make_tv_recommender()
+        assert recommender._calculate_rating_multiplier(7.5) == 0.75
+
+    def test_three_star_rating(self):
+        recommender = _make_tv_recommender()
+        assert recommender._calculate_rating_multiplier(5.5) == 0.5
+
+    def test_two_star_rating_above_threshold(self):
+        recommender = _make_tv_recommender()
+        assert recommender._calculate_rating_multiplier(4) == 0.25
+
+    def test_low_rating_with_negative_signals_enabled_is_negative(self):
+        recommender = _make_tv_recommender()
+        result = recommender._calculate_rating_multiplier(1.0)
+        assert result < 0
+
+    def test_low_rating_with_negative_signals_globally_disabled(self):
+        recommender = _make_tv_recommender()
+        recommender.config['negative_signals'] = {'enabled': False}
+        result = recommender._calculate_rating_multiplier(1.0)
+        assert result == 0.25
+
+
+class TestGetWatchedCountTV:
+    """Tests for PlexTVRecommender._get_watched_count user-source branches."""
+
+    @patch('recommenders.tv.get_watched_show_count', return_value=3)
+    def test_uses_single_user_when_set(self, mock_count):
+        recommender = _make_tv_recommender()
+        recommender.single_user = 'alice'
+
+        recommender._get_watched_count()
+
+        assert mock_count.call_args[0][1] == ['alice']
+
+    @patch('recommenders.base.MyPlexAccount')
+    @patch('recommenders.tv.get_watched_show_count', return_value=3)
+    def test_uses_managed_users_when_no_plex_users(self, mock_count, mock_account_cls):
+        recommender = _make_tv_recommender(
+            users={'plex_users': [], 'managed_users': ['bob'], 'admin_user': 'admin'}
+        )
+
+        recommender._get_watched_count()
+
+        assert mock_count.call_args[0][1] == ['bob']
+
+
+class TestGetPlexWatchedShowsData:
+    """Tests for PlexTVRecommender._get_plex_watched_shows_data.
+
+    __init__ eagerly calls this (plex_users installs gather watched data at
+    construction time), so these tests patch the network-touching utilities
+    *before* constructing the recommender and assert on the resulting state.
+    """
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.tv.get_plex_account_ids', return_value=[])
+    @patch('recommenders.tv.get_watched_show_count', return_value=0)
+    def test_returns_cached_counters_when_not_single_user_and_recalled(self, mock_count, mock_account_ids, mock_exists):
+        recommender = _make_tv_recommender()
+        cached = recommender.watched_data_counters
+        assert cached
+
+        result = recommender._get_plex_watched_shows_data()
+
+        assert result is cached
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.tv.process_counters_from_cache')
+    @patch('recommenders.tv.calculate_rewatch_multiplier', return_value=1.0)
+    @patch('recommenders.tv.calculate_recency_multiplier', return_value=1.0)
+    @patch('recommenders.tv.fetch_plex_watch_history_shows')
+    @patch('recommenders.tv.get_plex_account_ids')
+    @patch('recommenders.tv.get_watched_show_count', return_value=1)
+    def test_processes_watch_history_and_updates_counters(
+        self, mock_count, mock_account_ids, mock_history, mock_recency, mock_rewatch,
+        mock_process_counters, mock_exists
+    ):
+        mock_account_ids.return_value = ['acct1']
+        mock_history.return_value = ({99}, {99: 1700000000})
+
+        config = copy.deepcopy(TV_TEST_CONFIG)
+        config['negative_signals'] = {'dropped_shows': {'enabled': False}}
+        recommender = _make_tv_recommender(
+            config=config, show_cache_data={'99': {'title': 'Watched Show', 'tmdb_id': 888}}
+        )
+
+        assert 99 in recommender.watched_ids
+        mock_process_counters.assert_called_once()
+        assert 888 in recommender.watched_data_counters['tmdb_ids']
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.tv.log_error')
+    @patch('recommenders.tv.get_plex_account_ids', return_value=[])
+    @patch('recommenders.tv.get_watched_show_count', return_value=1)
+    def test_no_account_ids_logs_error(self, mock_count, mock_account_ids, mock_log_error, mock_exists):
+        _make_tv_recommender()
+
+        mock_log_error.assert_called()
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.tv.process_counters_from_cache')
+    @patch('recommenders.tv.calculate_rewatch_multiplier', return_value=1.0)
+    @patch('recommenders.tv.calculate_recency_multiplier', return_value=1.0)
+    @patch('recommenders.tv.identify_dropped_shows')
+    @patch('recommenders.tv.fetch_show_completion_data')
+    @patch('recommenders.tv.fetch_plex_watch_history_shows')
+    @patch('recommenders.tv.get_plex_account_ids')
+    @patch('recommenders.tv.get_watched_show_count', return_value=1)
+    def test_dropped_shows_processed_as_negative_signal(
+        self, mock_count, mock_account_ids, mock_history, mock_completion, mock_identify,
+        mock_recency, mock_rewatch, mock_process_counters, mock_exists
+    ):
+        mock_account_ids.return_value = ['acct1']
+        mock_history.return_value = ({50}, {50: 1700000000})
+        mock_completion.return_value = {50: {'watched_episodes': 2, 'total_episodes': 10, 'completion_percent': 20}}
+        mock_identify.return_value = {50}
+
+        recommender = _make_tv_recommender(show_cache_data={'50': {'title': 'Dropped Show', 'tmdb_id': 777}})
+
+        # Dropped show still tracked (so it isn't re-recommended) but is
+        # processed with a negative weight, not as a normal positive signal.
+        assert 777 in recommender.watched_data_counters['tmdb_ids']
+        mock_process_counters.assert_called_once()
+        call_kwargs = mock_process_counters.call_args
+        assert call_kwargs[1]['weight'] < 0
+
+    @patch('os.path.exists', return_value=False)
+    @patch('recommenders.tv.merge_show_watched_data')
+    @patch('recommenders.tv.fetch_tautulli_show_watched_data')
+    @patch('recommenders.tv.fetch_plex_watch_history_shows')
+    @patch('recommenders.tv.get_plex_account_ids')
+    @patch('recommenders.tv.get_watched_show_count', return_value=1)
+    def test_merges_tautulli_history_when_enabled(
+        self, mock_count, mock_account_ids, mock_history, mock_tautulli, mock_merge, mock_exists
+    ):
+        mock_account_ids.return_value = ['acct1']
+        mock_history.return_value = (set(), {})
+        mock_tautulli.return_value = ({60}, {60: 1700000000})
+        mock_merge.return_value = ({60}, {60: 1700000000})
+
+        config = copy.deepcopy(TV_TEST_CONFIG)
+        config['tautulli'] = {'enabled': True}
+        config['negative_signals'] = {'dropped_shows': {'enabled': False}}
+        _make_tv_recommender(config=config, show_cache_data={})
+
+        mock_merge.assert_called_once()
+
+
+class TestGetShowDetails:
+    """Tests for PlexTVRecommender.get_show_details."""
+
+    @patch('recommenders.tv.extract_genres', return_value=['Drama'])
+    @patch('recommenders.tv.extract_rating', return_value=7.5)
+    @patch('recommenders.tv.extract_ids_from_guids', return_value={'imdb_id': 'tt1', 'tmdb_id': 1})
+    def test_extracts_full_details(self, mock_ids, mock_rating, mock_genres):
+        recommender = _make_tv_recommender()
+        recommender.show_rating = True
+        recommender.show_cast = True
+        recommender.use_tmdb_keywords = False
+        actor = Mock(tag='Actor A')
+        show = Mock(title='Show A', year=2020, summary='Summary', studio='Studio A', roles=[actor])
+
+        result = recommender.get_show_details(show)
+
+        assert result['title'] == 'Show A'
+        assert result['studio'] == 'Studio A'
+        assert result['ratings']['audience_rating'] == 7.5
+        assert 'Actor A' in result['cast']
+        show.reload.assert_called_once()
+
+    @patch('recommenders.tv.extract_ids_from_guids', return_value={'imdb_id': None, 'tmdb_id': None})
+    def test_fetches_tmdb_keywords_when_enabled(self, mock_ids):
+        recommender = _make_tv_recommender()
+        recommender.use_tmdb_keywords = True
+        recommender.tmdb_api_key = 'key'
+        recommender._get_plex_item_tmdb_id = Mock(return_value=66)
+        recommender._get_tmdb_keywords_for_id = Mock(return_value={'kw1'})
+        show = Mock(title='Show B', year=2021, summary='', studio='N/A', roles=[])
+
+        result = recommender.get_show_details(show)
+
+        assert set(result['tmdb_keywords']) == {'kw1'}
+
+    def test_handles_exception_returns_empty_dict(self):
+        recommender = _make_tv_recommender()
+        show = Mock()
+        show.reload.side_effect = Exception("plex error")
+
+        result = recommender.get_show_details(show)
+
+        assert result == {}
+
+
+class TestFindPlexItemAndWatchedDataSelectionTV:
+    """Tests for _find_plex_item matching and _get_watched_data branch selection."""
+
+    def test_find_plex_item_matches_title_and_year(self):
+        recommender = _make_tv_recommender()
+        section = Mock()
+        match = Mock(title='X', year=2020)
+        other = Mock(title='X', year=1999)
+        section.search.return_value = [other, match]
+
+        result = recommender._find_plex_item(section, {'title': 'X', 'year': 2020})
+
+        assert result is match
+        section.search.assert_called_once_with(title='X')
+
+    def test_find_plex_item_returns_none_when_no_year_match(self):
+        recommender = _make_tv_recommender()
+        section = Mock()
+        section.search.return_value = [Mock(title='X', year=1999)]
+
+        result = recommender._find_plex_item(section, {'title': 'X', 'year': 2020})
+
+        assert result is None
+
+    def test_get_watched_data_uses_plex_history_when_plex_users_configured(self):
+        recommender = _make_tv_recommender(
+            users={'plex_users': ['user1'], 'managed_users': [], 'admin_user': 'admin'}
+        )
+        recommender._get_plex_watched_shows_data = Mock(return_value={'genres': {}})
+        recommender._get_managed_users_watched_data = Mock(return_value={'genres': {}})
+
+        recommender._get_watched_data()
+
+        recommender._get_plex_watched_shows_data.assert_called_once()
+        recommender._get_managed_users_watched_data.assert_not_called()
+
+    @patch('recommenders.base.MyPlexAccount')
+    @patch('recommenders.tv.get_watched_show_count', return_value=0)
+    def test_get_watched_data_uses_managed_users_when_no_plex_users(self, mock_count, mock_account_cls):
+        recommender = _make_tv_recommender(
+            users={'plex_users': [], 'managed_users': ['bob'], 'admin_user': 'admin'}
+        )
+        recommender._get_plex_watched_shows_data = Mock(return_value={'genres': {}})
+        recommender._get_managed_users_watched_data = Mock(return_value={'genres': {}})
+
+        recommender._get_watched_data()
+
+        recommender._get_managed_users_watched_data.assert_called_once()
+        recommender._get_plex_watched_shows_data.assert_not_called()
+
+
+class TestGetLibraryShowsSetError:
+    """Tests for PlexTVRecommender._get_library_shows_set exception handling."""
+
+    def test_returns_empty_set_on_error(self):
+        recommender = _make_tv_recommender()
+        recommender.plex.library.section.side_effect = Exception("boom")
+
+        result = recommender._get_library_shows_set()
+
+        assert result == set()
+
+
+class TestSaveCacheTV:
+    """Tests for PlexTVRecommender._save_cache."""
+
+    def test_save_cache_calls_save_watched_cache(self):
+        recommender = _make_tv_recommender()
+        recommender._save_watched_cache = Mock()
+
+        recommender._save_cache()
+
+        recommender._save_watched_cache.assert_called_once()
+
+
+class TestCalculateSimilarityFranchiseBonus:
+    """Tests for PlexTVRecommender._calculate_similarity_from_cache franchise/spinoff bonus."""
+
+    @patch('recommenders.tv.calculate_similarity_score', return_value=(0.5, {'details': {}}))
+    def test_shared_production_company_applies_bonus(self, mock_calc):
+        recommender = _make_tv_recommender()
+        recommender.watched_data = {
+            'genres': {}, 'studios': {}, 'actors': {}, 'languages': {}, 'tmdb_keywords': {},
+            'production_companies': {42: 3.0},
+        }
+        show_info = {'genres': [], 'studio': 'N/A', 'cast': [], 'language': 'N/A',
+                     'tmdb_keywords': [], 'production_company_ids': [42]}
+
+        score, breakdown = recommender._calculate_similarity_from_cache(show_info)
+
+        assert score > 0.5
+        assert 'franchise_bonus' in breakdown
+
+    @patch('recommenders.tv.calculate_similarity_score', return_value=(0.5, {'details': {}}))
+    def test_no_shared_production_company_no_bonus(self, mock_calc):
+        recommender = _make_tv_recommender()
+        recommender.watched_data = {
+            'genres': {}, 'studios': {}, 'actors': {}, 'languages': {}, 'tmdb_keywords': {},
+            'production_companies': {},
+        }
+        show_info = {'genres': [], 'studio': 'N/A', 'cast': [], 'language': 'N/A',
+                     'tmdb_keywords': [], 'production_company_ids': [42]}
+
+        score, breakdown = recommender._calculate_similarity_from_cache(show_info)
+
+        assert score == 0.5
+        assert 'franchise_bonus' not in breakdown
+
+
+class TestProcessRecommendationsTV:
+    """Tests for tv.process_recommendations (per-user/per-library orchestration, #157)."""
+
+    @patch('recommenders.tv.format_show_output', return_value='formatted')
+    @patch('recommenders.tv.PlexTVRecommender')
+    @patch('recommenders.tv.teardown_log_file')
+    @patch('recommenders.tv.setup_log_file')
+    def test_happy_path_prints_and_manages_labels(self, mock_setup, mock_teardown, mock_recommender_cls, mock_format):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': [{'title': 'A', 'year': 2020}]}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_instance.manage_plex_labels.assert_called_once_with([{'title': 'A', 'year': 2020}])
+
+    @patch('recommenders.tv.log_warning')
+    @patch('recommenders.tv.PlexTVRecommender')
+    @patch('recommenders.tv.teardown_log_file')
+    @patch('recommenders.tv.setup_log_file')
+    def test_no_recommendations_still_manages_labels(self, mock_setup, mock_teardown, mock_recommender_cls, mock_warn):
+        """Unlike movie.process_recommendations, TV always calls
+        manage_plex_labels (even with no new recs) to remove stale labels."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {'plex_recommendations': []}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_instance.manage_plex_labels.assert_called_once_with([])
+        mock_warn.assert_called()
+
+    @patch('recommenders.tv.PlexTVRecommender')
+    @patch('recommenders.tv.teardown_log_file')
+    @patch('recommenders.tv.setup_log_file')
+    def test_exception_is_caught_and_printed(self, mock_setup, mock_teardown, mock_recommender_cls):
+        mock_recommender_cls.side_effect = RuntimeError("boom")
+
+        # Should not raise - exception is caught and logged.
+        process_recommendations({'general': {}}, '/path/to/config.yml', 0)
+
+        mock_teardown.assert_called_once()

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.8.25"
+__version__ = "2.8.26"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- CI already measures `recommenders/` (`--cov=.` has no omit config) - the reported 90% overall was genuine, but it was masking thin per-file coverage in the core recommendation engine (base 61%, movie 56%, tv 54%, external 48%, exports 38%) that was never flagged as a gap.
- Adds ~120 unit tests exercising the real recommendation-engine logic and #157 per-library paths: label/collection management + candidate scoring in `base.py`, watched-history collection + rating-tier weighting in `movie.py`/`tv.py`, and `process_user_movie_library`/`process_user_tv_library` fan-out + `_resolve_library_groups` routing in `external.py`/`external_exports.py`.
- Per-file: base.py 61% -> 96%, movie.py 56% -> 92%, tv.py 54% -> 94%. Overall 90% -> 92% (gate is `--cov-fail-under=85`, unchanged, now backed by a genuinely-exercised core).
- `external.py`'s HTML/markdown/watchlist-generation functions and `external_exports.py`'s MDBList/Simkl/Trakt-sync export functions remain thin (largely untested) - out of scope for this pass since they're not part of the #157 core path; flagged in CHANGELOG for follow-up.

## Test plan
- [x] `pytest tests/ -v --cov=. --cov-fail-under=85` - 1665 passed, 92.48% coverage
- [x] gitleaks secret scan clean (dummy creds only, consistent with existing test fixtures)
- [x] `py_compile` on all changed files