### PR TITLE
feat: add ruff/mypy config and non-blocking lint CI job (2.10.13)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,42 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=85
 
+  lint:
+    runs-on: ubuntu-latest
+
+    # Non-blocking for now (every step below is continue-on-error) -
+    # this job was added by the 2.10.13 audit-remediation pass to start
+    # reporting ruff/mypy findings on every PR without wedging merges
+    # on a first pass across a codebase that had never been linted
+    # before. See CHANGELOG.md's [2.10.13]/[2.10.14] entries for the
+    # measured violation counts and the plan to flip pieces of this to
+    # blocking once they're clean on main.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install lint tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy
+
+      - name: ruff check
+        continue-on-error: true
+        run: ruff check .
+
+      - name: ruff format --check
+        continue-on-error: true
+        run: ruff format --check .
+
+      - name: mypy
+        continue-on-error: true
+        run: mypy .
+
   secret-scan:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.13] - 2026-07-25
+
+### Added
+
+- **Linter/formatter/type-checker configuration** - this repo had none
+  before (no ruff/flake8/black/mypy config anywhere, no lint step in
+  any of the 6 GitHub Actions workflows). Config and CI only in this
+  release; no code was reformatted (see 2.10.14 for that).
+  - `ruff.toml`: `line-length = 120` (measured off this codebase's own
+    per-line-length distribution - 99.7% of lines are already under
+    it), `target-version = "py310"` (matches requirements.lock's
+    pinned floor), and lint rules E/W (pycodestyle)/F (pyflakes)/I
+    (isort)/B (bugbear). `utils/__init__.py` gets a per-file `F401`
+    ignore - it's a barrel module that deliberately re-exports its
+    submodules' public names, so every import in it is "unused" by
+    F401's definition without actually being dead code.
+  - `mypy.ini`: non-strict, `ignore_missing_imports = True` - this
+    codebase is only partially annotated (`utils/self_update.py` ~94%,
+    `web/app.py` ~14%), so this is a reporting baseline, not an
+    immediate gate.
+  - Measured before deciding what to enable: `ruff check` -> 477
+    violations (179 `E501`, 101 `I001`, 71 `F401`, 28 `W293`, 22
+    `F541`, 16 `F841`, 11 `E402`, 9 `B904`, 9 `E731`, 8 `B007`, 8
+    `E741`, 7 `F811`, 3 `F821`, 2 `W292`, 1 `B017`, 1 `E714`, 1
+    `W291`); `ruff format --diff` -> 105 files would be reformatted, 9
+    already formatted; `mypy` -> 255 errors across 36 files. None of
+    these were large enough, on their own, to justify disabling a rule
+    outright.
+  - A new `lint` job in `.github/workflows/tests.yml` runs `ruff
+    check`, `ruff format --check`, and `mypy`, each with
+    `continue-on-error: true` - it reports on every PR without
+    wedging merges on a first pass across a never-linted codebase. The
+    existing `test`/`secret-scan` required checks are unchanged.
+
 ## [2.10.12] - 2026-07-25
 
 ### Fixed

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+# Non-strict on purpose - this codebase is only partially annotated
+# (utils/self_update.py ~94%, web/app.py ~14%, measured as part of the
+# 2.10.13 audit-remediation pass that added this file - see
+# CHANGELOG.md's [2.10.13] entry). Full --strict against a codebase
+# like that would produce noise, not signal; the goal here is a
+# reporting baseline (255 errors measured at introduction), not an
+# immediate gate - see the non-blocking `lint` job in
+# .github/workflows/tests.yml.
+python_version = 3.10
+ignore_missing_imports = True

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,59 @@
+# Ruff configuration (lint + format). No pyproject.toml exists in this
+# repo (see requirements*.txt/.lock's own header for why packaging
+# stays plain-script-shaped rather than a build-backend project) - this
+# file is the standalone equivalent, picked up automatically by ruff
+# without needing one.
+#
+# Added as part of the 2.10.13 audit-remediation pass, which measured
+# the codebase against this exact config before deciding what to
+# enable/ignore - see CHANGELOG.md's [2.10.13] entry for the violation
+# counts by rule that justified every choice below. Non-blocking in CI
+# for now (see .github/workflows/tests.yml's lint job) until the
+# 2.10.14 reformat lands.
+
+# 99.7% of lines in this codebase are under 120 columns already (measured
+# via a per-line-length histogram of every tracked .py file) - 120 keeps
+# the line length close to the codebase's actual, pre-existing style
+# instead of forcing the stricter 79/88 defaults onto ~63k lines of code
+# that were never written to fit them.
+line-length = 120
+
+# Matches requirements.lock's pinned `--python-version 3.10` floor
+# (also documented in requirements.txt and README.md) - the oldest
+# interpreter this project actually promises to run on.
+target-version = "py310"
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes - unused imports/variables, undefined names, etc.
+    "I",   # isort - import sorting/grouping
+    "B",   # flake8-bugbear - common real-world bug patterns
+]
+
+[lint.per-file-ignores]
+# utils/__init__.py deliberately re-exports its submodules' public names
+# (`from .cache import (...)`, `from .self_update import (...)`, etc.)
+# so the rest of the codebase can do `from utils import X` - see that
+# file itself. Every one of those imports is "unused" by F401's
+# definition (nothing in __init__.py itself references the name), but
+# removing any of them would be a real, breaking API change, not a
+# lint fix. This is the standard, well-known shape of a barrel
+# __init__.py; per-file-ignoring F401 here (rather than adding
+# `__all__` or per-import `# noqa`, either of which is a code change
+# out of scope for a config-only PR) is the correct fix, not a
+# workaround.
+"utils/__init__.py" = ["F401"]
+
+[lint.isort]
+# This codebase already groups "stdlib, then blank line, then
+# third-party/local" without stdlib/third-party/first-party
+# sub-grouping (see e.g. recommenders/external.py) - force-single-line
+# stays off and force-sort-within-sections stays default so isort's
+# fixes match that existing shape rather than inventing a new one.
+combine-as-imports = true
+
+[format]
+# Defaults (double quotes, space indentation) match the codebase's
+# existing predominant style - nothing overridden here.

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,7 +10,7 @@ import yaml
 from typing import Dict, List
 
 # Project version - single source of truth
-__version__ = "2.10.12"
+__version__ = "2.10.13"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Adds `ruff.toml` (line-length 120, py310 target, E/W/F/I/B rules, per-file F401 ignore for the `utils/__init__.py` barrel module) and `mypy.ini` (non-strict, ignore-missing-imports).
- Adds a non-blocking `lint` job to `.github/workflows/tests.yml` (ruff check, ruff format --check, mypy - each `continue-on-error: true`).
- Config and CI only - zero code reformatted in this PR (see the follow-up reformat PR for that).

## Measured (see CHANGELOG.md 2.10.13 for full breakdown)
- `ruff check`: 477 violations across 17 rule codes (179 E501, 101 I001, 71 F401, 28 W293, 22 F541, 16 F841, 11 E402, 9 B904, 9 E731, 8 B007, 8 E741, 7 F811, 3 F821, 2 W292, 1 B017, 1 E714, 1 W291)
- `ruff format --diff`: 105 files would change, 9 already formatted
- `mypy`: 255 errors across 36 files

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85`: 2333 passed, 1 skipped (unchanged - no code touched)