### PR TITLE
Launch the Windows binary windowed, with no console by default (v2.8.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.27] - 2026-07-23
+
+### Changed
+- **Windows binary launches with no console window**: `curatarr-windows-x86_64.exe` is now built windowed (`console=False` in `curatarr.spec`) - double-clicking it opens straight into the browser with no black console flash, logging instead to `%APPDATA%\curatarr\logs\curatarr.log`. Running it from an existing Command Prompt/PowerShell still prints normally (`curatarr_app.py` attaches to that parent console on startup), and `--debug`/`CURATARR_DEBUG=1` allocates a console for troubleshooting. Recommender subprocesses the web UI spawns (`web/job_runner.py`) now also pass `CREATE_NO_WINDOW` on Windows so they don't flash their own console windows either. macOS/Linux binaries are unaffected
+
 ## [2.8.26] - 2026-07-23
 
 ### Changed

--- a/curatarr.spec
+++ b/curatarr.spec
@@ -21,9 +21,17 @@ Notes:
   docs/BINARIES.md's "Building it yourself" section for the universal2
   prerequisites (a universal2 Python + universal2 wheels/fused wheels
   for pyyaml, ruamel.yaml.clib and markupsafe).
+- console is False only on Windows (windowed/no-console double-click
+  launch - curatarr_app.py handles attaching to a parent console when
+  run from cmd/PowerShell, allocating one for --debug, and file logging
+  otherwise - see that module's docstring). macOS/Linux keep console=True,
+  unchanged from before: the console flag mainly governs the Windows EXE
+  subsystem, and this spec never wraps macOS in a windowed .app BUNDLE,
+  so flipping it there wouldn't suppress a Terminal launch anyway.
 """
 
 import os
+import sys
 
 from PyInstaller.utils.hooks import collect_submodules
 
@@ -70,7 +78,7 @@ exe = EXE(
     upx=False,
     upx_exclude=[],
     runtime_tmpdir=None,
-    console=True,
+    console=sys.platform != 'win32',
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=os.environ.get('PYINSTALLER_TARGET_ARCH') or None,

--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -13,6 +13,16 @@ built by PyInstaller), that resolves to a per-user data directory
 instead of a repo checkout, since a downloaded binary has no repo
 checkout to anchor to.
 
+Windowed (no-console) launch on Windows
+------------------------------------------------------------------
+curatarr.spec builds the Windows exe with console=False, so
+double-clicking it never flashes a console window - see
+_configure_windowed_launch()/_attach_or_setup_console() below for how
+that interacts with CLI use (`curatarr.exe --run-recommender ...` from
+an existing cmd/PowerShell), --debug/CURATARR_DEBUG=1, and file
+logging. macOS/Linux builds are unaffected (console=True there,
+unchanged).
+
 Dispatcher mode - what makes the web UI's Run button work in a frozen
 binary
 ------------------------------------------------------------------
@@ -36,12 +46,96 @@ and call sys.exit() (see web/app.py's module docstring for why that's
 unsafe inside the server), which is exactly fine for a process whose
 only job is to run one recommender and exit - the same contract as the
 `python3 recommenders/<x>.py` invocation this replaces for a source
-install.
+install. That subprocess already gets its stdout/stderr piped back to
+the server via web/job_runner.py's Popen(stdout=PIPE) call, so it never
+runs _configure_windowed_launch() below - only the primary UI launch
+does.
 """
 
+import ctypes
+import logging
+import os
 import sys
 
 from web.app import main
+
+
+def _debug_requested() -> bool:
+    """True if --debug was passed or CURATARR_DEBUG=1 is set - gates
+    both _attach_or_setup_console()'s AllocConsole fallback and the log
+    level used when logging to file instead."""
+    return '--debug' in sys.argv[1:] or os.environ.get('CURATARR_DEBUG') == '1'
+
+
+def _boot_log_path() -> str:
+    """Where the windowed (no-console) Windows build logs to, since
+    there's no console to print to: %APPDATA%\\curatarr\\logs\\curatarr.log
+    on Windows, ~/.curatarr/logs/curatarr.log elsewhere - the same
+    per-user data dir a frozen binary already uses for config/cache/logs
+    (see utils.helpers.get_project_root)."""
+    from utils import get_project_root
+    return os.path.join(get_project_root(), 'logs', 'curatarr.log')
+
+
+def _configure_windowed_launch() -> None:
+    """Only meaningful for the frozen Windows build (curatarr.spec sets
+    console=False there). No-op everywhere else - macOS/Linux builds
+    (console=True, unchanged) and non-frozen dev runs (`python
+    curatarr_app.py` from an already-open terminal) already have a
+    normal, working console.
+    """
+    if os.name != 'nt' or not getattr(sys, 'frozen', False):
+        return
+    _attach_or_setup_console(_debug_requested())
+
+
+def _attach_or_setup_console(debug: bool) -> None:  # pragma: no cover - real Windows console/ctypes API, exercised by the Windows build test in the release PR, not unit-testable on Linux CI
+    """Three cases, in order:
+
+    1. Launched from an existing cmd/PowerShell: AttachConsole finds
+       that parent console, so CLI use (`curatarr.exe
+       --run-recommender ...`, or just running the exe directly from a
+       shell) keeps printing normally, exactly like the old
+       console=True build did.
+    2. Double-clicked with --debug/CURATARR_DEBUG=1 and no parent
+       console found: AllocConsole gives it a fresh one so debug output
+       is visible.
+    3. Double-clicked normally (the common case) and neither of the
+       above applied: no console at all. PyInstaller's windowed
+       (console=False) builds otherwise leave sys.stdout/sys.stderr in
+       a state that crashes the first time anything prints - point them
+       at a log file instead so nothing ever crashes trying to write to
+       them, and the output isn't just silently lost either.
+    """
+    kernel32 = ctypes.windll.kernel32
+    attach_parent_process = -1
+    attached = bool(kernel32.AttachConsole(attach_parent_process))
+    if not attached and debug:
+        attached = bool(kernel32.AllocConsole())
+
+    if attached:
+        for stream_name, handle_name, mode in (
+            ('stdin', 'CONIN$', 'r'),
+            ('stdout', 'CONOUT$', 'w'),
+            ('stderr', 'CONOUT$', 'w'),
+        ):
+            try:
+                setattr(sys, stream_name, open(handle_name, mode, encoding='utf-8', buffering=1))
+            except OSError:
+                pass  # keep whatever sys.stdout/stderr already were
+        return
+
+    log_path = _boot_log_path()
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    log_file = open(log_path, 'a', encoding='utf-8', buffering=1)
+    sys.stdout = log_file
+    sys.stderr = log_file
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        handlers=[logging.StreamHandler(log_file)],
+        force=True,
+    )
 
 
 def _run_one_recommender(engine: str, rest: list) -> None:
@@ -103,4 +197,5 @@ if __name__ == '__main__':
     if len(sys.argv) > 2 and sys.argv[1] == '--run-recommender':
         _dispatch_recommender(sys.argv[2:])
     else:
+        _configure_windowed_launch()
         main()

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -25,8 +25,13 @@ Each asset has a matching `<asset>.sha256` file with its checksum.
    protected your PC" because the binary isn't code-signed yet (see
    [Unsigned binaries](#unsigned-binaries)) - click **More info**, then
    **Run anyway**.
-3. A console window opens (that's the server log) and your browser
-   opens to `http://127.0.0.1:8787`.
+3. No console window opens - it launches straight into your browser at
+   `http://127.0.0.1:8787`. The server log instead goes to
+   `%APPDATA%\curatarr\logs\curatarr.log` (see
+   [Where data lives](#where-data-lives) below). Running it from an
+   existing Command Prompt/PowerShell window still prints there as
+   normal, and `curatarr.exe --debug` (or setting `CURATARR_DEBUG=1`)
+   opens a console too, for troubleshooting.
 
 ### macOS
 

--- a/tests/test_curatarr_app.py
+++ b/tests/test_curatarr_app.py
@@ -11,8 +11,19 @@ web UI's Run button work in a frozen PyInstaller binary (see
 web/job_runner.py's _build_command) - it dispatches to the requested
 recommender's own main() instead of shelling out to a
 recommenders/<x>.py file that doesn't exist once packaged.
+
+_attach_or_setup_console() (the AttachConsole/AllocConsole/CONOUT$
+dance behind the windowed, console=False Windows build) is marked
+`# pragma: no cover` in curatarr_app.py itself rather than unit-tested
+here - it needs the real Windows ctypes console API, which doesn't
+exist on the Linux CI runner (or this Mac dev machine). It's verified
+against an actual Windows build as part of the release process instead
+(see RELEASING.md). The tests below cover everything around it that
+*is* safely testable cross-platform: debug detection, the log path,
+and _configure_windowed_launch()'s not-frozen/not-Windows no-op guard.
 """
 
+import os
 import runpy
 import sys
 from unittest.mock import patch
@@ -34,6 +45,66 @@ class TestCuratarrApp:
         calls main() exactly once, matching run-ui.sh / run-ui.ps1."""
         runpy.run_module('curatarr_app', run_name='__main__')
         mock_main.assert_called_once_with()
+
+
+class TestDebugRequested:
+    """Tests for _debug_requested() - gates the AllocConsole fallback
+    and file-logging level in _attach_or_setup_console()."""
+
+    def test_true_when_debug_flag_present(self, monkeypatch):
+        monkeypatch.setattr(sys, 'argv', ['curatarr', '--debug'])
+        monkeypatch.delenv('CURATARR_DEBUG', raising=False)
+        assert curatarr_app._debug_requested() is True
+
+    def test_true_when_env_var_set(self, monkeypatch):
+        monkeypatch.setattr(sys, 'argv', ['curatarr'])
+        monkeypatch.setenv('CURATARR_DEBUG', '1')
+        assert curatarr_app._debug_requested() is True
+
+    def test_false_by_default(self, monkeypatch):
+        monkeypatch.setattr(sys, 'argv', ['curatarr'])
+        monkeypatch.delenv('CURATARR_DEBUG', raising=False)
+        assert curatarr_app._debug_requested() is False
+
+
+class TestBootLogPath:
+    """Tests for _boot_log_path() - where the windowed build logs to
+    when there's no console to print to."""
+
+    def test_joins_project_root_logs_curatarr_log(self, monkeypatch, tmp_path):
+        monkeypatch.setattr('utils.get_project_root', lambda: str(tmp_path))
+        result = curatarr_app._boot_log_path()
+        assert result == os.path.join(str(tmp_path), 'logs', 'curatarr.log')
+
+
+class TestConfigureWindowedLaunch:
+    """_configure_windowed_launch() is only meaningful for the frozen
+    Windows build (curatarr.spec's console=False) - everywhere else it
+    must be a no-op, since macOS/Linux builds and non-frozen dev runs
+    already have a normal, working console."""
+
+    def test_noop_when_not_frozen(self, monkeypatch):
+        monkeypatch.setattr(sys, 'frozen', False, raising=False)
+        monkeypatch.setattr(os, 'name', 'nt')
+        with patch('curatarr_app._attach_or_setup_console') as mock_attach:
+            curatarr_app._configure_windowed_launch()
+        mock_attach.assert_not_called()
+
+    def test_noop_when_not_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, 'frozen', True, raising=False)
+        monkeypatch.setattr(os, 'name', 'posix')
+        with patch('curatarr_app._attach_or_setup_console') as mock_attach:
+            curatarr_app._configure_windowed_launch()
+        mock_attach.assert_not_called()
+
+    def test_dispatches_when_frozen_on_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, 'frozen', True, raising=False)
+        monkeypatch.setattr(os, 'name', 'nt')
+        monkeypatch.setattr(sys, 'argv', ['curatarr'])
+        monkeypatch.delenv('CURATARR_DEBUG', raising=False)
+        with patch('curatarr_app._attach_or_setup_console') as mock_attach:
+            curatarr_app._configure_windowed_launch()
+        mock_attach.assert_called_once_with(False)
 
 
 class TestRunOneRecommender:

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -339,3 +339,51 @@ class TestForeignLockfile:
         finally:
             helper.kill()
             helper.wait()
+
+
+class TestWindowsSubprocessCreationFlags:
+    """Tests for suppressing a recommender subprocess's own console
+    window under the windowed (console=False, see curatarr.spec) build
+    - on real Windows, a console-subsystem child (powershell.exe for the
+    'full' engine, or the re-invoked frozen exe for the others) would
+    otherwise flash a console window even though its stdout/stderr are
+    already piped back to this process.
+
+    subprocess.CREATE_NO_WINDOW only exists as an attribute on win32
+    Python builds, so _build_command reads it via getattr(...,
+    default=0) - these tests force os.name to exercise both branches
+    without needing an actual Windows interpreter."""
+
+    def test_windows_popen_requests_create_no_window(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setattr(job_runner_mod.os, 'name', 'nt')
+        captured = {}
+
+        def _capture_and_boom(cmd, **kwargs):
+            captured.update(kwargs)
+            raise FileNotFoundError("[Errno 2] No such file or directory")
+
+        monkeypatch.setattr(job_runner_mod.subprocess, 'Popen', _capture_and_boom)
+        manager = _manager(curatarr_web_root)
+
+        with pytest.raises(JobError):
+            manager.start('movie', 'alice', ['alice', 'bob'])
+
+        assert captured.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
+        assert 'start_new_session' not in captured
+
+    def test_posix_popen_omits_creationflags(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setattr(job_runner_mod.os, 'name', 'posix')
+        captured = {}
+
+        def _capture_and_boom(cmd, **kwargs):
+            captured.update(kwargs)
+            raise FileNotFoundError("[Errno 2] No such file or directory")
+
+        monkeypatch.setattr(job_runner_mod.subprocess, 'Popen', _capture_and_boom)
+        manager = _manager(curatarr_web_root)
+
+        with pytest.raises(JobError):
+            manager.start('movie', 'alice', ['alice', 'bob'])
+
+        assert 'creationflags' not in captured
+        assert captured.get('start_new_session') is True

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.8.26"
+__version__ = "2.8.27"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -271,6 +271,17 @@ class JobManager:
                 # run.sh itself spawns movie.py/tv.py/external.py as
                 # further children, not just the immediate bash process.
                 popen_kwargs['start_new_session'] = True
+            else:
+                # Suppress the child's own console window - matters for
+                # the windowed (console=False, see curatarr.spec) build:
+                # without this, a console-subsystem child (powershell.exe
+                # for the 'full' engine on a source install, or the
+                # re-invoked frozen exe itself) would otherwise flash a
+                # console window even though stdout/stderr are already
+                # piped back to this process. getattr(...) default keeps
+                # this importable/testable on non-Windows (the attribute
+                # only exists in the subprocess module on win32).
+                popen_kwargs['creationflags'] = getattr(subprocess, 'CREATE_NO_WINDOW', 0)
             try:
                 process = subprocess.Popen(cmd, **popen_kwargs)
             except OSError as exc:


### PR DESCRIPTION
## Summary
- `curatarr.spec`: Windows EXE now built windowed (`console=False`) - double-clicking `curatarr-windows-x86_64.exe` opens straight into the browser with no console flash. macOS/Linux keep `console=True`, unchanged.
- `curatarr_app.py`: on the frozen Windows build, attaches to a parent console if launched from an existing cmd/PowerShell (CLI use still prints normally), allocates a console for `--debug`/`CURATARR_DEBUG=1`, and otherwise logs to `%APPDATA%\curatarr\logs\curatarr.log` with safe (never-`None`) stdout/stderr.
- `web/job_runner.py`: recommender subprocesses spawned by the web UI now pass `CREATE_NO_WINDOW` on Windows so they don't flash their own console windows under the windowed build.
- `utils/config.py`: version bump to 2.8.27.
- `docs/BINARIES.md`, `CHANGELOG.md`: updated for the new Windows launch behavior.
- Tests added for debug-flag detection, the boot log path, the windowed-launch no-op guard, and the Windows-only `creationflags` branch in the job runner.

## Test plan
- [x] Full test suite (`pytest tests/ --cov=. --cov-fail-under=85`): 1763 passed, 94.92% coverage.
- [x] Built the Windows exe locally with the same command CI uses (`pyinstaller --clean --noconfirm curatarr.spec`) and confirmed the windowed bootloader (`runw.exe`) was selected.
- [x] Default launch: confirmed no console is attached (`GetConsoleWindow() == 0`) and `curatarr.log` is created under `%APPDATA%\curatarr\logs\`.
- [x] Themed UI still served correctly from the packaged build: `style.css` (200, contains `#8b0000`/`#d4af37`/`Playfair Display`) and both webfonts (200, not 404).
- [x] `--debug`: confirmed a console is allocated (`GetConsoleWindow()` non-zero) and no log file is written (output goes to the console instead).
- [x] Triggered a real recommender run through the web UI's Run button against the packaged exe to exercise the `CREATE_NO_WINDOW` subprocess path end-to-end - subprocess spawned, ran, and its output was captured normally.
