### PR TITLE
fix: Horizon Huntarr silently missed movies added after Sequel Huntarr last run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.11] - 2026-07-25
+
+### Fixed
+
+- **Horizon Huntarr (`find_horizon_movies`) no longer silently skips movies added to Plex after Sequel Huntarr's last run.** It reused Sequel Huntarr's cached movie-to-collection map but trusted it wholesale instead of diffing against the current library the way Sequel Huntarr's own `find_missing_sequels` already does. A movie added to the library after Sequel Huntarr's last scan had no entry in that cache, so Horizon Huntarr never looked up its collection and never checked it for upcoming/unreleased sequels - with zero network calls even attempted, and no error or warning. It stayed invisible to Horizon recommendations until Sequel Huntarr happened to run again and refresh the shared cache. Fixed by having Horizon Huntarr diff its current library against the cached map the same way Sequel Huntarr does, fetching collection data only for the still-uncached (newly-owned) movies.
+
+## [2.10.10] - 2026-07-25
+
+### Changed
+
+- **Added direct test coverage for Sequel Huntarr (`find_missing_sequels`) and Horizon Huntarr (`find_horizon_movies`) in `recommenders/external.py`** - both functions were previously only ever referenced via `@patch('recommenders.external.find_missing_sequels'/'find_horizon_movies')` in `tests/test_external.py`, so their real gap-finding, caching, and TV-special-reconciliation logic never actually ran under CI. Added 41 new tests that mock only the TMDB HTTP boundary (`requests.get`) and the Plex library/guid scan, so the real branching logic executes: library-access failure, empty library, cache hit vs. miss, missing/failed collection lookups, fully-owned and no-released-movies skip paths, unreleased-date heuristics, live `Canceled`/`Released` status overrides, sort order, cache-save shape, and Sequel Huntarr's TV-special reconciliation (TMDB-guid, normalized-title, grandparent-title-combo, and title-suffix matching, plus not-found/search-failure/section-failure paths). `recommenders/external.py` coverage: 55% -> 73% (both target functions individually now fully covered bar one apparently-unreachable defensive line). Surfaced but deliberately left unfixed (out of scope for this pass, flagged for follow-up): when Sequel Huntarr's shared cache exists but is partial (a movie was added to the library after Sequel Huntarr's last run), `find_horizon_movies`'s cache-reuse branch trusts `movie_collections` wholesale instead of diffing against it the way `find_missing_sequels` does, so a legitimately-owned movie's collection is silently never (re)checked for upcoming releases until Sequel Huntarr happens to run again.
+
 ## [2.10.9] - 2026-07-25
 
 ### Fixed
@@ -65,12 +77,6 @@ All notable changes to Curatarr will be documented in this file.
 ### Chore
 
 - Added `.venv/` to `.gitignore` (was untracked but not ignored).
-
-## [2.10.10] - 2026-07-25
-
-### Changed
-
-- **Added direct test coverage for Sequel Huntarr (`find_missing_sequels`) and Horizon Huntarr (`find_horizon_movies`) in `recommenders/external.py`** - both functions were previously only ever referenced via `@patch('recommenders.external.find_missing_sequels'/'find_horizon_movies')` in `tests/test_external.py`, so their real gap-finding, caching, and TV-special-reconciliation logic never actually ran under CI. Added 41 new tests that mock only the TMDB HTTP boundary (`requests.get`) and the Plex library/guid scan, so the real branching logic executes: library-access failure, empty library, cache hit vs. miss, missing/failed collection lookups, fully-owned and no-released-movies skip paths, unreleased-date heuristics, live `Canceled`/`Released` status overrides, sort order, cache-save shape, and Sequel Huntarr's TV-special reconciliation (TMDB-guid, normalized-title, grandparent-title-combo, and title-suffix matching, plus not-found/search-failure/section-failure paths). `recommenders/external.py` coverage: 55% -> 73% (both target functions individually now fully covered bar one apparently-unreachable defensive line). Surfaced but deliberately left unfixed (out of scope for this pass, flagged for follow-up): when Sequel Huntarr's shared cache exists but is partial (a movie was added to the library after Sequel Huntarr's last run), `find_horizon_movies`'s cache-reuse branch trusts `movie_collections` wholesale instead of diffing against it the way `find_missing_sequels` does, so a legitimately-owned movie's collection is silently never (re)checked for upcoming releases until Sequel Huntarr happens to run again.
 
 ## [2.10.8] - 2026-07-25
 

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -1210,66 +1210,63 @@ def find_horizon_movies(
     movie_collections = sequel_cache.get('movie_collections', {})
     collection_details_cache = sequel_cache.get('collection_details', {})
 
-    # If no sequel cache, we need to build collection data
-    if not movie_collections:
-        total_items = len(items)
-        print(f"{CYAN}  Scanning {total_items} movies for collections...{RESET}")
+    # Diff the current library against the cached movie->collection map,
+    # exactly like find_missing_sequels does: trust the cache for ids it
+    # already knows about, but fetch collection data for any movie that
+    # isn't in it yet (e.g. added to Plex after Sequel Huntarr's last run).
+    # This intentionally always scans `items` rather than trusting
+    # movie_collections wholesale, so newly-owned movies aren't silently
+    # skipped.
+    total_items = len(items)
+    print(f"{CYAN}  Scanning {total_items} movies for collections...{RESET}")
 
-        collection_owned = {}
+    collection_owned = {}
 
-        for i, item in enumerate(items):
-            if i % 50 == 0:
-                show_progress("  Scanning library", i + 1, total_items)
+    for i, item in enumerate(items):
+        if i % 50 == 0:
+            show_progress("  Scanning library", i + 1, total_items)
 
-            tmdb_id = None
-            for guid in item.guids:
-                if 'tmdb://' in guid.id:
-                    try:
-                        tmdb_id = int(guid.id.split('tmdb://')[1])
-                        break
-                    except (ValueError, IndexError):
-                        continue
-
-            if not tmdb_id:
-                continue
-
-            tmdb_id_str = str(tmdb_id)
-            if tmdb_id_str in movie_collections:
-                coll_id = movie_collections[tmdb_id_str]
-                if coll_id:
-                    if coll_id not in collection_owned:
-                        collection_owned[coll_id] = set()
-                    collection_owned[coll_id].add(tmdb_id)
-            else:
-                # Fetch collection ID
+        tmdb_id = None
+        for guid in item.guids:
+            if 'tmdb://' in guid.id:
                 try:
-                    url = f"https://api.themoviedb.org/3/movie/{tmdb_id}"
-                    params = {'api_key': tmdb_api_key}
-                    response = requests.get(url, params=params, timeout=TMDB_REQUEST_TIMEOUT)
-
-                    if response.status_code == 200:
-                        data = response.json()
-                        collection = data.get('belongs_to_collection')
-                        if collection:
-                            coll_id = collection['id']
-                            movie_collections[tmdb_id_str] = coll_id
-                            if coll_id not in collection_owned:
-                                collection_owned[coll_id] = set()
-                            collection_owned[coll_id].add(tmdb_id)
-                        else:
-                            movie_collections[tmdb_id_str] = None
-                except (requests.RequestException, KeyError):
+                    tmdb_id = int(guid.id.split('tmdb://')[1])
+                    break
+                except (ValueError, IndexError):
                     continue
 
-        show_progress("  Scanning library", total_items, total_items)
-    else:
-        # Build collection_owned from cached data
-        collection_owned = {}
-        for tmdb_id_str, coll_id in movie_collections.items():
-            if coll_id and int(tmdb_id_str) in library_tmdb_ids:
+        if not tmdb_id:
+            continue
+
+        tmdb_id_str = str(tmdb_id)
+        if tmdb_id_str in movie_collections:
+            coll_id = movie_collections[tmdb_id_str]
+            if coll_id:
                 if coll_id not in collection_owned:
                     collection_owned[coll_id] = set()
-                collection_owned[coll_id].add(int(tmdb_id_str))
+                collection_owned[coll_id].add(tmdb_id)
+        else:
+            # Fetch collection ID
+            try:
+                url = f"https://api.themoviedb.org/3/movie/{tmdb_id}"
+                params = {'api_key': tmdb_api_key}
+                response = requests.get(url, params=params, timeout=TMDB_REQUEST_TIMEOUT)
+
+                if response.status_code == 200:
+                    data = response.json()
+                    collection = data.get('belongs_to_collection')
+                    if collection:
+                        coll_id = collection['id']
+                        movie_collections[tmdb_id_str] = coll_id
+                        if coll_id not in collection_owned:
+                            collection_owned[coll_id] = set()
+                        collection_owned[coll_id].add(tmdb_id)
+                    else:
+                        movie_collections[tmdb_id_str] = None
+            except (requests.RequestException, KeyError):
+                continue
+
+    show_progress("  Scanning library", total_items, total_items)
 
     print(f"{GREEN}  Found {len(collection_owned)} collections to check for upcoming movies{RESET}")
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -2109,20 +2109,16 @@ class TestFindHorizonMovies:
         assert saved['library_tmdb_ids'] == [1]
         assert saved['horizon_movies'][0]['tmdb_id'] == 2
 
-    def test_stale_partial_sequel_cache_silently_misses_newly_owned_movie_collection(self, tmp_path):
-        """Documents surprising behavior found while writing this coverage
-        (NOT fixed here - recommenders/external.py is out of scope for
-        this change). When the Sequel Huntarr cache exists but is PARTIAL
-        (e.g. the user added a new movie to Plex after Sequel Huntarr's
-        last run, so its tmdb_id was never recorded in movie_collections),
-        find_horizon_movies's cache-reuse branch trusts movie_collections
-        wholesale and never attempts to discover the new movie's
-        collection - unlike find_missing_sequels, which diffs against
-        movie_collections and fetches only the still-uncached ids. Net
-        effect: a legitimately-owned movie's upcoming sequel is silently
-        never surfaced, with zero network calls even attempted, until
-        Sequel Huntarr happens to run again and refresh the shared
-        cache."""
+    def test_stale_partial_sequel_cache_still_discovers_newly_owned_movie_collection(self, tmp_path):
+        """When the Sequel Huntarr cache exists but is PARTIAL (e.g. the
+        user added a new movie to Plex after Sequel Huntarr's last run, so
+        its tmdb_id was never recorded in movie_collections),
+        find_horizon_movies must diff the current library against the
+        cached movie_collections map - just like find_missing_sequels does
+        - and fetch collection data for the still-uncached ids, instead of
+        trusting the cache wholesale. Net effect: a legitimately-owned
+        movie's upcoming sequel is still discovered, without needing
+        Sequel Huntarr to run again first."""
         import time
         cache_dir = tmp_path / 'cache'
         cache_dir.mkdir()
@@ -2137,16 +2133,27 @@ class TestFindHorizonMovies:
             'missing_sequels': [],
         }))
         # The real, current Plex library owns tmdb_id=5, which does belong
-        # to a collection with a genuine upcoming sequel - but the code
-        # never finds out, because 5 isn't a key in movie_collections.
+        # to a collection with a genuine upcoming sequel. Since 5 isn't a
+        # key in movie_collections yet, discovering it requires a fetch.
         plex = _plex_with_libraries([_library_item(5)])
+        url_map = {
+            'https://api.themoviedb.org/3/movie/5': _tmdb_movie_detail_response(
+                belongs_to_collection={'id': 700}),
+            'https://api.themoviedb.org/3/collection/700': _tmdb_collection_detail_response(
+                700, 'Newly Discovered Collection', [
+                    {'id': 5, 'title': 'Owned', 'release_date': _PAST_DATE, 'genre_ids': []},
+                    {'id': 6, 'title': 'Upcoming Sequel', 'release_date': _FUTURE_DATE, 'genre_ids': []},
+                ]),
+            'https://api.themoviedb.org/3/movie/6': _tmdb_movie_detail_response(status='Planned'),
+        }
 
         with patch('recommenders.external.get_project_root', return_value=str(tmp_path)), \
-             patch('recommenders.external.requests.get') as mock_get:
+             patch('recommenders.external.requests.get', side_effect=_strict_get_dispatcher(url_map)):
             result = find_horizon_movies('key', plex, 'Movies')
 
-        assert result == []
-        mock_get.assert_not_called()
+        assert [m['tmdb_id'] for m in result] == [6]
+        assert result[0]['collection_name'] == 'Newly Discovered Collection'
+        assert result[0]['status'] == 'Planned'
 
 
 class TestCategorizeByStreamingServiceAllItems:

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.10"
+__version__ = "2.10.11"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary

- `find_horizon_movies` reused Sequel Huntarr's cached `movie_collections` map but trusted it wholesale instead of diffing against the current library the way `find_missing_sequels` already does.
- Net effect: a movie added to Plex after Sequel Huntarr's last run had no entry in the cache, so its collection was never looked up and it was silently excluded from Horizon recommendations - zero network calls even attempted, no error or warning - until Sequel Huntarr happened to run again and refresh the shared cache.
- Fix mirrors `find_missing_sequels`'s existing pattern: scan the current library each run, use the cached collection id when present, and fetch collection data only for tmdb_ids still missing from the cache (the newly-owned movies). No new caching approach, no shared-code refactor.
- Flips `test_stale_partial_sequel_cache_silently_misses_newly_owned_movie_collection` (added in #218, previously documented the bug) to `test_stale_partial_sequel_cache_still_discovers_newly_owned_movie_collection`, asserting the movie's collection is now discovered.
- Bumps to 2.10.10 with a CHANGELOG entry.

## Stacking / merge order

This stacks on #218 (base branch here is `test/cover-sequel-horizon-discovery`, not `main`, so the diff only shows this fix). #217 and #218 both bump to 2.10.9. Merge order matters: **#217, then #218, then this PR** (2.10.10).

## Test plan

- [x] `python -m pytest tests/ -q` - 2322 passed, 1 skipped (matches base branch baseline)
- [x] `python -m pytest tests/test_external.py --cov=recommenders.external --cov-report=term-missing -q` - 73% coverage (not below the 73% floor)
- [x] Stash-verified: reverted only `recommenders/external.py` (kept the updated test), reran the renamed test - it failed (`assert [] == [6]`), proving it genuinely exercises the bug. Restored the fix and reran - passes.
- [x] Searched the repo for other consumers of `movie_collections`/the huntarr cache - only `find_missing_sequels` and `find_horizon_movies` touch it; no other wholesale-trust instance found.
- [x] Performance: fix only adds a TMDB fetch for tmdb_ids missing from the cache (newly-owned movies since the last scan) - not a full-library refetch. The per-item library scan (no network call) already ran every time; only the network-call branch changes.