### PR TITLE
Local-first observability: structured logging, /metrics, /status.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.8] - 2026-07-25
+
+### Added
+
+- **Local-first observability**: structured logging, a Prometheus
+  `/metrics` endpoint, and a richer authenticated status endpoint - all
+  self-hosted, nothing shipped to a third-party service.
+  - **Structured logging**: opt-in JSON-lines log format alongside the
+    existing human-readable one, via the new `logging.format: json`
+    config key (default stays `text` - existing installs are
+    unaffected). Wired through `utils.display.setup_logging`, the same
+    place `logging.level` already plugs in. Every record is redacted
+    through the same `utils/redact.py` path every other log destination
+    in this codebase uses, so a token-shaped value is masked in JSON
+    output exactly as it already is in the human-readable one.
+  - **`/metrics`**: Prometheus text-format metrics on the web UI -
+    recommender run count/duration by engine and outcome, outbound API
+    request count/latency/error count by service (Plex, Radarr, Sonarr,
+    TMDB, Trakt, Simkl, MDBList, Tautulli), local cache hit/miss,
+    self-update attempts/failures, unhandled error count, and
+    `curatarr_build_info`. Rendered directly (no new runtime
+    dependency - see `utils/metrics.py`) from a small local JSON state
+    file, so scraping never makes a network call or triggers a Plex/
+    TMDB request. Behind the exact same token gate as every other route
+    once the server is bound non-loopback (Docker) - it surfaces
+    library/integration topology, which isn't public data any more than
+    the config screens are. `/login` and `/healthz` remain the only
+    unauthenticated routes.
+  - **`/status.json`**: authenticated readiness detail (last run time/
+    outcome, whether config.yml currently loads, whether a run is in
+    progress) that doesn't belong on the unauthenticated `/healthz`,
+    which stays exactly as boring as before (liveness + version only -
+    no library/user/integration detail).
+
 ## [2.10.7] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -179,6 +179,64 @@ written atomically, so a bad submission can't corrupt your config files.
 
 ---
 
+## Observability
+
+Local-first only - nothing here ever leaves your machine or gets shipped to a
+third-party service.
+
+### Structured logging
+
+Set `logging.format: json` in `config/config.yml` (default is `text`, the
+existing colored console output - nothing changes unless you opt in) for
+JSON-lines log output instead: one JSON object per line with `timestamp`,
+`level`, `logger`, `message`, plus any structured fields a given log call
+attaches (e.g. `user`, `engine`, `duration`). Convenient for feeding logs into
+`jq`, Loki, or another log aggregator. Secrets are redacted the same way
+either format - a leaked Plex/Sonarr/Radarr/etc. token is masked in JSON
+output exactly as it already is in the human-readable one.
+
+### `/metrics` (Prometheus)
+
+The web UI exposes Prometheus text-format metrics at `/metrics`:
+recommender run count/duration by engine and outcome, outbound API request
+count/latency/error count by service (Plex, Sonarr, Radarr, TMDB, Trakt,
+Simkl, MDBList, Tautulli), local cache hit/miss, self-update attempts/
+failures, unhandled error count, and a `curatarr_build_info` gauge carrying
+the running version. Rendered directly from a small local state file - no
+new runtime dependency, and scraping never makes a network call or triggers
+a Plex/TMDB request.
+
+**Same auth as everything else**: for a native install (bound to
+`127.0.0.1` only) `/metrics` needs no token, same as every other route. For
+Docker (bound `0.0.0.0` - see [docs/DOCKER.md](docs/DOCKER.md#authentication))
+it requires the exact same `CURATARR_AUTH_TOKEN` as the rest of the app -
+`/metrics` labels expose library names, user counts, and which integrations
+are configured, which isn't public data any more than the config screens
+are. Only `/login` and `/healthz` are ever unauthenticated.
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: curatarr
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["curatarr-host:8787"]
+    authorization:
+      credentials: "YOUR_CURATARR_AUTH_TOKEN"   # omit entirely for a loopback-only native install
+```
+
+### `/healthz` and `/status.json`
+
+`/healthz` stays unauthenticated and deliberately minimal - liveness plus
+version, nothing else - so it's safe to leave open to a container
+orchestrator's health check with no token. Richer readiness detail (last run
+time/outcome, whether `config.yml` currently loads, whether a run is in
+progress) lives instead on the authenticated `/status.json`, which - like
+`/metrics` - needs a token on a non-loopback bind.
+
+---
+
 ## What You Get
 
 ### In Plex
@@ -341,6 +399,7 @@ general:
 
 logging:
   level: INFO                  # DEBUG, INFO, WARNING, ERROR
+  format: text                 # text (default) | json - see Observability below
 ```
 
 `general.update_mode` controls how Curatarr handles new releases:

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -51,9 +51,15 @@ huntarr:
   sequel_huntarr: true    # Missing movies from collections you've started
   horizon_huntarr: true   # Upcoming unreleased movies from collections you own
 
-# Optional: Logging level
+# Optional: Logging level and format
 logging:
   level: INFO  # DEBUG, INFO, WARNING, ERROR
+  # format: text (default) - colored, human-readable console output.
+  # format: json - structured JSON-lines (one JSON object per log line:
+  #   timestamp, level, logger, message, plus any extra fields a call
+  #   site attaches) for log aggregators/SIEMs. Secrets are redacted the
+  #   same way either format.
+  # format: text
 
 # Optional: Multi-library support
 # Define one entry per Plex library you want Curatarr to manage separately

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -78,6 +78,12 @@ cookie so the browser doesn't need to resend it on every request.
 Scripts/reverse proxies can instead send it directly, either as
 `Authorization: Bearer <token>` or `X-Curatarr-Token: <token>`.
 
+This same token also gates `/metrics` (Prometheus text-format metrics) and
+`/status.json` - see the main [README's Observability
+section](../README.md#observability) for what each exposes and an example
+Prometheus scrape config. `/login` and `/healthz` remain the only
+unauthenticated routes.
+
 ### Opting out: `CURATARR_TRUSTED_NETWORK`
 
 If you've decided the published port is genuinely unreachable by

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -46,6 +46,8 @@ from utils import (
     get_authenticated_trakt_client,
     get_libraries_for_media_type,
     smart_open_html,
+    record_recommender_run,
+    record_unhandled_error,
 )
 
 # Import output generation
@@ -2825,6 +2827,28 @@ def _merge_user_runs(username: str, movie_runs: List[Dict], tv_runs: List[Dict])
 
 
 def main():
+    """Thin wrapper around _main_impl() that records
+    curatarr_recommender_runs_total/curatarr_recommender_run_duration_seconds
+    (engine='external' - see utils/metrics.py) for the whole run,
+    regardless of how it ends (normal completion, sys.exit(), or an
+    unhandled exception) - kept separate from _main_impl() itself so
+    that function's existing body/control flow (including its own
+    per-user try/except blocks) needed no re-indentation to add this."""
+    run_start = time.monotonic()
+    outcome = 'failure'
+    try:
+        _main_impl()
+        outcome = 'success'
+    except SystemExit:
+        raise
+    except Exception:
+        record_unhandled_error(component='external')
+        raise
+    finally:
+        record_recommender_run('external', outcome, time.monotonic() - run_start)
+
+
+def _main_impl():
     import argparse
     parser = argparse.ArgumentParser(description='External Recommendations Generator')
     parser.add_argument('--huntarr-only', action='store_true',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,27 @@ def _isolated_update_dismissal_dir(tmp_path_factory, monkeypatch):
         lambda: str(tmp_path_factory.mktemp('update_dismissal')),
     )
 
+
+@pytest.fixture(autouse=True)
+def _isolated_metrics_dir(tmp_path_factory, monkeypatch):
+    """Same reasoning as _isolated_update_dismissal_dir above, for
+    utils/metrics.py's on-disk metrics_state.json: its get_project_root()
+    also always resolves to the real repo/data dir regardless of a
+    test's Flask app project_root override, and metrics recording is
+    exercised incidentally by a lot of otherwise-unrelated tests (any
+    recommender run, any *arr/TMDB/Trakt/Simkl/Tautulli/MDBList client
+    call, any cache read - see each module's own utils.metrics call
+    sites). Without this, those tests would write a REAL
+    cache/metrics_state.json into the repo root. Tests that specifically
+    exercise metrics persistence/rendering (tests/test_metrics.py,
+    tests/test_web_metrics.py) override this per-test with their own
+    stable tmp_path, same layering the two fixtures above document.
+    """
+    monkeypatch.setattr(
+        'utils.metrics.get_project_root',
+        lambda: str(tmp_path_factory.mktemp('metrics_state')),
+    )
+
 _FAKE_MOVIE_PY = '''\
 import os
 import sys

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,10 +8,13 @@ import sys
 from io import StringIO
 from unittest.mock import Mock, patch, MagicMock
 
+import json
+
 from utils.display import (
     RED, GREEN, YELLOW, CYAN, RESET,
     ANSI_PATTERN,
     ColoredFormatter,
+    JsonFormatter,
     TeeLogger,
     setup_logging,
     print_user_header,
@@ -273,6 +276,112 @@ class TestSetupLogging:
         logger = setup_logging()
 
         assert logger.name == 'curatarr'
+
+
+class TestJsonFormatter:
+    """Tests for JsonFormatter - the opt-in structured (JSON-lines) log
+    format (see logging.format: json in config.yml / setup_logging)."""
+
+    def _record(self, msg='Test message', level=logging.INFO, extra=None):
+        record = logging.LogRecord(
+            name='curatarr', level=level, pathname='', lineno=0,
+            msg=msg, args=(), exc_info=None,
+        )
+        for key, value in (extra or {}).items():
+            setattr(record, key, value)
+        return record
+
+    def test_output_is_valid_json(self):
+        formatter = JsonFormatter()
+        formatted = formatter.format(self._record())
+        payload = json.loads(formatted)  # raises if not valid JSON
+        assert isinstance(payload, dict)
+
+    def test_has_consistent_core_fields(self):
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record(msg='hello world', level=logging.WARNING)))
+        assert payload['level'] == 'WARNING'
+        assert payload['logger'] == 'curatarr'
+        assert payload['message'] == 'hello world'
+        assert 'timestamp' in payload
+
+    def test_timestamp_is_iso8601(self):
+        from datetime import datetime
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record()))
+        # Raises ValueError if not a real ISO 8601 timestamp.
+        datetime.fromisoformat(payload['timestamp'])
+
+    def test_includes_structured_extra_fields(self):
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record(
+            msg='run finished',
+            extra={'user': 'alice', 'engine': 'movie', 'duration': 12.5},
+        )))
+        assert payload['user'] == 'alice'
+        assert payload['engine'] == 'movie'
+        assert payload['duration'] == 12.5
+
+    def test_redacts_token_shaped_value_in_message(self):
+        """Proves a token-shaped value is redacted in JSON output - same
+        contract utils/redact.py's other call sites already guarantee
+        for the human-readable format. Uses a run of 'x' characters as
+        the placeholder value (matches .gitleaks.toml's own allowlisted
+        placeholder shape, `x{16,}`) rather than a realistic-looking
+        secret literal, since this is a NEW line the secret-scan CI
+        check inspects on its own merits regardless of similar-shaped
+        values already existing elsewhere in the suite."""
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record(
+            msg='GET http://localhost:32400/library?X-Plex-Token=xxxxxxxxxxxxxxxxxxxx',
+        )))
+        assert 'xxxxxxxxxxxxxxxxxxxx' not in payload['message']
+        assert 'REDACTED' in payload['message']
+
+    def test_redacts_token_shaped_value_in_extra_field(self):
+        """Same placeholder value as test_masks_bearer_header in
+        tests/test_web_security.py's TestRedact."""
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record(
+            msg='Trakt call',
+            extra={'response_headers': 'Authorization: Bearer abcdefghijklmnop'},
+        )))
+        assert 'abcdefghijklmnop' not in payload['response_headers']
+        assert 'REDACTED' in payload['response_headers']
+
+    def test_does_not_leak_internal_logrecord_attributes(self):
+        formatter = JsonFormatter()
+        payload = json.loads(formatter.format(self._record()))
+        # 'msg'/'args'/'pathname'/etc. are internal LogRecord plumbing,
+        # not part of the documented structured field set.
+        assert 'msg' not in payload
+        assert 'args' not in payload
+        assert 'pathname' not in payload
+
+
+class TestSetupLoggingFormat:
+    """Tests for setup_logging()'s logging.format wiring (see
+    TestJsonFormatter above for the formatter's own behavior)."""
+
+    def test_default_format_is_colored_text(self):
+        setup_logging(debug=False)
+        root_handler = logging.getLogger().handlers[0]
+        assert isinstance(root_handler.formatter, ColoredFormatter)
+
+    def test_json_format_selects_json_formatter(self):
+        setup_logging(debug=False, config={'logging': {'format': 'json'}})
+        root_handler = logging.getLogger().handlers[0]
+        assert isinstance(root_handler.formatter, JsonFormatter)
+
+    def test_unknown_format_falls_back_to_text(self):
+        setup_logging(debug=False, config={'logging': {'format': 'xml'}})
+        root_handler = logging.getLogger().handlers[0]
+        assert isinstance(root_handler.formatter, ColoredFormatter)
+
+    def test_json_format_is_case_insensitive(self):
+        setup_logging(debug=False, config={'logging': {'format': 'JSON'}})
+        root_handler = logging.getLogger().handlers[0]
+        assert isinstance(root_handler.formatter, JsonFormatter)
 
 
 class TestPrintUserHeader:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,184 @@
+"""Tests for utils/metrics.py - the local-first, dependency-free
+Prometheus text-format metrics registry.
+
+Follows the same per-test-stable-tmp_path override pattern as
+tests/test_update_dismissal.py: tests/conftest.py's suite-wide
+_isolated_metrics_dir fixture hands out a FRESH throwaway dir on every
+call (fine for tests elsewhere in the suite that don't care about
+persistence across calls), but these tests need the SAME dir across
+multiple record_*()/render_prometheus_text() calls within one test.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from utils import metrics
+
+
+@pytest.fixture(autouse=True)
+def _isolated_metrics_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr('utils.metrics.get_project_root', lambda: str(tmp_path))
+    return tmp_path
+
+
+def _state_file_path(tmp_path):
+    return os.path.join(str(tmp_path), 'cache', 'metrics_state.json')
+
+
+class TestRecordRecommenderRun:
+    def test_increments_counter_and_histogram(self, tmp_path):
+        metrics.record_recommender_run('movie', 'success', 12.5)
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_recommender_runs_total{engine="movie",outcome="success"} 1.0' in text
+        assert 'curatarr_recommender_run_duration_seconds_count{engine="movie",outcome="success"} 1' in text
+        assert 'curatarr_recommender_run_duration_seconds_sum{engine="movie",outcome="success"} 12.5' in text
+
+    def test_accumulates_across_multiple_runs(self, tmp_path):
+        metrics.record_recommender_run('tv', 'success', 5.0)
+        metrics.record_recommender_run('tv', 'success', 7.0)
+        metrics.record_recommender_run('tv', 'failure', 1.0)
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_recommender_runs_total{engine="tv",outcome="success"} 2.0' in text
+        assert 'curatarr_recommender_runs_total{engine="tv",outcome="failure"} 1.0' in text
+
+    def test_persists_to_disk_state_file(self, tmp_path):
+        metrics.record_recommender_run('external', 'success', 3.0)
+        assert os.path.isfile(_state_file_path(tmp_path))
+
+    def test_survives_across_a_fresh_load_simulating_another_process(self, tmp_path):
+        """A recommender subprocess (see web/job_runner.py) records into
+        the same on-disk file a separately-running web server process
+        later reads - simulated here by never relying on any in-memory
+        state between the record call and the render call, both of
+        which independently call _load_state()/_state_path()."""
+        metrics.record_recommender_run('movie', 'success', 1.0)
+        # A fresh render (as a real /metrics scrape would do, from a
+        # different process than whatever recorded the run) still sees it.
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_recommender_runs_total{engine="movie",outcome="success"} 1.0' in text
+
+
+class TestRecordApiCall:
+    def test_success_and_error_tracked_separately(self):
+        metrics.record_api_call('radarr', 'success', 0.2)
+        metrics.record_api_call('radarr', 'error', 1.5)
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_api_requests_total{service="radarr",outcome="error"} 1.0' in text
+        assert 'curatarr_api_requests_total{service="radarr",outcome="success"} 1.0' in text
+
+    def test_track_api_call_context_manager_records_success(self):
+        with metrics.track_api_call('tmdb'):
+            pass
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_api_requests_total{service="tmdb",outcome="success"} 1.0' in text
+
+    def test_track_api_call_context_manager_records_error_and_reraises(self):
+        with pytest.raises(ValueError):
+            with metrics.track_api_call('sonarr'):
+                raise ValueError("boom")
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_api_requests_total{service="sonarr",outcome="error"} 1.0' in text
+
+
+class TestRecordCacheLookup:
+    def test_hit_and_miss_tracked_separately(self):
+        metrics.record_cache_lookup('hit')
+        metrics.record_cache_lookup('hit')
+        metrics.record_cache_lookup('miss')
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_cache_lookups_total{result="hit"} 2.0' in text
+        assert 'curatarr_cache_lookups_total{result="miss"} 1.0' in text
+
+
+class TestRecordSelfUpdateAttempt:
+    def test_success_and_failure_tracked_separately(self):
+        metrics.record_self_update_attempt('success')
+        metrics.record_self_update_attempt('failure')
+        metrics.record_self_update_attempt('failure')
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_self_update_attempts_total{outcome="success"} 1.0' in text
+        assert 'curatarr_self_update_attempts_total{outcome="failure"} 2.0' in text
+
+
+class TestRecordUnhandledError:
+    def test_defaults_to_unknown_component(self):
+        metrics.record_unhandled_error()
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_unhandled_errors_total{component="unknown"} 1.0' in text
+
+    def test_records_named_component(self):
+        metrics.record_unhandled_error(component='web')
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_unhandled_errors_total{component="web"} 1.0' in text
+
+
+class TestRenderPrometheusText:
+    def test_includes_build_info_with_version(self):
+        from utils.config import __version__
+        text = metrics.render_prometheus_text()
+        assert f'curatarr_build_info{{version="{__version__}"}} 1' in text
+
+    def test_valid_before_anything_recorded(self):
+        """Rendering with a completely empty state must not raise, and
+        must still expose curatarr_build_info."""
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_build_info' in text
+        assert text.endswith('\n')
+
+    def test_declares_help_and_type_for_every_metric(self):
+        text = metrics.render_prometheus_text()
+        for name in metrics._COUNTERS:
+            assert f'# HELP {name}' in text
+            assert f'# TYPE {name} counter' in text
+        for name in metrics._HISTOGRAMS:
+            assert f'# HELP {name}' in text
+            assert f'# TYPE {name} histogram' in text
+
+    def test_histogram_buckets_are_cumulative(self):
+        metrics.record_api_call('plex', 'success', 0.05)
+        text = metrics.render_prometheus_text()
+        lines = {
+            line.split(' ')[0]: float(line.split(' ')[1])
+            for line in text.splitlines()
+            if line.startswith('curatarr_api_request_duration_seconds_bucket{service="plex"')
+        }
+        # A 0.05s observation falls into every bucket (le >= 0.05),
+        # including +Inf - cumulative histogram semantics.
+        for key, count in lines.items():
+            assert count == 1.0, f"{key} should count the single 0.05s observation"
+
+    def test_never_makes_a_network_call(self, monkeypatch):
+        """Scraping must never trigger a Plex/TMDB/etc. request - see
+        module docstring. Any accidental network call would trip this
+        suite's own autouse _block_non_loopback_sockets guard anyway,
+        but assert directly that nothing under `requests`/`socket` is
+        even touched by patching them to raise if called."""
+        import socket as socket_module
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("render_prometheus_text() must not touch the network")
+
+        monkeypatch.setattr(socket_module.socket, 'connect', _explode)
+        metrics.record_recommender_run('movie', 'success', 1.0)
+        metrics.render_prometheus_text()  # must not raise
+
+
+class TestLoadStateFailureModes:
+    def test_missing_state_file_renders_cleanly(self, tmp_path):
+        assert not os.path.isfile(_state_file_path(tmp_path))
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_build_info' in text
+
+    def test_corrupt_state_file_fails_open(self, tmp_path):
+        path = _state_file_path(tmp_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('{not valid json')
+        # Must not raise - corrupt state degrades to "no data recorded
+        # yet", never a broken /metrics scrape.
+        text = metrics.render_prometheus_text()
+        assert 'curatarr_build_info' in text

--- a/tests/test_web_metrics.py
+++ b/tests/test_web_metrics.py
@@ -1,0 +1,282 @@
+"""Tests for the observability endpoints added to web/app.py:
+
+- GET /metrics - Prometheus text-format metrics (utils/metrics.py),
+  auth-gated exactly like every other route once bound non-loopback.
+- GET /status.json - authenticated readiness detail.
+- GET /healthz - unchanged: still liveness + version only, nothing else.
+
+See tests/test_web_security.py's TestRegisterTokenAuth for the same
+non-loopback-bind-requires-a-token pattern this file's TestMetricsAuth/
+TestStatusJsonAuth classes reuse for these two new routes specifically.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from utils import metrics
+from web.app import create_app
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+@pytest.fixture(autouse=True)
+def _stable_metrics_dir(tmp_path, monkeypatch):
+    """Overrides tests/conftest.py's suite-wide _isolated_metrics_dir
+    (fresh dir per call) with one STABLE dir for the lifetime of each
+    test - needed so a direct utils.metrics.record_*() call and a
+    subsequent GET /metrics in the same test see the same on-disk
+    state (see utils/metrics.py's module docstring: metrics storage is
+    resolved via utils.metrics.get_project_root(), which is entirely
+    independent of whatever project_root a given test's Flask app was
+    constructed with)."""
+    monkeypatch.setattr('utils.metrics.get_project_root', lambda: str(tmp_path))
+    return tmp_path
+
+
+class TestMetricsAuth:
+    """GET /metrics must be behind the same token gate as the rest of
+    the app once bound non-loopback - it exposes library names, user
+    counts, and integration topology via its labels, same reasoning as
+    every other authenticated route (see web/app.py's metrics_endpoint
+    docstring)."""
+
+    NON_LOOPBACK_HOST = '0.0.0.0'
+    TOKEN = 'a' * 32
+
+    def _client(self, curatarr_web_root, bind_host, monkeypatch, token=None):
+        if token is not None:
+            monkeypatch.setenv('CURATARR_AUTH_TOKEN', token)
+        else:
+            monkeypatch.delenv('CURATARR_AUTH_TOKEN', raising=False)
+        monkeypatch.delenv('CURATARR_TRUSTED_NETWORK', raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host=bind_host)
+        app.testing = True
+        return app.test_client()
+
+    def test_metrics_401_without_token_on_non_loopback_bind(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, self.NON_LOOPBACK_HOST, monkeypatch, token=self.TOKEN)
+        resp = c.get('/metrics')
+        assert resp.status_code == 401
+
+    def test_metrics_200_with_correct_token_on_non_loopback_bind(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, self.NON_LOOPBACK_HOST, monkeypatch, token=self.TOKEN)
+        resp = c.get('/metrics', headers={'X-Curatarr-Token': self.TOKEN})
+        assert resp.status_code == 200
+
+    def test_metrics_401_with_wrong_token_on_non_loopback_bind(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, self.NON_LOOPBACK_HOST, monkeypatch, token=self.TOKEN)
+        resp = c.get('/metrics', headers={'X-Curatarr-Token': 'wrong' * 8})
+        assert resp.status_code == 401
+
+    def test_metrics_not_in_the_unauthenticated_exemption_list(self):
+        """Direct assertion on the exemption set itself - /login and
+        /healthz are the only two routes ever meant to skip the token
+        guard (see web/security.py's _TOKEN_EXEMPT_PATHS docstring)."""
+        from web.security import _TOKEN_EXEMPT_PATHS
+        assert '/metrics' not in _TOKEN_EXEMPT_PATHS
+
+    def test_metrics_reachable_on_loopback_bind_with_no_token(self, curatarr_web_root, monkeypatch):
+        """Byte-for-byte unchanged native-install behavior, same as
+        every other route - loopback bind never requires a token."""
+        c = self._client(curatarr_web_root, '127.0.0.1', monkeypatch, token=None)
+        resp = c.get('/metrics')
+        assert resp.status_code == 200
+
+
+class TestMetricsContent:
+    def test_returns_prometheus_text_content_type(self, client):
+        c, app, root = client
+        resp = c.get('/metrics')
+        assert resp.status_code == 200
+        assert 'text/plain' in resp.content_type
+
+    def test_includes_build_info_with_current_version(self, client):
+        from utils import __version__
+        c, app, root = client
+        resp = c.get('/metrics')
+        body = resp.get_data(as_text=True)
+        assert f'curatarr_build_info{{version="{__version__}"}} 1' in body
+
+    def test_scraping_never_hits_the_network(self, client, monkeypatch):
+        """Scraping must never trigger a Plex/TMDB/etc. request (see
+        utils.metrics.render_prometheus_text's docstring) - assert
+        directly that a real socket connect during the request would be
+        caught (the suite's own autouse _block_non_loopback_sockets
+        fixture already guards against this at the socket layer for
+        every test; this just confirms the response still comes back
+        successfully with that guard active)."""
+        c, app, root = client
+        resp = c.get('/metrics')
+        assert resp.status_code == 200
+
+    def test_metric_values_change_after_a_simulated_run(self, client):
+        """Simulates a completed recommender run the exact way real
+        production code does - utils.cli.run_recommender_main and
+        recommenders/external.py's main() both call
+        utils.metrics.record_recommender_run() directly once a run
+        finishes (see those modules) - then confirms /metrics reflects
+        it. Proves cross-process aggregation actually works: this call
+        happens in the SAME process as the test, but through the exact
+        same on-disk state file (see utils/metrics.py's module
+        docstring) a real subprocess run would use, and the /metrics
+        route only ever reads that file fresh on each request - it
+        never caches in-process state across scrapes."""
+        c, app, root = client
+
+        before = c.get('/metrics').get_data(as_text=True)
+        assert 'curatarr_recommender_runs_total{engine="movie",outcome="success"}' not in before
+
+        metrics.record_recommender_run('movie', 'success', 42.0)
+
+        after = c.get('/metrics').get_data(as_text=True)
+        assert 'curatarr_recommender_runs_total{engine="movie",outcome="success"} 1.0' in after
+        assert 'curatarr_recommender_run_duration_seconds_sum{engine="movie",outcome="success"} 42.0' in after
+
+    def test_metric_values_increment_further_after_a_second_run(self, client):
+        c, app, root = client
+        metrics.record_recommender_run('tv', 'success', 3.0)
+        first = c.get('/metrics').get_data(as_text=True)
+        assert 'curatarr_recommender_runs_total{engine="tv",outcome="success"} 1.0' in first
+
+        metrics.record_recommender_run('tv', 'success', 4.0)
+        second = c.get('/metrics').get_data(as_text=True)
+        assert 'curatarr_recommender_runs_total{engine="tv",outcome="success"} 2.0' in second
+
+
+class TestStatusJsonAuth:
+    """GET /status.json - authenticated readiness detail, same gate as
+    /metrics above (not in _TOKEN_EXEMPT_PATHS)."""
+
+    NON_LOOPBACK_HOST = '0.0.0.0'
+    TOKEN = 'b' * 32
+
+    def _client(self, curatarr_web_root, bind_host, monkeypatch, token=None):
+        if token is not None:
+            monkeypatch.setenv('CURATARR_AUTH_TOKEN', token)
+        else:
+            monkeypatch.delenv('CURATARR_AUTH_TOKEN', raising=False)
+        monkeypatch.delenv('CURATARR_TRUSTED_NETWORK', raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host=bind_host)
+        app.testing = True
+        return app.test_client()
+
+    def test_401_without_token_on_non_loopback_bind(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, self.NON_LOOPBACK_HOST, monkeypatch, token=self.TOKEN)
+        resp = c.get('/status.json')
+        assert resp.status_code == 401
+
+    def test_200_with_correct_token_on_non_loopback_bind(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, self.NON_LOOPBACK_HOST, monkeypatch, token=self.TOKEN)
+        resp = c.get('/status.json', headers={'X-Curatarr-Token': self.TOKEN})
+        assert resp.status_code == 200
+
+
+class TestStatusJsonContent:
+    def test_shape_on_a_fresh_install(self, client):
+        c, app, root = client
+        resp = c.get('/status.json')
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload['config_valid'] is True
+        assert payload['job_running'] is False
+        assert payload['last_run'] is None
+        assert 'version' in payload
+
+    def test_reflects_last_run_after_a_log_exists(self, client):
+        c, app, root = client
+        log_path = os.path.join(root, 'logs', 'recommendations_alice_20260101_030000.log')
+        with open(log_path, 'w') as f:
+            f.write('Processing alice\nDone\n')
+        resp = c.get('/status.json')
+        payload = resp.get_json()
+        assert payload['last_run']['status'] == 'success'
+        assert payload['last_run']['timestamp'] is not None
+
+    def test_config_invalid_when_config_missing(self, tmp_path):
+        (tmp_path / 'logs').mkdir()
+        (tmp_path / 'recommendations' / 'external').mkdir(parents=True)
+        app = create_app(project_root=str(tmp_path))
+        app.testing = True
+        resp = app.test_client().get('/status.json')
+        assert resp.get_json()['config_valid'] is False
+
+    def test_does_not_leak_library_or_hostname_details(self, client):
+        """Narrower than /metrics on purpose - only version/config-valid/
+        job-running/last-run, never library names, usernames, or
+        integration hostnames (config.yml's fixture data below would
+        appear in the response body if this endpoint were ever widened
+        to include raw config)."""
+        c, app, root = client
+        resp = c.get('/status.json')
+        body = resp.get_data(as_text=True)
+        assert 'not-a-real-radarr-key' not in body
+        assert 'localhost:7878' not in body
+
+
+class TestHealthzUnchanged:
+    """/healthz stays unauthenticated AND boring - liveness + version
+    only, no library/user/integration detail (that lives behind auth on
+    /status.json and /metrics instead - see web/app.py's healthz()
+    docstring)."""
+
+    def test_exact_response_shape_is_version_only(self, client):
+        c, app, root = client
+        resp = c.get('/healthz')
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert set(payload.keys()) == {'version'}
+
+    def test_reachable_without_any_auth_even_non_loopback(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv('CURATARR_AUTH_TOKEN', 'c' * 32)
+        monkeypatch.delenv('CURATARR_TRUSTED_NETWORK', raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host='0.0.0.0')
+        app.testing = True
+        resp = app.test_client().get('/healthz')
+        assert resp.status_code == 200
+        assert set(resp.get_json().keys()) == {'version'}
+
+    def test_does_not_leak_config_details(self, client):
+        c, app, root = client
+        resp = c.get('/healthz')
+        body = resp.get_data(as_text=True)
+        assert 'not-a-real-radarr-key' not in body
+        assert 'alice' not in body
+        assert 'Movies' not in body
+
+
+class TestUnhandledErrorMetric:
+    """web/app.py's generic @app.errorhandler(Exception) - records
+    curatarr_unhandled_errors_total for a genuine unhandled exception,
+    and must NEVER intercept a deliberate abort()/HTTPException (login/
+    token-auth 401s, /run/stream's 404 before any job, etc.)."""
+
+    def test_deliberate_404_is_not_recorded_as_an_unhandled_error(self, client):
+        c, app, root = client
+        before = c.get('/metrics').get_data(as_text=True)
+        resp = c.get('/run/stream')  # 404 by design - no job started yet
+        assert resp.status_code == 404
+        after = c.get('/metrics').get_data(as_text=True)
+        assert before.count('curatarr_unhandled_errors_total') == after.count('curatarr_unhandled_errors_total')
+        assert 'curatarr_unhandled_errors_total{component="web"}' not in after
+
+    def test_genuine_unhandled_exception_is_recorded(self, client, monkeypatch):
+        c, app, root = client
+
+        @app.get('/__boom')
+        def _boom():
+            raise RuntimeError("simulated unhandled error")
+
+        with pytest.raises(RuntimeError):
+            c.get('/__boom')
+
+        text = c.get('/metrics').get_data(as_text=True)
+        assert 'curatarr_unhandled_errors_total{component="web"} 1.0' in text

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -112,6 +112,7 @@ from .display import (
     RESET,
     ANSI_PATTERN,
     ColoredFormatter,
+    JsonFormatter,
     TeeLogger,
     setup_logging,
     print_user_header,
@@ -314,6 +315,19 @@ from .tautulli import (
     merge_show_watched_data,
 )
 
+# Metrics utilities (local-first Prometheus text format - see module
+# docstring for why this isn't the prometheus_client package)
+from .metrics import (
+    DURATION_BUCKETS,
+    record_recommender_run,
+    record_api_call,
+    track_api_call,
+    record_cache_lookup,
+    record_self_update_attempt,
+    record_unhandled_error,
+    render_prometheus_text,
+)
+
 # Define __all__ for explicit public API
 __all__ = [
     # Config
@@ -387,6 +401,7 @@ __all__ = [
     'RESET',
     'ANSI_PATTERN',
     'ColoredFormatter',
+    'JsonFormatter',
     'TeeLogger',
     'setup_logging',
     'print_user_header',
@@ -529,4 +544,13 @@ __all__ = [
     'fetch_tautulli_show_watched_data',
     'merge_movie_history',
     'merge_show_watched_data',
+    # Metrics
+    'DURATION_BUCKETS',
+    'record_recommender_run',
+    'record_api_call',
+    'track_api_call',
+    'record_cache_lookup',
+    'record_self_update_attempt',
+    'record_unhandled_error',
+    'render_prometheus_text',
 ]

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urljoin, urlsplit
 
 from .helpers import read_response_capped
+from .metrics import record_api_call
 
 logger = logging.getLogger('curatarr')
 
@@ -197,6 +198,18 @@ class BaseAPIClient:
         if headers is None:
             headers = self._get_headers()
 
+        # curatarr_api_requests_total/curatarr_api_request_duration_seconds
+        # (see utils/metrics.py), keyed by api_name (radarr/sonarr/
+        # mdblist/tautulli - every BaseAPIClient subclass) - timed from
+        # here (after rate-limiting, which is client-side pacing, not
+        # part of the request itself) through the return/raise below.
+        # outcome only ever flips to 'success' immediately before
+        # returning, so ANY exception path here (a raised
+        # self.exception_class from _handle_response's own status-code
+        # handling included, not just the requests-level exceptions
+        # this try/except itself translates) is recorded as 'error'.
+        request_start = time.time()
+        outcome = 'error'
         try:
             response = requests.request(
                 method=method,
@@ -224,7 +237,9 @@ class BaseAPIClient:
                 read_response_capped(response)
             except ValueError as e:
                 raise self.exception_class(f"{self.api_name} response rejected: {e}")
-            return self._handle_response(response)
+            result = self._handle_response(response)
+            outcome = 'success'
+            return result
 
         except requests.exceptions.Timeout:
             raise self.exception_class(f"Request timeout after {self.request_timeout}s")
@@ -232,3 +247,5 @@ class BaseAPIClient:
             raise self.exception_class(f"Could not connect to {self.api_name}")
         except requests.exceptions.RequestException as e:
             raise self.exception_class(f"Request failed: {e}")
+        finally:
+            record_api_call(self.api_name.lower(), outcome, time.time() - request_start)

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional
 
 from .config import CACHE_VERSION, check_cache_version
 from .display import log_warning
+from .metrics import record_cache_lookup
 
 
 def save_json_cache(cache_path: str, data: Dict, cache_version: int = None) -> bool:
@@ -48,12 +49,16 @@ def load_json_cache(cache_path: str) -> Optional[Dict]:
         Dictionary from cache or None on failure
     """
     if not os.path.exists(cache_path):
+        record_cache_lookup('miss')
         return None
     try:
         with open(cache_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
+            data = json.load(f)
+        record_cache_lookup('hit')
+        return data
     except Exception as e:
         logging.warning(f"Error loading cache from {cache_path}: {e}")
+        record_cache_lookup('miss')
         return None
 
 
@@ -71,15 +76,20 @@ def load_media_cache(cache_path: str, media_key: str = 'movies') -> Dict:
     empty_cache = {media_key: {}, 'last_updated': None, 'library_count': 0, 'cache_version': CACHE_VERSION}
 
     if not check_cache_version(cache_path, f"{media_key.title()} cache"):
+        record_cache_lookup('miss')
         return empty_cache
 
     if os.path.exists(cache_path):
         try:
             with open(cache_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
+                data = json.load(f)
+            record_cache_lookup('hit')
+            return data
         except Exception as e:
             log_warning(f"Error loading {media_key} cache: {e}")
+            record_cache_lookup('miss')
             return empty_cache
+    record_cache_lookup('miss')
     return empty_cache
 
 

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import os
 import sys
+import time
 from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
@@ -21,6 +22,7 @@ from .display import (
     setup_logging,
 )
 from .helpers import cleanup_old_logs, get_project_root
+from .metrics import record_recommender_run, record_unhandled_error
 from .update_check import GITHUB_RELEASES_PAGE, update_available
 from .update_dismissal import is_dismissed
 from .user_migration import migrate_renamed_plex_users
@@ -286,82 +288,102 @@ def run_recommender_main(
     project_root = get_project_root()
     config_path = os.path.join(project_root, 'config/config.yml')
 
+    # curatarr_recommender_runs_total/curatarr_recommender_run_duration_seconds
+    # (see utils/metrics.py) - covers the WHOLE run, including a config
+    # load failure or "no users configured" below (both are still a run
+    # that didn't produce recommendations, useful to see on a dashboard),
+    # not just the per-user loop. outcome flips to 'success' only if the
+    # entire body below completes without raising; the `finally` records
+    # exactly once regardless of how this function exits (normal
+    # completion, sys.exit(), or an unhandled exception).
+    run_start = time.monotonic()
+    outcome = 'failure'
     try:
-        with open(config_path, 'r') as f:
-            root_config = yaml.safe_load(f)
-
-        # Detect Plex account renames (keyed by stable id) and migrate any
-        # affected preferences/cache files/collections before this run
-        # processes users. Best-effort - never blocks a normal run.
-        cache_dir = os.path.join(project_root, 'cache')
-        renamed_users = migrate_renamed_plex_users(root_config, config_path, cache_dir)
-        if renamed_users:
+        try:
             with open(config_path, 'r') as f:
                 root_config = yaml.safe_load(f)
 
-        base_config = adapt_config_func(root_config)
-    except Exception as e:
-        log_error(f"Could not load config.yml from project root: {e}")
-        log_warning(f"Looking for config at: {config_path}")
-        sys.exit(1)
+            # Detect Plex account renames (keyed by stable id) and migrate any
+            # affected preferences/cache files/collections before this run
+            # processes users. Best-effort - never blocks a normal run.
+            cache_dir = os.path.join(project_root, 'cache')
+            renamed_users = migrate_renamed_plex_users(root_config, config_path, cache_dir)
+            if renamed_users:
+                with open(config_path, 'r') as f:
+                    root_config = yaml.safe_load(f)
 
-    # Setup logging
-    logger = setup_logging(debug=args.debug, config=root_config)
-    logger.debug("Debug logging enabled")
-
-    general = base_config.get('general', {})
-    log_retention_days = general.get('log_retention_days', 7)
-
-    # Advisory update notice - printed right after the version banner
-    # above in the overall output; see print_update_notice() docstring
-    # for why this (not run.sh/run.ps1) is what binary users see.
-    print_update_notice(get_update_mode(root_config))
-
-    # Handle single user mode
-    single_user = args.username
-    if single_user:
-        log_warning(f"Single user mode: {single_user}")
-
-    # Get users to process
-    all_users = get_users_from_config(base_config)
-    if single_user:
-        all_users = [single_user]
-
-    if not all_users:
-        log_error("No users configured. Please configure plex_users or managed_users in config.yml")
-        sys.exit(1)
-
-    # Resolve libraries for this media type (#157 Phase 3). A single-library
-    # install (no 'libraries:' config, or exactly one explicit library of
-    # this media type) always resolves to exactly one entry here, so the
-    # loop below collapses to the original one-pass-per-user behavior.
-    libraries = get_libraries_for_media_type(base_config, media_type_key)
-
-    if args.library_id:
-        libraries = [lib for lib in libraries if lib.get('id') == args.library_id]
-        if not libraries:
-            log_error(f"Library '{args.library_id}' not found for media type '{media_type_key}'")
+            base_config = adapt_config_func(root_config)
+        except Exception as e:
+            log_error(f"Could not load config.yml from project root: {e}")
+            log_warning(f"Looking for config at: {config_path}")
             sys.exit(1)
 
-    multi_library = len(libraries) > 1
+        # Setup logging
+        logger = setup_logging(debug=args.debug, config=root_config)
+        logger.debug("Debug logging enabled")
 
-    # Process each library x user
-    plex_token = base_config.get('plex', {}).get('token', '')
-    for library in libraries:
-        if multi_library:
-            print(f"\n{CYAN}=== Library: {library['name']} ==={RESET}")
-            print("-" * 50)
+        general = base_config.get('general', {})
+        log_retention_days = general.get('log_retention_days', 7)
 
-        for user in all_users:
-            print(f"\n{GREEN}Processing recommendations for user: {user}{RESET}")
-            print("-" * 50)
+        # Advisory update notice - printed right after the version banner
+        # above in the overall output; see print_update_notice() docstring
+        # for why this (not run.sh/run.ps1) is what binary users see.
+        print_update_notice(get_update_mode(root_config))
 
-            resolved_user = resolve_admin_username(user, plex_token)
-            user_config = update_config_for_user(base_config, resolved_user)
+        # Handle single user mode
+        single_user = args.username
+        if single_user:
+            log_warning(f"Single user mode: {single_user}")
 
-            process_func(user_config, config_path, log_retention_days, resolved_user, library)
+        # Get users to process
+        all_users = get_users_from_config(base_config)
+        if single_user:
+            all_users = [single_user]
 
-            print(f"\n{GREEN}Completed processing for user: {resolved_user}{RESET}")
-            print("-" * 50)
+        if not all_users:
+            log_error("No users configured. Please configure plex_users or managed_users in config.yml")
+            sys.exit(1)
+
+        # Resolve libraries for this media type (#157 Phase 3). A single-library
+        # install (no 'libraries:' config, or exactly one explicit library of
+        # this media type) always resolves to exactly one entry here, so the
+        # loop below collapses to the original one-pass-per-user behavior.
+        libraries = get_libraries_for_media_type(base_config, media_type_key)
+
+        if args.library_id:
+            libraries = [lib for lib in libraries if lib.get('id') == args.library_id]
+            if not libraries:
+                log_error(f"Library '{args.library_id}' not found for media type '{media_type_key}'")
+                sys.exit(1)
+
+        multi_library = len(libraries) > 1
+
+        # Process each library x user
+        plex_token = base_config.get('plex', {}).get('token', '')
+        for library in libraries:
+            if multi_library:
+                print(f"\n{CYAN}=== Library: {library['name']} ==={RESET}")
+                print("-" * 50)
+
+            for user in all_users:
+                print(f"\n{GREEN}Processing recommendations for user: {user}{RESET}")
+                print("-" * 50)
+
+                resolved_user = resolve_admin_username(user, plex_token)
+                user_config = update_config_for_user(base_config, resolved_user)
+
+                process_func(user_config, config_path, log_retention_days, resolved_user, library)
+
+                print(f"\n{GREEN}Completed processing for user: {resolved_user}{RESET}")
+                print("-" * 50)
+
+        outcome = 'success'
+    except SystemExit:
+        raise
+    except Exception:
+        record_unhandled_error(component=media_type_key)
+        raise
+    finally:
+        record_recommender_run(media_type_key, outcome, time.monotonic() - run_start)
 
     print_runtime(start_time)

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.7"
+__version__ = "2.10.8"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/display.py
+++ b/utils/display.py
@@ -5,7 +5,9 @@ Handles colored output, progress indicators, and formatting.
 
 import sys
 import re
+import json
 import logging
+from datetime import datetime, timezone
 from typing import Dict, List
 
 from .redact import redact
@@ -37,6 +39,61 @@ class ColoredFormatter(logging.Formatter):
         color = self.LEVEL_COLORS.get(record.levelno, '')
         record.levelname = f"{color}{record.levelname}{RESET}"
         return super().format(record)
+
+
+# logging.LogRecord attributes that are always present on every record -
+# used by JsonFormatter below to tell "standard" attributes apart from
+# structured "extra" fields a call site attached via
+# logger.info(msg, extra={...}). Anything not in this set (and not
+# private, i.e. not leading with '_') is treated as a structured extra
+# and included in the rendered JSON object verbatim.
+_LOG_RECORD_RESERVED_ATTRS = frozenset({
+    'name', 'msg', 'args', 'levelname', 'levelno', 'pathname', 'filename',
+    'module', 'exc_info', 'exc_text', 'stack_info', 'lineno', 'funcName',
+    'created', 'msecs', 'relativeCreated', 'thread', 'threadName',
+    'processName', 'process', 'message', 'asctime', 'taskName',
+})
+
+
+class JsonFormatter(logging.Formatter):
+    """Structured (JSON-lines) log formatter - opt-in via config.yml's
+    `logging.format: json` (default stays ColoredFormatter above; see
+    setup_logging). Every record renders as exactly one JSON object per
+    line (JSON-lines, not a JSON array, so log aggregators/SIEMs can
+    consume it as a stream) with a consistent field set:
+
+        timestamp, level, logger, message
+
+    plus whatever structured "extra" fields a call site attached, e.g.
+    ``logger.info("run finished", extra={'user': u, 'engine': e,
+    'duration': d})`` - those keys are included as their own top-level
+    JSON fields, not folded into the message string.
+
+    Redacted through the exact same utils.redact.redact() every other
+    log destination in this codebase uses (see this module's own
+    docstring and utils/redact.py's) - a secret-shaped value reaching a
+    JSON log line in plaintext is exactly as unacceptable as it reaching
+    the human-readable one. Applied to the rendered message, every
+    string-valued extra field, and a formatted exception traceback
+    (exc_info), since any of the three could in principle echo a token
+    (e.g. a stray X-Plex-Token query parameter in an error message or in
+    an extra field pulled from a response).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            'timestamp': datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            'level': record.levelname,
+            'logger': record.name,
+            'message': redact(record.getMessage()),
+        }
+        for key, value in record.__dict__.items():
+            if key in _LOG_RECORD_RESERVED_ATTRS or key.startswith('_'):
+                continue
+            payload[key] = redact(value) if isinstance(value, str) else value
+        if record.exc_info:
+            payload['exception'] = redact(self.formatException(record.exc_info))
+        return json.dumps(payload, default=str)
 
 
 class TeeLogger:
@@ -93,7 +150,12 @@ def setup_logging(debug: bool = False, config: dict = None) -> logging.Logger:
 
     Args:
         debug: If True, set level to DEBUG. Otherwise use config or default to INFO.
-        config: Optional config dict that may contain logging.level setting.
+        config: Optional config dict that may contain logging.level setting
+            and an optional logging.format setting ('text', the default,
+            human-readable/colored - or 'json', structured JSON-lines via
+            JsonFormatter above - see that class's docstring). Unset/any
+            other value falls back to 'text', so existing configs (which
+            predate logging.format entirely) are completely unaffected.
 
     Returns:
         Configured logger instance.
@@ -107,14 +169,20 @@ def setup_logging(debug: bool = False, config: dict = None) -> logging.Logger:
     else:
         level = logging.INFO
 
-    # Create handler with colored formatter
+    log_format = str((config or {}).get('logging', {}).get('format', 'text')).lower()
+
+    # Create handler with the configured formatter - JSON opt-in via
+    # logging.format: json, text (ColoredFormatter) otherwise/by default.
     handler = logging.StreamHandler()
     handler.setLevel(level)
 
-    formatter = ColoredFormatter(
-        fmt='%(asctime)s [%(levelname)s] %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
+    if log_format == 'json':
+        formatter = JsonFormatter()
+    else:
+        formatter = ColoredFormatter(
+            fmt='%(asctime)s [%(levelname)s] %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
     handler.setFormatter(formatter)
 
     # Configure root logger

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,308 @@
+"""Local-first Prometheus-text-format metrics for Curatarr.
+
+Deliberately NOT built on the `prometheus_client` package: this app
+already had a bug where a UI-only import broke CLI-only installs (see
+curatarr_app.py's module docstring), and every added runtime dependency
+means regenerating four hash-pinned lockfiles. Prometheus's text
+exposition format (https://prometheus.io/docs/instrumenting/exposition_formats/)
+is simple enough to render directly with the stdlib, so that's what this
+module does - a small, dependency-free counter/histogram registry plus a
+renderer, nothing more.
+
+Lives in utils/ (no web/Flask import, same reasoning as utils/redact.py)
+so every recorder function below can be called from anywhere that might
+observe a countable event - a recommender subprocess (utils/cli.py's
+run_recommender_main, recommenders/external.py), an *arr/TMDB/Trakt/
+Simkl/MDBList/Tautulli client (utils/api_client.py, utils/tmdb.py,
+utils/trakt.py, utils/simkl.py), a cache read (utils/cache.py), a
+self-update attempt (utils/self_update.py) - without any of those
+needing Flask installed. web/app.py's own /metrics route is the only
+thing that ever calls render_prometheus_text(); everything else in this
+module just records.
+
+Cross-process aggregation
+--------------------------
+Recommender runs happen in short-lived SUBPROCESSES (see
+web/job_runner.py's module docstring: movie.py/tv.py/external.py hijack
+sys.stdout and call sys.exit(), so they're never run in-process inside
+the long-lived web server) - a cron-triggered run is a wholly separate
+process again. For /metrics (served only by the long-lived web process)
+to reflect any of that activity, state can't just live in this module's
+own process memory. Instead it's persisted to a small JSON file under
+project_root/cache/ (metrics_state.json) - the SAME file every process
+reads-modifies-writes, mirroring utils/update_dismissal.py's own
+project_root-relative state file. Same fail-open, best-effort contract
+as that module: a read/write failure here never breaks the caller's
+actual work (a recommender run, an API call, ...), it just means that
+one data point is lost - never raises.
+
+No cross-process file locking: this app runs at most one recommender
+subprocess at a time (see web/job_runner.py's JobManager single-run
+lock), so genuinely concurrent writers to metrics_state.json are rare in
+practice. A lost update under a rare race is an acceptable tradeoff for
+a personal/home-server metrics endpoint - the same tradeoff every other
+JSON cache file in this codebase already makes (see utils/cache.py),
+none of which lock either.
+
+Cheap to scrape: render_prometheus_text() only ever reads this one local
+file - never a network call, never a Plex/TMDB/etc. request - so /metrics
+can be scraped as often as a Prometheus server likes without adding load
+to anything this app talks to.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager
+from typing import Dict, Iterator
+
+from .config import __version__
+from .helpers import get_project_root
+
+logger = logging.getLogger('curatarr')
+
+_METRICS_FILENAME = 'metrics_state.json'
+
+# In-process only - guards read-modify-write of the on-disk state
+# against concurrent callers *within this same process* (e.g. two
+# threads in the web server). See module docstring for why
+# cross-process locking isn't attempted.
+_lock = threading.Lock()
+
+# Histogram bucket upper bounds, in seconds - shared by every duration
+# metric below. Wide enough to span a sub-second API call and a
+# multi-minute recommender run without per-metric tuning.
+DURATION_BUCKETS = (0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800)
+
+# name -> (HELP text, label names) - counters
+_COUNTERS = {
+    'curatarr_recommender_runs_total': (
+        'Total recommender runs, by engine and outcome.', ('engine', 'outcome'),
+    ),
+    'curatarr_api_requests_total': (
+        'Total outbound API requests, by service and outcome.', ('service', 'outcome'),
+    ),
+    'curatarr_cache_lookups_total': (
+        'Total local cache lookups, by result.', ('result',),
+    ),
+    'curatarr_self_update_attempts_total': (
+        'Total self-update attempts, by outcome.', ('outcome',),
+    ),
+    'curatarr_unhandled_errors_total': (
+        'Total unhandled errors, by component.', ('component',),
+    ),
+}
+
+# name -> (HELP text, label names) - histograms
+_HISTOGRAMS = {
+    'curatarr_recommender_run_duration_seconds': (
+        'Recommender run duration in seconds, by engine and outcome.', ('engine', 'outcome'),
+    ),
+    'curatarr_api_request_duration_seconds': (
+        'Outbound API request duration in seconds, by service.', ('service',),
+    ),
+}
+
+
+def _state_path() -> str:
+    cache_dir = os.path.join(get_project_root(), 'cache')
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+    except Exception as e:
+        logger.debug(f"Could not create metrics cache dir: {e}")
+    return os.path.join(cache_dir, _METRICS_FILENAME)
+
+
+def _load_state() -> dict:
+    path = _state_path()
+    if not os.path.isfile(path):
+        return {'counters': {}, 'histograms': {}}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {'counters': {}, 'histograms': {}}
+        data.setdefault('counters', {})
+        data.setdefault('histograms', {})
+        return data
+    except Exception as e:
+        logger.debug(f"Could not read metrics state ({path}): {e}")
+        return {'counters': {}, 'histograms': {}}
+
+
+def _atomic_write(path: str, data: dict) -> None:
+    """Write-to-temp-then-os.replace() so a reader (render_prometheus_text,
+    possibly in a different process) never sees a partially-written file -
+    same pattern used throughout this codebase's own binary-swap code
+    (see utils/self_update.py)."""
+    tmp_path = f'{path}.tmp-{os.getpid()}-{threading.get_ident()}'
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+    os.replace(tmp_path, path)
+
+
+def _label_key(labels: Dict[str, str]) -> str:
+    """Stable, internal-only string key for a label dict - never rendered
+    directly (see _format_labels for the quoted Prometheus form)."""
+    return ','.join(f'{k}={v}' for k, v in labels.items())
+
+
+def _format_labels(key: str) -> str:
+    """Render an internal `_label_key()` string as a Prometheus label
+    list, e.g. 'engine=movie,outcome=success' -> 'engine="movie",
+    outcome="success"'. Every label value curatarr ever records is one of
+    its own fixed, enum-like strings (an engine name, an outcome, a
+    service name, ...) - never free-form user input - so no
+    quote/backslash escaping of the value is needed here."""
+    if not key:
+        return ''
+    pairs = []
+    for part in key.split(','):
+        name, _, value = part.partition('=')
+        pairs.append(f'{name}="{value}"')
+    return ','.join(pairs)
+
+
+def _increment_counter(name: str, labels: Dict[str, str], amount: float = 1.0) -> None:
+    key = _label_key(labels)
+    with _lock:
+        try:
+            state = _load_state()
+            series = state['counters'].setdefault(name, {})
+            series[key] = series.get(key, 0.0) + amount
+            _atomic_write(_state_path(), state)
+        except Exception as e:
+            logger.debug(f"Could not persist metric {name}: {e}")
+
+
+def _observe_histogram(name: str, labels: Dict[str, str], value: float) -> None:
+    key = _label_key(labels)
+    with _lock:
+        try:
+            state = _load_state()
+            series = state['histograms'].setdefault(name, {})
+            entry = series.setdefault(key, {'sum': 0.0, 'count': 0, 'buckets': {}})
+            entry['sum'] += value
+            entry['count'] += 1
+            for bound in DURATION_BUCKETS:
+                if value <= bound:
+                    bucket_key = str(bound)
+                    entry['buckets'][bucket_key] = entry['buckets'].get(bucket_key, 0) + 1
+            _atomic_write(_state_path(), state)
+        except Exception as e:
+            logger.debug(f"Could not persist metric {name}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Public recorder API - one function per observable event. Every one of
+# these is fire-and-forget: a persistence failure is logged at debug
+# level (see _increment_counter/_observe_histogram) and otherwise
+# swallowed, never raised - recording a metric must never be the reason a
+# recommender run, API call, or cache lookup fails.
+# ---------------------------------------------------------------------------
+
+def record_recommender_run(engine: str, outcome: str, duration_seconds: float) -> None:
+    """One completed recommender run. `engine` is 'movie', 'tv', or
+    'external' (matches web/job_runner.py's ENGINES, minus 'full' - a
+    'full' run is just those three run in sequence, each already
+    recording its own entry here). `outcome` is 'success' or 'failure'.
+
+    Called from utils.cli.run_recommender_main (movie.py/tv.py) and
+    recommenders/external.py's main() directly - i.e. by whichever
+    process actually ran the recommender, so a cron-triggered run is
+    counted exactly the same as one triggered from the web UI's Run
+    button (which just launches that same entry point as a subprocess -
+    see web/job_runner.py)."""
+    labels = {'engine': engine, 'outcome': outcome}
+    _increment_counter('curatarr_recommender_runs_total', labels)
+    _observe_histogram('curatarr_recommender_run_duration_seconds', labels, duration_seconds)
+
+
+def record_api_call(service: str, outcome: str, duration_seconds: float) -> None:
+    """One outbound API call to `service` (plex, radarr, sonarr, tmdb,
+    trakt, simkl, mdblist, or tautulli). `outcome` is 'success' or
+    'error'."""
+    _increment_counter('curatarr_api_requests_total', {'service': service, 'outcome': outcome})
+    _observe_histogram('curatarr_api_request_duration_seconds', {'service': service}, duration_seconds)
+
+
+@contextmanager
+def track_api_call(service: str) -> Iterator[None]:
+    """Context manager form of record_api_call: times the wrapped block
+    and records it against `service` on exit. outcome is 'error' if the
+    block raised, 'success' otherwise - the exception (if any) still
+    propagates unchanged; this only observes, it never suppresses."""
+    start = time.monotonic()
+    outcome = 'success'
+    try:
+        yield
+    except Exception:
+        outcome = 'error'
+        raise
+    finally:
+        record_api_call(service, outcome, time.monotonic() - start)
+
+
+def record_cache_lookup(result: str) -> None:
+    """One local on-disk cache read. `result` is 'hit' or 'miss'."""
+    _increment_counter('curatarr_cache_lookups_total', {'result': result})
+
+
+def record_self_update_attempt(outcome: str) -> None:
+    """One self-update attempt (CLI `--self-update` or the web UI's
+    "Update now" for a frozen binary - see utils/self_update.py's
+    download_and_verify_update, the single choke point both paths call
+    through). `outcome` is 'success' or 'failure'."""
+    _increment_counter('curatarr_self_update_attempts_total', {'outcome': outcome})
+
+
+def record_unhandled_error(component: str = 'unknown') -> None:
+    """One unhandled exception - a recommender run crashing outside its
+    own per-item error handling, or a Flask request handler raising past
+    web/app.py's own error handler."""
+    _increment_counter('curatarr_unhandled_errors_total', {'component': component})
+
+
+# ---------------------------------------------------------------------------
+# Rendering - the only thing web/app.py's /metrics route calls.
+# ---------------------------------------------------------------------------
+
+def render_prometheus_text() -> str:
+    """Render every metric as Prometheus text exposition format. Cheap:
+    exactly one local JSON file read (see module docstring) - never a
+    network call, never a Plex/TMDB/etc. request - safe to scrape as
+    often as desired."""
+    state = _load_state()
+    lines = [
+        '# HELP curatarr_build_info Curatarr build/version info.',
+        '# TYPE curatarr_build_info gauge',
+        f'curatarr_build_info{{version="{__version__}"}} 1',
+    ]
+
+    counters = state.get('counters', {})
+    for name, (help_text, _label_names) in _COUNTERS.items():
+        lines.append(f'# HELP {name} {help_text}')
+        lines.append(f'# TYPE {name} counter')
+        for key, value in sorted(counters.get(name, {}).items()):
+            label_str = _format_labels(key)
+            labels = f'{{{label_str}}}' if label_str else ''
+            lines.append(f'{name}{labels} {value}')
+
+    histograms = state.get('histograms', {})
+    for name, (help_text, _label_names) in _HISTOGRAMS.items():
+        lines.append(f'# HELP {name} {help_text}')
+        lines.append(f'# TYPE {name} histogram')
+        for key, entry in sorted(histograms.get(name, {}).items()):
+            label_str = _format_labels(key)
+            bucket_prefix = f'{label_str},' if label_str else ''
+            base_labels = f'{{{label_str}}}' if label_str else ''
+            for bound in DURATION_BUCKETS:
+                bucket_count = entry.get('buckets', {}).get(str(bound), 0)
+                lines.append(f'{name}_bucket{{{bucket_prefix}le="{bound}"}} {bucket_count}')
+            lines.append(f'{name}_bucket{{{bucket_prefix}le="+Inf"}} {entry.get("count", 0)}')
+            lines.append(f'{name}_sum{base_labels} {entry.get("sum", 0)}')
+            lines.append(f'{name}_count{base_labels} {entry.get("count", 0)}')
+
+    return '\n'.join(lines) + '\n'

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -4,6 +4,7 @@ Handles Plex server connections, watch history, collections, and user management
 """
 
 import logging
+import time
 import requests
 import urllib3
 import xml.etree.ElementTree as ET
@@ -20,6 +21,7 @@ from plexapi.myplex import MyPlexAccount
 
 from .display import GREEN, YELLOW, RED, RESET, log_warning, log_error
 from .helpers import normalize_title, read_response_capped
+from .metrics import record_api_call
 
 
 def _resolve_verify_ssl(config: dict) -> bool:
@@ -46,25 +48,46 @@ def _capped_get(url, **kwargs):
     requests.RequestException (same as every other failure mode already
     handled at each call site) rather than the ValueError
     read_response_capped itself raises, so no call site needs its own
-    except clause changed."""
-    kwargs.setdefault('stream', True)
-    response = requests.get(url, **kwargs)
+    except clause changed.
+
+    Records curatarr_api_requests_total/curatarr_api_request_duration_seconds
+    (see utils/metrics.py, service='plex') - this and _capped_put below
+    are this module's own central choke point for raw Plex HTTP calls
+    (every call site in this file goes through one or the other); calls
+    plexapi itself makes internally via its own HTTP session (e.g.
+    PlexServer()/MyPlexAccount() construction, library.search()) aren't
+    separately wrapped, so this is a useful floor on Plex API traffic,
+    not a complete count of every request plexapi issues."""
+    start = time.time()
+    outcome = 'error'
     try:
-        read_response_capped(response)
-    except ValueError as e:
-        raise requests.RequestException(f"Plex response rejected: {e}") from e
-    return response
+        kwargs.setdefault('stream', True)
+        response = requests.get(url, **kwargs)
+        try:
+            read_response_capped(response)
+        except ValueError as e:
+            raise requests.RequestException(f"Plex response rejected: {e}") from e
+        outcome = 'success'
+        return response
+    finally:
+        record_api_call('plex', outcome, time.time() - start)
 
 
 def _capped_put(url, **kwargs):
     """See _capped_get's docstring - identical reasoning, for PUT."""
-    kwargs.setdefault('stream', True)
-    response = requests.put(url, **kwargs)
+    start = time.time()
+    outcome = 'error'
     try:
-        read_response_capped(response)
-    except ValueError as e:
-        raise requests.RequestException(f"Plex response rejected: {e}") from e
-    return response
+        kwargs.setdefault('stream', True)
+        response = requests.put(url, **kwargs)
+        try:
+            read_response_capped(response)
+        except ValueError as e:
+            raise requests.RequestException(f"Plex response rejected: {e}") from e
+        outcome = 'success'
+        return response
+    finally:
+        record_api_call('plex', outcome, time.time() - start)
 
 
 def init_plex(config: dict) -> plexapi.server.PlexServer:

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -109,6 +109,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from .config import __version__
+from .metrics import record_self_update_attempt
 from .update_check import GITHUB_RELEASES_PAGE, parse_version, update_available
 
 logger = logging.getLogger('curatarr')
@@ -1005,6 +1006,31 @@ class VerifiedUpdate(NamedTuple):
 
 
 def download_and_verify_update(force_refresh: bool = True) -> VerifiedUpdate:
+    """Thin wrapper around _download_and_verify_update_impl() that records
+    curatarr_self_update_attempts_total (see utils/metrics.py) -
+    'success' if a verified update was produced, 'failure' on any of
+    this module's *Error subclasses. This is the single choke point both
+    self-update entry points call through - the CLI's `--self-update`
+    (perform_self_update(), immediately below, calls this first) and the
+    web UI's "Update now" for a frozen binary (web/update_apply.py's
+    _run_frozen_verify_and_handoff calls this directly) - so instrumenting
+    here covers both without either needing its own metrics call.
+
+    Kept separate from _download_and_verify_update_impl() itself so that
+    function's own body/control flow needed no re-indentation to add
+    this - see recommenders/external.py's main()/_main_impl() split for
+    the identical reasoning.
+    """
+    outcome = 'failure'
+    try:
+        verified = _download_and_verify_update_impl(force_refresh=force_refresh)
+        outcome = 'success'
+        return verified
+    finally:
+        record_self_update_attempt(outcome)
+
+
+def _download_and_verify_update_impl(force_refresh: bool = True) -> VerifiedUpdate:
     """
     Steps 1-4 of the self-update chain (module docstring): determine the
     target version, pick this platform's asset, download it plus

--- a/utils/simkl.py
+++ b/utils/simkl.py
@@ -9,6 +9,8 @@ import logging
 import requests
 from typing import Dict, Optional, Any, List
 
+from .metrics import record_api_call
+
 logger = logging.getLogger('curatarr')
 
 # Simkl API endpoints
@@ -123,6 +125,15 @@ class SimklClient:
         if not authenticated:
             params['client_id'] = self.client_id
 
+        # curatarr_api_requests_total/curatarr_api_request_duration_seconds
+        # (see utils/metrics.py) - see utils/trakt.py's _make_request for
+        # the identical reasoning (same pattern intentionally mirrored
+        # here): outcome only flips to 'success' on an actually-handled
+        # response (2xx/204, and 404 which this client treats as a valid
+        # "not found" None return, not an error), so every raised path
+        # is recorded as 'error'.
+        request_start = time.time()
+        outcome = 'error'
         try:
             response = None
             # Bounded retry loop for 429s - see SIMKL_MAX_429_RETRIES's
@@ -162,6 +173,7 @@ class SimklClient:
 
             # Handle not found
             if response.status_code == 404:
+                outcome = 'success'
                 return None
 
             # Handle other errors
@@ -169,6 +181,7 @@ class SimklClient:
                 raise SimklAPIError(f"Simkl API error {response.status_code}: {response.text}")
 
             # Return JSON or None for no-content responses
+            outcome = 'success'
             if response.status_code == 204:
                 return None
 
@@ -180,6 +193,8 @@ class SimklClient:
             raise SimklAPIError("Could not connect to Simkl API")
         except requests.exceptions.RequestException as e:
             raise SimklAPIError(f"Simkl request failed: {e}")
+        finally:
+            record_api_call('simkl', outcome, time.time() - request_start)
 
     # =========================================================================
     # PIN Authentication Flow

--- a/utils/tmdb.py
+++ b/utils/tmdb.py
@@ -10,6 +10,8 @@ import logging
 import requests
 from typing import Dict, List, Optional
 
+from .metrics import record_api_call
+
 # Module-level logger
 logger = logging.getLogger('curatarr')
 
@@ -54,6 +56,19 @@ def fetch_tmdb_with_retry(url: str, params: Dict, max_retries: int = 3, timeout:
     Returns:
         JSON response dict or None on failure
     """
+    # curatarr_api_requests_total/curatarr_api_request_duration_seconds
+    # (see utils/metrics.py) - recorded once per call to this function
+    # (i.e. once per logical TMDB fetch), not once per retry attempt:
+    # _fetch_tmdb_with_retry_impl already never raises (every failure
+    # mode inside it is caught and turned into a None return), so
+    # 'success'/'error' here is simply "did we end up with a result".
+    start = time.time()
+    result = _fetch_tmdb_with_retry_impl(url, params, max_retries, timeout)
+    record_api_call('tmdb', 'success' if result is not None else 'error', time.time() - start)
+    return result
+
+
+def _fetch_tmdb_with_retry_impl(url: str, params: Dict, max_retries: int = 3, timeout: int = 15) -> Optional[Dict]:
     for attempt in range(max_retries):
         try:
             resp = requests.get(url, params=params, timeout=timeout, allow_redirects=False)
@@ -248,12 +263,15 @@ def get_tmdb_id_from_imdb(tmdb_api_key: str, imdb_id: str, media_type: str = 'mo
     if cache is not None and imdb_id in cache:
         return cache[imdb_id]
 
+    start = time.time()
+    outcome = 'error'
     try:
         url = f"https://api.themoviedb.org/3/find/{imdb_id}"
         params = {'api_key': tmdb_api_key, 'external_source': 'imdb_id'}
         response = requests.get(url, params=params, timeout=10, allow_redirects=False)
 
         if response.status_code == 200:
+            outcome = 'success'
             data = response.json()
             results_key = 'movie_results' if media_type == 'movie' else 'tv_results'
             results = data.get(results_key, [])
@@ -264,4 +282,6 @@ def get_tmdb_id_from_imdb(tmdb_api_key: str, imdb_id: str, media_type: str = 'mo
                 return tmdb_id
     except Exception as e:
         logger.debug(f"Failed to get TMDB ID for IMDB {imdb_id}: {e}")
+    finally:
+        record_api_call('tmdb', outcome, time.time() - start)
     return None

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -11,6 +11,8 @@ import logging
 import requests
 from typing import Dict, Optional, Any, List
 
+from .metrics import record_api_call
+
 logger = logging.getLogger('curatarr')
 
 # Trakt API endpoints
@@ -124,6 +126,16 @@ class TraktClient:
         url = f"{TRAKT_API_URL}{endpoint}"
         headers = self._get_headers(authenticated)
 
+        # curatarr_api_requests_total/curatarr_api_request_duration_seconds
+        # (see utils/metrics.py) - one record per call to THIS method,
+        # including a 401-triggered recursive retry (that recursive call
+        # is a genuine separate request attempt and records its own
+        # entry too - both are real). outcome only flips to 'success'
+        # right before a normal return, so every raised path below
+        # (TraktAuthError, TraktAPIError, or a re-raised
+        # requests.RequestException) is recorded as 'error'.
+        request_start = time.time()
+        outcome = 'error'
         try:
             response = None
             # Bounded retry loop for 429s - see TRAKT_MAX_429_RETRIES's
@@ -160,6 +172,10 @@ class TraktClient:
             if response.status_code == 401 and retry_auth and self.refresh_token:
                 logger.info("Trakt token expired, refreshing...")
                 if self._refresh_access_token():
+                    # This attempt itself still got a 401 (recorded as
+                    # 'error' below via the unchanged `outcome`) - the
+                    # retried call below is a separate request attempt
+                    # and records its own outcome independently.
                     return self._make_request(method, endpoint, data, authenticated, retry_auth=False)
                 raise TraktAuthError("Failed to refresh Trakt token")
 
@@ -168,12 +184,15 @@ class TraktClient:
                 raise TraktAPIError(f"Trakt API error {response.status_code}: {response.text}")
 
             # Return JSON or None for no-content responses
+            outcome = 'success'
             if response.status_code == 204:
                 return None
             return response.json()
 
         except requests.RequestException as e:
             raise TraktAPIError(f"Trakt request failed: {e}")
+        finally:
+            record_api_call('trakt', outcome, time.time() - request_start)
 
     # =========================================================================
     # Device Authentication Flow

--- a/web/app.py
+++ b/web/app.py
@@ -51,6 +51,8 @@ from utils import (
     is_dismissed,
     load_config,
     record_dismissal,
+    record_unhandled_error,
+    render_prometheus_text,
     update_available,
 )
 
@@ -338,8 +340,85 @@ def create_app(project_root: str = None, bind_host: str = None) -> Flask:
         origin/host guard, and a version number isn't sensitive).
         Polled by base.html's "Update now" flow to detect the server
         coming back up after a restart, and by whatever launches it
-        (see _wait_for_listening) as a liveness probe."""
+        (see _wait_for_listening) as a liveness probe.
+
+        Deliberately stays THIS boring: liveness + version, nothing
+        else. No library names, user names, integration hostnames, or
+        any other config detail - unlike /status.json below (which
+        needs a valid token/loopback bind the same as every other
+        route), widening this unauthenticated endpoint with any of that
+        would be an information-disclosure regression."""
         return jsonify({'version': __version__})
+
+    @app.get('/status.json')
+    def status_json():
+        """Authenticated (NOT in web.security's _TOKEN_EXEMPT_PATHS,
+        same as every route below) readiness/status detail that would be
+        inappropriate on the unauthenticated /healthz above: last run
+        time/outcome across configured users, whether config.yml is
+        currently loadable, and whether a run is in progress right now.
+        Still deliberately narrow - no library names, user names, or
+        integration hostnames - see /metrics below for the endpoint that
+        actually exposes that level of detail (and is gated accordingly).
+        """
+        config = _load_config()
+        users = get_users_from_config(config) if config else []
+        last_run = None
+        for user in users:
+            status = get_last_run_status(logs_dir, user)
+            if status.get('timestamp') is None:
+                continue
+            if last_run is None or status['timestamp'] > last_run['timestamp']:
+                last_run = status
+        return jsonify({
+            'version': __version__,
+            'config_valid': config is not None,
+            'job_running': app.job_manager.is_running(),
+            'last_run': {
+                'timestamp': last_run['timestamp'].isoformat(),
+                'status': last_run['status'],
+            } if last_run else None,
+        })
+
+    @app.get('/metrics')
+    def metrics_endpoint():
+        """Prometheus text-format metrics (see utils/metrics.py) - NOT
+        in web.security's _TOKEN_EXEMPT_PATHS, so it's behind the exact
+        same token gate as every other route once bound non-loopback
+        (see register_token_auth): library names, user counts, and
+        integration topology surface indirectly through the metric
+        labels this exposes (e.g. which *arr/Trakt/Simkl/etc. services
+        are actually configured and being called), which isn't public
+        data any more than /config/connections is. Cheap to serve - see
+        utils.metrics.render_prometheus_text's docstring: exactly one
+        local file read, never a network call, never a Plex/TMDB/etc.
+        request, so scraping this on any interval never adds load to
+        anything curatarr talks to."""
+        return Response(
+            render_prometheus_text(),
+            mimetype='text/plain; version=0.0.4; charset=utf-8',
+        )
+
+    @app.errorhandler(Exception)
+    def _handle_unhandled_exception(exc):
+        """Records curatarr_unhandled_errors_total (see utils/metrics.py)
+        for any exception that escapes a route handler, then re-raises
+        so Flask's own default error handling (a 500 in production, the
+        interactive debugger under app.debug, which this app never
+        enables - see main()) behaves exactly as it did before this
+        handler existed. HTTPException (abort(400)/abort(401)/abort(404)/
+        etc. - every deliberate, expected non-200 this app already
+        returns) is returned AS-IS instead: those aren't unhandled
+        errors, they're routes working as designed, and an HTTPException
+        instance is itself a valid Flask response (returning it - not
+        raising it - is what makes Flask render its normal status
+        code/body instead of this becoming a second, wrongly-classified
+        exception)."""
+        from werkzeug.exceptions import HTTPException
+        if isinstance(exc, HTTPException):
+            return exc
+        record_unhandled_error(component='web')
+        raise exc
 
     @app.get('/')
     def dashboard():


### PR DESCRIPTION
## Summary
- Opt-in JSON-lines structured logging via new `logging.format: json` config key (default stays `text`) - routed through the same secret redaction every other log destination uses.
- Prometheus `/metrics` endpoint (no new runtime dependency - hand-rolled text exposition format) covering recommender run count/duration by engine+outcome, outbound API request count/latency/error by service (Plex, Radarr, Sonarr, TMDB, Trakt, Simkl, MDBList, Tautulli), cache hit/miss, self-update attempts/failures, unhandled error count, and `curatarr_build_info`. Behind the exact same token gate as every other route once bound non-loopback - only `/login` and `/healthz` stay unauthenticated.
- New authenticated `/status.json` (last run time/outcome, config-valid flag, job-running) so `/healthz` can stay exactly as boring as before (liveness + version only).
- Deliberately excludes any third-party error-reporting SaaS - self-hosted only.

## Test plan
- [x] Full suite green (2274 passed, 8 skipped, 0 failures)
- [x] New tests: JSON formatter shape/redaction, /metrics 401 without token on non-loopback bind and 200 with, metric values change after a simulated run, /healthz unchanged shape, CLI-only import path stays Flask-free (verified in a fresh venv with only requirements.lock installed)