### PR TITLE
fix(ci): drop shallow --depth=1 from secret-scan base-ref fetch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,19 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch origin "$PR_BASE_REF" --depth=1
+            # No --depth here: the checkout step above already used
+            # fetch-depth: 0 (full history), so this is just an
+            # incremental fetch of any new commits on the base branch,
+            # not an expensive full re-fetch. A shallow (--depth=1)
+            # fetch of a base ref that's already an ancestor of HEAD
+            # through a full-history checkout (e.g. after a PR branch
+            # is updated with a merge of main) plants a shallow-graft
+            # boundary that stops rev-list's UNINTERESTING propagation
+            # at that commit, making `origin/main..HEAD` spuriously
+            # include the base branch's entire prior history instead of
+            # just the PR's own commits - which then makes gitleaks
+            # scan (and can flag) history that already exists on main.
+            git fetch origin "$PR_BASE_REF"
             echo "range=origin/${PR_BASE_REF}..HEAD" >> "$GITHUB_OUTPUT"
           else
             if [ -z "$EVENT_BEFORE" ] || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then


### PR DESCRIPTION
Fixes a git shallow-fetch/graft bug in the secret-scan job's commit-range computation. Discovered while updating PR #194's branch: a --depth=1 fetch of the base ref on top of an already full-history checkout (fetch-depth: 0) plants a shallow-graft boundary. When the PR branch's HEAD includes that same base commit as an ancestor via a merge (e.g. after gh pr update-branch), the graft breaks rev-list's UNINTERESTING propagation and origin/main..HEAD spuriously includes the base branch's entire prior history instead of just the PR's own commits - which then makes gitleaks scan (and can flag) history that already exists on main.\n\nReproduced directly in a fresh clone: on the affected branch, origin/main..HEAD went from 2 commits to 272 with --depth=1, and back to 2 without it.\n\nFix: drop --depth=1 from the fetch. The checkout step already has fetch-depth: 0, so this is an incremental fetch of new commits only, not an expensive re-fetch.