### PR TITLE
fix: stop test suite from leaking real network connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.1] - 2026-07-25
+
+### Fixed
+
+- **Test suite leaked real network connections.** `tests/test_movie.py`
+  and `tests/test_tv.py` construct `PlexMovieRecommender`/
+  `PlexTVRecommender` in most of their tests; construction eagerly
+  gathers watched-history data, and several of the utility calls in
+  that path (`get_watched_movie_count`/`get_watched_show_count`,
+  `get_plex_account_ids`, `fetch_show_completion_data`) weren't mocked
+  in most tests - so the suite was making real HTTPS calls to `plex.tv`
+  and real HTTP calls to whatever `plex.url` happened to be in the
+  test's fake config (usually `http://localhost`). Traced by
+  instrumenting `socket.socket.connect`. Beyond the token/network
+  leakage itself, an unreachable/slow real connect turns into a hang -
+  observed once as a 24-minute CI run that an identical re-run of the
+  same commit completed in 1m35s. Both files now default those calls to
+  their "nothing reachable" return values via a file-scoped autouse
+  fixture; tests that care about the specific behavior continue to
+  patch it themselves, same as before. The same unmocked-real-call
+  pattern (relying on a real request failing a particular way rather
+  than mocking it) was also found and fixed in three
+  `tests/test_trakt.py` "not authenticated" tests and three
+  `tests/test_external.py` tests reaching TMDB/Trakt for real.
+- **Added a suite-wide regression guard** (`tests/conftest.py`) that
+  blocks any `socket.connect()` to a non-loopback address during the
+  test run and raises immediately with the offending host in the
+  message, so a future accidental network call fails loudly and
+  instantly instead of silently leaking or hanging. Loopback
+  (`127.0.0.1`/`::1`/`localhost`) is still permitted, for the couple of
+  tests that legitimately bind and poll a real local server socket.
+
 ## [2.10.0] - 2026-07-25
 
 This release also carries the `scripts/release.sh` /

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,79 @@
 """Shared fixtures for the whole tests/ suite (web/ Flask UI fixtures,
-plus a couple of suite-wide safety nets - see _no_real_update_check_network
-and _isolated_update_dismissal_dir below)."""
+plus a couple of suite-wide safety nets - see _no_real_update_check_network,
+_isolated_update_dismissal_dir, and _block_non_loopback_sockets below)."""
 
 import os
+import socket as _socket_module
 import sys
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _is_loopback_address(address) -> bool:
+    """True if a socket.connect() address targets only this machine.
+
+    address is whatever was passed to socket.socket.connect() - for
+    AF_INET it's (host, port), for AF_INET6 it's (host, port, flowinfo,
+    scopeid), for AF_UNIX it's a path string (not a network egress at
+    all, so always allowed). By the time a real network stack call
+    reaches .connect(), the host is normally already a resolved IP
+    (requests/urllib3 resolve via getaddrinfo first), but 'localhost' is
+    allowed too for anything that connects before resolving.
+    """
+    if not isinstance(address, tuple) or not address:
+        return True
+    host = address[0]
+    if isinstance(host, bytes):
+        host = host.decode('ascii', 'ignore')
+    host = str(host)
+    return host in ('127.0.0.1', '::1', 'localhost') or host.startswith('127.')
+
+
+@pytest.fixture(autouse=True)
+def _block_non_loopback_sockets(monkeypatch):
+    """Suite-wide regression guard for tests/test_movie.py's and
+    tests/test_tv.py's network leak (PlexMovieRecommender/PlexTVRecommender
+    construction reaching real plex.tv / TMDB / etc. via unmocked
+    utils/plex.py calls - see _no_real_plex_watched_lookups in those two
+    files for the specific fix). That leak was traced by instrumenting
+    socket.socket.connect and observing real outbound TCP attempts from
+    otherwise fully-mocked tests; a runaway connect attempt like that can
+    silently leak the test runner's network position (and a real Plex
+    token, if one happens to be set in the environment) at best, and
+    hang CI for many minutes at worst (observed once: a 24-minute hang
+    that an identical re-run of the same commit did not reproduce,
+    because whether the outbound connect fails fast or hangs depends on
+    the runner's network egress policy, not on the test itself).
+
+    Patches socket.socket.connect (the single choke point every TCP
+    connection - direct socket use, socket.create_connection(), and
+    therefore urllib3/requests - eventually goes through) to allow
+    127.0.0.1/::1/localhost (loopback - e.g. tests/test_web_routes.py's
+    TestWaitForListening/TestBindRetry classes, which bind a real local
+    server socket and poll it) and raise immediately, with the offending
+    host in the message, for anything else. A loud, instant,
+    self-diagnosing failure instead of a silent leak or a multi-minute
+    hang - any test that legitimately needs to reach a real non-loopback
+    host must mock the call instead (mirroring the rest of this suite's
+    existing convention of mocking requests.get/MyPlexAccount/etc. rather
+    than hitting the network for real).
+    """
+    real_connect = _socket_module.socket.connect
+
+    def _guarded_connect(self, address, *args, **kwargs):
+        if not _is_loopback_address(address):
+            raise AssertionError(
+                f"Blocked outbound network connect attempt to {address!r} during "
+                "test run - tests must mock all real network calls (Plex, TMDB, "
+                "GitHub, etc.) rather than reach the network. If this is a "
+                "legitimate local-server test, it must connect to "
+                "127.0.0.1/::1/localhost only."
+            )
+        return real_connect(self, address, *args, **kwargs)
+
+    monkeypatch.setattr(_socket_module.socket, 'connect', _guarded_connect)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,6 +1,7 @@
 """Tests for recommenders/external.py - HTML watchlist and export functionality"""
 
 import pytest
+import requests
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 import os
@@ -788,8 +789,19 @@ class TestExportToTraktAutoSync:
 class TestExportToTraktUserMode:
     """Tests for export_to_trakt user_mode configuration."""
 
-    def test_mapping_mode_requires_valid_plex_users(self):
-        """Test that mapping mode requires configured plex_users."""
+    @patch('recommenders.external_exports.get_authenticated_trakt_client')
+    def test_mapping_mode_requires_valid_plex_users(self, mock_get_auth_client):
+        """Test that mapping mode requires configured plex_users.
+
+        export_to_trakt() gets an authenticated client - a real
+        get_authenticated_trakt_client() call, before this test's own
+        plex_users check even runs - so this must be mocked here too,
+        same as the other TestExportToTraktUserMode tests below.
+        """
+        mock_client = Mock()
+        mock_client.get_username.return_value = 'trakt_user'
+        mock_get_auth_client.return_value = mock_client
+
         config = {
             'trakt': {
                 'enabled': True,
@@ -807,8 +819,17 @@ class TestExportToTraktUserMode:
         result = export_to_trakt(config, [], 'api_key')
         assert result is None
 
-    def test_mapping_mode_rejects_empty_plex_users(self):
-        """Test that mapping mode rejects empty plex_users list."""
+    @patch('recommenders.external_exports.get_authenticated_trakt_client')
+    def test_mapping_mode_rejects_empty_plex_users(self, mock_get_auth_client):
+        """Test that mapping mode rejects empty plex_users list.
+
+        See test_mapping_mode_requires_valid_plex_users's docstring above
+        for why get_authenticated_trakt_client must be mocked here.
+        """
+        mock_client = Mock()
+        mock_client.get_username.return_value = 'trakt_user'
+        mock_get_auth_client.return_value = mock_client
+
         config = {
             'trakt': {
                 'enabled': True,
@@ -2931,9 +2952,17 @@ class TestDiscoverPopularByGenre:
 class TestFindSimilarContentThinProfile:
     """Tests for thin profile handling in find_similar_content_with_profile"""
 
-    def test_thin_profile_uses_reduced_iterations(self):
+    @patch('recommenders.external.requests.get')
+    def test_thin_profile_uses_reduced_iterations(self, mock_get):
         """Test that thin profiles use reduced iterations instead of full discovery"""
         from recommenders.external import find_similar_content_with_profile, is_thin_profile
+
+        # discover_candidates_by_profile hits the real TMDB Discover API via
+        # requests.get - mock it to fail the way an unreachable/uncalled API
+        # would (all callers here catch requests.RequestException and
+        # continue with empty results), rather than actually reaching
+        # api.themoviedb.org for real.
+        mock_get.side_effect = requests.RequestException("no real API in tests")
 
         # Create a thin profile (less than 40 items)
         thin_profile = {

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -15,6 +15,41 @@ from recommenders.movie import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_plex_watched_lookups(monkeypatch):
+    """File-wide safety net: PlexMovieRecommender.__init__ eagerly gathers
+    watched data on every construction (there is no "skip watched data"
+    mode), which means _get_watched_count() -> get_watched_movie_count()
+    and, since none of these tests have a real watched-cache file on
+    disk, _get_plex_watched_data() -> get_plex_account_ids() also run for
+    real on almost every test in this file. Both are real utils/plex.py
+    functions that make outbound network calls (get_watched_movie_count
+    constructs a real plexapi MyPlexAccount(token=...), which talks to
+    plex.tv; get_plex_account_ids does a real requests.get() against
+    config['plex']['url'], which in these tests is "http://localhost")
+    unless a test explicitly re-patches them - most tests here don't,
+    because they're not testing this behavior.
+
+    Discovered via instrumenting socket.socket.connect: without this,
+    most tests in this file open real TCP connections to plex.tv and to
+    localhost:80, which is a token/network leak at best and a
+    multi-minute CI hang at worst if either connect stalls instead of
+    failing fast.
+
+    Defaults both to their "no reachable Plex" return values (0 / [])
+    so every test here is network-safe by default. A test that cares
+    about the specific watched-count/account-id behavior patches
+    recommenders.movie.get_watched_movie_count /
+    recommenders.movie.get_plex_account_ids itself (see
+    TestPlexMovieRecommenderWatchedCount, TestGetPlexWatchedDataMovie
+    below) - that per-test patch is applied after this fixture and so
+    overrides it for the life of the test, same layering conftest.py's
+    suite-wide safety nets already use.
+    """
+    monkeypatch.setattr('recommenders.movie.get_watched_movie_count', lambda *a, **kw: 0)
+    monkeypatch.setattr('recommenders.movie.get_plex_account_ids', lambda *a, **kw: [])
+
+
 class TestMovieCache:
     """Tests for MovieCache class."""
 

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -911,8 +911,18 @@ class TestTraktClientImport:
 
         assert result == {"tt111", "tt222"}
 
-    def test_get_watched_movies_no_auth(self):
-        """Test get_watched_movies returns empty when not authenticated."""
+    @patch('utils.trakt.requests.request')
+    def test_get_watched_movies_no_auth(self, mock_request):
+        """Test get_watched_movies returns empty when not authenticated.
+
+        No access_token means _get_headers() omits the Authorization
+        header, but get_username() still makes a real (unauthenticated)
+        /users/settings request - the client has no local "skip the call
+        if unauthenticated" short-circuit, so this mocks the real 401 a
+        real Trakt server would return, rather than relying on an actual
+        unmocked network round-trip to produce one.
+        """
+        mock_request.return_value = Mock(status_code=401, text="Unauthorized")
         client = TraktClient("id", "secret")
         result = client.get_watched_movies()
         assert result == []
@@ -945,8 +955,14 @@ class TestTraktClientImport:
         result = client.get_watched_shows()
         assert result == []
 
-    def test_get_watchlist_no_auth(self):
-        """Test get_watchlist returns empty when not authenticated."""
+    @patch('utils.trakt.requests.request')
+    def test_get_watchlist_no_auth(self, mock_request):
+        """Test get_watchlist returns empty when not authenticated.
+
+        See test_get_watched_movies_no_auth's docstring above - same
+        reasoning (get_username() always makes a real request).
+        """
+        mock_request.return_value = Mock(status_code=401, text="Unauthorized")
         client = TraktClient("id", "secret")
         result = client.get_watchlist()
         assert result == []
@@ -975,8 +991,14 @@ class TestTraktClientImport:
         result = client.get_ratings()
         assert result == []
 
-    def test_get_ratings_no_auth(self):
-        """Test get_ratings returns empty when not authenticated."""
+    @patch('utils.trakt.requests.request')
+    def test_get_ratings_no_auth(self, mock_request):
+        """Test get_ratings returns empty when not authenticated.
+
+        See test_get_watched_movies_no_auth's docstring above - same
+        reasoning (get_username() always makes a real request).
+        """
+        mock_request.return_value = Mock(status_code=401, text="Unauthorized")
         client = TraktClient("id", "secret")
         result = client.get_ratings()
         assert result == []

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -15,6 +15,37 @@ from recommenders.tv import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_plex_watched_lookups(monkeypatch):
+    """File-wide safety net: PlexTVRecommender.__init__ eagerly gathers
+    watched data on every construction, which means _get_watched_count()
+    -> get_watched_show_count() and, since none of these tests have a
+    real watched-cache file on disk, _get_plex_watched_shows_data() ->
+    _get_plex_account_ids() -> get_plex_account_ids() also run for real
+    on almost every test in this file. Both are real utils/plex.py
+    functions that make outbound network calls (get_watched_show_count
+    constructs a real plexapi MyPlexAccount(token=...), which talks to
+    plex.tv; get_plex_account_ids does a real requests.get() against
+    config['plex']['url'], which in these tests is "http://localhost")
+    unless a test explicitly re-patches them - most tests here don't,
+    because they're not testing this behavior. See the identical
+    fixture/docstring in tests/test_movie.py for how this was found
+    (socket.socket.connect instrumentation) - same class of leak, same
+    fix, mirrored here for the TV recommender.
+
+    Defaults both to their "no reachable Plex" return values (0 / [])
+    so every test here is network-safe by default. A test that cares
+    about the specific watched-count/account-id behavior patches
+    recommenders.tv.get_watched_show_count /
+    recommenders.tv.get_plex_account_ids itself - that per-test patch is
+    applied after this fixture and so overrides it for the life of the
+    test, same layering conftest.py's suite-wide safety nets already
+    use.
+    """
+    monkeypatch.setattr('recommenders.tv.get_watched_show_count', lambda *a, **kw: 0)
+    monkeypatch.setattr('recommenders.tv.get_plex_account_ids', lambda *a, **kw: [])
+
+
 class TestShowCache:
     """Tests for ShowCache class."""
 
@@ -877,6 +908,8 @@ class TestPlexTVRecommenderShowDetails:
 class TestPlexTVRecommenderPlexAccountIds:
     """Tests for PlexTVRecommender Plex account ID methods."""
 
+    @patch('recommenders.tv.fetch_show_completion_data')
+    @patch('recommenders.tv.fetch_plex_watch_history_shows')
     @patch('recommenders.tv.get_plex_account_ids')
     @patch('recommenders.tv.ShowCache')
     @patch('recommenders.base.init_plex')
@@ -884,7 +917,7 @@ class TestPlexTVRecommenderPlexAccountIds:
     @patch('recommenders.base.get_tmdb_config')
     @patch('recommenders.base.load_config')
     @patch('os.makedirs')
-    def test_get_plex_account_ids_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_get_ids):
+    def test_get_plex_account_ids_calls_utility(self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_get_ids, mock_history, mock_completion):
         """Test that _get_plex_account_ids uses utility function."""
         mock_load.return_value = {
             'plex': {'url': 'http://localhost', 'token': 'abc'},
@@ -900,6 +933,16 @@ class TestPlexTVRecommenderPlexAccountIds:
         mock_plex.return_value = mock_plex_inst
         mock_cache.return_value = Mock(cache={'shows': {}})
         mock_get_ids.return_value = {'user1': '12345'}
+        # get_plex_account_ids returning a truthy value above means __init__'s
+        # own eager watched-data gather (_get_plex_watched_shows_data) takes
+        # the "found accounts" branch and calls both of these too - mock
+        # them so neither reaches the real network (see
+        # _no_real_plex_watched_lookups in this file for why that matters).
+        # fetch_show_completion_data in particular runs unconditionally
+        # whenever negative_signals.dropped_shows is enabled (the default),
+        # regardless of whether any shows were actually watched.
+        mock_history.return_value = (set(), {})
+        mock_completion.return_value = {}
 
         recommender = PlexTVRecommender('/path/to/config.yml')
         result = recommender._get_plex_account_ids()

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- tests/test_movie.py and tests/test_tv.py construct PlexMovieRecommender/PlexTVRecommender in most of their tests; construction eagerly gathers watched-history data through utility calls that weren't mocked, so the suite was making real HTTPS calls to plex.tv and real HTTP calls to whatever plex.url happened to be in the test config. Traced by instrumenting socket.socket.connect. Root cause of an observed 24-minute CI hang (an identical re-run of the same commit finished in 1m35s).
- Both files now default those calls to safe values via a file-scoped autouse fixture; tests that care about the specific behavior still patch it themselves.
- Added a suite-wide regression guard in tests/conftest.py that blocks any socket connect to a non-loopback address during the test run, with the offending host in the error message. Loopback stays allowed for the couple of tests that legitimately bind/poll a real local server socket.
- Audited the rest of the suite for the same relying-on-a-real-request pattern; found and fixed it in three tests/test_trakt.py 'not authenticated' tests and three tests/test_external.py tests.
- Bumped to 2.10.1, CHANGELOG entry added.

## Test plan
- [x] tests/test_movie.py: 63 passed in ~0.7s (previously hung/leaked to plex.tv and localhost:80)
- [x] tests/test_tv.py: 66 passed in ~0.8s
- [x] Full suite: 2182 passed, 28 failed, 5 skipped - failing set is byte-identical to the pre-existing Windows-only baseline (NTFS chmod, WinError 183, HOME-path assertions, POSIX-signal mocks)
- [x] py_compile on all changed files