### PR TITLE
fix: CLI-only install pulls in flask; self-update signature verification broken by CRLF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,15 @@ jobs:
           with open(path, 'rb') as f:
               for chunk in iter(lambda: f.read(1 << 20), b''):
                   h.update(chunk)
-          with open(path + '.sha256', 'w') as out:
+          # newline='\n' - without it, Python's default text-mode write
+          # translates \n to os.linesep, which is \r\n on windows-latest
+          # (the only OS in this matrix where the two differ). That CRLF
+          # then survives finalize-checksums' plain cat/sort verbatim
+          # into the published aggregate SHA256SUMS.txt, which no longer
+          # byte-matches what scripts/sign-release-checksums.sh signs -
+          # breaking utils/self_update.py's signature verification for
+          # every self-update (see that fix's CHANGELOG entry).
+          with open(path + '.sha256', 'w', newline='\n') as out:
               out.write(f'{h.hexdigest()}  {path}\n')
           "
           cat "$ASSET_NAME.sha256"
@@ -318,8 +326,15 @@ jobs:
 
           # Sorted + de-duplicated so re-running this job (e.g. a re-run
           # of a flaky matrix job) is idempotent rather than appending
-          # duplicate lines.
-          cat checksums/SHA256SUMS.txt checksums/*.sha256 | sort -u -k2 > SHA256SUMS.body.txt
+          # duplicate lines. `tr -d '\r'` strips any stray CR before
+          # sorting - defense in depth on top of the "Rename binary and
+          # compute SHA256" step's own newline='\n' fix above, in case a
+          # future change (or a differently-behaving runner) reintroduces
+          # one: the aggregate published here is exactly what
+          # scripts/sign-release-checksums.sh signs, so even one CR
+          # anywhere in it breaks utils/self_update.py's signature
+          # verification for every self-update, not just cosmetically.
+          cat checksums/SHA256SUMS.txt checksums/*.sha256 | tr -d '\r' | sort -u -k2 > SHA256SUMS.body.txt
 
           # A leading `# curatarr-version: X.Y.Z` comment line - inside
           # the file this whole workflow's later offline signing step
@@ -352,6 +367,20 @@ jobs:
               exit 1
             }
           done
+
+          # Regression guard for the CRLF signature-verification outage
+          # (see this fix's CHANGELOG entry): fail the build, not just a
+          # future self-update, if a CR ever makes it into the file this
+          # job publishes. Checked via file(1)'s own report rather than
+          # grepping for a raw \r byte directly - portable and avoids any
+          # grep-implementation-specific newline handling.
+          FILE_REPORT="$(file SHA256SUMS.txt)"
+          echo "file(1): $FILE_REPORT"
+          if printf '%s' "$FILE_REPORT" | grep -q CRLF; then
+            echo "::error::SHA256SUMS.txt contains a carriage return - this breaks utils/self_update.py's byte-exact signature verification for every client."
+            exit 1
+          fi
+          echo "Confirmed: SHA256SUMS.txt is LF-only."
 
       - name: Upload the aggregate SHA256SUMS.txt
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.4] - 2026-07-25
+
+### Fixed
+
+- **`curatarr_app.py` imported the web UI (`from web.app import main`) at
+  module level, unconditionally, before any argv dispatch.** A
+  CLI/cron-only source install - `pip install --require-hashes -r
+  requirements.lock`, which `requirements.txt`'s own header states is
+  sufficient, with UI-only deps deliberately split into
+  `requirements-ui.txt`/`.lock` so "a plain CLI/cron update never pulls
+  in the heavier UI stack" - had no `flask` installed, so **every**
+  invocation (`--version`, `--run-recommender`, everything) died with
+  `ModuleNotFoundError: No module named 'flask'` before reaching any
+  dispatch logic. Reproduced with a fresh venv + hash-verified
+  `requirements.lock`-only install.
+  The import is now deferred to `_launch_web_ui()`, reached only by the
+  actual web-UI launch path, and a CLI-only invocation that does hit it
+  (running the exe with no flags and no `requirements-ui.txt` installed)
+  now gets one clear, actionable message pointing at
+  `requirements-ui.txt` instead of a raw traceback. Still a plain
+  function-scoped `from web.app import main` (not `importlib`/
+  `__import__`), so PyInstaller's static import analysis still bundles
+  it into the standalone binary - confirmed via a real local build per
+  `docs/BINARIES.md`.
+
+- **In-binary self-update was completely broken since at least v2.9.2 -
+  every self-update attempt failed with `SSH signature does not verify
+  against the pinned release-signing key`, even though the release
+  itself was correctly signed.** Root cause:
+  `utils/self_update.py::verify_downloaded_asset()` read
+  `SHA256SUMS.txt` in **text mode**, which silently strips any `\r` via
+  Python's universal-newline translation; the published file's Windows
+  binary checksum line contained a CRLF line ending (the "Rename binary
+  and compute SHA256" step in `.github/workflows/release.yml` wrote it
+  with a plain text-mode `open(..., 'w')`, which turns `\n` into
+  `os.linesep` - `\r\n` - on the `windows-latest` runner), so the bytes
+  actually hashed for verification differed from the bytes
+  `scripts/sign-release-checksums.sh` had signed. Confirmed by
+  downloading the real published `SHA256SUMS.txt` for v2.9.2, v2.10.0,
+  and v2.10.2: all three contain a CRLF line ending on exactly that
+  line. Fixed on both ends:
+  - **Client**: `verify_downloaded_asset()` now reads `SHA256SUMS.txt`
+    and `SHA256SUMS.txt.sig` in binary mode and verifies the signature
+    against the exact bytes on disk - never a decoded/re-encoded
+    representation of them. This fixes every already-installed binary
+    the next time it attempts a self-update.
+  - **Release workflow**: the Windows `.sha256` sidecar is now written
+    with `newline='\n'` (no more CRLF at the source), and
+    `finalize-checksums` additionally strips any stray `\r` when
+    aggregating and fails the build if the published `SHA256SUMS.txt`
+    isn't LF-only - defense in depth, not just a fix at the one
+    location this was traced to.
+  Existing installs affected by this could not have self-updated to any
+  version before this fix landed; once v2.10.4 is published (and its own
+  `SHA256SUMS.txt` is confirmed LF-only), self-update resumes working
+  for them.
+
+Note: `2.10.1` and `2.10.3` (both above) landed on `main` but were never
+cut as their own published release/tag - their changes ship for the
+first time as part of this `2.10.4` release.
+
 ## [2.10.3] - 2026-07-25
 
 ### Fixed

--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -7,6 +7,13 @@ install, so the binary and the source-install web UI stay identical in
 behavior. All UI logic lives in web/app.py - keep it that way rather
 than adding anything here.
 
+`from web.app import main` is deferred to inside _launch_web_ui(),
+reached only by the no-flag launch path below, rather than imported at
+module level - a CLI/cron-only source install (requirements.txt, no
+requirements-ui.txt - see that file's header) never has flask
+installed, and every other flag (--version, --run-recommender,
+--self-update, --self-update-worker) needs to keep working without it.
+
 Where a packaged binary reads/writes config/cache/logs: see
 utils.helpers.get_project_root() - when running frozen (this file,
 built by PyInstaller), that resolves to a per-user data directory
@@ -75,8 +82,6 @@ import ctypes
 import logging
 import os
 import sys
-
-from web.app import main
 
 
 def _suppress_windows_crash_dialogs() -> None:  # pragma: no cover - real Windows API call, same category as _attach_or_setup_console below (not unit-testable on non-Windows CI)
@@ -250,6 +255,46 @@ def _run_self_update_cli() -> None:
     print(f"curatarr: updated to v{applied_version} - run curatarr again to use it.")
 
 
+def _launch_web_ui() -> None:
+    """Import and call web.app.main() - the normal (no-flag) launch path.
+
+    The import is deliberately deferred to here, inside a function, and
+    only reached by the final `else` branch of the dispatch below - NOT
+    at module level - so that `--version`, `--run-recommender`,
+    `--self-update`, and `--self-update-worker` never pull in the web
+    UI's stack (flask et al.) at all. Those are the paths a CLI/cron-only
+    source install (requirements.txt, no requirements-ui.txt - see that
+    file's header) actually uses; requiring flask just to import this
+    module made every one of them fail with a raw ModuleNotFoundError
+    even though none of them touch the UI.
+
+    Still a plain `from web.app import main` (not `importlib`/
+    `__import__`) so PyInstaller's static AST-walking import analysis
+    still discovers it for the frozen binary build - see this module's
+    docstring and _run_one_recommender's, and curatarr.spec's
+    hiddenimports, which lists flask/jinja2/werkzeug explicitly as
+    defense in depth regardless.
+    """
+    try:
+        from web.app import main
+    except ModuleNotFoundError as e:
+        if e.name is not None and (e.name == 'flask' or e.name.startswith('flask.')):
+            print(
+                "curatarr: the web UI needs additional dependencies that "
+                "aren't installed (flask and friends).\n"
+                "curatarr: install them with: pip install -r requirements-ui.txt\n"
+                "curatarr: (or use requirements-ui.lock for a hash-verified "
+                "install - see run-ui.sh/run-ui.ps1)\n"
+                "curatarr: for CLI/cron-only use, no extra install is needed - "
+                "run a recommender directly instead:\n"
+                "curatarr:   curatarr --run-recommender <movie|tv|external|full> [user]",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        raise
+    main()
+
+
 def _dispatch_recommender(argv: list) -> None:
     """argv is sys.argv[2:], e.g. ['movie', 'alice'] or ['external'] or
     ['full']. See the module docstring above for why this exists."""
@@ -316,4 +361,4 @@ if __name__ == '__main__':
             from utils.self_update import cleanup_stale_old_binary
             cleanup_stale_old_binary()
         _configure_windowed_launch()
-        main()
+        _launch_web_ui()

--- a/tests/test_curatarr_app.py
+++ b/tests/test_curatarr_app.py
@@ -25,6 +25,7 @@ and _configure_windowed_launch()'s not-frozen/not-Windows no-op guard.
 
 import os
 import runpy
+import subprocess
 import sys
 from unittest.mock import Mock, patch
 
@@ -34,10 +35,15 @@ import curatarr_app
 
 
 class TestCuratarrApp:
-    def test_imports_main_from_web_app(self):
-        """curatarr_app.main is the same function web.app.main() is."""
-        from web.app import main as web_app_main
-        assert curatarr_app.main is web_app_main
+    def test_launch_web_ui_imports_and_calls_web_app_main(self):
+        """_launch_web_ui() is the only place in this module that
+        imports web.app.main - deliberately deferred here (not at
+        module level, see this module's docstring and
+        _launch_web_ui's own) so CLI/cron-only paths (--version,
+        --run-recommender, --self-update) never need flask installed."""
+        with patch('web.app.main') as mock_main:
+            curatarr_app._launch_web_ui()
+        mock_main.assert_called_once_with()
 
     @patch('web.app.main')
     def test_running_as_script_calls_main(self, mock_main):
@@ -45,6 +51,80 @@ class TestCuratarrApp:
         calls main() exactly once, matching run-ui.sh / run-ui.ps1."""
         runpy.run_module('curatarr_app', run_name='__main__')
         mock_main.assert_called_once_with()
+
+
+class TestCliPathsDontNeedFlask:
+    """Regression coverage for the CLI-only-install bug fixed alongside
+    _launch_web_ui() (v2.10.4): `curatarr_app.py` used to do
+    `from web.app import main` at module level, unconditionally, before
+    any argv dispatch - so a CLI/cron-only install (`pip install -r
+    requirements.lock` per requirements.txt's own header, deliberately
+    without requirements-ui.txt/.lock's flask) died with
+    `ModuleNotFoundError: No module named 'flask'` on *every* invocation,
+    including `--version` and `--run-recommender`, neither of which
+    touch the web UI.
+
+    Run in a real subprocess with a meta path finder that makes
+    `import flask` raise ModuleNotFoundError, the same failure shape a
+    genuine CLI-only install (flask never pip-installed at all) hits -
+    proving these paths don't merely avoid *calling* flask code but
+    never attempt to import it in the first place. An in-process
+    `sys.modules` check can't do this reliably in a full suite run: other
+    test modules (test_web_*.py) import flask/web.app first and leave
+    them cached in sys.modules for the rest of the session regardless of
+    import order.
+    """
+
+    _BLOCK_FLASK = (
+        "import sys\n"
+        "class _BlockFlask:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'flask' or name.startswith('flask.'):\n"
+        "            raise ModuleNotFoundError(f'blocked for test: {name}', name=name)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _BlockFlask())\n"
+    )
+
+    def _run(self, extra_argv):
+        repo_root = os.path.dirname(os.path.abspath(curatarr_app.__file__))
+        script = (
+            self._BLOCK_FLASK
+            + f"sys.argv = ['curatarr_app.py'] + {extra_argv!r}\n"
+            + "import runpy\n"
+            + "runpy.run_path('curatarr_app.py', run_name='__main__')\n"
+        )
+        return subprocess.run(
+            [sys.executable, '-c', script],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_version_flag_succeeds_with_flask_unimportable(self):
+        result = self._run(['--version'])
+        from utils.config import __version__
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert result.stdout.strip() == __version__
+
+    def test_run_recommender_dispatch_does_not_need_flask(self):
+        """Only checks dispatch reaches _run_one_recommender without
+        ModuleNotFoundError on flask - the unknown-engine branch exits
+        (2) before touching Plex/network, keeping this a fast,
+        deterministic subprocess check."""
+        result = self._run(['--run-recommender', 'bogus'])
+        assert result.returncode == 2, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert 'ModuleNotFoundError' not in result.stderr
+        assert 'flask' not in result.stderr.lower()
+
+    def test_normal_launch_gives_actionable_error_not_a_traceback(self):
+        """The no-flag (web UI) launch path DOES need flask - but a
+        CLI-only install missing it must get one clear, actionable
+        message pointing at requirements-ui.txt, never a raw
+        ModuleNotFoundError traceback."""
+        result = self._run([])
+        assert result.returncode == 2, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert 'requirements-ui.txt' in result.stderr
+        assert 'Traceback' not in result.stderr
 
 
 class TestDispatchViaRunpy:

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -434,11 +434,17 @@ class TestVerifyDownloadedAsset:
         if version_line is not None:
             sums_text += f"# curatarr-version: {version_line}\n"
         sums_text += f"{digest}  {self.ASSET_NAME}\n"
+        sums_bytes = sums_text.encode('utf-8')
         sums_path = tmp_path / 'SHA256SUMS.txt'
-        sums_path.write_text(sums_text, encoding='utf-8')
-        sig_text = _sign(signing_key['key_path'], sums_text.encode('utf-8'), tmp_path)
+        # write_bytes(), not write_text() - write_text() applies the same
+        # os.linesep newline translation on write that verify_downloaded_
+        # asset's CRLF fix exists to be immune to on read: on Windows it
+        # would turn every \n here into \r\n on disk, no longer
+        # byte-identical to what actually gets signed on the next line.
+        sums_path.write_bytes(sums_bytes)
+        sig_text = _sign(signing_key['key_path'], sums_bytes, tmp_path)
         sig_path = tmp_path / 'SHA256SUMS.txt.sig'
-        sig_path.write_text(sig_text, encoding='utf-8')
+        sig_path.write_bytes(sig_text.encode('utf-8'))
         return str(asset_path), str(sums_path), str(sig_path)
 
     def test_passes_end_to_end(self, tmp_path, signing_key, monkeypatch):
@@ -509,6 +515,77 @@ class TestVerifyDownloadedAsset:
         assert digest == expected
 
 
+class TestVerifyDownloadedAssetCRLFSignedContent:
+    """Regression coverage for the v2.10.4 self-update outage: every
+    published SHA256SUMS.txt (v2.9.2 through v2.10.2, confirmed via
+    `file` on the real downloaded releases) contained a CRLF line
+    ending on the Windows binary's checksum line - the "Rename binary
+    and compute SHA256" step's `open(..., 'w')` used Python's default
+    text-mode write, which translates \\n to os.linesep (\\r\\n) on
+    windows-latest (see .github/workflows/release.yml). Reading that
+    same file back in text mode (the pre-fix
+    verify_downloaded_asset) silently strips the \\r on ANY platform
+    (Python's universal-newline translation isn't OS-specific on the
+    read side), producing a different byte sequence than what
+    scripts/sign-release-checksums.sh actually signed - so every
+    self-update, on every platform, failed
+    SignatureVerificationError."""
+
+    ASSET_NAME = 'curatarr-windows-x86_64.exe'
+
+    def test_text_mode_read_diverges_from_the_bytes_on_disk(self, tmp_path):
+        """Dependency-free proof of the underlying discrepancy (doesn't
+        need ssh-keygen): a file written with a CRLF line ending, read
+        back in text mode and re-encoded, is NOT the same bytes as what
+        was actually written to disk - i.e. no signature computed over
+        one could ever validate against the other."""
+        sums_bytes = b"abc123  " + self.ASSET_NAME.encode('ascii') + b"\r\n"
+        sums_path = tmp_path / 'SHA256SUMS.txt'
+        sums_path.write_bytes(sums_bytes)
+
+        with open(sums_path, 'r', encoding='utf-8') as f:
+            text_mode_reencoded = f.read().encode('utf-8')
+        with open(sums_path, 'rb') as f:
+            binary_mode = f.read()
+
+        assert binary_mode == sums_bytes
+        assert text_mode_reencoded != sums_bytes
+
+    @requires_ssh_keygen
+    def test_verify_downloaded_asset_succeeds_against_a_crlf_signed_file(self, tmp_path, signing_key, monkeypatch):
+        """The actual regression test: sign bytes that ALREADY contain a
+        CRLF line ending (matching the real published files, not a
+        CRLF introduced after signing), write those exact bytes to
+        disk, and confirm verify_downloaded_asset - reading the file in
+        binary mode - still verifies successfully."""
+        monkeypatch.setattr(self_update, '_pinned_public_key', lambda: signing_key['public_key'])
+
+        asset_path = tmp_path / self.ASSET_NAME
+        asset_path.write_bytes(b'fake windows binary bytes')
+        digest = self_update.sha256_file(str(asset_path))
+
+        # Same shape as the real published files: one LF-only entry,
+        # then the Windows asset's line terminated with CRLF - and the
+        # CR is present in what actually gets signed below, not added
+        # afterward.
+        sums_bytes = (
+            b"# curatarr-version: 9.9.9\n"
+            + (b"deadbeef" * 8) + b"  curatarr-linux-x86_64\n"
+            + digest.encode('ascii') + b"  " + self.ASSET_NAME.encode('ascii') + b"\r\n"
+        )
+        sums_path = tmp_path / 'SHA256SUMS.txt'
+        sums_path.write_bytes(sums_bytes)
+
+        sig_text = _sign(signing_key['key_path'], sums_bytes, tmp_path)
+        sig_path = tmp_path / 'SHA256SUMS.txt.sig'
+        sig_path.write_bytes(sig_text.encode('utf-8'))
+
+        result_digest = self_update.verify_downloaded_asset(  # must not raise
+            str(asset_path), str(sums_path), str(sig_path), self.ASSET_NAME, target_version='9.9.9',
+        )
+        assert result_digest == digest
+
+
 class TestVerifyDownloadedAssetVersionBinding:
     """FIX 17: the version NUMBER itself is bound to the same signature
     that already covers every asset hash (see .github/workflows/
@@ -526,11 +603,17 @@ class TestVerifyDownloadedAssetVersionBinding:
         if version_line is not None:
             sums_text += f"# curatarr-version: {version_line}\n"
         sums_text += f"{digest}  {self.ASSET_NAME}\n"
+        sums_bytes = sums_text.encode('utf-8')
         sums_path = tmp_path / 'SHA256SUMS.txt'
-        sums_path.write_text(sums_text, encoding='utf-8')
-        sig_text = _sign(signing_key['key_path'], sums_text.encode('utf-8'), tmp_path)
+        # write_bytes(), not write_text() - write_text() applies the same
+        # os.linesep newline translation on write that verify_downloaded_
+        # asset's CRLF fix exists to be immune to on read: on Windows it
+        # would turn every \n here into \r\n on disk, no longer
+        # byte-identical to what actually gets signed on the next line.
+        sums_path.write_bytes(sums_bytes)
+        sig_text = _sign(signing_key['key_path'], sums_bytes, tmp_path)
         sig_path = tmp_path / 'SHA256SUMS.txt.sig'
-        sig_path.write_text(sig_text, encoding='utf-8')
+        sig_path.write_bytes(sig_text.encode('utf-8'))
         return str(asset_path), str(sums_path), str(sig_path)
 
     def test_matching_version_line_passes(self, tmp_path, signing_key, monkeypatch):

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.3"
+__version__ = "2.10.4"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -589,16 +589,41 @@ def verify_downloaded_asset(asset_path: str, sums_path: str, sig_path: str, asse
     module's docstring and download_and_verify_update.
     """
     try:
-        with open(sums_path, 'r', encoding='utf-8') as f:
-            sums_text = f.read()
-        with open(sig_path, 'r', encoding='utf-8') as f:
-            sig_text = f.read()
+        # 'rb', not 'r' - the signature is over the EXACT bytes that were
+        # signed, and text-mode reads apply Python's universal-newline
+        # translation (any \r\n or bare \r silently becomes \n) before we
+        # ever see the content. A published SHA256SUMS.txt containing so
+        # much as one CRLF line ending (observed in practice on the
+        # Windows binary's checksum line - the sidecar that job writes
+        # is CRLF, and finalize-checksums' aggregation carries that
+        # through - see .github/workflows/release.yml) would then get
+        # hashed as a DIFFERENT byte sequence than what
+        # scripts/sign-release-checksums.sh actually signed, and
+        # signature verification would fail for every self-update - not
+        # a corrupted download, not a bad key, just this file being
+        # decoded before its signature was checked. Decoding to text
+        # (below) only happens AFTER verify_pinned_signature() has
+        # already proven these exact bytes are the ones that were
+        # signed - line-ending differences in the now-trusted text are
+        # harmless from here on, since parse_sha256sums()/
+        # parse_sha256sums_version() both use str.strip()/splitlines(),
+        # which already treat \r\n, \r, and \n as equivalent.
+        with open(sums_path, 'rb') as f:
+            sums_bytes = f.read()
+        with open(sig_path, 'rb') as f:
+            sig_bytes = f.read()
     except OSError as e:
         # Missing/unreadable either file (e.g. the .sig never got
         # downloaded/published at all) is exactly as fail-closed as a
         # signature that doesn't verify - never fall through and treat
         # "we don't have a signature" as "unsigned is fine".
         raise SignatureVerificationError(f"Could not read checksum/signature files: {e}") from e
+
+    # The armor is plain ASCII (BEGIN/END markers + base64 body) - _decode_armor
+    # strips whitespace per line regardless, so decoding this one to text
+    # (unlike sums_bytes above) has no bytes-vs-signature implication; it's
+    # only ever parsed, never itself hashed or compared byte-for-byte.
+    sig_text = sig_bytes.decode('utf-8')
 
     # Authenticity FIRST: SHA256SUMS.txt was just downloaded over
     # anonymous HTTPS and is no more trustworthy than the asset itself
@@ -607,9 +632,12 @@ def verify_downloaded_asset(asset_path: str, sums_path: str, sig_path: str, asse
     # attacker able to substitute the asset could trivially also
     # substitute a matching-but-unsigned (or unsigned-differently) sums
     # file, so checking the hash before the signature would verify
-    # nothing.
-    verify_pinned_signature(sums_text.encode('utf-8'), sig_text)
+    # nothing. Verified against the RAW bytes read above - never a
+    # decode()/encode() round trip, so there is no representation of
+    # this content that could differ from what was actually signed.
+    verify_pinned_signature(sums_bytes, sig_text)
 
+    sums_text = sums_bytes.decode('utf-8')
     sums = parse_sha256sums(sums_text)
     expected = sums.get(asset_name)
     if not expected:


### PR DESCRIPTION
## Summary
- `curatarr_app.py` imported the web UI (`from web.app import main`) unconditionally at module level, before any argv dispatch, so a CLI/cron-only install (`requirements.txt`/`requirements.lock` only, no `requirements-ui.txt`) failed with `ModuleNotFoundError: No module named 'flask'` on every invocation, including `--version` and `--run-recommender`. The import is now deferred to the actual web-UI launch path, with a clear actionable error for CLI-only users who hit it. PyInstaller still discovers and bundles it (confirmed via a real local build).
- In-binary self-update has been broken since at least v2.9.2: `verify_downloaded_asset()` read `SHA256SUMS.txt` in text mode, silently stripping the CRLF line ending present on the published Windows checksum line (introduced by a text-mode sidecar write on the windows-latest build job), so the bytes verified never matched what was actually signed. Fixed on both ends - the client now verifies the exact bytes on disk, and the release workflow no longer introduces or tolerates a CRLF in the published aggregate file (source fix + downstream strip + build-failing guard).
- Version bumped to 2.10.4; CHANGELOG updated (also notes 2.10.1/2.10.3 shipping unreleased until now).

## Test plan
- [x] Fresh venv, `pip install --require-hashes -r requirements.lock` only (no UI deps): `python curatarr_app.py --version` succeeds
- [x] Same venv, no-flag launch gives an actionable `requirements-ui.txt` message, not a traceback
- [x] `requirements-ui.lock` installed too: web UI starts and serves 200
- [x] PyInstaller binary built per docs/BINARIES.md: `--version` and the web UI both still work from the frozen exe
- [x] Regression test: CLI paths (`--version`, `--run-recommender`) succeed via subprocess with flask import blocked; normal launch gives the actionable message
- [x] Regression test: `verify_downloaded_asset` succeeds against a real ssh-keygen-signed SHA256SUMS.txt containing a CRLF line ending (fails against pre-fix code, verified locally)
- [x] Full suite: 2199 passed, 5 skipped, 28 failed (all pre-existing Windows-only: NTFS chmod, WinError 183/32, HOME-path assertions, POSIX-signal mocks - unchanged before/after this branch)