### PR TITLE
fix: Linux binaries required newer glibc than most server distros ship (2.10.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,41 @@ jobs:
   # `select_asset_name()` returns for macOS) is the only macOS asset
   # published from here on; an install still on the old name must
   # download the current binary manually (docs/BINARIES.md) instead.
+  #
+  # The two Linux entries (`ubuntu-latest`, `ubuntu-24.04-arm`) do NOT
+  # build directly on the runner like Windows/macOS do - both runner
+  # images resolve to Ubuntu 24.04, whose glibc (2.39) is newer than
+  # what a large share of real server distros ship: Debian 12 is 2.36,
+  # Ubuntu 22.04 LTS is 2.35, RHEL/Rocky/Alma 9 is 2.34 (all confirmed
+  # via `ldd --version` in each distro's official image, not guessed).
+  # glibc is backward- but not forward-compatible, so a binary built on
+  # 24.04 raw fails on all three with a loader error
+  # (`GLIBC_2.38' not found`) - see this fix's CHANGELOG entry. Instead,
+  # both Linux entries build inside a pinned `manylinux_2_28` container
+  # (glibc 2.28, AlmaLinux-8-based, the standard PyPA wide-compat build
+  # environment) via `matrix.container` + `docker run` below - chosen
+  # over an older runner image (e.g. `ubuntu-22.04`, which only gets us
+  # to glibc 2.35 and is one more OS EOL clock to track) and over
+  # dropping all the way to `manylinux2014` (glibc 2.17, which every
+  # compiled dependency here also happens to publish a wheel for - but
+  # going lower than the target baselines need buys nothing and the
+  # `manylinux_2_28` toolchain is the more actively maintained one of
+  # the two). 2.28 clears all three target baselines above with margin;
+  # every compiled dependency (`cryptography`, `cffi`, `markupsafe`,
+  # `pyyaml`, `charset-normalizer`) publishes a `manylinux2014`- or
+  # `manylinux_2_28`-tagged wheel for both x86_64 and aarch64 (verified
+  # against PyPI's own file listing for each pinned version in
+  # requirements.lock/requirements-ui.lock), so this floor is reachable
+  # by wheel selection alone - no dependency needs compiling from source
+  # to get there (that's the trap that cost Intel macOS support above;
+  # see the paragraph before this one). PyInstaller's own Linux
+  # bootloader (embedded in every onefile binary it produces) ships as a
+  # `manylinux2014` wheel already, so it was never the constraint.
+  # `docker run`'s own `-v "$PWD:/io"` bind mount (not `docker cp`) is
+  # fine here specifically because these are real Linux hosts, not the
+  # virtiofs-backed Colima VM used for local Mac verification (see
+  # docs/BINARIES.md) - that mount quirk doesn't apply to GitHub-hosted
+  # Linux runners.
   # ---------------------------------------------------------------------
   build-binaries:
     name: Build binary (${{ matrix.asset_name }})
@@ -173,15 +208,24 @@ jobs:
           - os: windows-latest
             asset_name: curatarr-windows-x86_64.exe
             dist_name: curatarr.exe
+            container: ''
           - os: ubuntu-latest
             asset_name: curatarr-linux-x86_64
             dist_name: curatarr
+            # Digest-pinned per this repo's convention (every action/image
+            # reference here is SHA-pinned) - `quay.io/pypa/manylinux_2_28_x86_64`.
+            container: 'quay.io/pypa/manylinux_2_28_x86_64@sha256:fdb9a9c223b215604dc7b6f7e8fff4b39bfea5fbaa7777a2e5544a60dfa437f8'
+            glibc_floor: '2.28'
           - os: ubuntu-24.04-arm
             asset_name: curatarr-linux-arm64
             dist_name: curatarr
+            # Digest-pinned - `quay.io/pypa/manylinux_2_28_aarch64`.
+            container: 'quay.io/pypa/manylinux_2_28_aarch64@sha256:e7035406e58d96b7407246af1f6514a3cbd753a0025b42b9adfbeadd3b29ba80'
+            glibc_floor: '2.28'
           - os: macos-latest
             asset_name: curatarr-macos-arm64
             dist_name: curatarr
+            container: ''
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -191,7 +235,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Windows/macOS: unchanged, builds directly with the runner's own
+      # Python (see "Set up Python" above). Linux: skipped - see the
+      # container-based step below instead, which uses the pinned
+      # manylinux image's own Python so every compiled dependency wheel
+      # it selects is bounded by that image's (older) glibc rather than
+      # the runner's.
       - name: Install dependencies
+        if: matrix.container == ''
         shell: bash
         run: |
           set -euo pipefail
@@ -199,10 +250,82 @@ jobs:
           pip install --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
 
       - name: Build binary with PyInstaller
+        if: matrix.container == ''
         shell: bash
         run: |
           set -euo pipefail
           pyinstaller --clean --noconfirm curatarr.spec
+
+      # Linux only (see build-binaries' own comment above for why): both
+      # dependency install and the PyInstaller build happen inside the
+      # pinned manylinux container in one `docker run`, using that
+      # image's own baked CPython 3.12 (`/opt/python/cp312-cp312`, built
+      # from source in that same container so it inherits its glibc
+      # floor too - not the runner's system Python). One invocation
+      # rather than two separate steps because each `docker run` starts
+      # a fresh, disposable container - packages `pip install`s in a
+      # first container would not exist in a second one.
+      - name: Install dependencies and build binary (manylinux container)
+        if: matrix.container != ''
+        shell: bash
+        env:
+          CONTAINER_IMAGE: ${{ matrix.container }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io \
+            "$CONTAINER_IMAGE" \
+            bash -c '
+              set -euo pipefail
+              PY=/opt/python/cp312-cp312/bin/python3.12
+              "$PY" -m pip install --upgrade pip
+              "$PY" -m pip install --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
+              "$PY" -m PyInstaller --clean --noconfirm curatarr.spec
+            '
+
+      # Regression guard for the glibc-floor fix itself: a future
+      # dependency bump could silently pick up a newer manylinux wheel
+      # (or the pinned container image could change) and reintroduce the
+      # exact "GLIBC_2.38' not found" failure this fix addresses - fail
+      # the build, not a future clean-install report, if that happens.
+      # `objdump -T` lists every dynamic symbol the binary references,
+      # including its versioned libc symbols (`GLIBC_x.y`); the highest
+      # one found is the actual minimum glibc this binary needs at
+      # runtime, independent of what any wheel tag claims.
+      - name: Assert Linux binary's glibc floor (regression guard)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          DIST_NAME: ${{ matrix.dist_name }}
+          INTENDED_FLOOR: ${{ matrix.glibc_floor }}
+        run: |
+          set -euo pipefail
+          command -v objdump >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq binutils
+          }
+
+          MAX_GLIBC="$(objdump -T "dist/$DIST_NAME" \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+            | sed 's/^GLIBC_//' \
+            | sort -V \
+            | tail -1)"
+
+          if [ -z "$MAX_GLIBC" ]; then
+            echo "::error::could not find any GLIBC_* versioned symbol in dist/$DIST_NAME - objdump output was not what this check expects, investigate before releasing"
+            exit 1
+          fi
+
+          echo "Detected glibc floor for dist/$DIST_NAME: GLIBC_$MAX_GLIBC (intended ceiling: GLIBC_$INTENDED_FLOOR)"
+
+          HIGHEST="$(printf '%s\n%s\n' "$MAX_GLIBC" "$INTENDED_FLOOR" | sort -V | tail -1)"
+          if [ "$HIGHEST" != "$INTENDED_FLOOR" ]; then
+            echo "::error::dist/$DIST_NAME references GLIBC_$MAX_GLIBC, which exceeds the intended floor of GLIBC_$INTENDED_FLOOR - this would regress the minimum supported glibc (Debian 12 / Ubuntu 22.04 LTS / RHEL 9 baselines documented in docs/BINARIES.md). A dependency bump likely pulled in a newer manylinux wheel, or the pinned container image changed - investigate before releasing."
+            exit 1
+          fi
+
+          echo "Confirmed: dist/$DIST_NAME's glibc floor (GLIBC_$MAX_GLIBC) is within the intended ceiling (GLIBC_$INTENDED_FLOOR)."
 
       - name: Verify macOS binary is arm64-only (not a universal/fat binary)
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,14 +188,23 @@ jobs:
   # requirements.lock/requirements-ui.lock), so this floor is reachable
   # by wheel selection alone - no dependency needs compiling from source
   # to get there (that's the trap that cost Intel macOS support above;
-  # see the paragraph before this one). PyInstaller's own Linux
+  # see the paragraph before this one). A wheel's manylinux TAG is only
+  # what its build environment supports, not necessarily the actual
+  # glibc symbol floor of the compiled code inside it - a real build
+  # showed the manylinux_2_28-tagged `cryptography` wheel this installs
+  # only references glibc symbols up to 2.17 in practice - which is
+  # exactly why the "Assert Linux binary's glibc floor" step below
+  # checks the built binary's actual referenced symbols with `objdump`
+  # rather than trusting any wheel tag. PyInstaller's own Linux
   # bootloader (embedded in every onefile binary it produces) ships as a
-  # `manylinux2014` wheel already, so it was never the constraint.
+  # `manylinux2014` wheel already, so it was never the constraint either.
   # `docker run`'s own `-v "$PWD:/io"` bind mount (not `docker cp`) is
-  # fine here specifically because these are real Linux hosts, not the
-  # virtiofs-backed Colima VM used for local Mac verification (see
-  # docs/BINARIES.md) - that mount quirk doesn't apply to GitHub-hosted
-  # Linux runners.
+  # fine here specifically because these are real Linux hosts with a
+  # normal working directory - not the Colima VM used for local Mac
+  # verification (see docs/BINARIES.md), where `-v` silently mounts an
+  # empty directory for any host path outside Colima's own default
+  # `$HOME`-only share (`/tmp` isn't shared by default), which is what
+  # actually made `docker cp` necessary there, not a virtiofs bug.
   # ---------------------------------------------------------------------
   build-binaries:
     name: Build binary (${{ matrix.asset_name }})
@@ -258,13 +267,31 @@ jobs:
 
       # Linux only (see build-binaries' own comment above for why): both
       # dependency install and the PyInstaller build happen inside the
-      # pinned manylinux container in one `docker run`, using that
-      # image's own baked CPython 3.12 (`/opt/python/cp312-cp312`, built
-      # from source in that same container so it inherits its glibc
-      # floor too - not the runner's system Python). One invocation
-      # rather than two separate steps because each `docker run` starts
-      # a fresh, disposable container - packages `pip install`s in a
-      # first container would not exist in a second one.
+      # pinned manylinux container in one `docker run`. This deliberately
+      # does NOT use the container's own baked `/opt/python/cp312-cp312`
+      # interpreters - confirmed via a real build attempt that every
+      # manylinux-image Python is built `--enable-shared=no` (no
+      # `libpython*.so` at all, only a static `.a`), because manylinux
+      # images exist to build *wheels* (which don't need libpython.so at
+      # wheel-install time), not to embed/freeze a whole interpreter the
+      # way PyInstaller requires - it fails outright with "Python was
+      # built without a shared library". Instead this installs the
+      # AlmaLinux 8 OS-packaged `python3.12`/`python3.12-devel` (`dnf`),
+      # which IS built shared (confirmed: `libpython3.12.so.1.0` present,
+      # `Py_ENABLE_SHARED=1`) and, being built by the same AlmaLinux 8
+      # base this image's manylinux_2_28 spec already requires, carries
+      # the same glibc 2.28 floor - not the runner's newer system Python.
+      # One invocation rather than two separate steps because each
+      # `docker run` starts a fresh, disposable container - packages
+      # `pip install`ed in a first container would not exist in a second
+      # one. Runs as the container's default root (needed for `dnf
+      # install` above) against the bind-mounted checkout, which on a
+      # real (non-rootless) Docker host means everything it writes under
+      # `dist/`/`build/` lands root-owned on the runner's filesystem -
+      # the final `chown -R "$HOST_UID:$HOST_GID"` hands it back to the
+      # actual runner user before the container exits, so the later
+      # "Rename binary and compute SHA256" step (which runs as that
+      # user, not root) can still `mv`/read it.
       - name: Install dependencies and build binary (manylinux container)
         if: matrix.container != ''
         shell: bash
@@ -275,13 +302,17 @@ jobs:
           docker run --rm \
             -v "$PWD:/io" \
             -w /io \
+            -e HOST_UID="$(id -u)" \
+            -e HOST_GID="$(id -g)" \
             "$CONTAINER_IMAGE" \
             bash -c '
               set -euo pipefail
-              PY=/opt/python/cp312-cp312/bin/python3.12
-              "$PY" -m pip install --upgrade pip
-              "$PY" -m pip install --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
+              dnf install -y -q python3.12 python3.12-devel python3.12-pip
+              PY=/usr/bin/python3.12
+              "$PY" -m pip install --quiet --upgrade pip
+              "$PY" -m pip install --quiet --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
               "$PY" -m PyInstaller --clean --noconfirm curatarr.spec
+              chown -R "$HOST_UID:$HOST_GID" /io/dist /io/build
             '
 
       # Regression guard for the glibc-floor fix itself: a future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.5] - 2026-07-25
+
+### Fixed
+
+- **The published `curatarr-linux-x86_64` and `curatarr-linux-arm64`
+  binaries required a newer glibc than most server distros ship,
+  failing to even start.** Both Linux entries in
+  `.github/workflows/release.yml`'s `build-binaries` matrix built on a
+  runner that resolves to Ubuntu 24.04 (glibc 2.39); glibc is backward-
+  but not forward-compatible, so the resulting binary failed on Debian
+  12 (glibc 2.36), Ubuntu 22.04 LTS (2.35), and RHEL/Rocky/AlmaLinux 9
+  (2.34) with `Failed to load Python shared library ... GLIBC_2.38' not
+  found` - a raw loader failure, not an actionable error. Reproduced on
+  a real clean Debian 12 install; confirmed Ubuntu 24.04 itself was
+  unaffected. Both Linux entries now build inside a pinned
+  `manylinux_2_28` container (glibc 2.28) instead of directly on the
+  runner - chosen because every compiled dependency
+  (`cryptography`, `cffi`, `markupsafe`, `pyyaml`, `charset-normalizer`)
+  already publishes a `manylinux_2_28`- or lower-tagged wheel for both
+  x86_64 and aarch64, so this floor needed compiling nothing from
+  source (see `build-binaries`' own comment for the full survey). This
+  covers all three baselines above with margin. A new build-time check
+  (`objdump -T` against the built binary's max referenced `GLIBC_*`
+  symbol) fails the job if a future dependency bump silently regresses
+  the floor. Verified with real container runs of the rebuilt binaries
+  on `debian:12`, `ubuntu:22.04`, `rockylinux:9`, and `ubuntu:24.04`
+  (`--version` on each). See `docs/BINARIES.md` for the documented
+  supported floor.
+
 ## [2.10.4] - 2026-07-25
 
 ### Fixed

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -267,15 +267,25 @@ for x86_64:
 docker run --rm -v "$PWD:/io" -w /io \
   quay.io/pypa/manylinux_2_28_x86_64@sha256:fdb9a9c223b215604dc7b6f7e8fff4b39bfea5fbaa7777a2e5544a60dfa437f8 \
   bash -c '
-    PY=/opt/python/cp312-cp312/bin/python3.12
+    dnf install -y -q python3.12 python3.12-devel python3.12-pip
+    PY=/usr/bin/python3.12
     "$PY" -m pip install --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
     "$PY" -m PyInstaller --clean --noconfirm curatarr.spec
   '
 ```
+
+The `dnf install` step matters: the manylinux image's own baked
+`/opt/python/cp*` interpreters are all built `--enable-shared=no`
+(no `libpython*.so`, only a static `.a`) since manylinux images exist to
+build *wheels*, not to embed a whole interpreter - PyInstaller fails
+outright ("Python was built without a shared library") against them.
+The AlmaLinux 8 OS package is built shared and still carries the same
+glibc 2.28 floor, since it's built by that same AlmaLinux 8 base.
 
 Swap in `quay.io/pypa/manylinux_2_28_aarch64@sha256:e7035406e58d96b7407246af1f6514a3cbd753a0025b42b9adfbeadd3b29ba80`
 for an arm64 build (native `docker run`, no emulation, on an arm64 host;
 `--platform linux/amd64` plus qemu on anything else). Verify the result
 with `objdump -T dist/curatarr | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1` -
 it must not exceed `GLIBC_2.28`, matching the CI job's own regression
-guard.
+guard (real builds have come in well under that, at `GLIBC_2.17`
+arm64 / `GLIBC_2.14` x86_64, so there's margin).

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -13,6 +13,16 @@ it, and it opens the web UI in your browser - no Python install, no
 | Linux (x86_64) | `curatarr-linux-x86_64` |
 | Linux (arm64) | `curatarr-linux-arm64` |
 
+Both Linux binaries require **glibc 2.28 or newer** (built inside a
+pinned `manylinux_2_28` container - see `.github/workflows/release.yml`'s
+`build-binaries` job comment for the full rationale and why that
+specific floor was chosen). This covers Debian 12 (glibc 2.36), Ubuntu
+22.04 LTS and newer (2.35), and RHEL/Rocky/AlmaLinux 9 and newer (2.34) -
+check your distro's floor with `ldd --version` if unsure. Older distros
+(e.g. Ubuntu 20.04, Debian 11, RHEL 8) are not supported by the
+prebuilt binary; run Curatarr from source there instead (see
+[Quick Start](../README.md#quick-start)).
+
 macOS binaries are Apple Silicon (arm64) only as of the release that
 dropped Intel macOS support - `cryptography` 49.0.0 removed x86_64
 macOS wheels entirely, and GitHub's last Intel macOS CI runner
@@ -242,3 +252,30 @@ above - no special interpreter or wheel-fusing needed, unlike the old
 universal2 build. Verify the result with `lipo -archs dist/curatarr` -
 it must list `arm64` only; anything else means PyInstaller picked up an
 unexpected toolchain.
+
+### Building the Linux binaries yourself
+
+Running the "Building it yourself" recipe directly on your own machine
+produces a binary tied to *your* machine's glibc - fine for local use,
+but not portable to older distros the way the published release asset
+is (see the glibc floor note above). To reproduce the actual published
+build, run the same recipe inside the same pinned container CI uses
+(`.github/workflows/release.yml`'s `build-binaries` job) instead, e.g.
+for x86_64:
+
+```bash
+docker run --rm -v "$PWD:/io" -w /io \
+  quay.io/pypa/manylinux_2_28_x86_64@sha256:fdb9a9c223b215604dc7b6f7e8fff4b39bfea5fbaa7777a2e5544a60dfa437f8 \
+  bash -c '
+    PY=/opt/python/cp312-cp312/bin/python3.12
+    "$PY" -m pip install --require-hashes -r requirements.lock -r requirements-ui.lock -r build-requirements.lock
+    "$PY" -m PyInstaller --clean --noconfirm curatarr.spec
+  '
+```
+
+Swap in `quay.io/pypa/manylinux_2_28_aarch64@sha256:e7035406e58d96b7407246af1f6514a3cbd753a0025b42b9adfbeadd3b29ba80`
+for an arm64 build (native `docker run`, no emulation, on an arm64 host;
+`--platform linux/amd64` plus qemu on anything else). Verify the result
+with `objdump -T dist/curatarr | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1` -
+it must not exceed `GLIBC_2.28`, matching the CI job's own regression
+guard.

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.4"
+__version__ = "2.10.5"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary

Both `curatarr-linux-x86_64` and `curatarr-linux-arm64` were built directly on runners that resolve to Ubuntu 24.04 (glibc 2.39). glibc is backward- but not forward-compatible, so the published binary failed to even start on Debian 12 (glibc 2.36), Ubuntu 22.04 LTS (2.35), and RHEL/Rocky/Alma 9 (2.34) with a raw loader error (`GLIBC_2.38' not found`), reproduced on a real clean Debian 12 install.

Both Linux matrix entries now build inside a pinned `manylinux_2_28` container (glibc 2.28) instead of directly on the runner. Every compiled dependency (cryptography, cffi, markupsafe, pyyaml, charset-normalizer) already publishes a manylinux_2_28-or-lower wheel for both x86_64 and aarch64, so this floor needed compiling nothing from source. A new build-time `objdump`-based check fails the job if a future dependency bump silently regresses the floor.

- `.github/workflows/release.yml`: manylinux_2_28 container build (digest-pinned) for both Linux matrix entries, chown-back for the root-run bind-mounted build output, glibc floor assertion step
- `docs/BINARIES.md`: documents the glibc 2.28 floor and covered distros, plus a reproducible local build recipe
- `CHANGELOG.md` / `utils/config.py`: 2.10.5

## Verification

Built and ran the actual x86_64 and arm64 binaries (via the exact commands now in release.yml, in a pinned manylinux_2_28 container) on real throwaway containers of all four target distros with `--version`:

| Distro | x86_64 | arm64 |
|---|---|---|
| debian:12 | pass | pass |
| ubuntu:22.04 | pass | pass |
| rockylinux:9 (RHEL 9 proxy) | pass | pass |
| ubuntu:24.04 (no regression) | pass | pass |

Also confirmed the currently-published v2.10.4 `curatarr-linux-x86_64` still fails on debian:12 with the exact reported error, as a before/after control.

Full local test suite: 2199 passed, 5 skipped, 28 failed (pre-existing Windows-only failures, unchanged from main).

This has NOT been verified via an actual Release-workflow run, since that only triggers on a signed tag push, which is out of scope here.

## Test plan

- [x] Real container runs on debian:12, ubuntu:22.04, rockylinux:9, ubuntu:24.04 for both architectures
- [x] Before/after comparison against the currently-published v2.10.4 binary
- [x] Full local test suite (no new failures vs main)
- [ ] Real Release-workflow run (only provable on the next actual tag)