### PR TITLE
fix: add missing Checkout step to finalize-checksums job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,6 +406,19 @@ jobs:
     needs: [release, build-binaries, build-macos-universal]
     runs-on: ubuntu-latest
     steps:
+      # This job's own `gh release download`/`gh release upload` calls
+      # below rely on `gh` auto-detecting owner/repo from the checked-out
+      # git remote, same as every other `gh release` call in this
+      # workflow (see `release`/`build-binaries`/`build-macos-universal`
+      # above) - none of them pass `--repo` explicitly. This job was
+      # missing its own Checkout step (the only job in this workflow that
+      # was), so `gh` had no repo to resolve and failed with "fatal: not
+      # a git repository" the first time this job actually ran (v2.8.29 -
+      # it was added alongside the self-update feature and had never
+      # been exercised by a real release tag before that).
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - name: Download existing SHA256SUMS.txt and every per-binary .sha256 sidecar
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- The v2.8.29 re-cut (PR #190) revealed a second, unrelated packaging bug: `finalize-checksums` (added alongside the v2.8.29 self-update feature, never exercised by a real release tag until now) has no Checkout step, unlike every other `gh release`-calling job in this workflow. `gh release download` then has no git remote to auto-detect owner/repo from and fails with `fatal: not a git repository`.
- Adds the same Checkout step used by the `release`/`build-binaries`/`build-macos-universal` jobs, which is exactly why those three succeeded in the same v2.8.29 CI run that this job failed in.

## Test plan
- [x] Full suite - 2096 passed, 1 skipped (unrelated to this change; workflow YAML has no local test harness)
- [x] Pattern directly matches 3 other jobs in the same file that succeeded doing unqualified `gh release create`/`gh release upload` calls in today's own v2.8.29 CI run, right after their own Checkout step
- Real validation is the next v2.8.29 CI run itself