### PR TITLE
fix: Windows self-update sidecar bug + 28 Windows test failures + macOS Gatekeeper docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.6] - 2026-07-25
+
+### Fixed
+
+- **The Windows self-updater's `.old` sidecar cleanup could permanently
+  brick self-update on Windows if a previous swap's leftover `.old`
+  file couldn't be deleted right away** (e.g. still locked by a
+  slow-to-exit previous process - exactly the scenario the code's own
+  cleanup already anticipated as non-fatal). `utils/self_update.py`'s
+  `_swap_windows` used `os.rename()` for its current-binary ->
+  `.old` step; Windows' `os.rename()` refuses to overwrite an existing
+  destination (`WinError 183`), so once that best-effort pre-cleanup
+  failed once, every subsequent self-update attempt would raise
+  `SwapError` at that same rename, forever, until a human manually
+  deleted the stale sidecar - Linux CI never caught this because
+  POSIX's `os.rename()` silently overwrites. Switched to `os.replace()`
+  (the cross-platform atomic form, already used for the actual binary
+  swap two lines below), so a stubborn leftover `.old` no longer blocks
+  future updates.
+
+### Testing
+
+- Triaged all 28 Windows-only test failures on a real Windows dev
+  machine (stable, reproducible, none of them occur on Linux CI).
+  5 turned out to be self-inflicted pollution from two OTHER tests
+  (`test_update_check.py`/`test_update_dismissal.py`) that pointed
+  `get_project_root()` at a hardcoded `/nonexistent/...` path assuming
+  it could never be created - true on POSIX (an ordinary user can't
+  `mkdir` under `/`) but false on Windows (an ordinary user CAN `mkdir`
+  directly under a drive root), so the directory got created for real
+  and leaked into later test runs; fixed by pointing at a path that's
+  genuinely uncreatable on any OS (a plain file sitting where a needed
+  parent directory would go) instead. Of the rest: one was the real
+  production bug above; the remainder were test-only platform
+  assumptions (NTFS chmod not preserving POSIX permission/exec bits,
+  `tempfile.NamedTemporaryFile` handles held open across a call that
+  needs to read/delete that same path - fine on POSIX, `WinError 32` on
+  Windows, hardcoded `/`-joined path assertions, `os.path.expanduser()`
+  preferring `%USERPROFILE%` over `%HOME%` on Windows, and a couple of
+  tests that mocked `os.kill`/`subprocess.run` without also forcing
+  `os.name` to the branch they were meant to exercise - on a real
+  Windows run they silently fell through to the OS's OWN process-table
+  query/`taskkill` instead of the mock, which is both the wrong branch
+  under test and, for the `_shut_down_old_server` case, a real
+  `taskkill` launched against whatever process actually happened to
+  own an arbitrary test PID). All fixed at the test level except the
+  two genuinely POSIX-only code paths (`_swap_posix` direct-call tests,
+  never invoked on Windows in production), which are now
+  `skipif(sys.platform == 'win32', ...)` with the specific reason named
+  in each. No assertions weakened; no tests skipped to hide a real
+  failure. Full suite: 2199 passed / 28 failed / 5 skipped before,
+  2224 passed / 0 failed / 8 skipped after, on the same Windows machine;
+  unchanged and still green on Linux CI.
+
+### Documentation
+
+- `docs/BINARIES.md`: documented that the macOS binary is unsigned and
+  unnotarized (`spctl -a -v` reports `rejected`) and, specifically,
+  that a quarantined binary run in a headless context (SSH, CI, no GUI
+  session) hangs indefinitely instead of failing fast, since Gatekeeper
+  has no dialog to show and nothing to wait for - clear the quarantine
+  attribute (`xattr -d com.apple.quarantine curatarr-macos-arm64`)
+  before running it that way.
+
 ## [2.10.5] - 2026-07-25
 
 ### Fixed

--- a/docs/BINARIES.md
+++ b/docs/BINARIES.md
@@ -108,12 +108,21 @@ warn you the first time you run a downloaded binary:
 
 - **Windows SmartScreen**: "Windows protected your PC" -> click
   **More info** -> **Run anyway**.
-- **macOS Gatekeeper**: right-click (or Control-click) the binary in
-  Finder -> **Open** -> confirm **Open** in the dialog. (A plain
-  double-click on a freshly-downloaded unsigned binary will just say
-  it "cannot be opened" and won't offer this option - it has to be the
-  right-click path the first time.) Alternatively, clear the quarantine
-  attribute from a terminal: `xattr -d com.apple.quarantine curatarr-macos-arm64`.
+- **macOS Gatekeeper**: the binary is neither signed nor notarized
+  (`spctl -a -v` reports `rejected`). A normal Finder download gets the
+  `com.apple.quarantine` extended attribute, and Gatekeeper blocks it:
+  right-click (or Control-click) the binary in Finder -> **Open** ->
+  confirm **Open** in the dialog. (A plain double-click on a
+  freshly-downloaded unsigned binary will just say it "cannot be
+  opened" and won't offer this option - it has to be the right-click
+  path the first time.) If it's already been blocked once, allow it via
+  **System Settings -> Privacy & Security** instead. Alternatively,
+  clear the quarantine attribute directly from a terminal:
+  `xattr -d com.apple.quarantine curatarr-macos-arm64`. In a headless
+  context (SSH, CI, anything with no GUI session attached) neither
+  prompt can appear at all - a quarantined binary run that way hangs
+  indefinitely instead of failing fast, since it's waiting on a dialog
+  nothing can show. Clear the quarantine attribute first in that case.
 - **Linux**: no equivalent gate; just needs `chmod +x`.
 
 Only download binaries from the official

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -39,7 +39,11 @@ class TestBaseCacheInit:
 
         cache = ConcreteCache('/tmp/cache')
 
-        assert cache.cache_path == '/tmp/cache/test_cache.json'
+        # os.path.join, not a hardcoded '/'-joined string: cache_path is
+        # built with os.path.join in production (see recommenders/base.py),
+        # which uses '\\' on Windows - matches that, same as every other
+        # cache_path assertion in this class.
+        assert cache.cache_path == os.path.join('/tmp/cache', 'test_cache.json')
 
     @patch('recommenders.base.load_media_cache')
     def test_init_loads_cache(self, mock_load):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,53 +36,58 @@ class TestCheckCacheVersion:
         assert result is False
 
     def test_returns_true_for_current_version(self):
+        # NamedTemporaryFile's own handle must be closed (i.e. outside
+        # the `with` block) before check_cache_version() touches the
+        # path - on Windows an open handle blocks a second open() AND
+        # the later os.unlink() with WinError 32; POSIX tolerates it,
+        # which is what let this go unnoticed for so long.
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'cache_version': CACHE_VERSION, 'data': {}}, f)
-            f.flush()
-            try:
-                result = check_cache_version(f.name)
-                assert result is True
-            finally:
-                os.unlink(f.name)
+            path = f.name
+        try:
+            result = check_cache_version(path)
+            assert result is True
+        finally:
+            os.unlink(path)
 
     def test_returns_false_for_old_version(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'cache_version': 1, 'data': {}}, f)
-            f.flush()
-            try:
-                result = check_cache_version(f.name)
-                assert result is False
-                # File should be deleted
-                assert not os.path.exists(f.name)
-            except Exception:
-                if os.path.exists(f.name):
-                    os.unlink(f.name)
-                raise
+            path = f.name
+        try:
+            result = check_cache_version(path)
+            assert result is False
+            # File should be deleted
+            assert not os.path.exists(path)
+        except Exception:
+            if os.path.exists(path):
+                os.unlink(path)
+            raise
 
     def test_returns_false_for_invalid_json(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write("not valid json")
-            f.flush()
-            try:
-                result = check_cache_version(f.name)
-                assert result is False
-            finally:
-                if os.path.exists(f.name):
-                    os.unlink(f.name)
+            path = f.name
+        try:
+            result = check_cache_version(path)
+            assert result is False
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
 
     def test_defaults_to_v1_if_no_version(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'data': {}}, f)  # No cache_version key
-            f.flush()
-            try:
-                result = check_cache_version(f.name)
-                # Should return False because v1 < CACHE_VERSION (2)
-                assert result is False
-            except Exception:
-                pass
-            finally:
-                if os.path.exists(f.name):
-                    os.unlink(f.name)
+            path = f.name
+        try:
+            result = check_cache_version(path)
+            # Should return False because v1 < CACHE_VERSION (2)
+            assert result is False
+        except Exception:
+            pass
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
 
 
 class TestGetConfigSection:
@@ -328,76 +333,80 @@ class TestLoadConfig:
     """Tests for load_config function with environment variable support"""
 
     def test_loads_yaml_config(self):
+        # NamedTemporaryFile's own handle must be closed (i.e. outside
+        # the `with` block) before load_config()/os.unlink() touch the
+        # path - Windows locks an open file against a second open() AND
+        # against unlink (WinError 32); POSIX tolerates it.
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n  token: abc123\n")
-            f.flush()
-            try:
-                result = load_config(f.name)
-                assert result['plex']['url'] == 'http://localhost:32400'
-                assert result['plex']['token'] == 'abc123'
-            finally:
-                os.unlink(f.name)
+            path = f.name
+        try:
+            result = load_config(path)
+            assert result['plex']['url'] == 'http://localhost:32400'
+            assert result['plex']['token'] == 'abc123'
+        finally:
+            os.unlink(path)
 
     def test_env_var_overrides_plex_token(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n  token: file_token\n")
-            f.flush()
-            try:
-                os.environ['PLEX_TOKEN'] = 'env_token'
-                result = load_config(f.name)
-                assert result['plex']['token'] == 'env_token'
-            finally:
-                del os.environ['PLEX_TOKEN']
-                os.unlink(f.name)
+            path = f.name
+        try:
+            os.environ['PLEX_TOKEN'] = 'env_token'
+            result = load_config(path)
+            assert result['plex']['token'] == 'env_token'
+        finally:
+            del os.environ['PLEX_TOKEN']
+            os.unlink(path)
 
     def test_env_var_overrides_plex_url(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n")
-            f.flush()
-            try:
-                os.environ['PLEX_URL'] = 'http://remote:32400'
-                result = load_config(f.name)
-                assert result['plex']['url'] == 'http://remote:32400'
-            finally:
-                del os.environ['PLEX_URL']
-                os.unlink(f.name)
+            path = f.name
+        try:
+            os.environ['PLEX_URL'] = 'http://remote:32400'
+            result = load_config(path)
+            assert result['plex']['url'] == 'http://remote:32400'
+        finally:
+            del os.environ['PLEX_URL']
+            os.unlink(path)
 
     def test_env_var_overrides_tmdb_api_key(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("tmdb:\n  api_key: file_key\n")
-            f.flush()
-            try:
-                os.environ['TMDB_API_KEY'] = 'env_key'
-                result = load_config(f.name)
-                assert result['tmdb']['api_key'] == 'env_key'
-            finally:
-                del os.environ['TMDB_API_KEY']
-                os.unlink(f.name)
+            path = f.name
+        try:
+            os.environ['TMDB_API_KEY'] = 'env_key'
+            result = load_config(path)
+            assert result['tmdb']['api_key'] == 'env_key'
+        finally:
+            del os.environ['TMDB_API_KEY']
+            os.unlink(path)
 
     def test_env_var_creates_section_if_missing(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n")
-            f.flush()
-            try:
-                os.environ['TMDB_API_KEY'] = 'env_key'
-                result = load_config(f.name)
-                assert result['tmdb']['api_key'] == 'env_key'
-            finally:
-                del os.environ['TMDB_API_KEY']
-                os.unlink(f.name)
+            path = f.name
+        try:
+            os.environ['TMDB_API_KEY'] = 'env_key'
+            result = load_config(path)
+            assert result['tmdb']['api_key'] == 'env_key'
+        finally:
+            del os.environ['TMDB_API_KEY']
+            os.unlink(path)
 
     def test_no_env_var_uses_file_value(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  token: file_token\n")
-            f.flush()
-            try:
-                # Ensure env var is not set
-                if 'PLEX_TOKEN' in os.environ:
-                    del os.environ['PLEX_TOKEN']
-                result = load_config(f.name)
-                assert result['plex']['token'] == 'file_token'
-            finally:
-                os.unlink(f.name)
+            path = f.name
+        try:
+            # Ensure env var is not set
+            if 'PLEX_TOKEN' in os.environ:
+                del os.environ['PLEX_TOKEN']
+            result = load_config(path)
+            assert result['plex']['token'] == 'file_token'
+        finally:
+            os.unlink(path)
 
 
 class TestModularConfigLoading:
@@ -443,12 +452,12 @@ class TestModularConfigLoading:
     def test_works_without_module_files(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n")
-            f.flush()
-            try:
-                result = load_config(f.name)
-                assert result['plex']['url'] == 'http://localhost:32400'
-            finally:
-                os.unlink(f.name)
+            path = f.name
+        try:
+            result = load_config(path)
+            assert result['plex']['url'] == 'http://localhost:32400'
+        finally:
+            os.unlink(path)
 
     def test_tuning_merges_into_config(self):
         import shutil

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -355,19 +355,33 @@ class TestGetProjectRoot:
 
     @patch('utils.helpers.sys.frozen', True, create=True)
     def test_frozen_windows_falls_back_to_home_without_appdata(self, tmp_path, monkeypatch):
-        """No %APPDATA% set (unusual, but shouldn't crash): fall back to ~\\curatarr."""
+        """No %APPDATA% set (unusual, but shouldn't crash): fall back to ~\\curatarr.
+
+        Patches os.path.expanduser directly rather than the HOME env
+        var: get_project_root()'s fallback is os.path.expanduser('~'),
+        and on a real Windows interpreter that's ntpath.expanduser,
+        which prefers %USERPROFILE% over %HOME% - so setting HOME alone
+        doesn't actually redirect it when this test itself runs on
+        real Windows, only on POSIX. Patching expanduser exercises the
+        branch logic under test on every platform, which is the point.
+        """
         monkeypatch.setattr(os, 'name', 'nt')
         monkeypatch.delenv('APPDATA', raising=False)
-        monkeypatch.setenv('HOME', str(tmp_path))
+        monkeypatch.setattr(os.path, 'expanduser', lambda p: str(tmp_path))
         root = get_project_root()
         assert root == os.path.join(str(tmp_path), 'curatarr')
         assert os.path.isdir(root)
 
     @patch('utils.helpers.sys.frozen', True, create=True)
     def test_frozen_posix_uses_dot_curatarr_in_home(self, tmp_path, monkeypatch):
-        """A frozen binary on macOS/Linux uses ~/.curatarr."""
+        """A frozen binary on macOS/Linux uses ~/.curatarr.
+
+        Patches os.path.expanduser directly (see
+        test_frozen_windows_falls_back_to_home_without_appdata above
+        for why) rather than the HOME env var.
+        """
         monkeypatch.setattr(os, 'name', 'posix')
-        monkeypatch.setenv('HOME', str(tmp_path))
+        monkeypatch.setattr(os.path, 'expanduser', lambda p: str(tmp_path))
         root = get_project_root()
         assert root == os.path.join(str(tmp_path), '.curatarr')
         assert os.path.isdir(root)
@@ -376,7 +390,7 @@ class TestGetProjectRoot:
     def test_frozen_reuses_existing_dir(self, tmp_path, monkeypatch):
         """Second run against an already-populated data dir doesn't error."""
         monkeypatch.setattr(os, 'name', 'posix')
-        monkeypatch.setenv('HOME', str(tmp_path))
+        monkeypatch.setattr(os.path, 'expanduser', lambda p: str(tmp_path))
         existing = os.path.join(str(tmp_path), '.curatarr')
         os.makedirs(existing)
         with open(os.path.join(existing, 'marker.txt'), 'w') as f:

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -860,6 +860,14 @@ class TestSwapPosix:
     the near-identical test shape this mirrors.
     """
 
+    @pytest.mark.skipif(
+        sys.platform == 'win32',
+        reason="NTFS has no POSIX exec bit for an extensionless file (os.stat only "
+               "synthesizes S_IEXEC for specific extensions like .exe/.bat/.cmd) - "
+               "os.chmod's exec-bit request is a no-op here regardless. _swap_posix "
+               "is never invoked on Windows in production (swap_binary dispatches to "
+               "_swap_windows there - see TestSwapWindows), so this is POSIX-only.",
+    )
     def test_replaces_current_with_new_and_sets_exec_bit(self, tmp_path):
         current = tmp_path / 'curatarr'
         current.write_bytes(b'old content')
@@ -898,6 +906,16 @@ class TestSwapPosix:
 
         assert (tmp_path / 'curatarr.old').read_bytes() == b'old content'
 
+    @pytest.mark.skipif(
+        sys.platform == 'win32',
+        reason="_swap_posix's current -> old_path step deliberately still uses plain "
+               "os.rename() (never os.replace() - see _swap_windows's docstring for "
+               "why THAT one needed to change), relying on POSIX rename(2)'s "
+               "silent-overwrite-of-an-existing-destination semantics, which Windows' "
+               "os.rename doesn't have (WinError 183). That's fine: _swap_posix is "
+               "never invoked on Windows in production (swap_binary dispatches to "
+               "_swap_windows there - see TestSwapWindows's own version of this test).",
+    )
     def test_stale_old_sidecar_removal_failure_is_non_fatal(self, tmp_path):
         """A leftover .old that can't be removed (e.g. still locked by a
         slow-to-exit previous process) must not abort the swap - the
@@ -973,14 +991,15 @@ class TestCurrentBinaryPath:
 
 
 class TestSwapWindows:
-    """_swap_windows itself only calls os.rename/os.replace - both work
-    identically against plain files on any OS, so its rename-then-move
-    LOGIC (including rollback) is fully exercisable here without
-    actually running on Windows. The Windows-specific claim being
-    tested is "you can rename a file out from under a process still
-    using it", which is a real-OS fact asserted in the module's
-    docstring/comments, not something a unit test proves - see
-    docs/BINARIES.md and this PR's Windows E2E evidence for that part.
+    """_swap_windows itself only calls os.replace (see its own
+    docstring for why not os.rename) - that works identically against
+    plain files on any OS, so its rename-then-move LOGIC (including
+    rollback) is fully exercisable here without actually running on
+    Windows. The Windows-specific claim being tested is "you can
+    rename a file out from under a process still using it", which is a
+    real-OS fact asserted in the module's docstring/comments, not
+    something a unit test proves - see docs/BINARIES.md and this PR's
+    Windows E2E evidence for that part.
     """
 
     def test_success_path(self, tmp_path):
@@ -1031,7 +1050,9 @@ class TestSwapWindows:
         new = tmp_path / 'new_download.tmp'
         new.write_bytes(b'new content')
 
-        with patch('utils.self_update.os.rename', side_effect=OSError('locked')):
+        # current -> old_path uses os.replace(), not os.rename() (see
+        # _swap_windows's docstring for why) - patch that.
+        with patch('utils.self_update.os.replace', side_effect=OSError('locked')):
             with pytest.raises(self_update.SwapError, match='Could not rename'):
                 self_update._swap_windows(str(current), str(new))
         assert current.read_bytes() == b'old content'
@@ -1048,7 +1069,10 @@ class TestSwapWindows:
 
         def _flaky_replace(src, dst):
             calls['n'] += 1
-            if calls['n'] == 1:
+            # Call 1 is the current -> old_path step (must succeed for
+            # real, same as production); call 2 is the actual "move
+            # new binary into place" step this test targets.
+            if calls['n'] == 2:
                 raise OSError('could not move new binary into place')
             return real_replace(src, dst)
 
@@ -1065,7 +1089,20 @@ class TestSwapWindows:
         new = tmp_path / 'new_download.tmp'
         new.write_bytes(b'new content')
 
-        with patch('utils.self_update.os.replace', side_effect=OSError('everything is on fire')):
+        real_replace = os.replace
+        calls = {'n': 0}
+
+        def _fails_from_second_call(src, dst):
+            calls['n'] += 1
+            # Call 1 (current -> old_path) must succeed for real so
+            # there's something at old_path left to fail to restore
+            # from below; calls 2+ (the move, then the rollback
+            # attempt) both fail.
+            if calls['n'] == 1:
+                return real_replace(src, dst)
+            raise OSError('everything is on fire')
+
+        with patch('utils.self_update.os.replace', side_effect=_fails_from_second_call):
             with pytest.raises(self_update.SwapError, match='rollback failed'):
                 self_update._swap_windows(str(current), str(new))
         # current_path is gone (both replace attempts failed) but the
@@ -1112,8 +1149,18 @@ class TestPreservePermissions:
 
         self_update._preserve_permissions(str(source), str(dest))
 
-        import stat as stat_module
-        assert stat_module.S_IMODE(os.stat(str(dest)).st_mode) == 0o755
+        if sys.platform == 'win32':
+            # NTFS/os.chmod on Windows has one real degree of freedom:
+            # the read-only DOS attribute, toggled by whether the
+            # requested mode includes S_IWRITE - there's no granular
+            # owner/group/other bit storage to check 0o755 against.
+            # Source's mode (0o755) has the write bit set, so the only
+            # meaningful, platform-appropriate assertion is that dest
+            # ends up writable (not read-only) too.
+            assert os.access(str(dest), os.W_OK)
+        else:
+            import stat as stat_module
+            assert stat_module.S_IMODE(os.stat(str(dest)).st_mode) == 0o755
 
     def test_missing_source_does_not_raise(self, tmp_path):
         dest = tmp_path / 'dest'

--- a/tests/test_self_update_handoff.py
+++ b/tests/test_self_update_handoff.py
@@ -188,6 +188,15 @@ class TestWriteScript:
         finally:
             shutil.rmtree(os.path.dirname(path), ignore_errors=True)
 
+    @pytest.mark.skipif(
+        sys.platform == 'win32',
+        reason="NTFS has no POSIX exec bit for a .sh file (os.stat only synthesizes "
+               "S_IEXEC for specific extensions like .exe/.bat/.cmd/.com) - os.chmod's "
+               "exec-bit request is a no-op here regardless. The os.name != 'nt' branch "
+               "under test never runs on Windows in production (the Windows hand-off "
+               "always writes .ps1 - see test_uses_ps1_extension_on_windows above), so "
+               "this is POSIX-only.",
+    )
     def test_uses_sh_extension_and_is_executable_on_posix(self, monkeypatch):
         monkeypatch.setattr(self_update_handoff.os, 'name', 'posix')
         path = self_update_handoff._write_script('#!/bin/sh\necho hi\n')

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -257,16 +257,25 @@ class TestGetLatestVersionSuccess:
         mock_get.assert_called_once()
 
     @patch('utils.update_check.requests.get')
-    def test_cache_write_failure_is_not_fatal(self, mock_get, monkeypatch):
+    def test_cache_write_failure_is_not_fatal(self, mock_get, monkeypatch, tmp_path):
         """A disk error writing the cache (permissions, full disk, a
         cache dir that doesn't exist, etc.) must not surface as an
         exception - worst case is just a re-check next call instead of
-        respecting the cache interval. Points the cache dir at a
-        nonexistent path (never created) so the real open() call fails
-        naturally, instead of risky global builtins.open patching."""
+        respecting the cache interval. Points the cache dir at a path
+        that can never be created - a plain file sits where the needed
+        parent directory would go, so os.makedirs always fails, on
+        every OS (a hardcoded '/nonexistent/...' string only reliably
+        stays uncreatable on POSIX, where a normal user can't mkdir
+        directly under '/' - on Windows, a normal user CAN mkdir
+        directly under a drive root, so that string would actually get
+        created for real and leak onto disk) - so the real open() call
+        fails naturally, instead of risky global builtins.open
+        patching."""
+        blocker = tmp_path / 'blocker'
+        blocker.write_bytes(b'not a directory')
         monkeypatch.setattr(
             'utils.update_check.get_project_root',
-            lambda: '/nonexistent/path/that/is/never/created',
+            lambda: str(blocker / 'unreachable'),
         )
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None

--- a/tests/test_update_dismissal.py
+++ b/tests/test_update_dismissal.py
@@ -163,17 +163,22 @@ class TestFailOpen:
         _seed_dismissal(tmp_path, {'dismissed_at': time.time()})
         assert is_dismissed('2.9.0') is False
 
-    def test_record_dismissal_write_failure_is_not_fatal(self, monkeypatch):
+    def test_record_dismissal_write_failure_is_not_fatal(self, monkeypatch, tmp_path):
         """A disk error writing the dismissal state (permissions, full
         disk, etc.) must not raise - worst case, the notice just keeps
         reappearing every check instead of being snoozed. Points the
-        cache dir at a nonexistent, never-created path so the real
-        open() call fails naturally, same technique tests/
-        test_update_check.py's own test_cache_write_failure_is_not_fatal
-        uses."""
+        cache dir at a path that can never be created - a plain file
+        sits where the needed parent directory would go, so
+        os.makedirs always fails, on every OS - so the real open()
+        call fails naturally, same technique tests/test_update_check.py's
+        own test_cache_write_failure_is_not_fatal uses (see its comment
+        for why a hardcoded '/nonexistent/...' string isn't reliably
+        uncreatable on Windows)."""
+        blocker = tmp_path / 'blocker'
+        blocker.write_bytes(b'not a directory')
         monkeypatch.setattr(
             'utils.update_dismissal.get_project_root',
-            lambda: '/nonexistent/path/that/is/never/created',
+            lambda: str(blocker / 'unreachable'),
         )
         try:
             record_dismissal('2.9.0')

--- a/tests/test_web_update_apply.py
+++ b/tests/test_web_update_apply.py
@@ -62,6 +62,7 @@ from web.update_apply import (
     _run_frozen_verify_and_handoff,
     _run_worker,
     _shut_down_old_server,
+    _updater_script,
     _windows_powershell_path,
     _windows_tasklist_path,
     _windows_taskkill_path,
@@ -316,33 +317,48 @@ class TestLockConcurrency:
 class TestCheckVerifiedUpdate:
     """Unit tests for the precondition-check helper itself (not through
     the route) - mirrors run.sh's/run.ps1's own --check-verified-update
-    mode being shelled out to, never reimplemented."""
+    mode being shelled out to, never reimplemented.
+
+    Writes the script via _updater_script(), not a hardcoded 'run.sh':
+    check_verified_update() looks for run.ps1 on Windows and run.sh
+    everywhere else, so a hardcoded 'run.sh' would leave the "script"
+    that subprocess.run is mocked to be invoked for permanently
+    missing on a real Windows run - os.path.isfile() would return
+    False, check_verified_update() would take its own "no script"
+    early return before ever calling the mocked subprocess.run, and
+    every test below would pass for the wrong reason (or, for
+    test_verified_tag_returned, fail outright).
+    """
 
     def test_missing_script_returns_none(self, tmp_path):
         assert check_verified_update(str(tmp_path)) is None
 
     @patch('web.update_apply.subprocess.run')
     def test_nonzero_exit_returns_none(self, mock_run, tmp_path):
-        (tmp_path / 'run.sh').write_text('#!/bin/bash\n', encoding='utf-8')
+        with open(_updater_script(str(tmp_path)), 'w', encoding='utf-8') as f:
+            f.write('#!/bin/bash\n')
         mock_run.return_value = Mock(returncode=1, stdout='')
         assert check_verified_update(str(tmp_path)) is None
 
     @patch('web.update_apply.subprocess.run')
     def test_verified_tag_returned(self, mock_run, tmp_path):
-        (tmp_path / 'run.sh').write_text('#!/bin/bash\n', encoding='utf-8')
+        with open(_updater_script(str(tmp_path)), 'w', encoding='utf-8') as f:
+            f.write('#!/bin/bash\n')
         mock_run.return_value = Mock(returncode=0, stdout='v2.9.0\n')
         assert check_verified_update(str(tmp_path)) == 'v2.9.0'
 
     @patch('web.update_apply.subprocess.run')
     def test_exception_is_not_fatal(self, mock_run, tmp_path):
-        (tmp_path / 'run.sh').write_text('#!/bin/bash\n', encoding='utf-8')
+        with open(_updater_script(str(tmp_path)), 'w', encoding='utf-8') as f:
+            f.write('#!/bin/bash\n')
         mock_run.side_effect = Exception('boom')
         assert check_verified_update(str(tmp_path)) is None
 
     @patch('web.update_apply.subprocess.run')
     def test_timeout_is_not_fatal(self, mock_run, tmp_path):
         import subprocess as sp
-        (tmp_path / 'run.sh').write_text('#!/bin/bash\n', encoding='utf-8')
+        with open(_updater_script(str(tmp_path)), 'w', encoding='utf-8') as f:
+            f.write('#!/bin/bash\n')
         mock_run.side_effect = sp.TimeoutExpired(cmd='run.sh', timeout=20)
         assert check_verified_update(str(tmp_path)) is None
 
@@ -362,11 +378,18 @@ class TestPidAlive:
         assert _pid_alive(0) is False
         assert _pid_alive(-1) is False
 
-    def test_permission_error_means_alive_but_owned_by_someone_else(self):
+    def test_permission_error_means_alive_but_owned_by_someone_else(self, monkeypatch):
+        # os.kill is only reached on the POSIX branch - _pid_alive's
+        # 'nt' branch shells out to tasklist instead (see
+        # test_own_pid_is_alive above and the class docstring), which
+        # would bypass this mock entirely and query the real process
+        # table on an actual Windows run.
+        monkeypatch.setattr('web.update_apply.os.name', 'posix')
         with patch('web.update_apply.os.kill', side_effect=PermissionError()):
             assert _pid_alive(1234) is True
 
-    def test_generic_os_error_means_not_alive(self):
+    def test_generic_os_error_means_not_alive(self, monkeypatch):
+        monkeypatch.setattr('web.update_apply.os.name', 'posix')
         with patch('web.update_apply.os.kill', side_effect=OSError('weird')):
             assert _pid_alive(1234) is False
 
@@ -492,7 +515,14 @@ class TestShutDownOldServer:
 
     @patch('web.update_apply.time.sleep')
     @patch('web.update_apply.os.kill')
-    def test_signals_then_waits_for_exit(self, mock_kill, mock_sleep):
+    def test_signals_then_waits_for_exit(self, mock_kill, mock_sleep, monkeypatch):
+        # os.kill is only reached on the POSIX branch - _shut_down_old_server's
+        # 'nt' branch shells out to taskkill instead (see this module's own
+        # docstring). Without forcing the branch, a real Windows run would
+        # bypass this mock and launch a REAL taskkill /F /PID against
+        # whatever process actually happens to own pid 12345 - exactly what
+        # this class's docstring says must never happen.
+        monkeypatch.setattr('web.update_apply.os.name', 'posix')
         calls = {'n': 0}
 
         def _fake_alive(pid):
@@ -505,7 +535,11 @@ class TestShutDownOldServer:
 
     @patch('web.update_apply.time.sleep')
     @patch('web.update_apply.os.kill', side_effect=ProcessLookupError())
-    def test_process_vanishing_mid_signal_does_not_raise(self, mock_kill, mock_sleep):
+    def test_process_vanishing_mid_signal_does_not_raise(self, mock_kill, mock_sleep, monkeypatch):
+        # See test_signals_then_waits_for_exit above for why this must
+        # force the POSIX branch rather than let a real Windows run
+        # silently take the taskkill branch instead.
+        monkeypatch.setattr('web.update_apply.os.name', 'posix')
         with patch('web.update_apply._pid_alive', return_value=True):
             _shut_down_old_server(12345, timeout=5)  # must not raise
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.5"
+__version__ = "2.10.6"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -852,16 +852,28 @@ def _swap_windows(current_path: str, new_binary_path: str) -> None:
     extremely unlikely case that the rollback ITSELF also fails,
     SwapError's message points at where the original binary can still
     be recovered from (`<current_path>.old`) - see cleanup_stale_old_binary
-    for the normal (successful-swap) cleanup of that same sidecar path."""
+    for the normal (successful-swap) cleanup of that same sidecar path.
+
+    Uses os.replace(), not os.rename(), for the current -> old_path
+    step: the best-effort cleanup right above is exactly that - best
+    effort - so old_path can still be there (e.g. still locked by a
+    slow-to-exit previous process, per that cleanup's own comment)
+    when this runs. os.rename() refuses to overwrite an existing
+    destination on Windows (WinError 183) - it would turn a merely
+    stale sidecar into a hard failure of every subsequent update
+    attempt, forever, until a human manually deletes it. os.replace()
+    is the cross-platform atomic form and overwrites unconditionally,
+    same as this same rename already relies on further down for the
+    rollback path."""
     old_path = _old_sidecar_path(current_path)
     try:
         if os.path.isfile(old_path):
             os.remove(old_path)  # clear out any leftover before reusing the name
     except OSError:
-        pass  # non-fatal - the rename below will just fail loudly if this is actually a problem
+        pass  # non-fatal - the os.replace() below tolerates old_path still being there
 
     try:
-        os.rename(current_path, old_path)
+        os.replace(current_path, old_path)
     except OSError as e:
         raise SwapError(f"Could not rename running exe {current_path} -> {old_path}: {e}") from e
 


### PR DESCRIPTION
## Summary
- Fixes a real Windows-only self-update bug: `_swap_windows` used `os.rename()` for the current-binary -> `.old` step, which refuses to overwrite an existing destination on Windows (WinError 183). A stale `.old` left over from a slow-to-exit previous process (already anticipated as non-fatal by the surrounding cleanup) would make every subsequent self-update attempt fail at that same rename, forever, until manually deleted. Switched to `os.replace()`, the cross-platform atomic form already used for the actual binary swap.
- Triages and fixes all 28 stable Windows-only test failures found while chasing the above: mostly test-only platform assumptions (NTFS chmod/exec-bit semantics, NamedTemporaryFile handles held open across a call needing that same path, hardcoded POSIX path/HOME assumptions, os.kill/subprocess mocks not forcing the branch under test, and two tests whose hardcoded /nonexistent path was actually creatable on Windows and polluted later runs). Two genuinely POSIX-only code paths are now explicitly skipped on win32 with a named reason. No assertions weakened, nothing skipped to hide a real failure.
- Documents the unsigned/unnotarized macOS binary's Gatekeeper behavior in docs/BINARIES.md, including that a quarantined binary hangs (rather than fails) when run headlessly (SSH/CI) with no GUI session to show the block dialog.
- Version bump to 2.10.6.

## Test plan
- [x] Full suite passes on Windows: 2199 passed / 28 failed / 5 skipped before -> 2224 passed / 0 failed / 8 skipped after
- [x] Full suite unaffected on Linux CI (see checks on this PR)