### PR TITLE
fix: selfupdate-e2e fixture patching (2.10.16)

### DIFF
--- a/.github/workflows/selfupdate-e2e.yml
+++ b/.github/workflows/selfupdate-e2e.yml
@@ -21,11 +21,47 @@ name: Self-Update E2E
 # fixtures without ever touching the real maintainer-only release
 # signing key (which never leaves the maintainer's own machine - see
 # RELEASING.md).
-
+#
+# Trigger design (2.10.16): this used to auto-run only on push to a
+# long-abandoned feature branch (feat/binary-self-update-2.8.29, ~23
+# commits diverged from main in both directions) plus workflow_dispatch
+# - i.e. never on a normal PR into main. That's exactly why the 2.10.14
+# ruff reformat could silently break
+# scripts/selfupdate_e2e/build_fixtures.py's source patching (see that
+# file's module docstring / 2.10.16 CHANGELOG) and merge undetected:
+# nothing in the real CI pipeline ever ran this workflow to catch it.
+# Fixed by wiring it into pull_request/push on main - but NOT
+# unconditionally on every PR: this is a slow (~35min timeout),
+# 3-platform job, so it's restricted to a path filter covering only the
+# files whose changes this workflow actually exists to catch (the
+# self-update runtime code + this harness itself), plus a weekly
+# scheduled run as a safety net for drift a path filter can't foresee
+# (e.g. a dependency/Python/PyInstaller version bump, or a whole-repo
+# tool pass like the 2.10.14 reformat touching one of these paths as a
+# side effect of something else). Deliberately NOT added as a required
+# branch-protection check: a required check that's skipped by its own
+# path filter on an unrelated PR can permanently block merging on some
+# GitHub configurations, which would be worse than the gap this closes.
 on:
   push:
     branches:
-      - feat/binary-self-update-2.8.29
+      - main
+    paths:
+      - "utils/self_update.py"
+      - "utils/self_update_handoff.py"
+      - "web/update_apply.py"
+      - "scripts/selfupdate_e2e/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "utils/self_update.py"
+      - "utils/self_update_handoff.py"
+      - "web/update_apply.py"
+      - "scripts/selfupdate_e2e/**"
+  schedule:
+    # Monday 07:00 UTC - the drift safety net described above.
+    - cron: "0 7 * * 1"
   workflow_dispatch: {}
 
 # Least-privilege default - this job only checks out, builds, and tests;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.16] - 2026-07-25
+
+### Fixed
+
+- **`scripts/selfupdate_e2e/build_fixtures.py`'s pinned-signing-key patcher
+  silently stopped working after the 2.10.14 `ruff format` reformat,
+  breaking `selfupdate-e2e.yml` on all three platforms.** That script
+  temporarily rewrites `utils/self_update.py`'s
+  `PINNED_SIGNING_PUBLIC_KEY_B64`/`PINNED_SIGNING_KEY_FINGERPRINT` to a
+  throwaway test key before building the CI-only test binaries (see that
+  script's module docstring), by matching the constants' declaration as
+  literal source text. The 2.10.14 reformat changed that declaration
+  from a multi-line parenthesized single-quoted form to a single-line
+  double-quoted one; the old regex then matched zero times, so
+  `patch_pinned_key()` silently never ran (the built test binaries still
+  trusted the real, maintainer-only pinned key instead of the throwaway
+  one), and every downstream fixture-signing/verification step failed
+  with cascading, confusing errors instead. Last known-green run of that
+  workflow: 2026-07-25T05:58Z, before the reformat merged.
+  - Fixed by parsing the file with `ast` and locating the two
+    assignments by their target NAME rather than by any particular
+    source-text shape, then rewriting only that AST node's exact span -
+    this survives quote-style, line-wrapping, and parenthesization
+    changes without needing to be touched again. Still fails loudly
+    (`SystemExit`) if it can't find exactly one matching assignment,
+    rather than silently skipping the patch - that fail-loud design is
+    what surfaced this bug in the first place, and is preserved
+    unchanged.
+  - The same fragile-regex pattern was also used for `utils/config.py`'s
+    `__version__` bump/read - converted to the same AST-based approach
+    for the same reason, even though it hadn't broken yet.
+  - Audited `scripts/selfupdate_stub_e2e/` (the separate, fast local
+    hand-off-script harness) for the same class of bug: it has none -
+    it never parses or regex-matches any real production source file at
+    all (its stub "binaries" are built from its own template file with
+    plain placeholder substitution, and it calls
+    `utils/self_update_handoff.py`'s real functions directly rather than
+    text-patching them).
+  - Added `tests/test_selfupdate_e2e_build_fixtures.py`, which feeds the
+    new AST-based patcher the old multi-line form, the new single-line
+    form, a third plausible reformatting, and this repo's own actual
+    current `utils/self_update.py` verbatim - reverting to the old regex
+    reproduces the original 0-match failure against the new/third forms,
+    confirming the test would have caught it.
+
+### Changed
+
+- **`selfupdate-e2e.yml` now runs on pull requests and pushes into
+  `main` that touch self-update code, instead of only on push to a
+  long-stale feature branch (`feat/binary-self-update-2.8.29`) plus
+  manual dispatch** - that stale-branch-only trigger is exactly why the
+  2.10.14 reformat's breakage above could merge into `main` completely
+  undetected: nothing in the real PR pipeline ever ran this workflow.
+  Scoped to a path filter (`utils/self_update.py`,
+  `utils/self_update_handoff.py`, `web/update_apply.py`,
+  `scripts/selfupdate_e2e/**`) rather than every PR unconditionally,
+  since this is a slow (35min timeout), 3-platform real-binary job; a
+  weekly scheduled run is added alongside it as a safety net for drift a
+  path filter can't foresee (dependency/Python/PyInstaller version
+  bumps, or a whole-repo tool pass like the 2.10.14 reformat touching
+  one of these paths as a side effect of something unrelated).
+  Deliberately not added to branch protection's required checks - see
+  the workflow file's own comment for why.
+
 ## [2.10.15] - 2026-07-25
 
 ### Fixed

--- a/scripts/selfupdate_e2e/build_fixtures.py
+++ b/scripts/selfupdate_e2e/build_fixtures.py
@@ -25,10 +25,10 @@ Usage:
 """
 
 import argparse
+import ast
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -93,26 +93,97 @@ def generate_attacker_signing_key(work_dir):
 SELF_UPDATE_PY_RELATIVE = os.path.join("utils", "self_update.py")
 CONFIG_PY_RELATIVE = os.path.join("utils", "config.py")
 
-_PINNED_KEY_RE = re.compile(
-    r"PINNED_SIGNING_PUBLIC_KEY_B64 = \(\n\s*'[^']*'\n\)\n"
-    r"PINNED_SIGNING_KEY_FINGERPRINT = '[^']*'\n"
-)
-_VERSION_RE = re.compile(r'^__version__ = "[^"]*"', re.MULTILINE)
+
+# =============================================================================
+# Source patching - by AST shape, never by source text shape.
+#
+# This file has to rewrite two throwaway constants inside a REAL source
+# file before building a binary from it (see module docstring), then put
+# the original text back. A previous version of this did that via a
+# regex matched against the constant declaration's exact text layout
+# (quote style/line-wrapping/parenthesization) - a routine `ruff format`
+# reformat (2.10.14) changed that layout, the regex silently matched
+# zero times, and patch_pinned_key() never ran, so every fixture build
+# quietly built binaries that still trusted the REAL pinned key instead
+# of the throwaway one, and the whole workflow failed downstream instead
+# (see 2.10.16 CHANGELOG). Fixed by locating the assignment by parsing
+# the file into an AST and matching on the target's NAME - which is
+# identical however the assignment happens to be formatted - and
+# rewriting only that node's exact span. Still fails loudly (raises
+# SystemExit) if it can't find exactly one matching assignment, rather
+# than silently skipping the patch - that fail-loud design is what
+# surfaced the original regex break in the first place.
+# =============================================================================
+
+
+def _line_start_offsets(source):
+    """offsets[i] is the absolute character offset of the start of line
+    i + 1 (ast line numbers are 1-indexed) - lets an ast node's
+    (lineno, col_offset)/(end_lineno, end_col_offset) be converted into
+    plain string slice indices."""
+    offsets = [0]
+    for line in source.splitlines(keepends=True):
+        offsets.append(offsets[-1] + len(line))
+    return offsets
+
+
+def _find_top_level_string_assignments(tree, name):
+    """Every top-level (module body) `<name> = "<string literal>"`
+    Assign node in `tree` - matched on AST shape (a single Name target
+    with this exact id, assigned a string constant), never on source
+    text shape, so quote style/line-wrapping/parenthesization can't
+    hide or duplicate a match."""
+    matches = []
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == name
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            matches.append(node)
+    return matches
+
+
+def _require_one(tree, name):
+    matches = _find_top_level_string_assignments(tree, name)
+    if len(matches) != 1:
+        raise SystemExit(
+            f'expected exactly one top-level `{name} = "..."` assignment, found {len(matches)} '
+            "- has that constant's declaration changed shape (renamed, moved into a class/function, "
+            "no longer a plain string literal)?"
+        )
+    return matches[0]
+
+
+def read_top_level_string_constant(source, name):
+    """Returns the string value of the sole top-level `name = "..."`
+    assignment in `source`. Fails loudly if it can't find exactly one."""
+    node = _require_one(ast.parse(source), name)
+    return node.value.value
+
+
+def replace_top_level_string_constant(source, name, new_value):
+    """Rewrites the sole top-level `name = "..."` assignment in `source`
+    to `name = <repr(new_value)>`, in place of whatever the original
+    assignment's exact text looked like. Fails loudly if it can't find
+    exactly one such assignment."""
+    tree = ast.parse(source)
+    node = _require_one(tree, name)
+    offsets = _line_start_offsets(source)
+    start = offsets[node.lineno - 1] + node.col_offset
+    end = offsets[node.end_lineno - 1] + node.end_col_offset
+    return source[:start] + f"{name} = {new_value!r}" + source[end:]
 
 
 def patch_pinned_key(repo_root, pub_b64, fingerprint):
     path = os.path.join(repo_root, SELF_UPDATE_PY_RELATIVE)
     with open(path, encoding="utf-8") as f:
         original = f.read()
-    replacement = (
-        f"PINNED_SIGNING_PUBLIC_KEY_B64 = (\n    '{pub_b64}'\n)\nPINNED_SIGNING_KEY_FINGERPRINT = '{fingerprint}'\n"
-    )
-    patched, n = _PINNED_KEY_RE.subn(replacement, original)
-    if n != 1:
-        raise SystemExit(
-            f"could not find exactly one PINNED_SIGNING_* block to patch in {path} "
-            f"(found {n}) - has that constant's format changed?"
-        )
+    patched = replace_top_level_string_constant(original, "PINNED_SIGNING_PUBLIC_KEY_B64", pub_b64)
+    patched = replace_top_level_string_constant(patched, "PINNED_SIGNING_KEY_FINGERPRINT", fingerprint)
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
     return original
@@ -128,19 +199,15 @@ def read_version(repo_root):
     path = os.path.join(repo_root, CONFIG_PY_RELATIVE)
     with open(path, encoding="utf-8") as f:
         content = f.read()
-    m = re.search(r'^__version__ = "([^"]*)"', content, re.MULTILINE)
-    if not m:
-        raise SystemExit(f"could not find __version__ in {path}")
-    return content, m.group(1)
+    version = read_top_level_string_constant(content, "__version__")
+    return content, version
 
 
 def bump_version(repo_root, new_version):
     path = os.path.join(repo_root, CONFIG_PY_RELATIVE)
     with open(path, encoding="utf-8") as f:
         content = f.read()
-    patched, n = _VERSION_RE.subn(f'__version__ = "{new_version}"', content)
-    if n != 1:
-        raise SystemExit(f"could not patch __version__ in {path} (found {n} matches)")
+    patched = replace_top_level_string_constant(content, "__version__", new_version)
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 

--- a/tests/test_selfupdate_e2e_build_fixtures.py
+++ b/tests/test_selfupdate_e2e_build_fixtures.py
@@ -1,0 +1,206 @@
+"""Tests for scripts/selfupdate_e2e/build_fixtures.py's source-patching
+helpers (replace_top_level_string_constant / read_top_level_string_constant
+/ patch_pinned_key / bump_version) - the ones that temporarily rewrite
+real constants in utils/self_update.py and utils/config.py before a
+throwaway CI binary is built from them (see that module's docstring).
+
+Regression coverage for the 2.10.16 fix: a routine `ruff format` reformat
+(2.10.14) changed PINNED_SIGNING_PUBLIC_KEY_B64/
+PINNED_SIGNING_KEY_FINGERPRINT's declaration from a multi-line
+parenthesized single-quoted form to a single-line double-quoted form,
+which silently broke the old regex-based patcher (0 matches instead of
+1) and made every selfupdate-e2e.yml run fail downstream instead. These
+tests feed the AST-based replacement BOTH shapes directly (plus a
+couple of other plausible reformattings) and assert all of them patch
+correctly - the whole point being that this must survive quote-style,
+line-wrapping, and parenthesization changes without being touched again.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "selfupdate_e2e")
+)
+
+import build_fixtures as bf
+
+OLD_MULTILINE_PARENTHESIZED_FORM = (
+    "PINNED_SIGNING_PUBLIC_KEY_B64 = (\n"
+    "    'AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q'\n"
+    ")\n"
+    "PINNED_SIGNING_KEY_FINGERPRINT = 'SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU'\n"
+)
+
+NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM = (
+    'PINNED_SIGNING_PUBLIC_KEY_B64 = "AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q"\n'
+    'PINNED_SIGNING_KEY_FINGERPRINT = "SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"\n'
+)
+
+# A third, deliberately different-again shape (single-line, single
+# quotes, no surrounding blank line) - proving this isn't just special
+# -cased to the two known-observed forms above.
+THIRD_PLAUSIBLE_FORM = (
+    "PINNED_SIGNING_PUBLIC_KEY_B64 = 'AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q'\n"
+    "PINNED_SIGNING_KEY_FINGERPRINT = 'SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU'\n"
+)
+
+
+class TestReplaceTopLevelStringConstant:
+    """The regression: this must patch identically no matter how the
+    two PINNED_SIGNING_* assignments happen to be formatted."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [OLD_MULTILINE_PARENTHESIZED_FORM, NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM, THIRD_PLAUSIBLE_FORM],
+        ids=["old_multiline_parenthesized", "new_single_line_double_quoted", "third_plausible_single_quoted"],
+    )
+    def test_patches_pinned_key_and_fingerprint_regardless_of_source_shape(self, source):
+        patched = bf.replace_top_level_string_constant(source, "PINNED_SIGNING_PUBLIC_KEY_B64", "TEST_PUB_B64")
+        patched = bf.replace_top_level_string_constant(patched, "PINNED_SIGNING_KEY_FINGERPRINT", "SHA256:testfpr")
+
+        assert bf.read_top_level_string_constant(patched, "PINNED_SIGNING_PUBLIC_KEY_B64") == "TEST_PUB_B64"
+        assert bf.read_top_level_string_constant(patched, "PINNED_SIGNING_KEY_FINGERPRINT") == "SHA256:testfpr"
+        # Must still be valid, parseable Python afterward.
+        compile(patched, "<patched>", "exec")
+
+    def test_leaves_everything_else_in_the_file_untouched(self):
+        source = f"BEFORE = 1\n{NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM}AFTER = 2\n"
+        patched = bf.replace_top_level_string_constant(source, "PINNED_SIGNING_PUBLIC_KEY_B64", "X")
+        assert "BEFORE = 1\n" in patched
+        assert "AFTER = 2\n" in patched
+        assert 'PINNED_SIGNING_KEY_FINGERPRINT = "SHA256:yrqOXw6sWZGPKON9mJJvjhsBKTgMzsn3VTGdNL5mxKU"' in patched
+
+    def test_new_value_containing_quotes_is_still_a_safe_literal(self):
+        # repr()-based, not naive string interpolation - a value with a
+        # single quote in it must not produce broken/unparseable source.
+        patched = bf.replace_top_level_string_constant("X = 'a'\n", "X", "it's-fine")
+        assert bf.read_top_level_string_constant(patched, "X") == "it's-fine"
+        compile(patched, "<patched>", "exec")
+
+    def test_fails_loudly_when_the_constant_cannot_be_found(self):
+        with pytest.raises(SystemExit):
+            bf.replace_top_level_string_constant("SOMETHING_ELSE = '1'\n", "PINNED_SIGNING_PUBLIC_KEY_B64", "x")
+
+    def test_fails_loudly_on_more_than_one_match(self):
+        source = "A = '1'\nA = '2'\n"
+        with pytest.raises(SystemExit):
+            bf.replace_top_level_string_constant(source, "A", "x")
+
+    def test_fails_loudly_when_the_constant_is_not_a_plain_string_literal(self):
+        # e.g. moved inside a function/class, or built from an
+        # expression - still must not silently no-op.
+        source = "def f():\n    PINNED_SIGNING_PUBLIC_KEY_B64 = '1'\n"
+        with pytest.raises(SystemExit):
+            bf.replace_top_level_string_constant(source, "PINNED_SIGNING_PUBLIC_KEY_B64", "x")
+
+
+class TestReadTopLevelStringConstant:
+    def test_reads_value_from_either_known_shape(self):
+        for source in (OLD_MULTILINE_PARENTHESIZED_FORM, NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM):
+            value = bf.read_top_level_string_constant(source, "PINNED_SIGNING_PUBLIC_KEY_B64")
+            assert value == "AAAAC3NzaC1lZDI1NTE5AAAAIINUnyyTuXRhMU7XEpgBwm3dKrkv0D3U7mz+21piPb8q"
+
+    def test_fails_loudly_when_missing(self):
+        with pytest.raises(SystemExit):
+            bf.read_top_level_string_constant("X = '1'\n", "MISSING_NAME")
+
+
+class TestPatchPinnedKeyAndBumpVersion:
+    """End-to-end against real file-on-disk helpers (patch_pinned_key /
+    restore_file / read_version / bump_version), against a throwaway
+    copy of the repo's real utils/self_update.py and utils/config.py -
+    proves the on-disk round trip (patch -> build -> restore) that
+    build_fixtures.py's main() relies on, without mutating this actual
+    checkout."""
+
+    @pytest.fixture
+    def fake_repo(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        (repo_root / "utils").mkdir(parents=True)
+        for relative, content in (
+            (bf.SELF_UPDATE_PY_RELATIVE, NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM),
+            (bf.CONFIG_PY_RELATIVE, '__version__ = "1.2.3"\n'),
+        ):
+            (repo_root / relative).write_text(content, encoding="utf-8")
+        return str(repo_root)
+
+    def test_patch_pinned_key_round_trips(self, fake_repo):
+        path = os.path.join(fake_repo, bf.SELF_UPDATE_PY_RELATIVE)
+        original = bf.patch_pinned_key(fake_repo, "NEWPUBKEY", "SHA256:newfpr")
+
+        with open(path, encoding="utf-8") as f:
+            patched = f.read()
+        assert "NEWPUBKEY" in patched
+        assert "SHA256:newfpr" in patched
+
+        bf.restore_file(fake_repo, bf.SELF_UPDATE_PY_RELATIVE, original)
+        with open(path, encoding="utf-8") as f:
+            restored = f.read()
+        assert restored == original == NEW_SINGLE_LINE_DOUBLE_QUOTED_FORM
+
+    def test_patch_pinned_key_round_trips_against_the_old_multiline_shape(self, fake_repo):
+        path = os.path.join(fake_repo, bf.SELF_UPDATE_PY_RELATIVE)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(OLD_MULTILINE_PARENTHESIZED_FORM)
+
+        original = bf.patch_pinned_key(fake_repo, "NEWPUBKEY", "SHA256:newfpr")
+        with open(path, encoding="utf-8") as f:
+            patched = f.read()
+        assert "NEWPUBKEY" in patched
+        assert "SHA256:newfpr" in patched
+
+        bf.restore_file(fake_repo, bf.SELF_UPDATE_PY_RELATIVE, original)
+        with open(path, encoding="utf-8") as f:
+            restored = f.read()
+        assert restored == OLD_MULTILINE_PARENTHESIZED_FORM
+
+    def test_bump_version_round_trips(self, fake_repo):
+        content, version = bf.read_version(fake_repo)
+        assert version == "1.2.3"
+
+        new_version = bf.synthetic_higher_version(version)
+        assert new_version == "1.2.73"
+        bf.bump_version(fake_repo, new_version)
+
+        _, bumped_version = bf.read_version(fake_repo)
+        assert bumped_version == new_version
+
+        bf.restore_file(fake_repo, bf.CONFIG_PY_RELATIVE, content)
+        restored_content, restored_version = bf.read_version(fake_repo)
+        assert restored_version == "1.2.3"
+        assert restored_content == content
+
+
+class TestAgainstThisRepoRealSelfUpdatePy:
+    """The actual regression check: run the real patch_pinned_key /
+    restore_file against a throwaway copy of THIS repo's real, current
+    utils/self_update.py (whatever shape it's in today) - not a
+    hand-written fixture string - so a future reformat that this test
+    suite hasn't been updated for yet is still exercised for real."""
+
+    def test_round_trips_against_this_repos_actual_self_update_py(self, tmp_path):
+        real_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        real_path = os.path.join(real_repo_root, bf.SELF_UPDATE_PY_RELATIVE)
+        with open(real_path, encoding="utf-8") as f:
+            real_content = f.read()
+
+        fake_repo = tmp_path / "repo"
+        (fake_repo / "utils").mkdir(parents=True)
+        target = fake_repo / bf.SELF_UPDATE_PY_RELATIVE
+        target.write_text(real_content, encoding="utf-8")
+
+        original = bf.patch_pinned_key(str(fake_repo), "NEWPUBKEY", "SHA256:newfpr")
+        assert original == real_content
+        with open(target, encoding="utf-8") as f:
+            patched = f.read()
+        assert "NEWPUBKEY" in patched
+        assert "SHA256:newfpr" in patched
+        compile(patched, str(target), "exec")
+
+        bf.restore_file(str(fake_repo), bf.SELF_UPDATE_PY_RELATIVE, original)
+        with open(target, encoding="utf-8") as f:
+            restored = f.read()
+        assert restored == real_content

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.15"
+__version__ = "2.10.16"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- `scripts/selfupdate_e2e/build_fixtures.py` patched `utils/self_update.py`'s pinned signing key by matching a regex against the constant's exact source-text layout. The 2.10.14 `ruff format` reformat changed that layout, the regex silently matched zero times, `patch_pinned_key()` never ran, and `selfupdate-e2e.yml` started failing on all three platforms at the fixture-build step.
- Replaced with an AST-based rewrite that locates the assignment by the target's NAME, not by source text shape - survives quote-style, line-wrapping, and parenthesization changes. Applied the same fix to `__version__` bump/read (same fragile-regex pattern, hadn't broken yet).
- Preserves the fail-loud behavior: raises `SystemExit` with a clear message if it can't find exactly one matching assignment - never silently skips the patch.
- Audited `scripts/selfupdate_stub_e2e/`: no equivalent fragility found - it never text-patches any real production source file.
- Added `tests/test_selfupdate_e2e_build_fixtures.py`: feeds the patcher both the old and new source shapes (plus a third plausible shape and this repo's own real `utils/self_update.py` verbatim) and asserts all patch correctly.
- Rewires `selfupdate-e2e.yml`'s trigger onto `pull_request`/`push` into `main`, path-filtered to the self-update code + this harness, plus a weekly schedule - replacing the stale `feat/binary-self-update-2.8.29`-only trigger that let this land undetected in the first place.
- Version bump to 2.10.16, CHANGELOG entry.

## Test plan
- [x] `pytest tests/ --cov=. --cov-fail-under=85`: 2348 passed, 1 skipped, 96.37% coverage
- [x] `ruff format --check .`: clean
- [x] `ruff check` on changed files: clean (repo-wide non-blocking findings unchanged)
- [x] `mypy` on changed files: clean
- [x] Manual round-trip of `patch_pinned_key`/`restore_file` against this repo's real `utils/self_update.py` (byte-identical restore)
- [ ] CI: test / lint / secret-scan