### PR TITLE
fix: make release scripts match the real two-hop, gh-delegated workflow (2.9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.9.3] - 2026-07-25
+
+Fixes `scripts/release.sh` and `scripts/sign-release-checksums.sh` so the
+documented release path matches how releases actually get cut on this
+project's machines, instead of assuming a single host with both `gh`
+authenticated and the signing key present.
+
+### Fixed
+
+- `scripts/release.sh`'s version precondition was inverted from reality:
+  it aborted whenever `__version__` already matched the target version,
+  but the version bump lands via its own PR (merged to `main` like any
+  other change) *before* tagging, since nothing can push to `main`
+  directly. The precondition now requires `__version__` to already equal
+  the target version and that `CHANGELOG.md` has a matching entry,
+  failing with a clear message naming the missing bump PR otherwise. The
+  script no longer bumps `__version__` or opens/merges a PR itself.
+- Neither script assumed the machine holding the release-signing
+  **private** key might not have `gh` authenticated on it (or installed
+  at all). `scripts/sign-release-checksums.sh` now detects this and
+  delegates `gh release view/download/upload` over SSH to
+  `CURATARR_GH_SSH_HOST`, transferring only the public
+  `SHA256SUMS.txt`/`SHA256SUMS.txt.sig` - the private key is read only
+  locally and never leaves the signing machine. `scripts/release.sh` no
+  longer depends on `gh` at all (tagging and pushing are plain git).
+- Neither script accounted for a two-hop remote topology (a checkout
+  whose own `origin` is another machine, which is the one actually
+  connected to GitHub): a tag pushed from such a checkout reached only
+  the intermediate host, so `.github/workflows/release.yml` silently
+  never fired. `scripts/release.sh` now detects whether `origin` points
+  at GitHub, pushes onward from `CURATARR_GH_SSH_HOST`/
+  `CURATARR_GH_SSH_REPO_DIR` when it doesn't, and confirms via a direct
+  `git ls-remote` against `github.com/OrchestratedChaos/curatarr` that
+  the ref actually landed before proceeding - failing loudly instead of
+  silently if it never does.
+- Added `--dry-run` to both scripts: runs every precondition (including
+  the `gh`-delegation detection) and prints the exact commands a real
+  run would execute, without tagging, pushing, signing, or uploading
+  anything.
+
 ## [2.9.2] - 2026-07-25
 
 Suppresses stray Windows console windows from background helper

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,26 +53,90 @@ git config gpg.format ssh
 for the tag-signing command itself - it doesn't need to be your default
 `user.email`.)
 
-Also make sure `gh auth status` is logged in with repo write access.
+Also make sure `gh auth status` is logged in with repo write access
+(needed for the bump PR below; `scripts/release.sh` itself no longer
+calls `gh` at all - see "Two-hop push" and "Cutting a release" below).
 
-## Cutting a release (one command)
+### Machine setup for `scripts/release.sh` / `scripts/sign-release-checksums.sh`
 
-```
-./scripts/release.sh 2.8.22
-```
+Two things this project's actual machine layout requires that neither
+script can assume by default (no personal hostnames or paths are
+hardcoded into either - both fail with a clear message instead of
+guessing):
 
-This does everything end to end:
+- **Two-hop push.** If the `origin` remote on the machine you run
+  `scripts/release.sh` from does **not** point at
+  `github.com/OrchestratedChaos/curatarr` (e.g. it points at another one
+  of your own machines, which in turn has a GitHub-connected `origin`),
+  set:
+  ```
+  export CURATARR_GH_SSH_HOST=<ssh-alias-of-the-github-connected-machine>
+  export CURATARR_GH_SSH_REPO_DIR=<absolute-path-to-its-curatarr-checkout>
+  ```
+  `scripts/release.sh` pushes the tag to `origin` first, then - only if
+  `origin` isn't GitHub - SSHes to `$CURATARR_GH_SSH_HOST`, `cd`s to
+  `$CURATARR_GH_SSH_REPO_DIR`, and runs `git push origin <tag>` there,
+  then confirms (via a direct `git ls-remote` against
+  `https://github.com/OrchestratedChaos/curatarr.git`, independent of
+  either host) that the tag actually landed before declaring success. If
+  it never lands, the script fails loudly rather than silently leaving
+  `.github/workflows/release.yml` un-triggered.
+- **gh delegation.** `scripts/sign-release-checksums.sh` must run on the
+  machine holding the signing **private** key, which isn't necessarily
+  the machine where `gh` is authenticated. It checks `gh auth status`
+  locally first; if that fails, it requires `CURATARR_GH_SSH_HOST` (same
+  var as above) and delegates every `gh release view/download/upload`
+  call to that host over SSH. Only the public `SHA256SUMS.txt` /
+  `SHA256SUMS.txt.sig` files ever cross that connection - the private
+  key is read only locally and never transferred.
 
-1. Checks you're on a clean, up-to-date `main`.
-2. Bumps `__version__` in `utils/config.py` on a `release/vX.Y.Z` branch.
-3. Pushes the branch, opens a PR, waits for the `test` check, and
-   squash-merges it.
-4. Pulls the merged commit back into local `main`.
-5. Creates a **signed annotated tag** `vX.Y.Z` (`git tag -s`), signed with
+Set both env vars in your shell profile on any machine where they apply;
+neither script has (or should have) a working default for them.
+
+## Cutting a release
+
+The version bump and the tag are two separate steps on purpose: `main` only
+ever moves via a reviewed PR (nothing pushes to `main` directly), so the
+bump has to land **before** `scripts/release.sh` runs - the script's own
+precondition check enforces this instead of racing it.
+
+1. **Bump the version** (separate PR, merged like any other change): bump
+   `__version__` in `utils/config.py`, add a `## [X.Y.Z] - YYYY-MM-DD`
+   entry to `CHANGELOG.md`, open a PR, get the `test` check green, squash-merge
+   it, and sync local `main` on whichever machine you'll run
+   `scripts/release.sh` from.
+2. **Dry-run it** (recommended - catches a stale local `main`, a missing
+   `CURATARR_GH_SSH_HOST`/`CURATARR_GH_SSH_REPO_DIR`, a missing
+   `CHANGELOG.md` entry, etc. before touching anything):
+   ```
+   ./scripts/release.sh --dry-run 2.8.22
+   ```
+   This runs every precondition and prints the exact `git tag` / `git
+   verify-tag` / `git push` (and, if needed, the two-hop `ssh ... git push`)
+   commands a real run would execute, without running any of them.
+3. **Cut it for real:**
+   ```
+   ./scripts/release.sh 2.8.22
+   ```
+
+This:
+
+1. Checks you're on a clean `main` whose `__version__` already equals
+   `2.8.22` (i.e. step 1's PR has merged) and whose `CHANGELOG.md` has a
+   `[2.8.22]` entry, and that local `main` matches
+   `github.com/OrchestratedChaos/curatarr`'s `main` exactly.
+2. Creates a **signed annotated tag** `vX.Y.Z` (`git tag -s`), signed with
    the noreply principal so the push won't hit GH007.
-6. Verifies the tag locally against `.github/allowed_signers` and the
+3. Verifies the tag locally against `.github/allowed_signers` and the
    pinned fingerprint - if that fails, it aborts and does **not** push.
-7. Pushes the tag.
+4. Pushes the tag (two-hop if configured, see above) and confirms it
+   actually reached GitHub before finishing.
+
+Note: pushing a `v*` tag is itself subject to the repo's tag protection
+ruleset (see "Tag protection ruleset" below) - the account/token doing the
+push (locally, or on `$CURATARR_GH_SSH_HOST` in the two-hop case) needs to
+be on that ruleset's bypass list (Admin role), or the push is rejected by
+GitHub regardless of how correctly the script itself ran.
 
 Pushing the tag triggers `.github/workflows/release.yml`, which:
 
@@ -113,14 +177,24 @@ release-signing **private** key stays off CI entirely, same as tag
 signing. Signing `SHA256SUMS.txt` is therefore a separate, manual,
 offline step, run on whichever machine actually holds
 `~/.ssh/curatarr_release_signing` (this project's convention: a
-Windows machine, via Git Bash - `ssh-keygen`/`gh` both work fine
-there), **after** `scripts/release.sh` has cut the release and CI's
-`build-binaries` / `build-macos-universal` / `finalize-checksums` jobs
-have all finished:
+Windows machine, via Git Bash), **after** `scripts/release.sh` has cut
+the release and CI's `build-binaries` / `build-macos-universal` /
+`finalize-checksums` jobs have all finished:
 
 ```
 ./scripts/sign-release-checksums.sh 2.8.29
 ```
+
+(`--dry-run 2.8.29` first is recommended - it runs every prerequisite
+check, including whether `gh` needs to be delegated over SSH, and prints
+the exact commands a real run would execute without downloading, signing,
+or uploading anything.)
+
+The signing machine does not need `gh` authenticated on it - see "gh
+delegation" above. If it isn't, this delegates `gh release
+view/download/upload` over SSH to `$CURATARR_GH_SSH_HOST`; only the
+public `SHA256SUMS.txt`/`SHA256SUMS.txt.sig` ever cross that connection,
+never `~/.ssh/curatarr_release_signing` itself.
 
 This downloads the tag's aggregate `SHA256SUMS.txt`, signs it with
 `ssh-keygen -Y sign -f ~/.ssh/curatarr_release_signing -n file

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,30 +1,53 @@
 #!/usr/bin/env bash
-# One-command release helper for Curatarr.
+# One-command release helper for Curatarr: tags, verifies, and publishes a
+# release commit that has ALREADY landed on main via its own version-bump PR.
 #
-# Usage: ./scripts/release.sh <version>   (e.g. ./scripts/release.sh 2.8.22)
+# Usage: ./scripts/release.sh [--dry-run] <version>   (e.g. ./scripts/release.sh 2.8.22)
+#
+# This script does NOT bump __version__, open a PR, or merge anything - main
+# only ever moves via a reviewed PR, and this script never pushes to main.
+# The version-bump PR is a separate, prior step (see RELEASING.md): merge it
+# first, THEN run this script to tag the commit it produced.
+#
+# Two-hop push: if `origin` here is not github.com/OrchestratedChaos/curatarr
+# (e.g. a Windows checkout whose `origin` is actually another machine that
+# itself pushes on to GitHub), set:
+#   CURATARR_GH_SSH_HOST     - SSH alias/host of a machine whose own `origin`
+#                               IS github.com/OrchestratedChaos/curatarr
+#   CURATARR_GH_SSH_REPO_DIR - absolute path to the curatarr checkout there
+# This script pushes to `origin` first, then (only if `origin` isn't GitHub)
+# pushes onward from that host, then confirms the ref actually landed on
+# GitHub via `git ls-remote` before declaring success. No default host is
+# hardcoded here - both vars are required whenever `origin` isn't GitHub.
 #
 # Run this from a machine that has:
-#   - `gh` authenticated (`gh auth status`) with repo write access
 #   - the release-signing key configured for git (see RELEASING.md):
 #       git config user.signingkey ~/.ssh/curatarr_release_signing
 #       git config gpg.format ssh
+#   - network access to github.com (plain git/https - `gh` is NOT required
+#     by this script; only sign-release-checksums.sh needs `gh`, and it can
+#     delegate that over SSH too - see that script and RELEASING.md)
 #
 # What it does:
-#   1. Verifies you're on a clean, up-to-date main.
-#   2. Bumps __version__ in utils/config.py.
-#   3. Opens a PR with the bump, waits for the `test` check, squash-merges it.
-#   4. Pulls the merged commit into main.
-#   5. Creates a signed annotated tag vX.Y.Z on that commit.
-#   6. Verifies the tag locally against .github/allowed_signers before
+#   1. Verifies you're on a clean, up-to-date main whose __version__ already
+#      equals <version> (i.e. the bump PR has merged) and whose CHANGELOG.md
+#      has an entry for <version>.
+#   2. Creates a signed annotated tag vX.Y.Z on that commit.
+#   3. Verifies the tag locally against .github/allowed_signers before
 #      pushing anything (fail closed if the signature/fingerprint is wrong).
-#   7. Pushes the tag, which triggers .github/workflows/release.yml.
+#   4. Pushes the tag (two-hop if needed, see above) and confirms it landed
+#      on GitHub, which triggers .github/workflows/release.yml.
+#
+# --dry-run runs every precondition and prints the exact commands a real
+# run would execute, without creating a tag, pushing, signing, or uploading
+# anything - use it to sanity-check the path before a real release.
 #
 # GH007 ("push would publish a private email address"): the tag is signed
 # with user.email set to the maintainer's GitHub noreply address
 # (see RELEASE_TAG_EMAIL below), which is also listed as a principal in
 # .github/allowed_signers for the same signing key. This avoids GitHub's
 # push-protection rejection while still verifying under the pinned key
-# fingerprint. The version-bump commit itself uses your normal git identity.
+# fingerprint.
 
 set -euo pipefail
 
@@ -33,20 +56,43 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 REMOTE="origin"
 MAIN_BRANCH="main"
-REQUIRED_CHECK="test"
 ALLOWED_SIGNERS_FILE=".github/allowed_signers"
 RELEASE_SIGNER_FINGERPRINT="SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
 RELEASE_TAG_EMAIL="252325559+OrchestratedChaos@users.noreply.github.com"
+GITHUB_REPO="OrchestratedChaos/curatarr"
+GITHUB_REMOTE_URL="https://github.com/${GITHUB_REPO}.git"
+CONFIG_FILE="utils/config.py"
+CHANGELOG_FILE="CHANGELOG.md"
 
 # ---------------------------------------------------------------------------
 # Args
 # ---------------------------------------------------------------------------
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <version>   (e.g. $0 2.8.22)" >&2
+DRY_RUN=0
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$VERSION" ]; then
+        echo "ERROR: unexpected extra argument: $arg" >&2
+        exit 1
+      fi
+      VERSION="$arg"
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 [--dry-run] <version>   (e.g. $0 2.8.22)" >&2
   exit 1
 fi
 
-VERSION="$1"
 TAG="v${VERSION}"
 
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -57,15 +103,56 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-echo "==> Releasing ${TAG} from $(pwd)"
+echo "==> Releasing ${TAG} from $(pwd)$([ "$DRY_RUN" -eq 1 ] && echo ' [dry-run]')"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+# True if $1 is a remote name whose URL points at github.com. Covers
+# git@github.com:owner/repo.git, https://github.com/owner/repo.git, and
+# ssh://git@github.com/owner/repo.git forms.
+remote_is_github() {
+  local url
+  url="$(git remote get-url "$1" 2>/dev/null)" || return 1
+  case "$url" in
+    *github.com*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Pushes ref $2 (kind $1: "tags" or "heads") to $REMOTE, pushes it onward to
+# GitHub via CURATARR_GH_SSH_HOST/CURATARR_GH_SSH_REPO_DIR if $REMOTE itself
+# isn't GitHub, then confirms - via a direct, host-independent `git
+# ls-remote` against github.com - that the ref actually landed there.
+# Fails loudly (not silently) if it never does.
+push_ref_and_confirm_on_github() {
+  local ref_kind="$1" ref_name="$2"
+
+  echo "==> Pushing ${ref_name} to ${REMOTE}"
+  git push "$REMOTE" "$ref_name"
+
+  if [ "$IS_GITHUB_REMOTE" -eq 0 ]; then
+    echo "==> ${REMOTE} is not GitHub - pushing ${ref_name} onward from ${CURATARR_GH_SSH_HOST}"
+    ssh "$CURATARR_GH_SSH_HOST" "cd '${CURATARR_GH_SSH_REPO_DIR}' && git push origin '${ref_name}'"
+  fi
+
+  echo "==> Confirming refs/${ref_kind}/${ref_name} exists on github.com/${GITHUB_REPO}"
+  local ls_output
+  if ! ls_output="$(git ls-remote "$GITHUB_REMOTE_URL" "refs/${ref_kind}/${ref_name}")"; then
+    echo "ERROR: could not reach ${GITHUB_REMOTE_URL} to confirm ${ref_name}" >&2
+    exit 1
+  fi
+  if [ -z "$ls_output" ]; then
+    echo "ERROR: ${ref_name} was pushed but never appeared on github.com/${GITHUB_REPO} - aborting." >&2
+    exit 1
+  fi
+  echo "==> Confirmed: $ls_output"
+}
 
 # ---------------------------------------------------------------------------
 # Safety checks
 # ---------------------------------------------------------------------------
 echo "==> Checking prerequisites"
-
-command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not found" >&2; exit 1; }
-gh auth status >/dev/null 2>&1 || { echo "ERROR: gh is not authenticated (run: gh auth login)" >&2; exit 1; }
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ]; then
@@ -84,76 +171,95 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
   exit 1
 fi
 
-if git ls-remote --tags "$REMOTE" | grep -qF "refs/tags/${TAG}"; then
+echo "==> Checking $TAG doesn't already exist on $REMOTE or GitHub"
+if ! REMOTE_TAGS="$(git ls-remote --tags "$REMOTE")"; then
+  echo "ERROR: could not reach $REMOTE to check existing tags" >&2
+  exit 1
+fi
+if printf '%s\n' "$REMOTE_TAGS" | grep -qF "refs/tags/${TAG}"; then
   echo "ERROR: tag $TAG already exists on $REMOTE" >&2
   exit 1
 fi
-
-echo "==> Pulling latest $MAIN_BRANCH"
-git fetch "$REMOTE" "$MAIN_BRANCH"
-if [ "$(git rev-parse HEAD)" != "$(git rev-parse "$REMOTE/$MAIN_BRANCH")" ]; then
-  git pull --ff-only "$REMOTE" "$MAIN_BRANCH"
+if ! GITHUB_TAGS="$(git ls-remote --tags "$GITHUB_REMOTE_URL")"; then
+  echo "ERROR: could not reach $GITHUB_REMOTE_URL to check existing tags" >&2
+  exit 1
+fi
+if printf '%s\n' "$GITHUB_TAGS" | grep -qF "refs/tags/${TAG}"; then
+  echo "ERROR: tag $TAG already exists on github.com/${GITHUB_REPO}" >&2
+  exit 1
 fi
 
-# ---------------------------------------------------------------------------
-# Bump __version__ and open the PR
-# ---------------------------------------------------------------------------
-CONFIG_FILE="utils/config.py"
+echo "==> Checking __version__ in $CONFIG_FILE matches $VERSION (bump PR must already be merged)"
 CURRENT_VERSION="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' "$CONFIG_FILE")"
-echo "==> Current version: ${CURRENT_VERSION:-<unknown>}, bumping to ${VERSION}"
-
-if [ "$CURRENT_VERSION" = "$VERSION" ]; then
-  echo "ERROR: $CONFIG_FILE already has __version__ = \"$VERSION\"" >&2
+if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+  echo "ERROR: $CONFIG_FILE has __version__ = \"${CURRENT_VERSION:-<unknown>}\", expected \"$VERSION\"." >&2
+  echo "       The version-bump PR (bumping __version__ to \"$VERSION\") must be merged to" >&2
+  echo "       $MAIN_BRANCH before running this script - see RELEASING.md." >&2
   exit 1
 fi
 
-BUMP_BRANCH="release/${TAG}"
-git checkout -b "$BUMP_BRANCH"
-
-# Portable in-place sed (GNU/BSD)
-sed -i.bak "s/^__version__ = \".*\"/__version__ = \"${VERSION}\"/" "$CONFIG_FILE"
-rm -f "${CONFIG_FILE}.bak"
-
-if [ -z "$(git status --porcelain "$CONFIG_FILE")" ]; then
-  echo "ERROR: version bump produced no change in $CONFIG_FILE" >&2
-  git checkout "$MAIN_BRANCH"
-  git branch -D "$BUMP_BRANCH"
+echo "==> Checking $CHANGELOG_FILE has an entry for [$VERSION]"
+if ! grep -qF "## [${VERSION}]" "$CHANGELOG_FILE"; then
+  echo "ERROR: $CHANGELOG_FILE has no '## [$VERSION]' entry - add one (as part of the bump PR) before releasing." >&2
   exit 1
 fi
 
-git add "$CONFIG_FILE"
-git commit -m "${VERSION}"
+echo "==> Checking local $MAIN_BRANCH matches github.com/${GITHUB_REPO}'s $MAIN_BRANCH"
+LOCAL_MAIN_SHA="$(git rev-parse HEAD)"
+if ! GITHUB_MAIN_SHA="$(git ls-remote "$GITHUB_REMOTE_URL" "refs/heads/$MAIN_BRANCH" | awk '{print $1}')"; then
+  echo "ERROR: could not reach $GITHUB_REMOTE_URL to read $MAIN_BRANCH" >&2
+  exit 1
+fi
+if [ -z "$GITHUB_MAIN_SHA" ]; then
+  echo "ERROR: $GITHUB_REMOTE_URL returned no SHA for refs/heads/$MAIN_BRANCH" >&2
+  exit 1
+fi
+if [ "$LOCAL_MAIN_SHA" != "$GITHUB_MAIN_SHA" ]; then
+  echo "ERROR: local $MAIN_BRANCH ($LOCAL_MAIN_SHA) does not match github.com/${GITHUB_REPO}'s $MAIN_BRANCH ($GITHUB_MAIN_SHA)." >&2
+  echo "       Sync local $MAIN_BRANCH (via $REMOTE, making sure $REMOTE is itself synced with GitHub first) and re-run." >&2
+  exit 1
+fi
 
-echo "==> Pushing ${BUMP_BRANCH} and opening PR"
-git push -u "$REMOTE" "$BUMP_BRANCH"
-
-PR_URL="$(gh pr create \
-  --base "$MAIN_BRANCH" \
-  --head "$BUMP_BRANCH" \
-  --title "${VERSION}" \
-  --body "Version bump for release ${TAG}.")"
-echo "==> PR: $PR_URL"
-PR_NUMBER="$(basename "$PR_URL")"
-
-echo "==> Waiting for required check '${REQUIRED_CHECK}' on PR #${PR_NUMBER}"
-gh pr checks "$PR_NUMBER" --watch --fail-fast
-
-echo "==> Squash-merging PR #${PR_NUMBER}"
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+IS_GITHUB_REMOTE=0
+if remote_is_github "$REMOTE"; then
+  IS_GITHUB_REMOTE=1
+  echo "==> $REMOTE points directly at GitHub - no two-hop push needed"
+else
+  echo "==> $REMOTE ($(git remote get-url "$REMOTE")) is not GitHub - two-hop push required"
+  if [ -z "${CURATARR_GH_SSH_HOST:-}" ]; then
+    echo "ERROR: CURATARR_GH_SSH_HOST is unset. Set it to the SSH alias of a machine whose own" >&2
+    echo "       'origin' remote IS github.com/${GITHUB_REPO} (see RELEASING.md)." >&2
+    exit 1
+  fi
+  if [ -z "${CURATARR_GH_SSH_REPO_DIR:-}" ]; then
+    echo "ERROR: CURATARR_GH_SSH_REPO_DIR is unset. Set it to the absolute path of the curatarr" >&2
+    echo "       checkout on \$CURATARR_GH_SSH_HOST ($CURATARR_GH_SSH_HOST)." >&2
+    exit 1
+  fi
+  echo "==> Will push onward via CURATARR_GH_SSH_HOST=$CURATARR_GH_SSH_HOST CURATARR_GH_SSH_REPO_DIR=$CURATARR_GH_SSH_REPO_DIR"
+fi
 
 # ---------------------------------------------------------------------------
-# Sync main, tag, verify, push
+# Dry run: stop here, print the plan
 # ---------------------------------------------------------------------------
-echo "==> Syncing local $MAIN_BRANCH"
-git checkout "$MAIN_BRANCH"
-git pull --ff-only "$REMOTE" "$MAIN_BRANCH"
-
-MERGED_VERSION="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' "$CONFIG_FILE")"
-if [ "$MERGED_VERSION" != "$VERSION" ]; then
-  echo "ERROR: after merge, $CONFIG_FILE has __version__ = \"$MERGED_VERSION\", expected \"$VERSION\"" >&2
-  exit 1
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "==> [dry-run] All preconditions passed for ${TAG} (on $(git rev-parse --short HEAD))."
+  echo "[dry-run] A real run would execute:"
+  echo "  git -c user.email=\"$RELEASE_TAG_EMAIL\" tag -s \"$TAG\" -m \"$TAG\""
+  echo "  git config gpg.ssh.allowedSignersFile \"$ALLOWED_SIGNERS_FILE\""
+  echo "  git verify-tag \"$TAG\"   # must verify against pinned fingerprint $RELEASE_SIGNER_FINGERPRINT, else abort"
+  echo "  git push \"$REMOTE\" \"$TAG\""
+  if [ "$IS_GITHUB_REMOTE" -eq 0 ]; then
+    echo "  ssh \"$CURATARR_GH_SSH_HOST\" \"cd '$CURATARR_GH_SSH_REPO_DIR' && git push origin '$TAG'\"   # two-hop"
+  fi
+  echo "  git ls-remote \"$GITHUB_REMOTE_URL\" \"refs/tags/$TAG\"   # confirm it landed on GitHub"
+  echo "[dry-run] No tag was created; nothing was pushed, signed, or uploaded."
+  exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# Tag, verify, push
+# ---------------------------------------------------------------------------
 echo "==> Creating signed tag ${TAG} (signer email: ${RELEASE_TAG_EMAIL})"
 git -c user.email="$RELEASE_TAG_EMAIL" tag -s "$TAG" -m "$TAG"
 
@@ -177,7 +283,7 @@ echo "$VERIFY_OUTPUT"
 # plain substring search, so a fingerprint injected elsewhere (e.g. a
 # crafted tag message) can never be picked up in place of the
 # actually-verified key.
-TAG_FPR="$(printf '%s\n' "$VERIFY_OUTPUT" | grep -oE 'with [A-Za-z0-9-]+ key SHA256:[A-Za-z0-9+/=]+' | grep -oE 'SHA256:[A-Za-z0-9+/=]+' | head -1)"
+TAG_FPR="$(printf '%s\n' "$VERIFY_OUTPUT" | grep -oE 'with [A-Za-z0-9-]+ key SHA256:[A-Za-z0-9+/=]+' | grep -oE 'SHA256:[A-Za-z0-9+/=]+' | head -1)" || true
 
 if [ -z "$TAG_FPR" ] || [ "$TAG_FPR" != "$RELEASE_SIGNER_FINGERPRINT" ]; then
   echo "ERROR: $TAG did not verify against the pinned fingerprint ($RELEASE_SIGNER_FINGERPRINT) - not pushing" >&2
@@ -186,12 +292,13 @@ if [ -z "$TAG_FPR" ] || [ "$TAG_FPR" != "$RELEASE_SIGNER_FINGERPRINT" ]; then
 fi
 
 echo "==> Verified. Pushing ${TAG}"
-git push "$REMOTE" "$TAG"
+push_ref_and_confirm_on_github "tags" "$TAG"
 
 echo "==> Done. .github/workflows/release.yml will publish the GitHub Release for ${TAG}."
 echo "==> Once its build-binaries / build-macos-universal / finalize-checksums jobs finish"
-echo "    (watch: gh run list --workflow=release.yml), sign the aggregate checksums on a"
-echo "    machine holding the release-signing PRIVATE key:"
+echo "    (watch: gh run list --workflow=release.yml - delegate over SSH via CURATARR_GH_SSH_HOST"
+echo "    if gh isn't authenticated on this machine), sign the aggregate checksums on a machine"
+echo "    holding the release-signing PRIVATE key:"
 echo "      ./scripts/sign-release-checksums.sh ${VERSION}"
 echo "    Until that runs, ${TAG}'s binaries publish fine but the in-binary self-updater"
 echo "    (utils/self_update.py) can't yet treat ${TAG} as a verified self-update target."

--- a/scripts/sign-release-checksums.sh
+++ b/scripts/sign-release-checksums.sh
@@ -5,7 +5,8 @@
 # module's docstring and RELEASING.md's "Signing a release's checksums"
 # section for the full authenticity model.
 #
-# Usage: ./scripts/sign-release-checksums.sh <version>   (e.g. ./scripts/sign-release-checksums.sh 2.8.29)
+# Usage: ./scripts/sign-release-checksums.sh [--dry-run] <version>
+#        (e.g. ./scripts/sign-release-checksums.sh 2.8.29)
 #
 # Run this AFTER scripts/release.sh has cut the release AND
 # .github/workflows/release.yml's build-binaries / build-macos-universal /
@@ -16,16 +17,25 @@
 # first.
 #
 # Must be run on a machine that has:
-#   - `gh` authenticated (`gh auth status`) with repo write access
 #   - the release-signing PRIVATE key, which lives ONLY here - never in
-#     CI, never in this repo. Default path: ~/.ssh/curatarr_release_signing
-#     (override with CURATARR_SIGNING_KEY=/path/to/key). See
-#     RELEASING.md's "One-time setup" for how that key was generated.
+#     CI, never in this repo, and it is never copied off this machine by
+#     this script. Default path: ~/.ssh/curatarr_release_signing (override
+#     with CURATARR_SIGNING_KEY=/path/to/key). See RELEASING.md's
+#     "One-time setup" for how that key was generated.
+#
+# `gh` (GitHub CLI) does the actual publish/download/upload calls, but it
+# does NOT need to be authenticated on this machine: if `gh auth status`
+# fails locally, this script delegates every `gh` call over SSH to
+# CURATARR_GH_SSH_HOST (a machine where `gh auth status` succeeds), and
+# only ever transfers the public SHA256SUMS.txt / SHA256SUMS.txt.sig files
+# over that connection - the private signing key never leaves this
+# machine. CURATARR_GH_SSH_HOST is required (no default hardcoded here)
+# whenever local gh isn't authenticated.
 #
 # What it does:
-#   1. Verifies prerequisites (gh, ssh-keygen, the signing key, its
-#      fingerprint) and that the target release + its SHA256SUMS.txt
-#      asset actually exist.
+#   1. Verifies prerequisites (ssh-keygen, the signing key, its
+#      fingerprint, a usable `gh` - local or delegated) and that the
+#      target release + its SHA256SUMS.txt asset actually exist.
 #   2. Downloads that SHA256SUMS.txt.
 #   3. Signs it: `ssh-keygen -Y sign -f <key> -n file SHA256SUMS.txt`
 #      (namespace "file" - matches SIGNATURE_NAMESPACE in
@@ -37,6 +47,10 @@
 #      "never publish something that doesn't even verify against our
 #      own key" discipline as scripts/release.sh's tag signing.
 #   5. Uploads SHA256SUMS.txt.sig to the release.
+#
+# --dry-run runs every prerequisite check (including the gh-delegation
+# detection) and prints what it would do, without downloading, signing,
+# or uploading anything.
 
 set -euo pipefail
 
@@ -52,18 +66,39 @@ RELEASE_SIGNER_FINGERPRINT="SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"
 # defense here is the fingerprint check below, not which principal
 # string is used.
 VERIFY_PRINCIPAL="jasonbsmith1568@gmail.com"
+GITHUB_REPO="OrchestratedChaos/curatarr"
 SUMS_FILENAME="SHA256SUMS.txt"
 SIG_FILENAME="SHA256SUMS.txt.sig"
 
 # ---------------------------------------------------------------------------
 # Args
 # ---------------------------------------------------------------------------
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <version>   (e.g. $0 2.8.29)" >&2
+DRY_RUN=0
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$VERSION" ]; then
+        echo "ERROR: unexpected extra argument: $arg" >&2
+        exit 1
+      fi
+      VERSION="$arg"
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 [--dry-run] <version>   (e.g. $0 2.8.29)" >&2
   exit 1
 fi
 
-VERSION="$1"
 TAG="v${VERSION}"
 
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -74,15 +109,76 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-echo "==> Signing checksums for ${TAG} from $(pwd)"
+echo "==> Signing checksums for ${TAG} from $(pwd)$([ "$DRY_RUN" -eq 1 ] && echo ' [dry-run]')"
+
+# ---------------------------------------------------------------------------
+# gh delegation: run `gh` locally if authenticated here, else over SSH on
+# CURATARR_GH_SSH_HOST. The signing key never leaves this machine either
+# way - only these wrapper functions ever call `gh`, and only to
+# view/download/upload plain, public release assets.
+# ---------------------------------------------------------------------------
+GH_DELEGATE=0
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  echo "==> gh is authenticated locally - running gh commands directly"
+else
+  echo "==> gh is not authenticated locally - delegating gh calls over SSH"
+  if [ -z "${CURATARR_GH_SSH_HOST:-}" ]; then
+    echo "ERROR: gh is not authenticated locally (or not installed), and CURATARR_GH_SSH_HOST is" >&2
+    echo "       unset. Set CURATARR_GH_SSH_HOST to the SSH alias of a machine where" >&2
+    echo "       'gh auth status' succeeds." >&2
+    exit 1
+  fi
+  if ! ssh "$CURATARR_GH_SSH_HOST" "command -v gh >/dev/null 2>&1 && gh auth status" >/dev/null 2>&1; then
+    echo "ERROR: gh is not authenticated on \$CURATARR_GH_SSH_HOST ($CURATARR_GH_SSH_HOST) either." >&2
+    exit 1
+  fi
+  GH_DELEGATE=1
+  echo "==> Will delegate gh calls to $CURATARR_GH_SSH_HOST"
+fi
+
+# $1=tag - true if the release exists (view only, no output kept).
+gh_release_view() {
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    ssh "$CURATARR_GH_SSH_HOST" "gh release view '$1' -R '$GITHUB_REPO'" >/dev/null
+  else
+    gh release view "$1" -R "$GITHUB_REPO" >/dev/null
+  fi
+}
+
+# $1=tag $2=asset pattern $3=local destination path - downloads straight
+# to $3, streaming over SSH via `-O -` when delegated so the asset never
+# needs to land in an intermediate file on the delegate host.
+gh_release_download_to() {
+  local tag="$1" pattern="$2" dest="$3"
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    ssh "$CURATARR_GH_SSH_HOST" "gh release download '$tag' -p '$pattern' -O - -R '$GITHUB_REPO'" > "$dest"
+  else
+    gh release download "$tag" -p "$pattern" -O "$dest" -R "$GITHUB_REPO"
+  fi
+}
+
+# $1=tag $2=local file path - uploads $2 to the release. When delegated,
+# `gh release upload` has no stdin/stdout form (unlike download), so the
+# file is scp'd to a throwaway remote temp dir, uploaded from there, and
+# that temp dir is removed - only ever the already-self-verified public
+# .sig file, never the private key.
+gh_release_upload() {
+  local tag="$1" local_file="$2" base remote_tmp
+  base="$(basename "$local_file")"
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    remote_tmp="$(ssh "$CURATARR_GH_SSH_HOST" 'mktemp -d')"
+    scp -q "$local_file" "$CURATARR_GH_SSH_HOST:$remote_tmp/$base"
+    ssh "$CURATARR_GH_SSH_HOST" "gh release upload '$tag' '$remote_tmp/$base' --clobber -R '$GITHUB_REPO' && rm -rf '$remote_tmp'"
+  else
+    gh release upload "$tag" "$local_file" --clobber -R "$GITHUB_REPO"
+  fi
+}
 
 # ---------------------------------------------------------------------------
 # Prerequisites
 # ---------------------------------------------------------------------------
 echo "==> Checking prerequisites"
 
-command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not found" >&2; exit 1; }
-gh auth status >/dev/null 2>&1 || { echo "ERROR: gh is not authenticated (run: gh auth login)" >&2; exit 1; }
 command -v ssh-keygen >/dev/null 2>&1 || { echo "ERROR: ssh-keygen not found" >&2; exit 1; }
 
 if [ ! -f "$SIGNING_KEY" ]; then
@@ -104,9 +200,30 @@ if [ "$KEY_FPR" != "$RELEASE_SIGNER_FINGERPRINT" ]; then
 fi
 echo "==> Signing key fingerprint OK: $KEY_FPR"
 
-if ! gh release view "$TAG" >/dev/null 2>&1; then
+if ! gh_release_view "$TAG"; then
   echo "ERROR: release $TAG not found - has scripts/release.sh been run for this version?" >&2
   exit 1
+fi
+echo "==> Release $TAG exists"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "==> [dry-run] All prerequisites passed for ${TAG}."
+  echo "[dry-run] A real run would execute:"
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    echo "  ssh \"$CURATARR_GH_SSH_HOST\" \"gh release download '$TAG' -p '$SUMS_FILENAME' -O - -R '$GITHUB_REPO'\" > <tmp>/$SUMS_FILENAME"
+  else
+    echo "  gh release download \"$TAG\" -p \"$SUMS_FILENAME\" -O <tmp>/$SUMS_FILENAME -R \"$GITHUB_REPO\""
+  fi
+  echo "  ssh-keygen -Y sign -f \"$SIGNING_KEY\" -n file <tmp>/$SUMS_FILENAME"
+  echo "  ssh-keygen -Y verify -f \"$ALLOWED_SIGNERS_FILE\" -I \"$VERIFY_PRINCIPAL\" -n file -s <tmp>/$SIG_FILENAME < <tmp>/$SUMS_FILENAME"
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    echo "  scp <tmp>/$SIG_FILENAME \"$CURATARR_GH_SSH_HOST:<remote-tmp>/$SIG_FILENAME\""
+    echo "  ssh \"$CURATARR_GH_SSH_HOST\" \"gh release upload '$TAG' '<remote-tmp>/$SIG_FILENAME' --clobber -R '$GITHUB_REPO'\""
+  else
+    echo "  gh release upload \"$TAG\" <tmp>/$SIG_FILENAME --clobber -R \"$GITHUB_REPO\""
+  fi
+  echo "[dry-run] Nothing was downloaded, signed, or uploaded."
+  exit 0
 fi
 
 # ---------------------------------------------------------------------------
@@ -117,7 +234,7 @@ trap 'rm -rf "$WORKDIR"' EXIT
 cd "$WORKDIR"
 
 echo "==> Downloading ${SUMS_FILENAME} from ${TAG}"
-if ! gh release download "$TAG" -p "$SUMS_FILENAME" -O "$SUMS_FILENAME" -R OrchestratedChaos/curatarr; then
+if ! gh_release_download_to "$TAG" "$SUMS_FILENAME" "$SUMS_FILENAME"; then
   echo "ERROR: could not download ${SUMS_FILENAME} from ${TAG} - has the release.yml workflow's" >&2
   echo "       finalize-checksums job finished yet? Check: gh run list --workflow=release.yml" >&2
   exit 1
@@ -147,6 +264,6 @@ fi
 echo "==> Self-verification OK"
 
 echo "==> Uploading ${SIG_FILENAME} to ${TAG}"
-gh release upload "$TAG" "$WORKDIR/$SIG_FILENAME" --clobber -R OrchestratedChaos/curatarr
+gh_release_upload "$TAG" "$WORKDIR/$SIG_FILENAME"
 
 echo "==> Done. ${TAG}'s SHA256SUMS.txt is now signed - self-update targeting ${TAG} will verify."

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.9.2"
+__version__ = "2.9.3"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
scripts/release.sh required __version__ to already differ from the target
version, so it could never run once the version-bump PR (required, since
nothing pushes to main directly) had already merged. Both release scripts
also hard-required gh auth and a single-hop origin, neither of which
holds on this project's actual machines: the signing key lives on one
machine, gh is authenticated on another, reached only through an
intermediate remote.

- release.sh now requires __version__ and a CHANGELOG.md entry to already
  match the target version, verifies local main against
  github.com/OrchestratedChaos/curatarr directly, and no longer
  bumps/opens/merges anything itself - that's a separate, prior PR.
- release.sh no longer depends on gh at all; tagging and pushing are
  plain git, with a two-hop push (CURATARR_GH_SSH_HOST /
  CURATARR_GH_SSH_REPO_DIR) confirmed via a direct git ls-remote against
  github.com before declaring success - fails loudly instead of silently
  if a tag never lands.
- sign-release-checksums.sh delegates gh release view/download/upload
  over SSH to CURATARR_GH_SSH_HOST when gh isn't authenticated locally,
  moving only the public SHA256SUMS.txt/.sig - the private signing key
  never leaves the signing machine.
- Both scripts gain --dry-run (prints the exact plan without tagging,
  pushing, signing, or uploading).
- RELEASING.md updated to match: bump-lands-first ordering, two-hop
  push, gh-delegation env vars, tag-ruleset Admin bypass, --dry-run
  pre-flight.

No tag is cut as part of this PR.