### PR TITLE
Show dismissible update notice for every update_mode, incl. off (v2.8.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.8.31] - 2026-07-24
+
+### Changed
+- **Update notice now shown for every `general.update_mode`, including `off`**: an opted-out install silently missing every update forever was a bug, not a feature - `off` only ever meant "don't apply automatically", never "don't tell me". The web UI's dismissible banner (`web/app.py`'s `_update_banner_context`) and the CLI's advisory notice (`utils/cli.py`'s `print_update_notice`) both now check for a newer release regardless of mode; `utils/update_check.py`'s `get_latest_version()` no longer special-cases `update_mode: off` to skip the network entirely - every mode uses the exact same ~12h-cached fetch path. Nothing about *applying* updates changed: `force` still auto-applies (source installs only), `notify`/`off` are still manual either way, and `run.sh`/`run.ps1`'s own interactive `Update available: vX. Update now? [y/N]` launch prompt is still skipped for `off` (that's now the only thing `off` actually disables)
+- **Update dismissal is now a 7-day snooze, not effectively permanent**: the web banner's dismiss button used to set a cookie that suppressed one specific version string for a full year; it's now server-side state (`utils/update_dismissal.py`, new - a small `cache/dismissed_update.json`, same convention `utils/update_check.py`'s own cache file uses) snoozed for exactly 7 days, after which the same version is offered again if you're still on it. A release newer than the one dismissed always overrides an active snooze immediately - dismissal is scoped to the exact version string, never "any future update". Server-side (rather than cookie) storage is also what lets the CLI notice respect the same dismissal the web UI wrote, and vice versa - the old per-version cookie (`UPDATE_DISMISS_COOKIE`) is removed
+
 ## [2.8.30] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Binaries self-update: the app notifies you (CLI and web UI banner) when a newer 
 - **One command** — `./run.sh` handles everything
 - **Multi-library support** — Each Plex library gets its own Sonarr/Radarr root folder, quality profile, tags, monitor/search, and optionally its own *arr instance; recommendations run per-library so Movies, TV, Anime, and Kids each follow their own rules
 - **Modular config** — Main settings plus optional integration files
-- **Update notifications** — Notifies (CLI + web UI) when a newer signed release exists; set `update_mode: force` to auto-apply on each run instead
+- **Update notifications** — Notifies (CLI + dismissible web UI banner) when a newer signed release exists, for every `update_mode` including `off`; set `update_mode: force` to auto-apply on each run instead
 - **Smart caching** — Auto-clears incompatible caches after updates
 - **Auto-scheduling** — Optional daily cron job
 - **Clean logs** — Know exactly what happened
@@ -356,7 +356,19 @@ logging:
   behavior). Binaries never auto-apply anything regardless of this setting -
   `force` on a binary install just behaves like `notify` (banner + CLI
   notice only; use the **Update now** button or `--self-update` to apply).
-- `off` — never check for updates.
+- `off` — same CLI notice and web UI banner as `notify` above: `off` never
+  means "don't tell me", only "don't ask me and don't apply automatically"
+  (an opted-out install silently missing every update forever was
+  considered a bug, not a feature). The one thing `off` actually disables is
+  `run.sh`/`run.ps1`'s interactive `Update available: vX. Update now? [y/N]`
+  prompt on launch (source installs only) - the dismissible banner, its
+  **Update now** button, and the CLI notice all still work exactly like
+  `notify`.
+
+Either way, the web UI banner's dismiss button (**×**) doesn't hide a
+version forever - it snoozes that specific version for 7 days, after which
+it's shown again if you're still on it. A release newer than the one you
+dismissed is never held back by an existing snooze; it shows immediately.
 
 `general.auto_update` (legacy) is still read as a fallback if `update_mode`
 isn't set: `true` behaves like `force`, `false` behaves like `off`. Existing
@@ -721,8 +733,9 @@ python -c "import yaml; print(yaml.safe_load(open('config/config.yml')))"
 - Plex connection failed → Check URL and token
 - No recommendations → User needs more watch history
 - "Cache outdated" message → Normal after updates, rebuilds automatically
-- Want to disable update checks/notifications entirely → Set `general.update_mode: off` in config/config.yml
+- Want to stop `run.sh`/`run.ps1`'s interactive "Update now? [y/N]" prompt on launch → Set `general.update_mode: off` in config/config.yml (the dismissible CLI/web notices still appear either way - see `general.update_mode` above)
 - Want updates auto-applied instead of just notified → Set `general.update_mode: force`
+- Want a specific update's notice to stop appearing for a while → Click the **×** on the web UI banner (snoozes that version for 7 days)
 
 ### Docker
 See [docs/DOCKER.md](docs/DOCKER.md#troubleshooting) for the full Docker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for the whole tests/ suite (web/ Flask UI fixtures,
 plus a couple of suite-wide safety nets - see _no_real_update_check_network
-below)."""
+and _isolated_update_dismissal_dir below)."""
 
 import os
 import sys
@@ -44,6 +44,26 @@ def _no_real_update_check_network(tmp_path_factory, monkeypatch):
     )
     monkeypatch.setattr('utils.update_check._fetch_latest_version', lambda: None)
 
+
+@pytest.fixture(autouse=True)
+def _isolated_update_dismissal_dir(tmp_path_factory, monkeypatch):
+    """Same reasoning as _no_real_update_check_network above, for the
+    update-dismissal state (utils/update_dismissal.py) added in v2.8.31:
+    its get_project_root() also always resolves to the real repo/data
+    dir regardless of a test's Flask app project_root override. Without
+    this, any test that exercises a dismissed/snoozed banner would write
+    a REAL dismissed_update.json into the repo root. Tests that actually
+    need dismissal state to persist across calls within a single test
+    (tests/test_update_dismissal.py, the snooze tests in tests/
+    test_web_update_banner.py) override this per-test with a stable
+    tmp_path, same layering _no_real_update_check_network documents for
+    the update-check cache above.
+    """
+    monkeypatch.setattr(
+        'utils.update_dismissal.get_project_root',
+        lambda: str(tmp_path_factory.mktemp('update_dismissal')),
+    )
+
 _FAKE_MOVIE_PY = '''\
 import os
 import sys
@@ -85,11 +105,15 @@ users:
     alice:
       display_name: "Alice A"
 general:
-  # Off by default in this shared fixture so the update-banner context
-  # processor (web/app.py) doesn't make a real network call on every
-  # single web test's template render - tests that specifically exercise
-  # the update banner (tests/test_web_update_banner.py) write their own
-  # config.yml with a non-off update_mode.
+  # Off by default in this shared fixture, purely as a reasonable
+  # default value - unlike before v2.8.31, this no longer skips the
+  # update-banner context processor's update_available() call (every
+  # mode, including 'off', calls it now); the real reason no test here
+  # accidentally renders a banner is _no_real_update_check_network above
+  # patching _fetch_latest_version to always return None regardless of
+  # mode. Tests that specifically exercise the update banner (tests/
+  # test_web_update_banner.py) write their own config.yml with whatever
+  # update_mode they need.
   update_mode: off
 libraries:
   - id: movies

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -868,16 +868,48 @@ class TestPrintUpdateNotice:
     users - see docstring)."""
 
     @patch('utils.cli.update_available')
-    def test_off_mode_never_calls_update_available(self, mock_update_available, capsys):
+    def test_off_mode_no_newer_version_prints_nothing(self, mock_update_available, capsys):
+        mock_update_available.return_value = ('2.8.28', '2.8.28', False)
         print_update_notice('off')
-        mock_update_available.assert_not_called()
+        mock_update_available.assert_called_once_with(update_mode='off')
         assert capsys.readouterr().out == ''
+
+    @patch('utils.cli.update_available')
+    def test_off_mode_still_prints_when_a_newer_version_exists(self, mock_update_available, capsys, monkeypatch):
+        """As of v2.8.31, 'off' only means "don't auto-apply" - it must
+        NOT suppress the notice itself (that was the bug this fixed)."""
+        monkeypatch.setattr(sys, 'frozen', False, raising=False)
+        mock_update_available.return_value = ('2.9.0', '2.8.28', True)
+        print_update_notice('off')
+        out = capsys.readouterr().out
+        assert 'Update available: v2.9.0' in out
 
     @patch('utils.cli.update_available')
     def test_no_newer_version_prints_nothing(self, mock_update_available, capsys):
         mock_update_available.return_value = ('2.8.28', '2.8.28', False)
         print_update_notice('notify')
         assert capsys.readouterr().out == ''
+
+    @patch('utils.cli.is_dismissed')
+    @patch('utils.cli.update_available')
+    def test_dismissed_version_prints_nothing(self, mock_update_available, mock_is_dismissed, capsys):
+        """Respects the same 7-day snooze the web UI's dismiss button
+        writes (utils.update_dismissal) - see tests/test_update_dismissal.py
+        for the snooze-window/version-override unit tests themselves."""
+        mock_update_available.return_value = ('2.9.0', '2.8.28', True)
+        mock_is_dismissed.return_value = True
+        print_update_notice('notify')
+        mock_is_dismissed.assert_called_once_with('2.9.0')
+        assert capsys.readouterr().out == ''
+
+    @patch('utils.cli.is_dismissed')
+    @patch('utils.cli.update_available')
+    def test_non_dismissed_version_still_prints(self, mock_update_available, mock_is_dismissed, capsys, monkeypatch):
+        monkeypatch.setattr(sys, 'frozen', False, raising=False)
+        mock_update_available.return_value = ('2.9.0', '2.8.28', True)
+        mock_is_dismissed.return_value = False
+        print_update_notice('notify')
+        assert 'Update available: v2.9.0' in capsys.readouterr().out
 
     @patch('utils.cli.update_available')
     def test_source_notify_mode_points_at_run_sh(self, mock_update_available, capsys, monkeypatch):

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -196,20 +196,47 @@ class TestGetLatestVersionFailOpen:
 
 
 class TestGetLatestVersionOffMode:
-    """update_mode='off' must skip the network entirely."""
+    """As of v2.8.31, update_mode='off' no longer skips the network -
+    'off' only ever meant "don't auto-apply", never "don't tell me an
+    update exists" (see get_latest_version's own docstring for why this
+    changed: an opted-out install silently missing updates forever was
+    the bug). 'off' now uses the exact same cache/fetch path as
+    'notify'/'force', with no special-casing at all."""
 
     @patch('utils.update_check.requests.get')
-    def test_off_mode_never_calls_network(self, mock_get):
-        result = get_latest_version(update_mode='off')
-        assert result is None
-        mock_get.assert_not_called()
+    def test_off_mode_fetches_same_as_notify(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {'tag_name': 'v2.9.0'}
+        mock_get.return_value = mock_response
+
+        result = get_latest_version(update_mode='off', force_refresh=True)
+
+        assert result == '2.9.0'
+        mock_get.assert_called_once()
 
     @patch('utils.update_check.requests.get')
-    def test_off_mode_ignores_existing_cache(self, mock_get, tmp_path):
+    def test_off_mode_uses_existing_fresh_cache_without_a_network_call(self, mock_get, tmp_path):
         _seed_cache(tmp_path, {'latest': '9.9.9', 'checked_at': time.time()})
+
         result = get_latest_version(update_mode='off')
-        assert result is None
+
+        assert result == '9.9.9'
         mock_get.assert_not_called()
+
+    @patch('utils.update_check.requests.get')
+    def test_off_mode_refetches_on_stale_cache(self, mock_get, tmp_path):
+        stale_time = time.time() - (UPDATE_CHECK_INTERVAL_HOURS + 1) * 3600
+        _seed_cache(tmp_path, {'latest': '2.9.0', 'checked_at': stale_time})
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {'tag_name': 'v2.10.0'}
+        mock_get.return_value = mock_response
+
+        result = get_latest_version(update_mode='off')
+
+        assert result == '2.10.0'
+        mock_get.assert_called_once()
 
 
 class TestGetLatestVersionSuccess:

--- a/tests/test_update_dismissal.py
+++ b/tests/test_update_dismissal.py
@@ -1,0 +1,213 @@
+"""Tests for utils/update_dismissal.py - the server-side 7-day snooze
+shared by the web UI's dismissible update banner (web/app.py) and the
+CLI's advisory update notice (utils/cli.py's print_update_notice).
+
+The banner/CLI-level wiring into this module is covered separately
+(tests/test_web_update_banner.py's TestDismiss/TestDismissSnooze,
+tests/test_cli.py's TestPrintUpdateNotice) - these tests exercise
+record_dismissal()/is_dismissed() directly, in isolation.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from utils.update_dismissal import (
+    DISMISS_SNOOZE_DAYS,
+    DISMISS_SNOOZE_SECONDS,
+    is_dismissed,
+    record_dismissal,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_dismissal_dir(tmp_path, monkeypatch, _isolated_update_dismissal_dir):
+    """Every test gets its own throwaway, STABLE (per-test) dir instead
+    of touching the real one - overrides tests/conftest.py's suite-wide
+    _isolated_update_dismissal_dir (which hands out a fresh dir on every
+    call, fine for tests that don't care about persistence) the same
+    way tests/test_update_check.py's own _isolated_cache_dir overrides
+    _no_real_update_check_network for the same reason.
+    """
+    monkeypatch.setattr('utils.update_dismissal.get_project_root', lambda: str(tmp_path))
+    return tmp_path
+
+
+def _dismissal_file_path(tmp_path):
+    return os.path.join(str(tmp_path), 'cache', 'dismissed_update.json')
+
+
+def _seed_dismissal(tmp_path, data):
+    path = _dismissal_file_path(tmp_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+    return path
+
+
+def _seed_dismissal_raw(tmp_path, text):
+    path = _dismissal_file_path(tmp_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(text)
+    return path
+
+
+class TestConstants:
+    def test_snooze_is_seven_days(self):
+        assert DISMISS_SNOOZE_DAYS == 7
+        assert DISMISS_SNOOZE_SECONDS == 7 * 24 * 60 * 60
+
+
+class TestIsDismissedNoState:
+    def test_never_dismissed_returns_false(self):
+        assert is_dismissed('2.9.0') is False
+
+    def test_empty_version_returns_false(self):
+        assert is_dismissed('') is False
+
+
+class TestRecordAndReadRoundTrip:
+    def test_record_then_immediately_dismissed(self, tmp_path):
+        record_dismissal('2.9.0')
+        assert is_dismissed('2.9.0') is True
+
+    def test_writes_expected_json_shape(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        path = _dismissal_file_path(tmp_path)
+        assert os.path.isfile(path)
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+        assert data == {'version': '2.9.0', 'dismissed_at': 1000.0}
+
+    def test_record_empty_version_writes_nothing(self, tmp_path):
+        record_dismissal('')
+        assert not os.path.isfile(_dismissal_file_path(tmp_path))
+
+    def test_record_overwrites_a_previous_dismissal(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        record_dismissal('2.10.0', now=2000.0)
+        assert is_dismissed('2.9.0') is False  # overwritten, no longer the recorded version
+        assert is_dismissed('2.10.0', now=2000.0) is True
+
+
+class TestSnoozeWindow:
+    """The exact 7-day boundary - see DISMISS_SNOOZE_SECONDS."""
+
+    def test_dismissed_moments_ago_is_snoozed(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        assert is_dismissed('2.9.0', now=1000.0 + 1) is True
+
+    def test_dismissed_just_under_seven_days_ago_is_still_snoozed(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        assert is_dismissed('2.9.0', now=1000.0 + DISMISS_SNOOZE_SECONDS - 1) is True
+
+    def test_dismissed_exactly_seven_days_ago_is_no_longer_snoozed(self, tmp_path):
+        """Boundary is a strict '<', not '<=' - see is_dismissed's
+        (current_time - dismissed_at) < DISMISS_SNOOZE_SECONDS check."""
+        record_dismissal('2.9.0', now=1000.0)
+        assert is_dismissed('2.9.0', now=1000.0 + DISMISS_SNOOZE_SECONDS) is False
+
+    def test_dismissed_well_over_seven_days_ago_is_not_snoozed(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        assert is_dismissed('2.9.0', now=1000.0 + DISMISS_SNOOZE_SECONDS + 3600) is False
+
+    def test_default_now_uses_real_time(self, tmp_path):
+        """Real-world usage: no `now` override, real time.time() on both
+        sides - a dismissal recorded 'just now' must read back as
+        dismissed 'just now', with no explicit time mocking needed."""
+        record_dismissal('2.9.0')
+        assert is_dismissed('2.9.0') is True
+
+
+class TestNewerVersionOverridesSnooze:
+    def test_newer_version_than_dismissed_is_not_suppressed(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        # Well within the snooze window time-wise, but a DIFFERENT
+        # (newer) version is being asked about.
+        assert is_dismissed('2.10.0', now=1000.0 + 60) is False
+
+    def test_older_version_than_dismissed_is_also_not_suppressed(self, tmp_path):
+        """Dismissal is scoped to the EXACT version dismissed, never
+        "any version up to and including this one" - an older version
+        string being re-checked (unusual, but not this module's job to
+        assume impossible) must not be treated as still-dismissed
+        either."""
+        record_dismissal('2.10.0', now=1000.0)
+        assert is_dismissed('2.9.0', now=1000.0 + 60) is False
+
+
+class TestFailOpen:
+    """Any unreadable/corrupt/unexpected state must resolve to "not
+    dismissed" (the notice IS shown) - never silently swallow a pending
+    update notice because of a filesystem hiccup."""
+
+    def test_corrupt_json_file_is_not_dismissed(self, tmp_path):
+        _seed_dismissal_raw(tmp_path, '{not valid json')
+        assert is_dismissed('2.9.0') is False
+
+    def test_missing_dismissed_at_field_is_not_dismissed(self, tmp_path):
+        _seed_dismissal(tmp_path, {'version': '2.9.0'})
+        assert is_dismissed('2.9.0') is False
+
+    def test_non_numeric_dismissed_at_is_not_dismissed(self, tmp_path):
+        _seed_dismissal(tmp_path, {'version': '2.9.0', 'dismissed_at': 'not-a-number'})
+        assert is_dismissed('2.9.0') is False
+
+    def test_missing_version_field_is_not_dismissed(self, tmp_path):
+        _seed_dismissal(tmp_path, {'dismissed_at': time.time()})
+        assert is_dismissed('2.9.0') is False
+
+    def test_record_dismissal_write_failure_is_not_fatal(self, monkeypatch):
+        """A disk error writing the dismissal state (permissions, full
+        disk, etc.) must not raise - worst case, the notice just keeps
+        reappearing every check instead of being snoozed. Points the
+        cache dir at a nonexistent, never-created path so the real
+        open() call fails naturally, same technique tests/
+        test_update_check.py's own test_cache_write_failure_is_not_fatal
+        uses."""
+        monkeypatch.setattr(
+            'utils.update_dismissal.get_project_root',
+            lambda: '/nonexistent/path/that/is/never/created',
+        )
+        try:
+            record_dismissal('2.9.0')
+        except Exception as e:
+            pytest.fail(f'record_dismissal() raised instead of failing open: {e}')
+
+    def test_is_dismissed_read_failure_is_not_fatal(self, tmp_path):
+        """A directory where the file should be (unreadable as JSON in
+        any useful sense) must not raise - same fail-open contract,
+        exercised via _read_dismissal()'s try/except around open()."""
+        path = _dismissal_file_path(tmp_path)
+        os.makedirs(path, exist_ok=True)  # a directory, not a file, at that exact path
+        try:
+            result = is_dismissed('2.9.0')
+        except Exception as e:
+            pytest.fail(f'is_dismissed() raised instead of failing open: {e}')
+        assert result is False
+
+
+class TestPersistsAcrossCalls:
+    """Proves this is genuine on-disk state, not anything held in
+    process/module-level memory - separate, independent calls (no
+    shared object between them) must still see the same state, the same
+    way a real web server restart or a separate CLI invocation would."""
+
+    def test_state_survives_independent_read_after_write(self, tmp_path):
+        record_dismissal('2.9.0', now=1000.0)
+        # A second, wholly independent call - nothing carried over except
+        # what's on disk at _dismissal_path().
+        assert is_dismissed('2.9.0', now=1000.5) is True
+
+    def test_state_visible_to_a_second_isolated_read(self, tmp_path):
+        record_dismissal('2.9.0')
+        with open(_dismissal_file_path(tmp_path), encoding='utf-8') as f:
+            on_disk = json.load(f)
+        assert on_disk['version'] == '2.9.0'
+        assert isinstance(on_disk['dismissed_at'], (int, float))

--- a/tests/test_web_update_banner.py
+++ b/tests/test_web_update_banner.py
@@ -5,10 +5,20 @@ its gating by general.update_mode.
 The version-check itself (utils/update_check.py) is unit-tested
 separately in tests/test_update_check.py - these tests mock
 web.app.update_available so no test here ever touches the network.
+
+As of v2.8.31, the banner renders for EVERY update_mode (including
+'off') whenever a newer version is known - dismissal is a server-side
+7-day snooze (utils/update_dismissal.py), not a permanent-per-version
+browser cookie. The snooze/version-override mechanics themselves are
+unit-tested in tests/test_update_dismissal.py; TestDismiss below covers
+this file's own concern: the /update/dismiss route + banner context
+processor actually wiring into that module correctly.
 """
 
+import json
 import os
 import sys
+import time
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -26,6 +36,22 @@ def client(curatarr_web_root):
     return app.test_client(), app, curatarr_web_root
 
 
+@pytest.fixture(autouse=True)
+def _isolated_dismissal_dir(tmp_path, monkeypatch):
+    """Overrides tests/conftest.py's suite-wide
+    _isolated_update_dismissal_dir (which hands every call a FRESH
+    throwaway tmp dir, fine for tests that never care about dismissal
+    state) with a single STABLE directory for the duration of each test
+    here - this file's TestDismiss tests write a dismissal via one
+    request and need a later request to actually see it, which requires
+    utils.update_dismissal.get_project_root() to keep resolving to the
+    same place across calls within a test. Same layering
+    tests/test_update_check.py's own _isolated_cache_dir documents.
+    """
+    monkeypatch.setattr('utils.update_dismissal.get_project_root', lambda: str(tmp_path))
+    return tmp_path
+
+
 def _write_config(root, update_mode=None):
     config_path = module_path(root, 'config')
     general = f'general:\n  update_mode: {update_mode}\n' if update_mode else ''
@@ -37,14 +63,40 @@ def _write_config(root, update_mode=None):
         )
 
 
+def _seed_dismissal(root, version, dismissed_at):
+    """Directly writes utils.update_dismissal's on-disk state (matches
+    that module's own project_root/cache/dismissed_update.json
+    convention - see _isolated_dismissal_dir above for why `root` here
+    is the same directory utils.update_dismissal.get_project_root() is
+    patched to resolve to) - lets snooze-boundary tests control the
+    dismissed_at timestamp precisely without waiting real days or
+    monkeypatching the global time module."""
+    path = os.path.join(str(root), 'cache', 'dismissed_update.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump({'version': version, 'dismissed_at': dismissed_at}, f)
+
+
 class TestBannerGating:
-    def test_hidden_when_update_mode_off(self, client):
+    def test_shown_when_update_mode_off_and_newer_version_available(self, client):
+        """As of v2.8.31, 'off' only means "don't auto-apply" - it must
+        NOT suppress the banner itself (that was the bug this fixed:
+        opted-out users silently missing updates forever)."""
         c, app, root = client
         _write_config(root, update_mode='off')
 
-        with patch('web.app.update_available') as mock_update_available:
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
             resp = c.get('/')
-            mock_update_available.assert_not_called()
+
+        assert b'update-banner' in resp.data
+        assert b'v2.9.0' in resp.data
+
+    def test_hidden_when_update_mode_off_and_no_newer_version(self, client):
+        c, app, root = client
+        _write_config(root, update_mode='off')
+
+        with patch('web.app.update_available', return_value=('2.8.28', '2.8.28', False)):
+            resp = c.get('/')
 
         assert b'update-banner' not in resp.data
 
@@ -54,6 +106,21 @@ class TestBannerGating:
 
         with patch('web.app.update_available', return_value=('2.8.28', '2.8.28', False)):
             resp = c.get('/')
+
+        assert b'update-banner' not in resp.data
+
+    def test_hidden_when_config_missing_never_calls_update_available(self, client):
+        """Distinct from the update_mode='off' case above: a config that
+        can't even be loaded must still skip update_available() entirely
+        (see test_broken_config_fails_open_no_banner_no_500 below for the
+        "config exists but is invalid YAML" variant) - there's simply no
+        update_mode to resolve yet."""
+        c, app, root = client
+        os.remove(module_path(root, 'config'))
+
+        with patch('web.app.update_available') as mock_update_available:
+            resp = c.get('/')
+            mock_update_available.assert_not_called()
 
         assert b'update-banner' not in resp.data
 
@@ -191,15 +258,24 @@ class TestBannerContent:
 
 
 class TestDismiss:
-    def test_dismiss_sets_cookie_and_redirects(self, client):
+    def test_dismiss_persists_server_side_and_redirects(self, client):
+        """As of v2.8.31, dismissal is server-side state (utils/
+        update_dismissal.py), not a cookie - see that module's docstring
+        for why (this app has no other session boundary, and the CLI
+        notice needs to see the same dismissal a browser cookie never
+        could)."""
         c, app, root = client
         _write_config(root, update_mode='notify')
 
         resp = c.post('/update/dismiss', data={'version': '2.9.0', 'next': '/'})
 
         assert resp.status_code == 303
-        set_cookie = resp.headers.get('Set-Cookie', '')
-        assert 'curatarr_update_dismissed=2.9.0' in set_cookie
+        # No cookie at all - server-side is the sole source of truth now.
+        assert 'curatarr_update_dismissed' not in resp.headers.get('Set-Cookie', '')
+
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
+            resp = c.get('/')
+        assert b'update-banner' not in resp.data
 
     def test_dismiss_redirects_to_next(self, client):
         c, app, root = client
@@ -221,7 +297,7 @@ class TestDismiss:
     def test_dismissed_version_suppresses_banner(self, client):
         c, app, root = client
         _write_config(root, update_mode='notify')
-        c.set_cookie('curatarr_update_dismissed', '2.9.0')
+        c.post('/update/dismiss', data={'version': '2.9.0', 'next': '/'})
 
         with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
             resp = c.get('/')
@@ -231,10 +307,82 @@ class TestDismiss:
     def test_dismissing_older_version_does_not_suppress_a_newer_one(self, client):
         c, app, root = client
         _write_config(root, update_mode='notify')
-        c.set_cookie('curatarr_update_dismissed', '2.9.0')
+        c.post('/update/dismiss', data={'version': '2.9.0', 'next': '/'})
 
         with patch('web.app.update_available', return_value=('2.10.0', '2.8.28', True)):
             resp = c.get('/')
 
         assert b'update-banner' in resp.data
         assert b'v2.10.0' in resp.data
+
+    def test_dismiss_works_when_update_mode_is_off(self, client):
+        """The dismiss button is reachable from an 'off'-mode banner too
+        (it now renders one - see TestBannerGating above), and must
+        snooze it exactly the same way."""
+        c, app, root = client
+        _write_config(root, update_mode='off')
+        c.post('/update/dismiss', data={'version': '2.9.0', 'next': '/'})
+
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
+            resp = c.get('/')
+
+        assert b'update-banner' not in resp.data
+
+
+class TestDismissSnooze:
+    """7-day snooze window + persistence-across-app-instances - the
+    banner-level integration of utils/update_dismissal.py's contract
+    (unit-tested in isolation, including the exact 7-day boundary, in
+    tests/test_update_dismissal.py). Seeds the on-disk dismissal state
+    directly (_seed_dismissal) rather than going through a real 7-day
+    wait or monkeypatching the global time module."""
+
+    def test_dismissal_within_snooze_window_hides_banner(self, client):
+        c, app, root = client
+        _write_config(root, update_mode='notify')
+        _seed_dismissal(root, '2.9.0', time.time() - 6 * 24 * 60 * 60)  # 6 days ago
+
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
+            resp = c.get('/')
+
+        assert b'update-banner' not in resp.data
+
+    def test_dismissal_expires_after_seven_days(self, client):
+        c, app, root = client
+        _write_config(root, update_mode='notify')
+        _seed_dismissal(root, '2.9.0', time.time() - (7 * 24 * 60 * 60 + 1))  # just over 7 days ago
+
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
+            resp = c.get('/')
+
+        assert b'update-banner' in resp.data
+        assert b'v2.9.0' in resp.data
+
+    def test_newer_version_overrides_an_active_snooze(self, client):
+        c, app, root = client
+        _write_config(root, update_mode='notify')
+        _seed_dismissal(root, '2.9.0', time.time() - 60)  # dismissed 1 minute ago, well within snooze
+
+        with patch('web.app.update_available', return_value=('2.10.0', '2.8.28', True)):
+            resp = c.get('/')
+
+        assert b'update-banner' in resp.data
+        assert b'v2.10.0' in resp.data
+
+    def test_dismissal_persists_across_a_fresh_app_instance(self, client):
+        """Proves the dismissal is genuine server-side/on-disk state, not
+        anything cached in-process on the Flask app object - a brand new
+        create_app() call (i.e. a server restart) against the same
+        project root must still see it."""
+        c, app, root = client
+        _write_config(root, update_mode='notify')
+        c.post('/update/dismiss', data={'version': '2.9.0', 'next': '/'})
+
+        fresh_app = create_app(project_root=root)
+        fresh_app.testing = True
+        fresh_client = fresh_app.test_client()
+
+        with patch('web.app.update_available', return_value=('2.9.0', '2.8.28', True)):
+            resp = fresh_client.get('/')
+
+        assert b'update-banner' not in resp.data

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -68,6 +68,14 @@ from .update_check import (
     update_available,
 )
 
+# Update-dismissal (7-day snooze) state - shared by the web banner and
+# the CLI notice (see module docstring)
+from .update_dismissal import (
+    DISMISS_SNOOZE_DAYS,
+    record_dismissal,
+    is_dismissed,
+)
+
 # In-binary self-update utilities (frozen/PyInstaller binaries only -
 # see module docstring; source installs keep using run.sh/run.ps1)
 from .self_update import (
@@ -366,6 +374,10 @@ __all__ = [
     'parse_version',
     'get_latest_version',
     'update_available',
+    # Update dismissal (7-day snooze)
+    'DISMISS_SNOOZE_DAYS',
+    'record_dismissal',
+    'is_dismissed',
     # Display
     'RED',
     'GREEN',

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -22,6 +22,7 @@ from .display import (
 )
 from .helpers import cleanup_old_logs, get_project_root
 from .update_check import GITHUB_RELEASES_PAGE, update_available
+from .update_dismissal import is_dismissed
 from .user_migration import migrate_renamed_plex_users
 
 
@@ -176,21 +177,28 @@ def print_update_notice(update_mode: str) -> None:
     curatarr_app.py's `--self-update` dispatch) - this notice's
     frozen-branch message points at that flag first.
 
+    As of v2.8.31, this prints for EVERY update_mode, including 'off' -
+    'off' only ever meant "don't auto-apply", never "don't tell me" (see
+    utils.config.get_update_mode's docstring); staying silent about a
+    pending update by default was the actual bug this fixed. Respects
+    the same 7-day dismissal snooze the web UI's banner writes (see
+    utils.update_dismissal) - dismissing a version in the web UI also
+    quiets this CLI notice for that same version/window, and vice versa
+    isn't possible (the CLI has no dismiss action of its own, it only
+    ever reads state the web UI wrote).
+
     Fails open by construction: utils.update_check.update_available()
     never raises, so a broken/offline check just means no notice gets
-    printed - it can never block or break a run. update_mode == 'off'
-    is handled by update_available() itself (skips the network call
-    entirely), checked again here for clarity at the call site.
+    printed - it can never block or break a run.
 
     Args:
         update_mode: 'notify' | 'force' | 'off' (see
             utils.config.get_update_mode)
     """
-    if update_mode == 'off':
-        return
-
     latest, current, is_newer = update_available(update_mode=update_mode)
     if not is_newer:
+        return
+    if is_dismissed(latest):
         return
 
     if os.environ.get('RUNNING_IN_DOCKER') == 'true':

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.8.30"
+__version__ = "2.8.31"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/update_check.py
+++ b/utils/update_check.py
@@ -179,16 +179,20 @@ def get_latest_version(update_mode: str = 'notify', force_refresh: bool = False)
     Never raises.
 
     Args:
-        update_mode: 'notify' | 'force' | 'off'. 'off' skips the network
-            entirely and returns None without even reading the cache -
-            a user who disabled update checks shouldn't have this
-            module touch the network at all.
+        update_mode: 'notify' | 'force' | 'off' - accepted for call-site
+            symmetry with update_available()/print_update_notice(), but
+            no longer changes fetch behavior: as of v2.8.31, EVERY mode
+            (including 'off') uses this exact same cache/fetch path, so
+            an opted-out ('off') install still learns a newer release
+            exists (via the dismissible web banner / CLI notice - see
+            web/app.py's _update_banner_context and utils.cli's
+            print_update_notice) even though it will never auto-apply
+            one. 'off' only ever meant "don't APPLY updates automatically",
+            never "don't tell me one exists" - see utils.config.
+            get_update_mode's docstring for the mode's actual contract.
         force_refresh: bypass the on-disk cache/interval (used by tests
             and by anything that explicitly wants a fresh check).
     """
-    if update_mode == 'off':
-        return None
-
     if not force_refresh:
         cache = _read_cache()
         if cache and isinstance(cache.get('checked_at'), (int, float)):

--- a/utils/update_dismissal.py
+++ b/utils/update_dismissal.py
@@ -1,0 +1,133 @@
+"""
+Server-side "dismiss the update notice" state for Curatarr.
+
+Shared by the web UI's dismissible update banner (web/app.py's
+_update_banner_context / update_dismiss route) AND the CLI's advisory
+update notice (utils/cli.py's print_update_notice), so dismissing the
+banner in the browser also quiets the CLI notice for the same window,
+and vice versa - there's exactly one dismissal state, not one per
+surface. Stored server-side (a small JSON file under project_root/
+cache/ - same gitignored, per-install convention utils/update_check.py's
+own update_check_cache.json uses, see that module's _cache_path())
+rather than a browser cookie: this is a single-tenant, localhost-only
+app with no other session/auth boundary to key a per-browser cookie
+against (see web/app.py's module docstring), and a server-side file is
+the only way the CLI notice - a separate process/invocation with no
+HTTP request or cookie jar at all - can ever see what the web UI
+dismissed.
+
+Dismissal is a SNOOZE, not permanent (v2.8.31 - previously the web
+banner's now-removed per-version cookie stayed dismissed for a full
+year, effectively forever for that version). Semantics:
+  - Dismissing the currently-offered version hides it for
+    DISMISS_SNOOZE_DAYS; after that, the SAME version is offered again.
+    This matters because, as of v2.8.31, update_mode: off/notify never
+    auto-apply anything - without a re-notify, a user who dismissed
+    once could otherwise miss a pending update indefinitely.
+  - A version NEWER than the one that was dismissed always overrides
+    an active snooze immediately - dismissal is scoped to the EXACT
+    version string dismissed, never "any future update".
+
+Fail-open by construction, matching utils.update_check's own contract:
+any read/write error here means "not dismissed" (the notice is shown)
+or "dismissal not recorded" (never "silently remember a dismissal that
+didn't actually happen") - a broken dismissal state must never be the
+reason an update goes unnoticed.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+from .helpers import get_project_root
+
+logger = logging.getLogger('curatarr')
+
+# How long dismissing a specific version snoozes it for. Deliberately
+# much shorter than UPDATE_CHECK_INTERVAL_HOURS-driven version
+# *freshness* (utils.update_check) staying at ~12h - this constant only
+# governs how long a dismissal is honored, never how often the network
+# is polled for a possibly-newer version.
+DISMISS_SNOOZE_DAYS = 7
+DISMISS_SNOOZE_SECONDS = DISMISS_SNOOZE_DAYS * 24 * 60 * 60
+
+_DISMISSAL_FILENAME = 'dismissed_update.json'
+
+
+def _dismissal_path() -> str:
+    # Same directory/convention as utils.update_check._cache_path() -
+    # project_root/cache/, gitignored, never directly in project_root
+    # itself (which for a source install IS the git checkout).
+    cache_dir = os.path.join(get_project_root(), 'cache')
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+    except Exception as e:
+        logger.debug(f"Could not create update-dismissal cache dir: {e}")
+    return os.path.join(cache_dir, _DISMISSAL_FILENAME)
+
+
+def record_dismissal(version: str, now: Optional[float] = None) -> None:
+    """Persist that `version` (e.g. "2.9.0", no 'v' prefix - matches
+    update_available()'s own `latest` shape) was just dismissed.
+
+    Never raises: a failure to persist just means the notice keeps
+    showing up on the next check, the same fail-toward-"still notify"
+    direction as every other error path in this module.
+
+    Args:
+        version: the exact version string that was dismissed.
+        now: override for the current time - tests only; real callers
+            never pass this (defaults to time.time()).
+    """
+    if not version:
+        return
+    path = _dismissal_path()
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(
+                {'version': version, 'dismissed_at': now if now is not None else time.time()},
+                f,
+            )
+    except Exception as e:
+        logger.debug(f"Could not write update-dismissal state: {e}")
+
+
+def _read_dismissal() -> Optional[dict]:
+    path = _dismissal_path()
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def is_dismissed(version: str, now: Optional[float] = None) -> bool:
+    """True if `version` is currently snoozed - see module docstring for
+    the exact-version-match + DISMISS_SNOOZE_DAYS-elapsed contract.
+
+    Fails open (False - i.e. the notice IS shown) on: no dismissal ever
+    recorded, an unreadable/corrupt state file, a dismissal for a
+    DIFFERENT version (including an older one - a newer release always
+    overrides an existing snooze), or a snooze whose window has already
+    elapsed.
+
+    Args:
+        version: the version currently being offered (e.g. `latest`
+            from update_available()).
+        now: override for the current time - tests only; real callers
+            never pass this (defaults to time.time()).
+    """
+    if not version:
+        return False
+    state = _read_dismissal()
+    if not state or state.get('version') != version:
+        return False
+    dismissed_at = state.get('dismissed_at')
+    if not isinstance(dismissed_at, (int, float)):
+        return False
+    current_time = now if now is not None else time.time()
+    return (current_time - dismissed_at) < DISMISS_SNOOZE_SECONDS

--- a/web/app.py
+++ b/web/app.py
@@ -36,7 +36,16 @@ from flask import (
 from flask.testing import FlaskClient
 from werkzeug.datastructures import Headers
 
-from utils import __version__, get_project_root, get_update_mode, get_users_from_config, load_config, update_available
+from utils import (
+    __version__,
+    get_project_root,
+    get_update_mode,
+    get_users_from_config,
+    is_dismissed,
+    load_config,
+    record_dismissal,
+    update_available,
+)
 
 from .config_app import register_config_routes
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
@@ -49,13 +58,6 @@ from .update_apply import (
 )
 
 DEFAULT_PORT = 8787
-
-# Cookie used to persist a per-version dismissal of the update banner
-# (see create_app()'s _update_banner_context / update_dismiss). One
-# year is effectively "until the next release the user hasn't seen",
-# since dismissal is keyed to the specific 'latest' version string.
-UPDATE_DISMISS_COOKIE = 'curatarr_update_dismissed'
-UPDATE_DISMISS_COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
 # How long the SSE stream waits for a new line before sending a
 # keepalive comment - see run_stream()'s generate().
@@ -139,6 +141,18 @@ def create_app(project_root: str = None) -> Flask:
         through every route individually - this covers config_app.py's
         routes too since they render through this same Flask app.
 
+        As of v2.8.31, the banner renders for EVERY general.update_mode,
+        including 'off' - 'off' only ever meant "don't auto-apply", not
+        "don't tell me" (see utils.config.get_update_mode's docstring),
+        so an opted-out install silently missing updates was the actual
+        bug this fixed. It's still hidden when there's genuinely nothing
+        to show (no config loaded yet, no newer version known, or the
+        offered version is within its 7-day dismiss snooze - see
+        utils.update_dismissal). 'force' still shows it too - run.sh/
+        run.ps1 (not this banner) is what auto-applies in force mode, so
+        a force-mode source install can still have a pending update this
+        banner is the only place it surfaces (e.g. between runs).
+
         Fails open just like utils.update_check: any exception here
         (config missing/unreadable, network error, whatever) just means
         no banner, never a 500 - a broken update check must never break
@@ -148,18 +162,21 @@ def create_app(project_root: str = None) -> Flask:
             config = _load_config()
             # No config at all (missing/unreadable) is already a degraded
             # state the app can't really run normally in - skip the check
-            # rather than defaulting to 'notify', which would mean an
-            # HTTP call on every single page render for an install that
-            # can't even load its config yet.
-            update_mode = get_update_mode(config) if config else 'off'
-            if update_mode == 'off':
+            # entirely (never even calls update_available) rather than
+            # defaulting to some mode, which would mean an HTTP call on
+            # every single page render for an install that can't even
+            # load its config yet.
+            if not config:
                 return {'update_banner': None}
+            update_mode = get_update_mode(config)
             latest, current, is_newer = update_available(update_mode=update_mode)
             if not is_newer:
                 return {'update_banner': None}
-            # Dismissal is per-version: bumping to a newer release than
-            # the one that was dismissed shows the banner again.
-            if request.cookies.get(UPDATE_DISMISS_COOKIE) == latest:
+            # 7-day dismiss snooze, keyed to the exact version offered -
+            # see utils.update_dismissal.is_dismissed's docstring for why
+            # a newer release than the one dismissed always overrides an
+            # active snooze instead of also being suppressed.
+            if is_dismissed(latest):
                 return {'update_banner': None}
             return {
                 'update_banner': {
@@ -180,24 +197,21 @@ def create_app(project_root: str = None) -> Flask:
 
     @app.post('/update/dismiss')
     def update_dismiss():
-        """Persist a per-version banner dismissal as a cookie (no server-
-        side state needed - this is purely a display preference, not a
-        security-relevant setting). Redirects back to wherever the
-        dismiss button was clicked from."""
+        """Snooze the update banner for this version for 7 days (see
+        utils.update_dismissal) - server-side state, not a cookie (as of
+        v2.8.31): this app is single-tenant/localhost-only with no other
+        session boundary (see this module's docstring), and server-side
+        state is what lets utils.cli's print_update_notice respect the
+        same dismissal, which a browser cookie never could. Redirects
+        back to wherever the dismiss button was clicked from."""
         version = request.form.get('version', '')
         next_url = request.form.get('next') or url_for('dashboard')
         # Only ever redirect to a same-app relative path - never let an
         # attacker-controlled 'next' turn this into an open redirect.
         if not next_url.startswith('/') or next_url.startswith('//'):
             next_url = url_for('dashboard')
-        response = redirect(next_url, code=303)
-        if version:
-            response.set_cookie(
-                UPDATE_DISMISS_COOKIE, version,
-                max_age=UPDATE_DISMISS_COOKIE_MAX_AGE,
-                httponly=True, samesite='Lax',
-            )
-        return response
+        record_dismissal(version)
+        return redirect(next_url, code=303)
 
     @app.post('/update/apply')
     def update_apply_route():


### PR DESCRIPTION
## Summary
- general.update_mode: off used to skip the update-check network call entirely, so an opted-out install silently missed every release forever - off only ever meant "don't apply automatically", never "don't tell me". The web UI banner and CLI notice now check for a newer release regardless of mode; the only thing off still disables is run.sh/run.ps1's interactive launch-time "Update now? [y/N]" prompt.
- The web banner's dismiss button is now a 7-day snooze (utils/update_dismissal.py, new - small server-side cache/dismissed_update.json, shared with the CLI notice) instead of an effectively-permanent per-version cookie. A release newer than the one dismissed always overrides an active snooze immediately.
- force mode behavior is unchanged (still auto-applies for source installs; binaries never auto-apply regardless of mode).

## Test plan
- tests/test_update_dismissal.py (new) - snooze window boundaries (6 days / exactly 7 days / >7 days), newer-version-overrides-snooze, fail-open on corrupt/missing state, persistence across independent calls
- tests/test_web_update_banner.py - banner shown for off+notify+force when newer version exists, hidden only when no newer version or config missing/broken; dismiss persists server-side and survives a fresh create_app() instance (proves it isn't in-process state)
- tests/test_update_check.py - off mode now fetches/caches exactly like notify/force
- tests/test_cli.py - CLI notice prints for off when a newer version exists, respects the dismissal snooze
- Full suite: 2153 passed, 1 skipped; coverage 95.54% (gate 85%)

Branch: feat/update-banner-all-modes-2.8.31
