### PR TITLE
fix: resolve cache directory via get_project_root()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.3] - 2026-07-25
+
+### Fixed
+
+- **`recommenders/base.py` computed its cache directory relative to its
+  own `__file__` instead of going through `get_project_root()`**, the
+  resolver every other cache/config/log path in the app already uses
+  (`utils/cli.py`, `recommenders/external.py`, `utils/update_check.py`,
+  `utils/update_dismissal.py`, `web/app.py`). Two consequences:
+  - **Docker**: this resolved to `/app/cache`, which `docker-compose.yml`
+    never mounts (it mounts `./cache:/data/cache`, matching the
+    documented `CURATARR_CONFIG_DIR=/data` layout) - so the movie/TV
+    library cache, per-user watched-history cache, and the Trakt/TMDB
+    lookup caches were silently lost on every container recreate.
+    Existing Docker installs will see one slower run while these
+    caches rebuild in the correct, now-persistent location.
+  - **Frozen (PyInstaller) binary**: this resolved inside `sys._MEIPASS`,
+    a temp directory deleted on exit, so these same caches never
+    persisted across runs at all for binary installs. They now persist
+    in the same per-user data directory (`%APPDATA%\curatarr` /
+    `~/.curatarr`) already used for config/logs.
+  Plain source installs without `CURATARR_CONFIG_DIR` set are unaffected
+  - old and new paths were already identical for that case. A source
+    install run with `CURATARR_CONFIG_DIR` set will have its existing
+    cache files moved automatically (best-effort, logged, never blocks
+    a run) from the old repo-relative `cache/` to the correct location.
+
 ## [2.10.2] - 2026-07-25
 
 ### Removed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -68,6 +68,8 @@ from utils import (
     load_trakt_enhance_cache,
     save_trakt_enhance_cache,
     enhance_profile_with_trakt,
+    get_project_root,
+    migrate_legacy_cache_dir,
 )
 
 logger = logging.getLogger('curatarr')
@@ -434,9 +436,19 @@ class BaseRecommender(ABC):
         self.use_tmdb_keywords = tmdb_config['use_keywords']
         self.tmdb_api_key = tmdb_config['api_key']
 
-        # Setup cache directory
-        self.cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'cache')
+        # Setup cache directory - routed through get_project_root() (same
+        # resolver as utils/cli.py and recommenders/external.py) rather than
+        # a __file__-relative path, so it honors CURATARR_CONFIG_DIR/the
+        # frozen-binary per-user data dir instead of always landing next to
+        # the installed code (which Docker doesn't mount and a PyInstaller
+        # onefile binary deletes on exit). config-level 'cache_dir' override
+        # (relative subdir name or absolute path) is applied the same way
+        # external.py's cache_dir setup does - os.path.join() already
+        # discards project_root when the override is absolute.
+        legacy_cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'cache')
+        self.cache_dir = os.path.join(get_project_root(), self.config.get('cache_dir', 'cache'))
         os.makedirs(self.cache_dir, exist_ok=True)
+        migrate_legacy_cache_dir(legacy_cache_dir, self.cache_dir)
 
         # Load display options
         self.confirm_operations = general_config.get('confirm_operations', False)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,9 @@ import plexapi.exceptions
 from unittest.mock import Mock, patch, MagicMock
 from collections import Counter
 
+import recommenders.base as base_module
 from recommenders.base import BaseCache, BaseRecommender
+from utils.helpers import get_project_root
 
 
 class ConcreteCache(BaseCache):
@@ -538,6 +540,170 @@ class TestBaseRecommenderInit:
         recommender = BadWeightsRecommender('/path/to/config.yml')
 
         mock_warn.assert_called()
+
+
+class TestBaseRecommenderCacheDirResolution:
+    """Tests for BaseRecommender's cache_dir setup (recommenders/base.py).
+
+    Prior to 2.10.3 this was computed relative to base.py's own
+    __file__, bypassing get_project_root() entirely - meaning it ignored
+    CURATARR_CONFIG_DIR (Docker) and, for a frozen binary, resolved
+    inside the PyInstaller temp unpack dir that's deleted on exit. These
+    tests cover the fix: cache_dir must go through get_project_root(),
+    same as utils/cli.py and recommenders/external.py, honoring both
+    that override and the config-level 'cache_dir' override.
+
+    get_project_root() is @lru_cache(maxsize=1), so tests that rely on
+    the real (unmocked) function clear its cache before/after - same
+    convention as TestGetProjectRoot in tests/test_helpers.py.
+    """
+
+    def setup_method(self):
+        get_project_root.cache_clear()
+
+    def teardown_method(self):
+        get_project_root.cache_clear()
+
+    @patch('recommenders.base.migrate_legacy_cache_dir')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_cache_dir_honors_config_dir_env_override(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_migrate,
+        tmp_path, monkeypatch,
+    ):
+        """CURATARR_CONFIG_DIR (Docker) must be honored by cache_dir,
+        not just the fixed default of a directory next to base.py."""
+        override = str(tmp_path / "data")
+        monkeypatch.setenv('CURATARR_CONFIG_DIR', override)
+
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc'},
+            'general': {},
+            'weights': {'genre': 0.5, 'actor': 0.5},
+        }
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender.cache_dir == os.path.join(override, 'cache')
+
+    @patch('recommenders.base.migrate_legacy_cache_dir')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_cache_dir_config_override_relative_name(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_migrate,
+    ):
+        """config.yml's cache_dir: <relative subdir name> is joined onto
+        the resolved project root, matching external.py's own handling."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc'},
+            'general': {},
+            'weights': {'genre': 0.5, 'actor': 0.5},
+            'cache_dir': 'my_custom_cache',
+        }
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        with patch('recommenders.base.get_project_root', return_value=os.path.join('C:\\', 'project', 'root')):
+            recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender.cache_dir == os.path.join('C:\\', 'project', 'root', 'my_custom_cache')
+
+    @patch('recommenders.base.migrate_legacy_cache_dir')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_cache_dir_config_override_absolute_path(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_migrate, tmp_path,
+    ):
+        """config.yml's cache_dir: <absolute path> is used verbatim -
+        os.path.join() discards the project root when the second
+        component is already absolute, so this must NOT get nested
+        under the resolved project root."""
+        absolute_cache_dir = str(tmp_path / "abs_cache")
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc'},
+            'general': {},
+            'weights': {'genre': 0.5, 'actor': 0.5},
+            'cache_dir': absolute_cache_dir,
+        }
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        with patch('recommenders.base.get_project_root', return_value=os.path.join('C:\\', 'project', 'root')):
+            recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender.cache_dir == absolute_cache_dir
+        assert not recommender.cache_dir.startswith(os.path.join('C:\\', 'project', 'root'))
+
+    @patch('recommenders.base.migrate_legacy_cache_dir')
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_cache_dir_defaults_to_cache_subdir(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_migrate,
+    ):
+        """No config-level cache_dir override -> defaults to 'cache' under
+        the resolved project root (unchanged default behavior)."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc'},
+            'general': {},
+            'weights': {'genre': 0.5, 'actor': 0.5},
+        }
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        with patch('recommenders.base.get_project_root', return_value=os.path.join('C:\\', 'project', 'root')):
+            recommender = ConcreteRecommender('/path/to/config.yml')
+
+        assert recommender.cache_dir == os.path.join('C:\\', 'project', 'root', 'cache')
+
+    @patch('recommenders.base.init_plex')
+    @patch('recommenders.base.get_configured_users')
+    @patch('recommenders.base.get_tmdb_config')
+    @patch('recommenders.base.load_config')
+    @patch('os.makedirs')
+    def test_init_invokes_legacy_cache_migration(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex,
+    ):
+        """The best-effort legacy-cache-dir migration is invoked once per
+        init with the pre-2.10.3 __file__-relative path and the resolved
+        cache_dir - actual migration behavior is covered separately in
+        tests/test_helpers.py::TestMigrateLegacyCacheDir."""
+        mock_load.return_value = {
+            'plex': {'url': 'http://localhost', 'token': 'abc'},
+            'general': {},
+            'weights': {'genre': 0.5, 'actor': 0.5},
+        }
+        mock_users.return_value = {'plex_users': [], 'managed_users': [], 'admin_user': 'admin'}
+        mock_tmdb.return_value = {'use_keywords': True, 'api_key': 'key'}
+        mock_plex.return_value = Mock()
+
+        expected_legacy_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(base_module.__file__))),
+            'cache',
+        )
+
+        with patch('recommenders.base.get_project_root', return_value=os.path.join('C:\\', 'project', 'root')), \
+             patch('recommenders.base.migrate_legacy_cache_dir') as mock_migrate:
+            recommender = ConcreteRecommender('/path/to/config.yml')
+
+        mock_migrate.assert_called_once_with(expected_legacy_dir, recommender.cache_dir)
 
 
 class TestBaseRecommenderGetUserContext:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,8 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 from utils.helpers import (
     normalize_title, map_path, cleanup_old_logs, compute_profile_hash,
-    get_project_root, no_window_kwargs, TITLE_SUFFIXES_TO_STRIP,
+    get_project_root, migrate_legacy_cache_dir, no_window_kwargs,
+    TITLE_SUFFIXES_TO_STRIP,
 )
 
 
@@ -422,6 +423,103 @@ class TestGetProjectRoot:
         root = get_project_root()
         assert os.path.isdir(os.path.join(root, 'utils'))
         assert os.path.isdir(os.path.join(root, 'web'))
+
+
+class TestMigrateLegacyCacheDir:
+    """Tests for migrate_legacy_cache_dir() - the best-effort, one-time
+    move of cache files from the pre-2.10.3 __file__-relative cache
+    directory to the get_project_root()-resolved one (see
+    recommenders/base.py's cache_dir setup)."""
+
+    def test_moves_files_to_new_location(self, tmp_path):
+        legacy_dir = tmp_path / "legacy" / "cache"
+        new_dir = tmp_path / "new" / "cache"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "all_movies_cache.json").write_text('{"movies": {}}')
+        (legacy_dir / "watched_cache_plex_admin.json").write_text('{}')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        assert not (legacy_dir / "all_movies_cache.json").exists()
+        assert not (legacy_dir / "watched_cache_plex_admin.json").exists()
+        assert (new_dir / "all_movies_cache.json").read_text() == '{"movies": {}}'
+        assert (new_dir / "watched_cache_plex_admin.json").exists()
+
+    def test_does_not_overwrite_existing_file_at_new_location(self, tmp_path):
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        new_dir.mkdir()
+        (legacy_dir / "all_movies_cache.json").write_text('"stale"')
+        (new_dir / "all_movies_cache.json").write_text('"current"')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        # New location's file is untouched; stale legacy copy is left in place
+        # rather than clobbering it.
+        assert (new_dir / "all_movies_cache.json").read_text() == '"current"'
+        assert (legacy_dir / "all_movies_cache.json").read_text() == '"stale"'
+
+    def test_same_resolved_path_is_a_noop(self, tmp_path):
+        """Legacy and new paths resolving to the same directory (the
+        normal case for every install without CURATARR_CONFIG_DIR set) -
+        must not touch anything."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        (cache_dir / "all_movies_cache.json").write_text('"data"')
+
+        migrate_legacy_cache_dir(str(cache_dir), str(cache_dir))
+
+        assert (cache_dir / "all_movies_cache.json").read_text() == '"data"'
+
+    def test_missing_legacy_dir_is_a_noop(self, tmp_path):
+        """Nothing to migrate (Docker/frozen-binary case where the old
+        location never had anything persisted in it) - must not raise
+        or create the new directory."""
+        legacy_dir = tmp_path / "does_not_exist"
+        new_dir = tmp_path / "new"
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        assert not new_dir.exists()
+
+    def test_ignores_subdirectories(self, tmp_path):
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        (legacy_dir / "subdir").mkdir()
+        (legacy_dir / "subdir" / "nested.json").write_text('{}')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        # Only flat files are migrated - a subdirectory is left alone.
+        assert (legacy_dir / "subdir" / "nested.json").exists()
+
+    @patch('utils.helpers.log_warning')
+    @patch('utils.helpers.shutil.move')
+    def test_move_failure_logs_warning_and_does_not_raise(self, mock_move, mock_warn, tmp_path):
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        (legacy_dir / "all_movies_cache.json").write_text('"data"')
+        mock_move.side_effect = OSError("simulated move failure")
+
+        # Must not raise.
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        mock_warn.assert_called_once()
+
+    @patch('utils.helpers.log_info')
+    def test_logs_migrated_filenames_at_info(self, mock_info, tmp_path):
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        (legacy_dir / "all_movies_cache.json").write_text('"data"')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        mock_info.assert_called_once()
+        assert "all_movies_cache.json" in mock_info.call_args[0][0]
 
 
 class TestNoWindowKwargs:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -179,6 +179,7 @@ from .counters import (
 from .helpers import (
     TITLE_SUFFIXES_TO_STRIP,
     get_project_root,
+    migrate_legacy_cache_dir,
     normalize_title,
     map_path,
     cleanup_old_logs,
@@ -431,6 +432,7 @@ __all__ = [
     # Helpers
     'TITLE_SUFFIXES_TO_STRIP',
     'get_project_root',
+    'migrate_legacy_cache_dir',
     'normalize_title',
     'map_path',
     'cleanup_old_logs',

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.2"
+__version__ = "2.10.3"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,6 +5,7 @@ Miscellaneous helper utilities for Curatarr.
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -61,6 +62,63 @@ def get_project_root() -> str:
         os.makedirs(root, exist_ok=True)
         return root
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:
+    """
+    One-time best-effort migration of curatarr's cache directory from
+    the pre-2.10.3 location (computed relative to recommenders/base.py's
+    own __file__, bypassing get_project_root() entirely - see
+    recommenders/base.py's cache_dir setup) to the get_project_root()-
+    resolved location.
+
+    In practice only reachable for a source install run with
+    CURATARR_CONFIG_DIR set, where the two locations genuinely differ
+    and the old one may still have files on disk:
+      - Docker: the old /app/cache is destroyed by the container
+        recreate that delivers this fix, so there's nothing to migrate.
+      - Frozen binary: the old location was inside a PyInstaller
+        --onefile temp unpack dir already deleted when that earlier run
+        exited, so there's nothing to migrate.
+      - Source install with no CURATARR_CONFIG_DIR: both __file__-relative
+        computations land on the same repo root - old and new paths are
+        identical, so this is a same-directory no-op.
+    Callers don't need to special-case any of the above; legacy_dir
+    equal to (or empty/missing at) new_dir all just no-op below.
+
+    Only moves files that don't already exist at the new location -
+    never overwrites/clobbers a cache the new location already has.
+    Never raises: any failure is logged as a warning and the run
+    continues with whatever ended up on disk - worst case, an
+    unmigrated cache simply regenerates rather than blocking a run.
+    """
+    try:
+        if not os.path.isdir(legacy_dir):
+            return
+        if os.path.realpath(legacy_dir) == os.path.realpath(new_dir):
+            return
+
+        moved = []
+        for filename in os.listdir(legacy_dir):
+            legacy_path = os.path.join(legacy_dir, filename)
+            if not os.path.isfile(legacy_path):
+                continue
+            new_path = os.path.join(new_dir, filename)
+            if os.path.exists(new_path):
+                # New location already has this cache - don't clobber it,
+                # just leave the stale legacy copy where it is.
+                continue
+            os.makedirs(new_dir, exist_ok=True)
+            shutil.move(legacy_path, new_path)
+            moved.append(filename)
+
+        if moved:
+            log_info(
+                f"Migrated {len(moved)} cache file(s) from legacy location "
+                f"{legacy_dir} to {new_dir}: {', '.join(sorted(moved))}"
+            )
+    except Exception as e:
+        log_warning(f"Cache directory migration from {legacy_dir} skipped due to error: {e}")
 
 
 # Response bodies from a USER-CONFIGURED host (Radarr/Sonarr/Tautulli/


### PR DESCRIPTION
## Summary
- recommenders/base.py computed self.cache_dir relative to its own __file__ instead of going through get_project_root(), the resolver every other cache/config/log path already uses (utils/cli.py, recommenders/external.py, utils/update_check.py, utils/update_dismissal.py, web/app.py).
- In Docker this landed on /app/cache, which docker-compose.yml never mounts (it mounts ./cache:/data/cache) - so the movie/TV library cache, per-user watched-history cache, and Trakt/TMDB lookup caches were silently lost on every container recreate.
- For a frozen PyInstaller binary it resolved inside sys._MEIPASS, a temp dir deleted on exit, so these caches never persisted across runs at all.
- cache_dir is now routed through get_project_root() plus the existing config-level cache_dir override, matching the pattern already used in recommenders/external.py and utils/cli.py (including the absolute-path override case, handled correctly by os.path.join's built-in absolute-path behavior - same as external.py relies on).
- Adds a best-effort, non-fatal one-time migration (utils/helpers.migrate_legacy_cache_dir) for the one case where the old and new paths actually differ and old files may exist: a source install with CURATARR_CONFIG_DIR set. Docker's old /app/cache is destroyed by the container recreate that delivers this fix, and the frozen binary's old location was already gone when its process exited, so migration is a safe no-op for both of those.

## Test plan
- [x] tests/test_helpers.py::TestMigrateLegacyCacheDir - migration moves files, doesn't clobber existing files at the new location, no-ops when paths resolve identically or the legacy dir is missing, ignores subdirectories, and logs a warning (never raises) on move failure.
- [x] tests/test_base.py::TestBaseRecommenderCacheDirResolution - cache_dir honors CURATARR_CONFIG_DIR, honors the config-level cache_dir override for both a relative name and an absolute path, defaults to 'cache' under the resolved root, and invokes the migration helper once per init with the correct legacy/new paths.
- [x] Full suite: 2194 passed, 28 failed (pre-existing Windows-only: NTFS chmod, WinError 183/32, HOME-path assertions, POSIX-signal mocks - identical failure set on unmodified main), 5 skipped.