### PR TITLE
fix: audit remediation batch 1 (2.10.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/
 dist/
 *.buildvenv/
 .buildvenv/
+.venv/
 
 # Self-update fast local stub test harness compiled output (see
 # scripts/selfupdate_stub_e2e/build_stubs.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.9] - 2026-07-25
+
+### Fixed
+
+- **Windows users' Trakt watch-history sync was silently never running.**
+  `run.sh` syncs Plex watch history to Trakt before generating
+  recommendations when `config/trakt.yml` has `auto_sync: true` - the
+  setup wizard asks Windows users this same question and saves their
+  answer via `run.ps1`, but `run.ps1` had no equivalent step at all, so
+  the saved answer was never honored. Added the matching step to
+  `run.ps1`'s `Main` function in the same position run.sh runs it
+  (before recommendations, so both internal and external recommenders
+  benefit).
+- **An append-only log could grow forever and was structurally
+  unremovable by its own cleanup.** `run.sh`'s optional cron job
+  redirected output with `>> logs/daily-run.log 2>&1` - a single file
+  every run appends to, with no cap. `cleanup_old_logs()` only removes
+  `.log` files by mtime, but an append-only file's mtime is refreshed
+  on every write, so it could never cross the retention threshold.
+  `run.sh`'s generated cron command now writes each run to its own
+  timestamped log file instead, and `cleanup_old_logs()` also
+  force-truncates (in place, so an already-appending process just
+  keeps writing from the new end-of-file) any `.log` file over a new
+  `MAX_LOG_FILE_BYTES` cap regardless of mtime, as a safety net for
+  any other append-only logging setup (docker-compose cron, an
+  external scheduler, etc.).
+- **Cache writes could be corrupted by a mid-write crash or a
+  concurrent writer.** `utils/cache.py`'s save functions truncated and
+  wrote the target file directly - a process dying mid-write, or two
+  processes sharing the same `./cache` volume (docker-compose runs a
+  `curatarr` and a `curatarr-recommend` service), could leave a
+  truncated/corrupt file that then silently forces a full re-scan.
+  Switched to write-temp-then-`os.replace()`, matching the pattern
+  already used by `web/config_io.py` and `utils/metrics.py`.
+- Corrected `README.md`'s documented default for
+  `min_relevance_score` (was `0.25`, actual shipped default is `0.65`
+  - matches `config/tuning.example.yml` and every code default).
+- Rewrote the README's Contributing section to describe the actual
+  policy - external PRs are closed automatically
+  (`.github/workflows/auto-close-prs.yml`), it previously invited PRs
+  against `main`.
+- `utils/plex.py` and `utils/tmdb.py` now use the `PLEX_REQUEST_TIMEOUT`
+  / `TMDB_REQUEST_TIMEOUT` constants (already defined in
+  `utils/config.py` but never wired up) instead of hardcoded literal
+  timeouts; the one deliberately-longer Plex call (large watch-history
+  page fetch) got its own named `PLEX_LONG_REQUEST_TIMEOUT` constant
+  instead of an unexplained `timeout=60`. No effective timeout values
+  changed.
+- Added debug-level logging to previously-silent `except: pass` blocks
+  in `web/job_runner.py` and `utils/self_update.py` so a real failure
+  in these paths leaves a trace instead of vanishing - `self_update.py`
+  is integrity-sensitive, so a swallowed `OSError` there was exactly
+  the kind of bug that could hide silently. No control flow changed;
+  the exceptions are still swallowed.
+
+### Removed
+
+- Deleted dead function `balance_genres_proportionally` in
+  `recommenders/external.py` (verified zero callers repo-wide).
+
+### Chore
+
+- Added `.venv/` to `.gitignore` (was untracked but not ignored).
+
 ## [2.10.8] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ collections:
   stale_removal_days: 7       # Rotate unwatched Plex collection labels
 
 external_recommendations:
-  min_relevance_score: 0.25   # See note below
+  min_relevance_score: 0.65   # See note below
   auto_open_html: false       # Open HTML watchlist in browser after run
 ```
 
@@ -648,9 +648,9 @@ The `min_relevance_score` setting (0.0-1.0) controls how strictly personal the e
 3. This ensures you get personally relevant content, not just popular movies
 
 **Tuning:**
-- `0.25` (default) — Balanced. Most users should start here.
-- `0.50` — Stricter. Only highly relevant recommendations.
-- `0.10` — Looser. More variety, but less personalized.
+- `0.65` (default) — Balanced. Most users should start here.
+- `0.50` — Looser. More variety, less strictly personalized.
+- `0.25` — Much looser. Maximum variety, least personalized.
 
 If you're seeing too many "random" recommendations, increase this value.
 
@@ -833,10 +833,10 @@ Have an idea for Curatarr? We track feature requests as GitHub Issues and **your
 
 ### Code Contributions
 
-Bug fixes and small improvements are welcome. Open an issue first for
-anything nontrivial so the approach can be discussed before you sink time
-into it, then send a PR against `main`. The test suite runs on every PR
-(`.github/workflows/tests.yml`) - keep it green.
+This is a solo-maintained project and external pull requests are not
+accepted - any PR not opened by the maintainer is closed automatically.
+Bug reports and feature requests via GitHub issues are very welcome (see
+above); if you want changes beyond that, fork it.
 
 ---
 

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -1540,67 +1540,6 @@ def get_user_watch_history(plex: Any, config: Dict, username: str, media_type: s
         log_warning(f"  Warning: Could not fetch watch history: {e}")
         return []
 
-def balance_genres_proportionally(
-    recommendations: List[Dict],
-    genre_distribution: Dict,
-    limit: int,
-    media_type: str = 'movie'
-) -> List[Dict]:
-    """
-    Balance recommendations to match user's genre distribution from watch history
-    Prevents any single genre from dominating the list
-    """
-    if not genre_distribution or not recommendations:
-        return recommendations[:limit]
-
-    genre_map = TMDB_MOVIE_GENRES if media_type == 'movie' else TMDB_TV_GENRES
-
-    # Calculate target counts for each genre
-    genre_targets = {}
-    for genre_name, percentage in genre_distribution.items():
-        target_count = int(limit * percentage)
-        # Ensure at least 1 slot for genres that exist in history
-        if target_count == 0 and percentage > 0:
-            target_count = 1
-        genre_targets[genre_name] = target_count
-
-    # Track how many of each genre we've added
-    genre_counts = {genre: 0 for genre in genre_targets}
-
-    balanced_recs = []
-    remaining_recs = []
-
-    # First pass: add items up to their genre targets
-    for rec in recommendations:
-        if len(balanced_recs) >= limit:
-            break
-
-        # Get primary genre (first genre_id)
-        primary_genre_id = rec['genre_ids'][0] if rec['genre_ids'] else None
-        primary_genre = genre_map.get(primary_genre_id, 'Unknown')
-
-        # Check if this genre is under its target
-        if primary_genre in genre_targets and genre_counts[primary_genre] < genre_targets[primary_genre]:
-            balanced_recs.append(rec)
-            genre_counts[primary_genre] += 1
-        else:
-            remaining_recs.append(rec)
-
-    # Second pass: fill remaining slots with best-scored items regardless of genre
-    remaining_needed = limit - len(balanced_recs)
-    if remaining_needed > 0:
-        balanced_recs.extend(remaining_recs[:remaining_needed])
-
-    print(f"Genre balancing: {len(balanced_recs)} items selected")
-    for genre, count in sorted(genre_counts.items(), key=lambda x: x[1], reverse=True):
-        if count > 0:
-            target = genre_targets.get(genre, 0)
-            actual_pct = (count / len(balanced_recs) * 100) if balanced_recs else 0
-            target_pct = genre_distribution.get(genre, 0) * 100
-            print(f"  {genre}: {count} items ({actual_pct:.1f}% actual vs {target_pct:.1f}% target)")
-
-    return balanced_recs
-
 def is_in_library(tmdb_id: Optional[int], title: Optional[str], year: Optional[str], library_data: Dict) -> bool:
     """Check if item is in library by TMDB ID or title+year"""
     # Check TMDB ID first (fast O(1) lookup)

--- a/run.ps1
+++ b/run.ps1
@@ -1480,12 +1480,25 @@ function Main {
         Start-SetupWizard -pythonCmd $pythonCmd
     }
 
-    # Step 4: Create logs directory
+    # Step 4: Sync Plex watch history to Trakt (if enabled)
+    # This runs FIRST so both internal and external recommenders benefit
+    if ((Test-Path "config/trakt.yml") -and (Select-String -Path "config/trakt.yml" -Pattern "auto_sync: true" -Quiet -ErrorAction SilentlyContinue)) {
+        Write-Cyan "=== Syncing Watch History to Trakt ==="
+        & $pythonCmd utils/trakt_sync.py
+        if ($LASTEXITCODE -eq 0) {
+            Write-Green "OK Trakt sync complete"
+        } else {
+            Write-Yellow "! Trakt sync skipped"
+        }
+        Write-Host ""
+    }
+
+    # Step 5: Create logs directory
     if (-not (Test-Path "logs")) {
         New-Item -ItemType Directory -Path "logs" | Out-Null
     }
 
-    # Step 5: Run recommendations
+    # Step 6: Run recommendations
     Write-Cyan "=== Running Recommendations ==="
     Write-Host ""
 
@@ -1509,7 +1522,7 @@ function Main {
     }
     Write-Host ""
 
-    # Step 6: Generate external recommendations (watchlist)
+    # Step 7: Generate external recommendations (watchlist)
     Write-Cyan "=== Generating External Watchlists ==="
     & $pythonCmd recommenders/external.py
     if ($LASTEXITCODE -eq 0) {
@@ -1519,7 +1532,7 @@ function Main {
     }
     Write-Host ""
 
-    # Step 7: Scheduled task setup (first run only)
+    # Step 8: Scheduled task setup (first run only)
     if ($isFirstRun) {
         Setup-Schedule
     }

--- a/run.sh
+++ b/run.sh
@@ -461,7 +461,14 @@ show_cron_info() {
 }
 
 setup_cron_job() {
-    CRON_CMD="0 3 * * * cd $SCRIPT_DIR && ./run.sh >> logs/daily-run.log 2>&1"
+    # Each run gets its own timestamped log file (evaluated by the shell
+    # at cron-fire time, not here) instead of a single ever-growing append
+    # file - an append-only log's mtime is refreshed on every write, so
+    # cleanup_old_logs()'s age-based retention could never delete it.
+    # The backslash-percent sequences below are crontab(5) escaping so
+    # cron passes a literal % through to `date` (at cron-fire time) instead
+    # of treating an unescaped % as a stdin separator.
+    CRON_CMD="0 3 * * * cd $SCRIPT_DIR && ./run.sh >> logs/daily-run_\$(date +\%Y\%m\%d_\%H\%M\%S).log 2>&1"
 
     # Check if cron entry already exists
     if crontab -l 2>/dev/null | grep -q "$SCRIPT_DIR/run.sh"; then

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,6 +6,7 @@ import pytest
 import os
 import json
 import tempfile
+from unittest.mock import patch
 from utils.cache import (
     save_json_cache,
     load_json_cache,
@@ -404,5 +405,101 @@ class TestSaveWatchedCache:
             # Keys should be strings in JSON
             assert '123' in loaded['plex_tmdb_cache']
             assert '789' in loaded['plex_tmdb_cache']
+        finally:
+            os.unlink(cache_path)
+
+
+class TestAtomicCacheWrite:
+    """Tests proving cache saves are atomic (write-temp-then-os.replace()):
+    a failed/interrupted write must never leave the existing cache file
+    truncated or corrupted, and must not leave an orphaned temp file
+    behind."""
+
+    def test_save_json_cache_failure_leaves_original_intact(self):
+        """A write that fails partway through must not touch the
+        original file's content."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            cache_path = f.name
+            f.write('{"original": "data"}')
+
+        try:
+            with patch('utils.cache.json.dump', side_effect=ValueError("boom")):
+                result = save_json_cache(cache_path, {"new": "data"})
+
+            assert result is False
+            with open(cache_path, 'r') as f:
+                content = f.read()
+            assert content == '{"original": "data"}'
+        finally:
+            os.unlink(cache_path)
+
+    def test_save_json_cache_failure_leaves_no_temp_file(self):
+        """A failed write must clean up its temp file rather than
+        leaving an orphaned .tmp- file in the cache directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, "cache.json")
+            with open(cache_path, 'w') as f:
+                f.write('{"original": "data"}')
+
+            with patch('utils.cache.json.dump', side_effect=ValueError("boom")):
+                result = save_json_cache(cache_path, {"new": "data"})
+
+            assert result is False
+            assert os.listdir(tmpdir) == ["cache.json"]
+
+    def test_save_json_cache_success_leaves_no_temp_file(self):
+        """A successful write replaces the target and leaves no
+        leftover temp file behind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, "cache.json")
+
+            result = save_json_cache(cache_path, {"key": "value"})
+
+            assert result is True
+            assert os.listdir(tmpdir) == ["cache.json"]
+
+    def test_save_media_cache_failure_leaves_original_intact(self):
+        """A failed media cache write must not corrupt the existing
+        cache file."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            cache_path = f.name
+            f.write('{"original": "data"}')
+
+        try:
+            with patch('utils.cache.json.dump', side_effect=ValueError("boom")):
+                result = save_media_cache(cache_path, {"movies": {}}, media_key='movies')
+
+            assert result is False
+            with open(cache_path, 'r') as f:
+                content = f.read()
+            assert content == '{"original": "data"}'
+        finally:
+            os.unlink(cache_path)
+
+    def test_save_watched_cache_failure_leaves_original_intact(self):
+        """A failed watched cache write must not corrupt the existing
+        cache file - this is the cache docker-compose's `curatarr` and
+        `curatarr-recommend` services could otherwise race on."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            cache_path = f.name
+            f.write('{"original": "data"}')
+
+        try:
+            with patch('utils.cache.json.dump', side_effect=ValueError("boom")):
+                result = save_watched_cache(
+                    cache_path,
+                    {},
+                    {},
+                    {},
+                    set(),
+                    {},
+                    watched_count=0,
+                    media_type='movie'
+                )
+
+            assert result is False
+            with open(cache_path, 'r') as f:
+                content = f.read()
+            assert content == '{"original": "data"}'
         finally:
             os.unlink(cache_path)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import patch
+from utils.config import MAX_LOG_FILE_BYTES
 from utils.helpers import (
     normalize_title, map_path, cleanup_old_logs, compute_profile_hash,
     get_project_root, migrate_legacy_cache_dir, no_window_kwargs,
@@ -287,6 +288,49 @@ class TestCleanupOldLogs:
 
             assert not os.path.exists(old_log)
             assert os.path.exists(new_log)
+
+    def test_truncates_oversized_append_only_log(self):
+        """An append-only log's mtime is refreshed on every write, so it
+        can never age past retention_days - proves the size-based cap
+        catches what the mtime check structurally cannot."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            huge_log = os.path.join(tmpdir, "daily-run.log")
+            with open(huge_log, 'wb') as f:
+                f.write(b"x" * (MAX_LOG_FILE_BYTES + 1))
+
+            # Freshly written - mtime is "now", nowhere near the
+            # retention_days cutoff.
+            cleanup_old_logs(tmpdir, retention_days=7)
+
+            assert os.path.exists(huge_log)
+            assert os.path.getsize(huge_log) == 0
+
+    def test_keeps_log_under_size_cap(self):
+        """A log under the cap is left alone by the size check (mtime
+        rules still apply as normal)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            small_log = os.path.join(tmpdir, "daily-run.log")
+            with open(small_log, 'wb') as f:
+                f.write(b"x" * 100)
+
+            cleanup_old_logs(tmpdir, retention_days=7)
+
+            assert os.path.exists(small_log)
+            assert os.path.getsize(small_log) == 100
+
+    @patch('utils.helpers.os.path.getsize')
+    def test_handles_size_check_error(self, mock_getsize):
+        """Errors while checking/truncating for size are handled
+        gracefully, matching the existing per-file error handling."""
+        mock_getsize.side_effect = OSError("stat failed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "test.log")
+            with open(log_path, 'w') as f:
+                f.write("log content")
+
+            # Should not raise
+            cleanup_old_logs(tmpdir, retention_days=7)
 
 
 class TestComputeProfileHash:

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -7,12 +7,34 @@ import os
 import json
 import copy
 import logging
+import tempfile
 from datetime import datetime
 from typing import Dict, Optional
 
 from .config import CACHE_VERSION, check_cache_version
 from .display import log_warning
 from .metrics import record_cache_lookup
+
+
+def _atomic_write_json(cache_path: str, data: Dict, **json_kwargs) -> None:
+    """Write-to-temp-then-os.replace() so a reader never sees a partially
+    written or truncated file - whether this process dies mid-write, or
+    two processes race on the same cache file (docker-compose runs a
+    `curatarr` and a `curatarr-recommend` service against the same
+    shared ./cache volume). Same pattern used by web/config_io.py's
+    config writer.
+    """
+    directory = os.path.dirname(cache_path) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix='.tmp-', suffix='.json', dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, **json_kwargs)
+        os.replace(tmp_path, cache_path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
 
 
 def save_json_cache(cache_path: str, data: Dict, cache_version: int = None) -> bool:
@@ -30,8 +52,7 @@ def save_json_cache(cache_path: str, data: Dict, cache_version: int = None) -> b
     try:
         if cache_version is not None:
             data['cache_version'] = cache_version
-        with open(cache_path, 'w', encoding='utf-8') as f:
-            json.dump(data, f, indent=4, ensure_ascii=False)
+        _atomic_write_json(cache_path, data, indent=4, ensure_ascii=False)
         return True
     except Exception as e:
         logging.error(f"Error saving cache to {cache_path}: {e}")
@@ -106,8 +127,7 @@ def save_media_cache(cache_path: str, cache_data: Dict, media_key: str = 'movies
         True on success, False on failure
     """
     try:
-        with open(cache_path, 'w', encoding='utf-8') as f:
-            json.dump(cache_data, f, indent=4, ensure_ascii=False)
+        _atomic_write_json(cache_path, cache_data, indent=4, ensure_ascii=False)
         return True
     except Exception as e:
         log_warning(f"Error saving {media_key} cache: {e}")
@@ -161,8 +181,7 @@ def save_watched_cache(
             'last_updated': datetime.now().isoformat()
         }
 
-        with open(cache_path, 'w', encoding='utf-8') as f:
-            json.dump(cache_data, f, indent=4, ensure_ascii=False)
+        _atomic_write_json(cache_path, cache_data, indent=4, ensure_ascii=False)
 
         logging.debug(f"Saved watched cache: {watched_count} {media_type}s, {len(watched_ids)} IDs")
         return True

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.8"
+__version__ = "2.10.9"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus
@@ -95,6 +95,20 @@ PLEX_REQUEST_TIMEOUT = 30
 TMDB_REQUEST_TIMEOUT = 10
 SONARR_REQUEST_TIMEOUT = 30
 RADARR_REQUEST_TIMEOUT = 30
+
+# A handful of Plex calls (e.g. a watch-history page fetch of up to
+# 10000 items) legitimately take longer than the default request timeout
+# above - this is a deliberate, separate ceiling for just those call
+# sites, not a general Plex timeout.
+PLEX_LONG_REQUEST_TIMEOUT = 60
+
+# Cap on any single log file under logs/ before cleanup_old_logs() force-
+# truncates it, regardless of its mtime. Needed because an append-only log
+# (e.g. a cron job's `>> logs/daily-run.log` redirect) has its mtime
+# refreshed on every write, so the normal age-based retention_days cleanup
+# below can never delete it - left unchecked it grows forever. 20MB is
+# comfortably larger than any single run's own log output.
+MAX_LOG_FILE_BYTES = 20 * 1024 * 1024
 
 # Collection bonus parameters (for movies in user's started collections)
 COLLECTION_BONUS_BASE = 0.05          # Base bonus multiplier

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from typing import Dict
 
+from .config import MAX_LOG_FILE_BYTES
 from .display import log_info, log_warning
 
 
@@ -323,6 +324,17 @@ def cleanup_old_logs(log_dir: str, retention_days: int) -> None:
     """
     Remove log files older than specified retention period.
 
+    Also force-truncates any single .log file that has grown past
+    MAX_LOG_FILE_BYTES, regardless of its mtime. This exists for
+    append-only logs (e.g. a cron job's `>> logs/daily-run.log`
+    redirect) - every write refreshes the mtime, so the age-based
+    removal below can never trigger for them and they would otherwise
+    grow forever. Truncating in place (rather than removing/renaming)
+    is deliberate: a process that already has the file open in append
+    mode keeps writing from the new end-of-file without needing to
+    reopen it - the same "copytruncate" strategy logrotate uses for
+    this exact situation.
+
     Args:
         log_dir: Directory containing log files
         retention_days: Number of days to retain logs (0 = keep all)
@@ -338,6 +350,21 @@ def cleanup_old_logs(log_dir: str, retention_days: int) -> None:
                 continue
 
             filepath = os.path.join(log_dir, filename)
+
+            try:
+                file_size = os.path.getsize(filepath)
+                if file_size > MAX_LOG_FILE_BYTES:
+                    with open(filepath, 'w'):
+                        pass
+                    log_info(
+                        f"Truncated oversized log: {filename} "
+                        f"({file_size} bytes > {MAX_LOG_FILE_BYTES} cap)"
+                    )
+                    continue
+            except Exception as e:
+                log_warning(f"Failed to check/truncate oversized log {filename}: {e}")
+                continue
+
             try:
                 file_mtime = datetime.fromtimestamp(os.path.getmtime(filepath))
                 if file_mtime < cutoff_time:

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -19,6 +19,7 @@ logger = logging.getLogger('curatarr')
 
 from plexapi.myplex import MyPlexAccount
 
+from .config import PLEX_REQUEST_TIMEOUT, PLEX_LONG_REQUEST_TIMEOUT
 from .display import GREEN, YELLOW, RED, RESET, log_warning, log_error
 from .helpers import normalize_title, read_response_capped
 from .metrics import record_api_call
@@ -132,7 +133,7 @@ def get_plex_account_ids(config: Dict, users_to_match: List[str]) -> List[str]:
             f"{config['plex']['url']}/accounts",
             headers={'X-Plex-Token': config['plex']['token']},
             verify=_resolve_verify_ssl(config),
-            timeout=30
+            timeout=PLEX_REQUEST_TIMEOUT
         )
         response.raise_for_status()
         root = ET.fromstring(response.content)
@@ -222,7 +223,7 @@ def get_watched_movie_count(config: Dict, users_to_check: List[str]) -> int:
                 url,
                 headers={'X-Plex-Token': config['plex']['token']},
                 verify=_resolve_verify_ssl(config),
-                timeout=30,
+                timeout=PLEX_REQUEST_TIMEOUT,
             )
             root = ET.fromstring(response.content)
 
@@ -262,7 +263,7 @@ def get_watched_show_count(config: Dict, users_to_check: List[str]) -> int:
                 url,
                 headers={'X-Plex-Token': config['plex']['token']},
                 verify=_resolve_verify_ssl(config),
-                timeout=30,
+                timeout=PLEX_REQUEST_TIMEOUT,
             )
             root = ET.fromstring(response.content)
 
@@ -328,7 +329,7 @@ def fetch_plex_watch_history_movies(config: Dict, account_ids: List[str], movies
                         params=params,
                         headers={'X-Plex-Token': token},
                         verify=_resolve_verify_ssl(config),
-                        timeout=30,
+                        timeout=PLEX_REQUEST_TIMEOUT,
                     )
                     response.raise_for_status()
 
@@ -405,7 +406,7 @@ def fetch_plex_watch_history_shows(
                 params=params,
                 headers={'X-Plex-Token': config['plex']['token']},
                 verify=_resolve_verify_ssl(config),
-                timeout=30,
+                timeout=PLEX_REQUEST_TIMEOUT,
             )
             response.raise_for_status()
 
@@ -479,11 +480,14 @@ def fetch_show_completion_data(
         }
 
         try:
+            # This history/all page can return up to 10000 items
+            # (X-Plex-Container-Size above) - larger than a typical Plex
+            # call, so it gets the longer of the two timeouts.
             response = _capped_get(
                 url, params=params,
                 headers={'X-Plex-Token': config['plex']['token']},
                 verify=_resolve_verify_ssl(config),
-                timeout=60
+                timeout=PLEX_LONG_REQUEST_TIMEOUT
             )
             response.raise_for_status()
             root = ET.fromstring(response.content)
@@ -611,7 +615,7 @@ def fetch_watch_history_with_tmdb(plex: Any, config: Dict, account_ids: List[str
                 params=params,
                 headers={'X-Plex-Token': config['plex']['token']},
                 verify=_resolve_verify_ssl(config),
-                timeout=30,
+                timeout=PLEX_REQUEST_TIMEOUT,
             )
             if response.status_code != 200:
                 continue
@@ -1188,7 +1192,7 @@ def apply_user_label_restrictions(
 
         # Fetch all users via direct API (works for both shared and managed users)
         users_url = "https://plex.tv/api/users"
-        response = _capped_get(users_url, headers={'X-Plex-Token': plex_token}, timeout=30)
+        response = _capped_get(users_url, headers={'X-Plex-Token': plex_token}, timeout=PLEX_REQUEST_TIMEOUT)
         response.raise_for_status()
 
         # Parse XML response to get user IDs and names
@@ -1265,7 +1269,7 @@ def apply_user_label_restrictions(
                     update_url,
                     params=params,
                     headers={'X-Plex-Token': plex_token},
-                    timeout=30,
+                    timeout=PLEX_REQUEST_TIMEOUT,
                 )
                 put_response.raise_for_status()
                 print(f"{GREEN}Applied exclusions for {username}: hiding labels {exclude_labels}{RESET}")

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -1094,8 +1094,8 @@ def _download_and_verify_update_impl(force_refresh: bool = True) -> VerifiedUpda
             if os.path.isfile(asset_path):
                 try:
                     os.remove(asset_path)
-                except OSError:
-                    pass
+                except OSError as cleanup_exc:
+                    logger.debug(f"Could not remove partial download {asset_path}: {cleanup_exc}")
             raise
 
     return VerifiedUpdate(
@@ -1252,6 +1252,6 @@ def perform_self_update(force_refresh: bool = True) -> str:
         if os.path.isfile(verified.asset_path):
             try:
                 os.remove(verified.asset_path)
-            except OSError:
-                pass
+            except OSError as cleanup_exc:
+                logger.debug(f"Could not remove leftover asset {verified.asset_path}: {cleanup_exc}")
     return verified.version

--- a/utils/tmdb.py
+++ b/utils/tmdb.py
@@ -10,6 +10,7 @@ import logging
 import requests
 from typing import Dict, List, Optional
 
+from .config import TMDB_REQUEST_TIMEOUT
 from .metrics import record_api_call
 
 # Module-level logger
@@ -268,7 +269,7 @@ def get_tmdb_id_from_imdb(tmdb_api_key: str, imdb_id: str, media_type: str = 'mo
     try:
         url = f"https://api.themoviedb.org/3/find/{imdb_id}"
         params = {'api_key': tmdb_api_key, 'external_source': 'imdb_id'}
-        response = requests.get(url, params=params, timeout=10, allow_redirects=False)
+        response = requests.get(url, params=params, timeout=TMDB_REQUEST_TIMEOUT, allow_redirects=False)
 
         if response.status_code == 200:
             outcome = 'success'

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -22,6 +22,7 @@ this long-lived Flask server process itself, so the stdout-hijacking/
 sys.exit() behavior above stays safe.
 """
 
+import logging
 import os
 import queue
 import signal
@@ -34,6 +35,8 @@ from typing import Dict, List, Optional
 from utils.helpers import no_window_kwargs
 
 from .security import redact
+
+logger = logging.getLogger('curatarr')
 
 ENGINES = ('full', 'movie', 'tv', 'external')
 
@@ -80,7 +83,7 @@ def _safe_queue_put(q: "queue.Queue", item) -> None:
         try:
             q.get_nowait()
         except queue.Empty:
-            pass
+            logger.debug("_safe_queue_put: queue was full but emptied itself under race - nothing to drop")
         try:
             q.put_nowait(item)
         except queue.Full:
@@ -218,8 +221,8 @@ class JobManager:
     def _remove_lock(self) -> None:
         try:
             os.remove(self._lock_path())
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug(f"_remove_lock: could not remove lockfile {self._lock_path()}: {exc}")
 
     def _foreign_run_in_progress(self) -> bool:
         """True if a lockfile left by a *different* process points at a
@@ -398,8 +401,8 @@ class JobManager:
             if log_file is not None:
                 try:
                     log_file.close()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug(f"Error closing job log file: {exc}")
             # Always reap the child, even on the failure path above -
             # otherwise a log-open failure (or any other exception
             # raised before Popen.wait() ran) leaves it a zombie.
@@ -431,6 +434,6 @@ class JobManager:
                 job.process.terminate()
             else:
                 os.killpg(os.getpgid(job.process.pid), signal.SIGTERM)
-        except (ProcessLookupError, OSError):
-            pass
+        except (ProcessLookupError, OSError) as exc:
+            logger.debug(f"Could not terminate job process {job.process.pid}: {exc}")
         self._remove_lock()


### PR DESCRIPTION
## Summary

Fixes ten confirmed audit findings from a static review:

- **P0**: Windows Trakt watch-history sync was silently never running - `run.ps1` had no equivalent of `run.sh`'s Trakt sync step, so the setup wizard's saved `auto_sync` answer was never honored. Added the matching step to `run.ps1`'s `Main`, same relative ordering as `run.sh`.
- **P1**: The cron-generated `logs/daily-run.log` was append-only with no cap - and structurally could never be cleaned up by `cleanup_old_logs()`'s mtime-based retention, since every append refreshes the mtime. Fixed both ends: `run.sh`'s cron command now writes a per-run timestamped log file, and `cleanup_old_logs()` gained a `MAX_LOG_FILE_BYTES` size cap that force-truncates any oversized `.log` file regardless of mtime (covers docker-compose/external-scheduler setups too).
- **P1**: `utils/cache.py`'s save functions truncated cache files in place - a crash mid-write, or two processes sharing the same `./cache` volume (docker-compose's `curatarr` + `curatarr-recommend`), could corrupt a cache file. Converted to write-temp-then-`os.replace()`, matching `web/config_io.py`/`utils/metrics.py`'s existing pattern.
- **P2**: Added `.venv/` to `.gitignore` (was untracked but not ignored).
- **P1**: README documented `min_relevance_score` default as `0.25`; verified the real default is `0.65` everywhere in code and config - fixed the docs, left the code alone.
- **P1**: Rewrote README's Contributing section - it invited PRs against `main`, but `.github/workflows/auto-close-prs.yml` auto-closes every non-maintainer PR (confirmed intentional). Workflow untouched.
- **P2**: Deleted dead `balance_genres_proportionally` (verified zero callers repo-wide before removing).
- **P1**: Wired `PLEX_REQUEST_TIMEOUT`/`TMDB_REQUEST_TIMEOUT` into their call sites instead of hardcoded literals (8 sites in `utils/plex.py`, 1 in `utils/tmdb.py`). The one deliberately-longer Plex call (large watch-history page fetch) got its own named `PLEX_LONG_REQUEST_TIMEOUT` instead of an unexplained `timeout=60`. No effective timeout values changed.
- **P1**: Added debug-level logging to previously-silent `except: pass` blocks in `web/job_runner.py` (4 sites) and `utils/self_update.py` (2 sites, integrity-sensitive) - control flow unchanged, exceptions still swallowed, just no longer invisible.
- Bumped version to 2.10.9, added CHANGELOG entry.

## Test plan

- [x] `pytest tests/ -q` - 2289 passed, 1 skipped (pre-existing/unrelated)
- [x] `pytest tests/ --cov=. --cov-fail-under=85` - 95.72% coverage, gate passes
- [x] `py_compile` on every touched `.py` file
- [x] `bash -n run.sh` syntax check
- [x] Manually traced the new cron command's escaping through cron's own `%`-unescaping rules and a fresh `bash -c` simulation to confirm `date` evaluates at cron-fire time, not at `setup_cron_job()` run time
- [ ] **`run.ps1` change is UNTESTED at runtime** - no Windows environment available in this session. Needs a real Windows smoke test (`.un.ps1` with `config/trakt.yml` present and `auto_sync: true`) before this ships in a release.
