### PR TITLE
fix: audit remediation batch 2 (2.10.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,51 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.12] - 2026-07-25
+
+### Fixed
+
+- **`run.ps1` could abort mid-run on PowerShell 7.x where a plain PS 5.1
+  run would just warn and continue.** Every native-command call in the
+  script (`git`, `python`, ...) is followed by a `$LASTEXITCODE` check
+  that expects to handle a non-zero exit itself, matching `run.sh`'s
+  `|| echo ...` fallbacks - but PowerShell 7's
+  `$PSNativeCommandUseErrorActionPreference` (default has varied across
+  7.x) can turn that same non-zero exit into a *terminating* error under
+  this script's `$ErrorActionPreference = "Stop"`, aborting the whole
+  run before the check ever gets a chance to run. Found 17 call sites
+  with this exposure (the Trakt-sync step added in 2.10.11 plus 16
+  others - dependency install, update-check/apply, and the
+  recommendation steps). Fixed once, consistently, by forcing
+  `$PSNativeCommandUseErrorActionPreference = $false` at script scope,
+  restoring identical `$LASTEXITCODE`-based handling on both Windows
+  PowerShell 5.1 (which has no such variable at all - setting it there
+  is harmless) and PowerShell 7.x.
+- **`curatarr --help` / `-h` launched the full web UI instead of
+  printing usage.** `curatarr_app.py`'s argv dispatch had no case for
+  `--help`/`-h`, so both fell through to the same `else` branch as a
+  normal no-flag launch. Added real usage output (`--help`, `--version`,
+  `--self-update`, `--run-recommender <movie|tv|external|full> [user]`,
+  `--debug`) that exits 0 without touching Flask, and a regression test
+  proving it works even when Flask isn't installed (CLI/cron-only
+  installs).
+
+### Changed
+
+- Consolidated the `CHANGELOG.md` entries for `2.10.9` and `2.10.10`
+  into `2.10.11` - neither was ever tagged or released (`2.10.8` shipped,
+  then `2.10.11` shipped next), so a user reading the changelog could
+  believe they could install versions that never existed as releases.
+
 ## [2.10.11] - 2026-07-25
+
+_`2.10.9` and `2.10.10` were never tagged or released - their changes
+are folded into this entry rather than listed as separate installable
+versions._
 
 ### Fixed
 
 - **Horizon Huntarr (`find_horizon_movies`) no longer silently skips movies added to Plex after Sequel Huntarr's last run.** It reused Sequel Huntarr's cached movie-to-collection map but trusted it wholesale instead of diffing against the current library the way Sequel Huntarr's own `find_missing_sequels` already does. A movie added to the library after Sequel Huntarr's last scan had no entry in that cache, so Horizon Huntarr never looked up its collection and never checked it for upcoming/unreleased sequels - with zero network calls even attempted, and no error or warning. It stayed invisible to Horizon recommendations until Sequel Huntarr happened to run again and refresh the shared cache. Fixed by having Horizon Huntarr diff its current library against the cached map the same way Sequel Huntarr does, fetching collection data only for the still-uncached (newly-owned) movies.
-
-## [2.10.10] - 2026-07-25
-
-### Changed
-
-- **Added direct test coverage for Sequel Huntarr (`find_missing_sequels`) and Horizon Huntarr (`find_horizon_movies`) in `recommenders/external.py`** - both functions were previously only ever referenced via `@patch('recommenders.external.find_missing_sequels'/'find_horizon_movies')` in `tests/test_external.py`, so their real gap-finding, caching, and TV-special-reconciliation logic never actually ran under CI. Added 41 new tests that mock only the TMDB HTTP boundary (`requests.get`) and the Plex library/guid scan, so the real branching logic executes: library-access failure, empty library, cache hit vs. miss, missing/failed collection lookups, fully-owned and no-released-movies skip paths, unreleased-date heuristics, live `Canceled`/`Released` status overrides, sort order, cache-save shape, and Sequel Huntarr's TV-special reconciliation (TMDB-guid, normalized-title, grandparent-title-combo, and title-suffix matching, plus not-found/search-failure/section-failure paths). `recommenders/external.py` coverage: 55% -> 73% (both target functions individually now fully covered bar one apparently-unreachable defensive line). Surfaced but deliberately left unfixed (out of scope for this pass, flagged for follow-up): when Sequel Huntarr's shared cache exists but is partial (a movie was added to the library after Sequel Huntarr's last run), `find_horizon_movies`'s cache-reuse branch trusts `movie_collections` wholesale instead of diffing against it the way `find_missing_sequels` does, so a legitimately-owned movie's collection is silently never (re)checked for upcoming releases until Sequel Huntarr happens to run again.
-
-## [2.10.9] - 2026-07-25
-
-### Fixed
-
 - **Windows users' Trakt watch-history sync was silently never running.**
   `run.sh` syncs Plex watch history to Trakt before generating
   recommendations when `config/trakt.yml` has `auto_sync: true` - the
@@ -68,6 +97,10 @@ All notable changes to Curatarr will be documented in this file.
   is integrity-sensitive, so a swallowed `OSError` there was exactly
   the kind of bug that could hide silently. No control flow changed;
   the exceptions are still swallowed.
+
+### Changed
+
+- **Added direct test coverage for Sequel Huntarr (`find_missing_sequels`) and Horizon Huntarr (`find_horizon_movies`) in `recommenders/external.py`** - both functions were previously only ever referenced via `@patch('recommenders.external.find_missing_sequels'/'find_horizon_movies')` in `tests/test_external.py`, so their real gap-finding, caching, and TV-special-reconciliation logic never actually ran under CI. Added 41 new tests that mock only the TMDB HTTP boundary (`requests.get`) and the Plex library/guid scan, so the real branching logic executes: library-access failure, empty library, cache hit vs. miss, missing/failed collection lookups, fully-owned and no-released-movies skip paths, unreleased-date heuristics, live `Canceled`/`Released` status overrides, sort order, cache-save shape, and Sequel Huntarr's TV-special reconciliation (TMDB-guid, normalized-title, grandparent-title-combo, and title-suffix matching, plus not-found/search-failure/section-failure paths). `recommenders/external.py` coverage: 55% -> 73% (both target functions individually now fully covered bar one apparently-unreachable defensive line). Surfaced but deliberately left unfixed (out of scope for this pass, flagged for follow-up): when Sequel Huntarr's shared cache exists but is partial (a movie was added to the library after Sequel Huntarr's last run), `find_horizon_movies`'s cache-reuse branch trusts `movie_collections` wholesale instead of diffing against it the way `find_missing_sequels` does, so a legitimately-owned movie's collection is silently never (re)checked for upcoming releases until Sequel Huntarr happens to run again.
 
 ### Removed
 

--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -11,8 +11,9 @@ than adding anything here.
 reached only by the no-flag launch path below, rather than imported at
 module level - a CLI/cron-only source install (requirements.txt, no
 requirements-ui.txt - see that file's header) never has flask
-installed, and every other flag (--version, --run-recommender,
---self-update, --self-update-worker) needs to keep working without it.
+installed, and every other flag (--help/-h, --version,
+--run-recommender, --self-update, --self-update-worker) needs to
+keep working without it.
 
 Where a packaged binary reads/writes config/cache/logs: see
 utils.helpers.get_project_root() - when running frozen (this file,
@@ -192,6 +193,35 @@ def _attach_or_setup_console(debug: bool) -> None:  # pragma: no cover - real Wi
     )
 
 
+_USAGE = """usage: curatarr [--help] [--version] [--self-update] [--debug]
+               [--run-recommender {movie,tv,external,full} [USER] [--debug]]
+
+With no arguments, launches the curatarr web UI.
+
+options:
+  --help, -h                    Show this message and exit.
+  --version                     Print the installed version and exit.
+  --self-update                 Download, verify, and apply the latest
+                                 signed release in place (downloaded
+                                 binary only - source installs update via
+                                 ./run.sh or run.ps1 instead).
+  --run-recommender ENGINE [USER]
+                                 Run a single recommender in-process and
+                                 exit: ENGINE is one of movie, tv,
+                                 external, full (movie+tv+external in
+                                 sequence). USER is optional.
+  --debug                       Enable debug logging (combine with any
+                                 of the above, or with no arguments).
+
+--self-update-worker is used internally by the web UI's "Update now"
+button and is not meant to be run directly.
+"""
+
+
+def _print_usage() -> None:
+    print(_USAGE, end='')
+
+
 def _run_one_recommender(engine: str, rest: list) -> None:
     """Run a single recommender's own main() with sys.argv rewritten to
     look like a normal `recommenders/<engine>.py [user] [--debug]`
@@ -325,7 +355,10 @@ def _dispatch_recommender(argv: list) -> None:
 
 if __name__ == '__main__':
     _suppress_windows_crash_dialogs()
-    if len(sys.argv) > 2 and sys.argv[1] == '--run-recommender':
+    if len(sys.argv) > 1 and sys.argv[1] in ('--help', '-h'):
+        _print_usage()
+        sys.exit(0)
+    elif len(sys.argv) > 2 and sys.argv[1] == '--run-recommender':
         _dispatch_recommender(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == '--self-update-worker':
         # DETACHED worker for the web UI's "Update now" button when

--- a/run.ps1
+++ b/run.ps1
@@ -13,6 +13,19 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# PowerShell 7 introduced $PSNativeCommandUseErrorActionPreference, whose
+# default has varied across 7.x releases. When it is $true, a native
+# command (git, python, etc.) exiting non-zero becomes a *terminating*
+# error under $ErrorActionPreference = "Stop" - aborting this whole
+# script at the point of the call, before the `if ($LASTEXITCODE ...)`
+# checks throughout this file ever get a chance to run. Force it off so
+# every one of those checks behaves identically on Windows PowerShell
+# 5.1 (which doesn't have this variable at all - assigning it here is
+# harmless, it's simply read by nothing there) and PowerShell 7.x. Set
+# once at script scope so it covers every native-command call site in
+# this file, not just one.
+$PSNativeCommandUseErrorActionPreference = $false
+
 # Color functions
 function Write-Cyan { param($msg) Write-Host $msg -ForegroundColor Cyan }
 function Write-Green { param($msg) Write-Host $msg -ForegroundColor Green }

--- a/tests/test_curatarr_app.py
+++ b/tests/test_curatarr_app.py
@@ -106,6 +106,11 @@ class TestCliPathsDontNeedFlask:
         assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
         assert result.stdout.strip() == __version__
 
+    def test_help_flag_succeeds_with_flask_unimportable(self):
+        result = self._run(['--help'])
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        assert 'usage: curatarr' in result.stdout
+
     def test_run_recommender_dispatch_does_not_need_flask(self):
         """Only checks dispatch reaches _run_one_recommender without
         ModuleNotFoundError on flask - the unknown-engine branch exits
@@ -155,6 +160,22 @@ class TestDispatchViaRunpy:
             runpy.run_module('curatarr_app', run_name='__main__')
         assert exc_info.value.code == 2
         assert '--self-update only applies to a downloaded binary' in capsys.readouterr().err
+
+    def test_help_flag_prints_usage_and_exits_0(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, 'argv', ['curatarr', '--help'])
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_module('curatarr_app', run_name='__main__')
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert 'usage: curatarr' in out
+        assert '--run-recommender' in out
+
+    def test_short_h_flag_prints_usage_and_exits_0(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, 'argv', ['curatarr', '-h'])
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_module('curatarr_app', run_name='__main__')
+        assert exc_info.value.code == 0
+        assert 'usage: curatarr' in capsys.readouterr().out
 
     def test_frozen_normal_launch_cleans_up_stale_binary_before_main(self, monkeypatch):
         monkeypatch.setattr(sys, 'argv', ['curatarr'])

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.11"
+__version__ = "2.10.12"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Force `$PSNativeCommandUseErrorActionPreference = $false` in run.ps1 so PowerShell 7.x behaves like 5.1 for every native-command + $LASTEXITCODE pattern in the file (17 call sites had this exposure - the 2.10.11 Trakt-sync step plus 16 others).
- `curatarr --help` / `-h` now prints real usage and exits 0 instead of falling through to the web UI launch.
- Consolidated the never-tagged `2.10.9`/`2.10.10` CHANGELOG entries into `2.10.11` so the changelog only lists installable versions.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85`: 2333 passed, 1 skipped, 96.70% coverage