### PR TITLE
fix: drop transitional curatarr-macos-universal compat asset (2.10.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,17 +152,15 @@ jobs:
   # the old build-macos-universal job (python.org's universal2
   # interpreter, delocate-merge wheel fusing) is gone.
   #
-  # Asset naming is transitional for exactly this one release: the
-  # canonical name is `curatarr-macos-arm64` (what
-  # `utils/self_update.py`'s `select_asset_name()` returns for macOS
-  # going forward), but existing installs running an older binary still
-  # request the old `curatarr-macos-universal` name when checking for
-  # updates - so this job publishes BOTH names, identical bytes, each
-  # with its own `.sha256` sidecar, so those installs can still
-  # self-update at least once more (to a version whose
-  # select_asset_name() has moved on) instead of 404ing and failing
-  # closed. Drop the `curatarr-macos-universal` duplicate-publish steps
-  # in a future release once this is no longer needed.
+  # The transitional `curatarr-macos-universal` duplicate-publish steps
+  # (identical bytes uploaded under the old pre-2.10.0 asset name, so
+  # installs still requesting that name could self-update at least once
+  # more instead of 404ing) have now been removed - see CHANGELOG.md's
+  # [2.10.0] and later entries for why they existed and when they were
+  # dropped. `curatarr-macos-arm64` (what `utils/self_update.py`'s
+  # `select_asset_name()` returns for macOS) is the only macOS asset
+  # published from here on; an install still on the old name must
+  # download the current binary manually (docs/BINARIES.md) instead.
   # ---------------------------------------------------------------------
   build-binaries:
     name: Build binary (${{ matrix.asset_name }})
@@ -244,28 +242,6 @@ jobs:
           "
           cat "$ASSET_NAME.sha256"
 
-      # Transitional-only (see the build-binaries job comment above):
-      # publish the exact same bytes under the old curatarr-macos-universal
-      # name too, so installs running a pre-2.10.0 binary (whose
-      # select_asset_name() still requests that name) can self-update at
-      # least once more instead of 404ing and failing closed.
-      - name: Publish transitional curatarr-macos-universal duplicate (identical bytes, old asset name)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cp curatarr-macos-arm64 curatarr-macos-universal
-          python -c "
-          import hashlib
-          h = hashlib.sha256()
-          with open('curatarr-macos-universal', 'rb') as f:
-              for chunk in iter(lambda: f.read(1 << 20), b''):
-                  h.update(chunk)
-          with open('curatarr-macos-universal.sha256', 'w') as out:
-              out.write(f'{h.hexdigest()}  curatarr-macos-universal\n')
-          "
-          cat curatarr-macos-universal.sha256
-
       - name: Upload binary to the release
         shell: bash
         env:
@@ -276,18 +252,6 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" \
             "$ASSET_NAME" \
             "$ASSET_NAME.sha256" \
-            --clobber
-
-      - name: Upload transitional curatarr-macos-universal duplicate to the release
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release upload "$GITHUB_REF_NAME" \
-            curatarr-macos-universal \
-            curatarr-macos-universal.sha256 \
             --clobber
 
   # ---------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.2] - 2026-07-25
+
+### Removed
+
+- **Transitional `curatarr-macos-universal` compat asset removed.**
+  v2.10.0 dropped Intel macOS support and renamed the macOS asset to
+  `curatarr-macos-arm64`, but published both names (identical bytes) for
+  one release so installs still on 2.9.2 or earlier - whose self-updater
+  requests the old name - could self-update at least once more instead
+  of 404ing. That transitional period is now over: `release.yml` no
+  longer builds or publishes `curatarr-macos-universal` or its `.sha256`
+  sidecar, and only `curatarr-macos-arm64` is published for macOS going
+  forward. **Installs still on 2.9.2 or earlier on macOS can no longer
+  self-update** - they must download `curatarr-macos-arm64` manually
+  from the [releases page](https://github.com/OrchestratedChaos/curatarr/releases)
+  (see `docs/BINARIES.md`) and replace their binary by hand. Installs
+  already on 2.10.0+ are unaffected, since `select_asset_name()` has
+  only ever requested the canonical `curatarr-macos-arm64` name.
+
 ## [2.10.1] - 2026-07-25
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -157,11 +157,12 @@ Pushing the tag triggers `.github/workflows/release.yml`, which:
    release`) as its only gate: it never runs for a tag that failed the
    signature/fingerprint/version checks above, and it does not
    re-verify them independently on top - one gate, not two that could
-   drift out of sync. The macOS matrix entry additionally publishes an
-   identical-bytes `curatarr-macos-universal` duplicate (own `.sha256`
-   too) - transitional-only, for pre-2.10.0 installs whose self-updater
-   still requests that old asset name; drop it in a future release once
-   no longer needed (see the job's own comment in `release.yml`).
+   drift out of sync. (The macOS matrix entry additionally published an
+   identical-bytes `curatarr-macos-universal` duplicate for one
+   transitional release, so pre-2.10.0 installs whose self-updater still
+   requested that old asset name could self-update once more - that
+   duplicate-publish step has since been removed; see CHANGELOG.md and
+   the job's own comment in `release.yml`.)
 8. Once ALL of those finish, `finalize-checksums` downloads every
    per-binary `.sha256` plus the source-archive-only `SHA256SUMS.txt`
    from step 5, combines them into one aggregate `SHA256SUMS.txt`

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -13,19 +13,20 @@ it, and it opens the web UI in your browser - no Python install, no
 | Linux (x86_64) | `curatarr-linux-x86_64` |
 | Linux (arm64) | `curatarr-linux-arm64` |
 
-macOS binaries are Apple Silicon (arm64) only as of this release -
-`cryptography` 49.0.0 removed x86_64 macOS wheels entirely, and
-GitHub's last Intel macOS CI runner (`macos-13`) is retired
-(`macos-15-intel` remains but sunsets Aug 2027), so there's no longer a
-supported way to build or test an Intel macOS binary. Intel Mac users
-should run Curatarr from source instead - see [Quick
-Start](../README.md#quick-start) in the main README; the source install
-has no architecture restriction. This one release also still publishes
-an identically-byte `curatarr-macos-universal` asset for a transitional
-period, purely so installs still running a pre-2.10.0 binary (whose
-self-updater requests that old name) can self-update at least once more
-- see [Self-updating](#self-updating) below. New installs should always
-download `curatarr-macos-arm64`.
+macOS binaries are Apple Silicon (arm64) only as of the release that
+dropped Intel macOS support - `cryptography` 49.0.0 removed x86_64
+macOS wheels entirely, and GitHub's last Intel macOS CI runner
+(`macos-13`) is retired (`macos-15-intel` remains but sunsets Aug
+2027), so there's no longer a supported way to build or test an Intel
+macOS binary. Intel Mac users should run Curatarr from source instead -
+see [Quick Start](../README.md#quick-start) in the main README; the
+source install has no architecture restriction. A transitional
+identical-bytes `curatarr-macos-universal` asset was published for one
+release so pre-2.10.0 installs (whose self-updater requested that old
+name) could self-update at least once more; that duplicate has since
+been removed - an install still requesting it must download
+`curatarr-macos-arm64` manually instead (see [Self-updating](#self-updating)
+below).
 
 Each asset has a matching `<asset>.sha256` file with its checksum, and the
 release also publishes an aggregate `SHA256SUMS.txt` (every asset's checksum

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.1"
+__version__ = "2.10.2"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -183,12 +183,12 @@ ASSET_LINUX_ARM64 = 'curatarr-linux-arm64'
 # (cryptography 49.0.0 removed x86_64 macOS wheels entirely, and
 # GitHub's last Intel macOS runner is retired) - macOS binaries are now
 # arm64-only, same one-name-per-platform shape as every other OS. The
-# old 'curatarr-macos-universal' name is still published as an
-# identical-bytes duplicate for exactly one transitional release (see
-# release.yml's build-binaries job comment) so pre-2.10.0 installs can
-# still self-update at least once more, but this function - which only
-# ever runs INSIDE the binary requesting its OWN next asset - always
-# requests the canonical name going forward.
+# old 'curatarr-macos-universal' name was published as an
+# identical-bytes duplicate for one transitional release so pre-2.10.0
+# installs could still self-update at least once more (see CHANGELOG.md)
+# - that duplicate has since been dropped, and this function has never
+# had a fallback to it: it only ever runs INSIDE the binary requesting
+# its OWN next asset, so it always requests the canonical name.
 ASSET_MACOS_ARM64 = 'curatarr-macos-arm64'
 
 _X86_64_MACHINE_NAMES = ('x86_64', 'amd64')
@@ -228,11 +228,7 @@ def select_asset_name(sys_platform: Optional[str] = None, machine: Optional[str]
         # dropped Intel macOS support (see ASSET_MACOS_ARM64's own
         # comment) - no architecture branch here, same as before, but
         # now because there's only one build rather than because one
-        # build covers both architectures. This is exactly why the
-        # transitional curatarr-macos-universal duplicate exists on the
-        # release side (see release.yml): a pre-2.10.0 binary's OWN
-        # baked-in copy of this function still requests that old name,
-        # not this one.
+        # build covers both architectures.
         return ASSET_MACOS_ARM64
 
     if sys_platform.startswith('linux'):


### PR DESCRIPTION
## Summary
- Removes the identical-bytes `curatarr-macos-universal` duplicate asset that v2.10.0 published for one release so pre-2.10.0 installs could self-update past the macOS asset rename
- `release.yml`'s `build-binaries` job no longer builds/uploads that duplicate or its `.sha256` sidecar; macOS now publishes `curatarr-macos-arm64` only, same as every other platform
- Updated stale comments/docs (RELEASING.md, docs/BINARIES.md, utils/self_update.py) to reflect the duplicate is gone rather than transitional
- Bumped to 2.10.2, CHANGELOG entry notes installs on 2.9.2 or earlier must now download the binary manually instead of self-updating

## Test plan
- [x] Full pytest suite: 2182 passed, 5 skipped, 28 failed (pre-existing Windows-only failures: NTFS chmod, WinError 183/32, HOME-path assertions, POSIX-signal mocks)
- [x] YAML syntax check on release.yml
- [x] py_compile on changed Python files
- [x] Confirmed select_asset_name() has no fallback to the old asset name on darwin