### PR TITLE
fix: suppress stray Windows console windows from background subprocesses (2.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.9.2] - 2026-07-25
+
+Suppresses stray Windows console windows from background helper
+subprocesses on a windowed (console=False) build.
+
+### Fixed
+
+- Five subprocess spawns that were missing `CREATE_NO_WINDOW` on
+  Windows could each flash a console window: `web/job_runner.py`'s
+  stale-lock `tasklist` check, and `web/update_apply.py`'s
+  `-CheckVerifiedUpdate`/`-ApplyVerifiedUpdate` PowerShell
+  invocations, `tasklist` polling loop, and `taskkill`. All five
+  already pipe/capture their child's output, so hiding the window
+  loses nothing. Added a shared `utils.helpers.no_window_kwargs()`
+  helper (returns `{}` on non-Windows) rather than repeating the
+  `getattr(subprocess, 'CREATE_NO_WINDOW', 0)` guard at each site.
+- The daily 3 AM scheduled task (`run.ps1`'s `Setup-ScheduledTask`)
+  now launches with `-WindowStyle Hidden`, so it no longer pops a
+  console window when the user is logged in.
+
 ## [2.9.1] - 2026-07-24
 
 Maintenance release: dependency bump and lock file refresh. No feature

--- a/run.ps1
+++ b/run.ps1
@@ -1422,7 +1422,7 @@ function Setup-ScheduledTask {
     }
 
     try {
-        $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -File `"$ScriptDir\run.ps1`"" -WorkingDirectory $ScriptDir
+        $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$ScriptDir\run.ps1`"" -WorkingDirectory $ScriptDir
         $trigger = New-ScheduledTaskTrigger -Daily -At 3am
         $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,12 +4,13 @@ Tests for utils/helpers.py - Miscellaneous helper functions.
 
 import pytest
 import os
+import subprocess
 import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import patch
 from utils.helpers import (
     normalize_title, map_path, cleanup_old_logs, compute_profile_hash,
-    get_project_root, TITLE_SUFFIXES_TO_STRIP,
+    get_project_root, no_window_kwargs, TITLE_SUFFIXES_TO_STRIP,
 )
 
 
@@ -421,3 +422,25 @@ class TestGetProjectRoot:
         root = get_project_root()
         assert os.path.isdir(os.path.join(root, 'utils'))
         assert os.path.isdir(os.path.join(root, 'web'))
+
+
+class TestNoWindowKwargs:
+    """no_window_kwargs() - shared subprocess.run()/Popen() kwargs that
+    suppress a console window on Windows for the short-lived helper
+    children (tasklist/taskkill/powershell precondition checks) spread
+    across web/job_runner.py and web/update_apply.py - see that
+    function's own docstring for why this is centralized rather than
+    each call site repeating its own getattr(...) guard.
+
+    subprocess.CREATE_NO_WINDOW only exists as an attribute on win32
+    Python builds, so both the implementation and these tests read it
+    via getattr(..., default=0) - monkeypatching os.name exercises both
+    branches without needing an actual Windows interpreter."""
+
+    def test_windows_returns_create_no_window_flag(self, monkeypatch):
+        monkeypatch.setattr(os, 'name', 'nt')
+        assert no_window_kwargs() == {'creationflags': getattr(subprocess, 'CREATE_NO_WINDOW', 0)}
+
+    def test_posix_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setattr(os, 'name', 'posix')
+        assert no_window_kwargs() == {}

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -387,3 +387,35 @@ class TestWindowsSubprocessCreationFlags:
 
         assert 'creationflags' not in captured
         assert captured.get('start_new_session') is True
+
+
+class TestPidAliveWindowsTasklist:
+    """_pid_alive's Windows branch (a foreign-lockfile liveness probe -
+    see TestForeignLockfile above) shells out to tasklist, same
+    console-window concern as _build_command's own child above - see
+    utils.helpers.no_window_kwargs's docstring."""
+
+    def test_tasklist_call_suppresses_console_window(self, monkeypatch):
+        monkeypatch.setattr(job_runner_mod.os, 'name', 'nt')
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured['cmd'] = cmd
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(cmd, 0, stdout='1234 python.exe', stderr='')
+
+        monkeypatch.setattr(job_runner_mod.subprocess, 'run', _fake_run)
+
+        assert job_runner_mod._pid_alive(1234) is True
+        assert captured['cmd'][0] == 'tasklist'
+        assert captured.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
+
+    def test_posix_branch_never_calls_subprocess(self, monkeypatch):
+        monkeypatch.setattr(job_runner_mod.os, 'name', 'posix')
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("subprocess.run should not be called on the POSIX branch")
+
+        monkeypatch.setattr(job_runner_mod.subprocess, 'run', _boom)
+
+        assert job_runner_mod._pid_alive(os.getpid()) is True

--- a/tests/test_web_update_apply.py
+++ b/tests/test_web_update_apply.py
@@ -33,6 +33,7 @@ kill the test process/runner).
 """
 
 import os
+import subprocess
 import sys
 from unittest.mock import Mock, patch
 
@@ -780,6 +781,7 @@ class TestWindowsBranches:
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == _windows_powershell_path()
         assert '-CheckVerifiedUpdate' in cmd
+        assert mock_run.call_args.kwargs.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
 
     def test_pid_alive_uses_tasklist(self, monkeypatch):
         monkeypatch.setattr('web.update_apply.os.name', 'nt')
@@ -787,6 +789,7 @@ class TestWindowsBranches:
             mock_run.return_value = Mock(stdout='1234 python.exe')
             assert _pid_alive(1234) is True
             assert mock_run.call_args[0][0][0] == _windows_tasklist_path()
+            assert mock_run.call_args.kwargs.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
 
     def test_pid_alive_tasklist_exception_fails_toward_alive(self, monkeypatch):
         monkeypatch.setattr('web.update_apply.os.name', 'nt')
@@ -807,6 +810,7 @@ class TestWindowsBranches:
         assert cmd[0] == _windows_taskkill_path()
         assert '/F' in cmd
         assert cmd == [_windows_taskkill_path(), '/F', '/PID', '1234']
+        assert mock_run.call_args.kwargs.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
 
     @patch('web.update_apply.subprocess.Popen')
     def test_relaunch_ui_uses_powershell_and_creationflags(self, mock_popen, monkeypatch):
@@ -836,6 +840,7 @@ class TestWindowsBranches:
         apply_cmd = mock_run.call_args[0][0]
         assert apply_cmd[0] == _windows_powershell_path()
         assert '-ApplyVerifiedUpdate' in apply_cmd
+        assert mock_run.call_args.kwargs.get('creationflags') == getattr(subprocess, 'CREATE_NO_WINDOW', 0)
 
 
 class TestRunWorkerLogsApplyStderr:

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.9.1"
+__version__ = "2.9.2"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,6 +5,7 @@ Miscellaneous helper utilities for Curatarr.
 import hashlib
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timedelta
 from functools import lru_cache
@@ -130,6 +131,33 @@ def resolve_system_executable(preferred_path: str, fallback_name: str) -> str:
     if os.path.isfile(preferred_path):
         return preferred_path
     return fallback_name
+
+
+def no_window_kwargs() -> Dict[str, int]:
+    """subprocess.run()/Popen() kwargs to suppress a console window on
+    Windows for a short-lived helper child (tasklist/taskkill/powershell
+    precondition-check invocations) whose output is already captured via
+    capture_output=True/stdout=PIPE - never anything a visible window
+    would show the user that a log/capture doesn't already have. Returns
+    {} on non-Windows: subprocess.CREATE_NO_WINDOW doesn't exist there,
+    so a bare reference would raise AttributeError (same reasoning as
+    web/job_runner.py's/web/update_apply.py's own getattr(...) guard
+    around this constant, which this centralizes for every call site
+    that only needs the plain "no window" flag - not the
+    CREATE_NEW_PROCESS_GROUP/DETACHED_PROCESS combinations
+    web/update_apply.py's _relaunch_ui and utils/self_update_handoff.py
+    use for their own detached, longer-lived children, which stay
+    exactly as they are).
+
+    Deliberately NOT gated on debug mode: every call site this is used
+    from already pipes its child's stdout/stderr, so hiding the window
+    never hides any output - see curatarr_app.py's _debug_requested()/
+    AllocConsole() path for the separate, existing mechanism that gives
+    the main process itself a console on request.
+    """
+    if os.name == 'nt':
+        return {'creationflags': getattr(subprocess, 'CREATE_NO_WINDOW', 0)}
+    return {}
 
 
 def harden_file_permissions(path: str) -> None:

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -31,6 +31,8 @@ import threading
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from utils.helpers import no_window_kwargs
+
 from .security import redact
 
 ENGINES = ('full', 'movie', 'tv', 'external')
@@ -94,6 +96,7 @@ def _pid_alive(pid: int) -> bool:
             result = subprocess.run(
                 ['tasklist', '/FI', f'PID eq {pid}'],
                 capture_output=True, text=True, timeout=3,
+                **no_window_kwargs(),
             )
             return str(pid) in result.stdout
         except Exception:

--- a/web/update_apply.py
+++ b/web/update_apply.py
@@ -106,7 +106,7 @@ import time
 from typing import Optional
 
 from utils import self_update, self_update_handoff
-from utils.helpers import resolve_system_executable
+from utils.helpers import no_window_kwargs, resolve_system_executable
 from utils.update_check import update_available
 
 logger = logging.getLogger('curatarr')
@@ -206,6 +206,7 @@ def check_verified_update(project_root: str, timeout: float = CHECK_TIMEOUT_SECO
             cmd = [_posix_bash_path(), script, '--check-verified-update']
         result = subprocess.run(
             cmd, cwd=project_root, capture_output=True, text=True, timeout=timeout,
+            **no_window_kwargs(),
         )
         if result.returncode != 0:
             return None
@@ -427,6 +428,7 @@ def _pid_alive(pid: int) -> bool:
             result = subprocess.run(
                 [_windows_tasklist_path(), '/FI', f'PID eq {pid}'],
                 capture_output=True, text=True, timeout=3,
+                **no_window_kwargs(),
             )
             return str(pid) in result.stdout
         except Exception:
@@ -510,7 +512,11 @@ def _shut_down_old_server(pid: int, timeout: float) -> None:
         return
     try:
         if os.name == 'nt':
-            subprocess.run([_windows_taskkill_path(), '/F', '/PID', str(pid)], capture_output=True, timeout=5)
+            subprocess.run(
+                [_windows_taskkill_path(), '/F', '/PID', str(pid)],
+                capture_output=True, timeout=5,
+                **no_window_kwargs(),
+            )
         else:
             os.kill(pid, signal.SIGTERM)
     except (ProcessLookupError, OSError):
@@ -778,6 +784,7 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
         try:
             result = subprocess.run(
                 apply_cmd, cwd=project_root, capture_output=True, text=True, timeout=APPLY_TIMEOUT_SECONDS,
+                **no_window_kwargs(),
             )
             output = (result.stdout or '').strip()
             print(f"[update-worker] apply result: {output!r} (exit {result.returncode})", flush=True)


### PR DESCRIPTION
Five subprocess spawns on Windows were missing CREATE_NO_WINDOW despite already piping/capturing their child output, so each could flash a console window on the windowed (console=False) build:\n\n- web/job_runner.py: stale-lock tasklist check\n- web/update_apply.py: -CheckVerifiedUpdate / -ApplyVerifiedUpdate PowerShell invocations, the tasklist polling loop, and taskkill\n\nAdded a shared utils.helpers.no_window_kwargs() helper (returns {} on non-Windows, matching every existing getattr(subprocess, "CREATE_NO_WINDOW", 0) guard already in this codebase) instead of repeating that guard at each site. Not gated on debug mode - all five already capture output through pipes, so hiding the window never hides anything a log/capture doesn't already have; the existing --debug/CURATARR_DEBUG AllocConsole() path is untouched for anyone who wants a console on the main process.\n\nAlso adds -WindowStyle Hidden to the daily scheduled task's PowerShell invocation (run.ps1's Setup-ScheduledTask).\n\nVersion bump to 2.9.2 + CHANGELOG entry.