### PR TITLE
fix: shell script dedup (2.10.18)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,13 @@ pytest.ini
 .coverage
 build-requirements.txt
 scripts/
+# ...except scripts/lib/ - shared shell helpers (colors.sh,
+# pip-install.sh) that run.sh itself now sources (see Dockerfile's own
+# COPY for this - run.sh is one of the two app-code files intentionally
+# still copied into the image below, so its own runtime dependencies
+# have to come with it).
+!scripts/lib/
+!scripts/lib/*
 
 # Python cache / venvs
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.18] - 2026-07-26
+
+### Changed
+
+- **Extracted two byte-identical duplications across the shell install
+  scripts into `scripts/lib/`:**
+  - `scripts/lib/pip-install.sh` (`curatarr_pip_install`) - the
+    "prefer hash-verified lockfile(s), fall back to plain pinned
+    requirements" pip install logic `run.sh` and `run-ui.sh` each
+    implemented independently (their own comments cross-referenced
+    each other's copy). Each script keeps its own success/failure
+    messaging and timing via callback functions - user-visible output
+    is unchanged.
+  - `scripts/lib/colors.sh` - the ANSI colour variables `run.sh` and
+    `setup.sh` each defined byte-identically. `docker-entrypoint.sh`
+    intentionally keeps its own (still byte-identical) RED/YELLOW/NC
+    subset - `.dockerignore` excludes `scripts/` wholesale from the
+    Docker build context, and carving out a negation exception for one
+    3-line file wasn't worth the added build fragility.
+  - `run.sh` is the one script from this pair that IS shipped inside
+    the Docker image (alongside `docker-entrypoint.sh`, even though
+    nothing in the image actually invokes it) - `Dockerfile` now also
+    `COPY`s `scripts/lib/` and `.dockerignore` carries a matching
+    negation, verified with a real `docker build` + container run
+    (previously would have failed with `run.sh: line N:
+    /app/scripts/lib/colors.sh: No such file or directory` if anyone
+    ran it inside the container).
+  - One intentional, minor behavior change: if `run.sh` finds neither
+    `requirements.lock` nor `requirements.txt` at all (previously
+    silent no-op), it now fails clearly with the same
+    "Failed to install Python dependencies" error used for every other
+    install failure, instead of continuing on to fail later with a
+    more confusing error deeper in the app.
+- **Documented (not converged) the 4x version-comparison duplication**
+  (`utils/update_check.py`'s `parse_version()`, `run.sh`'s
+  `version_gt`/`version_ge`, `run-ui.sh`'s inline copy, `run.ps1`'s
+  `ConvertTo-VersionTuple`): genuinely irreducible, for two independent
+  reasons now documented at each site - (1) the Python-floor gate in
+  all three scripts runs before dependencies are installed, so calling
+  into `utils.update_check` (which pulls in `utils/__init__.py`'s
+  ~20 third-party-backed submodule imports) isn't safe on a fresh
+  checkout; (2) that same floor check compares a 3-component runtime
+  version against a 2-component `requirements.lock` floor string, which
+  `parse_version()`'s deliberate exactly-3-component anchoring would
+  reject outright. No functional shell/PowerShell logic changed for
+  this item, comments only.
+
 ## [2.10.17] - 2026-07-26
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,13 @@ COPY recommenders/ recommenders/
 COPY utils/ utils/
 COPY web/ web/
 COPY run.sh docker-entrypoint.sh ./
+# run.sh now sources scripts/lib/colors.sh and scripts/lib/pip-install.sh
+# (shared with run-ui.sh/setup.sh, host-side-only otherwise - see the
+# 2.10.18 audit-remediation pass) - it needs its own copy of those
+# alongside it even though nothing in this image actually invokes
+# run.sh itself (see .dockerignore's negation for why scripts/ as a
+# whole otherwise stays excluded).
+COPY scripts/lib/ scripts/lib/
 RUN sed -i 's/\r$//' run.sh docker-entrypoint.sh && \
     chmod +x run.sh docker-entrypoint.sh
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,6 +25,11 @@
 
 set -e
 
+# Kept as its own copy rather than sourcing scripts/lib/colors.sh
+# (which run.sh/setup.sh share): .dockerignore excludes scripts/
+# wholesale from the build context (app code only, no dev tooling -
+# see that file), so sharing this 3-line subset here isn't worth
+# carving a negation exception into it.
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'

--- a/run-ui.sh
+++ b/run-ui.sh
@@ -7,6 +7,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Shared "hash-verified lockfile, fall back to plain requirements" pip
+# install helper - also used by run.sh.
+source "$SCRIPT_DIR/scripts/lib/pip-install.sh"
+
 if ! command -v python3 &> /dev/null; then
     echo "Python 3 not found. Install Python 3.10+ first." >&2
     exit 1
@@ -16,6 +20,15 @@ fi
 # read the floor back out of requirements.lock's own header instead of a
 # second hardcoded copy, so a version bump there can't silently drift out
 # of sync with this script.
+#
+# This inline parser is intentionally NOT calling into
+# utils/update_check.py's parse_version() (the app's canonical version
+# parser - see run.sh's version_gt/version_ge for the full rationale,
+# which applies here too): this check runs BEFORE install_deps() below,
+# so importing utils.update_check (which pulls in utils/__init__.py's
+# ~20 third-party-backed submodule imports) isn't safe on a fresh
+# checkout, and REQUIRED_PYTHON is a 2-component "X.Y" string that
+# parse_version's exactly-3-component anchoring would reject anyway.
 PYTHON_VERSION="$(python3 --version | awk '{print $2}')"
 if [ -f "requirements.lock" ]; then
     REQUIRED_PYTHON="$(grep -oE -- '--python-version [0-9]+\.[0-9]+' requirements.lock | head -1 | awk '{print $2}')"
@@ -36,13 +49,15 @@ fi
 # UI's own deps (flask/ruamel.yaml - requirements-ui.txt). Prefer the
 # hashed locks when present, same rationale as run.sh; fall back to the
 # plain pinned files (still reproducible, just unverified) otherwise.
+# The actual pip3 invocation/fallback is shared with run.sh - see
+# scripts/lib/pip-install.sh (curatarr_pip_install).
+_run_ui_on_hash_fail() {
+    echo "Hash-verified install failed (hash/platform mismatch?) - falling back to a" >&2
+    echo "normal pinned install (no hash verification) for this run." >&2
+}
+
 install_deps() {
-    if [ -f "requirements.lock" ] && [ -f "requirements-ui.lock" ]; then
-        pip3 install --require-hashes -r requirements.lock -r requirements-ui.lock --quiet && return
-        echo "Hash-verified install failed (hash/platform mismatch?) - falling back to a" >&2
-        echo "normal pinned install (no hash verification) for this run." >&2
-    fi
-    pip3 install -r requirements.txt -r requirements-ui.txt --quiet
+    curatarr_pip_install "requirements.lock requirements-ui.lock" "requirements.txt requirements-ui.txt" _run_ui_on_hash_fail
 }
 
 if ! python3 -c "import flask, ruamel.yaml" &> /dev/null; then

--- a/run.ps1
+++ b/run.ps1
@@ -170,6 +170,20 @@ function Check-Dependencies {
 # "2.8.21") into an [int[]] tuple. Returns $null if any component isn't a
 # plain integer (mirrors the Python `except ValueError: return None` /
 # `sys.exit(1)` fail-closed behavior this replaces).
+#
+# PowerShell can't share run.sh's bash source, but it CAN shell out to
+# the same canonical Python (utils/update_check.py's parse_version()) -
+# deliberately not done here, for the same two reasons run.sh's
+# version_gt/version_ge document: (1) this is used for the Python-floor
+# gate in Check-Dependencies, which runs BEFORE pip installs anything -
+# invoking Python to import utils.update_check would first execute
+# utils/__init__.py's ~20 third-party-backed submodule imports, which
+# aren't guaranteed installed yet on a fresh checkout; (2) the floor
+# value read out of requirements.lock's `--python-version X.Y` header is
+# 2-component, while parse_version() requires exactly 3 - it would
+# reject that input outright. This function's own variable-length
+# tuple support (see Compare-VersionTuple below) is what makes comparing
+# a 3-component runtime version against that 2-component floor work.
 function ConvertTo-VersionTuple {
     param([string]$VersionString)
 

--- a/run.sh
+++ b/run.sh
@@ -26,16 +26,17 @@ for arg in "$@"; do
     esac
 done
 
-# Color codes for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-
 # Get script directory (absolute path)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+
+# Color codes for output - shared with setup.sh (docker-entrypoint.sh
+# keeps its own copy - see scripts/lib/colors.sh's docstring for why).
+source "$SCRIPT_DIR/scripts/lib/colors.sh"
+
+# Shared "hash-verified lockfile, fall back to plain requirements" pip
+# install helper - also used by run-ui.sh.
+source "$SCRIPT_DIR/scripts/lib/pip-install.sh"
 
 # Trust anchor for signed release verification. Fingerprint is pinned in
 # this script (not just in the allowed_signers file) so a tampered
@@ -100,7 +101,7 @@ check_and_install_dependencies() {
     fi
     echo -e "${GREEN}✓ pip3 found${NC}"
 
-    # Install Python dependencies from the fully-hashed lock file
+    # Install Python dependencies - prefer the fully-hashed lock file
     # (requirements.lock, generated from requirements.txt - see the
     # comment at the top of that file). `--require-hashes` makes pip
     # refuse to install anything whose downloaded artifact doesn't match
@@ -113,36 +114,42 @@ check_and_install_dependencies() {
     # interpreter/platform combo can trip that up even when the floor
     # check above passed), fall back to the normal pinned install from
     # requirements.txt with a clear warning rather than hard-failing the
-    # whole update. Hashed stays the primary, preferred path.
+    # whole update. Hashed stays the primary, preferred path. The actual
+    # pip3 invocation/fallback is shared with run-ui.sh - see
+    # scripts/lib/pip-install.sh (curatarr_pip_install); this only keeps
+    # its own messaging, via the callbacks below, so wording/timing stay
+    # exactly as before.
+    _run_sh_pip_fallback_reason=""
+    _run_sh_on_hash_fail() {
+        echo -e "${YELLOW}⚠ Hash-verified install failed (hash/platform mismatch?)${NC}"
+        echo -e "${YELLOW}  Falling back to a normal pinned install from requirements.txt${NC}"
+        echo -e "${YELLOW}  (no hash verification for this run). See RELEASING.md if this${NC}"
+        echo -e "${YELLOW}  persists.${NC}"
+        _run_sh_pip_fallback_reason="hash_fail"
+    }
+    _run_sh_on_no_lock() {
+        if [ -f "requirements.txt" ]; then
+            echo -e "${YELLOW}requirements.lock not found, falling back to requirements.txt (no hash verification)${NC}"
+        fi
+        _run_sh_pip_fallback_reason="no_lock"
+    }
+
     if [ -f "requirements.lock" ]; then
         echo -e "${CYAN}Installing Python dependencies (hash-verified)...${NC}"
-        if pip3 install --require-hashes -r requirements.lock --quiet; then
+    fi
+
+    if curatarr_pip_install "requirements.lock" "requirements.txt" _run_sh_on_hash_fail _run_sh_on_no_lock; then
+        if [ "$CURATARR_PIP_INSTALL_MODE" = "hash-verified" ]; then
             echo -e "${GREEN}✓ All dependencies installed (hash-verified)${NC}"
+        elif [ "$_run_sh_pip_fallback_reason" = "hash_fail" ]; then
+            echo -e "${GREEN}✓ All dependencies installed (fallback, unhashed)${NC}"
         else
-            echo -e "${YELLOW}⚠ Hash-verified install failed (hash/platform mismatch?)${NC}"
-            echo -e "${YELLOW}  Falling back to a normal pinned install from requirements.txt${NC}"
-            echo -e "${YELLOW}  (no hash verification for this run). See RELEASING.md if this${NC}"
-            echo -e "${YELLOW}  persists.${NC}"
-            if [ -f "requirements.txt" ]; then
-                pip3 install -r requirements.txt --quiet || {
-                    echo -e "${RED}❌ Failed to install Python dependencies${NC}"
-                    echo "Try running manually: pip3 install -r requirements.txt"
-                    exit 1
-                }
-                echo -e "${GREEN}✓ All dependencies installed (fallback, unhashed)${NC}"
-            else
-                echo -e "${RED}❌ Failed to install Python dependencies${NC}"
-                exit 1
-            fi
+            echo -e "${GREEN}✓ All dependencies installed${NC}"
         fi
-    elif [ -f "requirements.txt" ]; then
-        echo -e "${YELLOW}requirements.lock not found, falling back to requirements.txt (no hash verification)${NC}"
-        pip3 install -r requirements.txt --quiet || {
-            echo -e "${RED}❌ Failed to install Python dependencies${NC}"
-            echo "Try running manually: pip3 install -r requirements.txt"
-            exit 1
-        }
-        echo -e "${GREEN}✓ All dependencies installed${NC}"
+    else
+        echo -e "${RED}❌ Failed to install Python dependencies${NC}"
+        echo "Try running manually: pip3 install -r requirements.txt"
+        exit 1
     fi
 
     echo ""
@@ -152,6 +159,28 @@ check_and_install_dependencies() {
 # AUTO-UPDATE FROM GITHUB (SSH-signed release tags only)
 # ------------------------------------------------------------------------
 
+# version_gt A B / version_ge A B: intentionally NOT calling into
+# utils/update_check.py's parse_version() (audited as duplicate logic -
+# see PR history) despite that being the app's canonical version
+# parser. Two independent reasons it can't be reused here:
+#   1. version_ge is called from check_and_install_dependencies() BEFORE
+#      pip installs anything (the Python-floor gate has to run before
+#      requirements.lock/.txt are installed, by design - see that
+#      function). `from utils.update_check import parse_version` would
+#      first execute utils/__init__.py, which unconditionally imports
+#      ~20 submodules (yaml/requests/plexapi/cryptography-backed) - on
+#      a fresh checkout with no deps installed yet, that import would
+#      fail with exactly the class of error this gate exists to avoid.
+#   2. Even post-install, parse_version() requires EXACTLY 3 dotted
+#      components (its own anchoring is deliberate - see that
+#      function's docstring). The Python-floor comparison here compares
+#      a 3-component runtime version (e.g. "3.12.1") against a
+#      2-component floor string pulled from requirements.lock's own
+#      `--python-version X.Y` header (e.g. "3.10") - parse_version would
+#      reject the 2-component side outright. The looser parser below
+#      relies on Python's own tuple comparison short-circuiting on the
+#      first differing element, which is what makes comparing
+#      different-length tuples work correctly here.
 # version_gt A B: succeeds (exit 0) if dotted version A is strictly
 # greater than dotted version B. Pure-python so behavior is identical on
 # macOS/Linux regardless of whether `sort -V` is available.

--- a/scripts/lib/colors.sh
+++ b/scripts/lib/colors.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Shared ANSI colour codes for Curatarr's shell scripts. Sourced by
+# run.sh and setup.sh, which used to each define these byte-identically
+# (see the 2.10.18 audit-remediation pass).
+#
+# docker-entrypoint.sh has its own (still byte-identical, RED/YELLOW/NC
+# subset only) copy rather than sourcing this file: .dockerignore
+# excludes scripts/ wholesale from the Docker build context (see that
+# file's comment on keeping the image to app code only, no dev
+# tooling), so this would need a .dockerignore negation exception
+# carved out just to thread a 3-line copy through - not worth the
+# added Docker-build fragility for that one file.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color

--- a/scripts/lib/pip-install.sh
+++ b/scripts/lib/pip-install.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Shared "prefer hash-verified lockfile(s), fall back to plain pinned
+# requirements file(s)" pip install helper. Sourced by run.sh and
+# run-ui.sh, which used to each implement this same fallback contract
+# independently (their own comments cross-referenced each other's
+# copy - see the 2.10.18 audit-remediation pass).
+#
+# Only the pip3 invocation + fallback decision is shared here - each
+# caller keeps its own success/failure messaging (run.sh wants colored
+# checkmark/warning output and a hard `exit 1` on total failure;
+# run-ui.sh is quieter and relies on `set -e`) via optional callback
+# function names, so this doesn't change either script's user-visible
+# behavior or timing.
+#
+# curatarr_pip_install LOCK_FILES REQ_FILES [ON_HASH_FAIL_FN] [ON_NO_LOCK_FN]
+#
+#   LOCK_FILES / REQ_FILES: space-separated lists of one or more paths
+#     (e.g. a single pair for run.sh's core deps, or two files' worth
+#     for run-ui.sh's core + web-UI deps).
+#   ON_HASH_FAIL_FN: name of a function to call (no args), if given,
+#     right after a hash-verified install attempt fails, before
+#     falling back - lets the caller print its own warning at the
+#     right moment (before the fallback install runs, not after).
+#   ON_NO_LOCK_FN: name of a function to call (no args), if given,
+#     when LOCK_FILES doesn't apply (empty, or not every file in it
+#     exists) - before falling back straight to REQ_FILES.
+#
+#   Sets CURATARR_PIP_INSTALL_MODE to "hash-verified" or "fallback" on
+#   success (the caller distinguishes "fallback because no lockfile"
+#   from "fallback because hash-verified failed" itself, e.g. via its
+#   own callback setting a variable - see run.sh's call site).
+#
+#   Returns 0 on success (either path). Returns non-zero if the
+#   hash-verified attempt (when applicable) failed AND the fallback
+#   also failed, or if none of REQ_FILES exist to fall back to at all.
+curatarr_pip_install() {
+    local lock_files="$1"
+    local req_files="$2"
+    local on_hash_fail_fn="$3"
+    local on_no_lock_fn="$4"
+    local f
+    CURATARR_PIP_INSTALL_MODE=""
+
+    local all_locks_exist=1
+    if [ -z "$lock_files" ]; then
+        all_locks_exist=0
+    else
+        for f in $lock_files; do
+            [ -f "$f" ] || { all_locks_exist=0; break; }
+        done
+    fi
+
+    if [ "$all_locks_exist" -eq 1 ]; then
+        local lock_args=""
+        for f in $lock_files; do
+            lock_args="$lock_args -r $f"
+        done
+        # shellcheck disable=SC2086  # intentional word-splitting of -r flags
+        if pip3 install --require-hashes $lock_args --quiet; then
+            CURATARR_PIP_INSTALL_MODE="hash-verified"
+            return 0
+        fi
+        [ -n "$on_hash_fail_fn" ] && "$on_hash_fail_fn"
+    else
+        [ -n "$on_no_lock_fn" ] && "$on_no_lock_fn"
+    fi
+
+    local req_args=""
+    local any_req_exists=0
+    for f in $req_files; do
+        if [ -f "$f" ]; then
+            req_args="$req_args -r $f"
+            any_req_exists=1
+        fi
+    done
+    [ "$any_req_exists" -eq 1 ] || return 1
+
+    # shellcheck disable=SC2086
+    if pip3 install $req_args --quiet; then
+        CURATARR_PIP_INSTALL_MODE="fallback"
+        return 0
+    fi
+    return 1
+}

--- a/setup.sh
+++ b/setup.sh
@@ -15,15 +15,13 @@ set -e
 # match" into an unwanted hard exit for them.
 set -o pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
+
+# Color codes for output - shared with run.sh (docker-entrypoint.sh
+# keeps its own copy - see scripts/lib/colors.sh's docstring for why).
+source "$SCRIPT_DIR/scripts/lib/colors.sh"
 
 echo -e "${CYAN}===============================================${NC}"
 echo -e "${CYAN}        Curatarr Setup Wizard${NC}"

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.17"
+__version__ = "2.10.18"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Extracted the hash-verified-lockfile-with-fallback pip install logic (run.sh + run-ui.sh) into scripts/lib/pip-install.sh, and the ANSI color vars (run.sh + setup.sh) into scripts/lib/colors.sh.
- docker-entrypoint.sh keeps its own color copy (dockerignore excludes scripts/ wholesale; not worth a negation exception for 3 lines). run.sh IS shipped in the Docker image though, so Dockerfile/.dockerignore were updated so its new scripts/lib/ dependency is actually available there - verified with a real docker build + container run (web mode reached HTTP 200; run.sh no longer errors on the missing source file).
- Documented, but did not converge, the 4x version-comparison duplication (utils/update_check.py parse_version / run.sh / run-ui.sh / run.ps1): genuinely irreducible per the CHANGELOG entry - the Python-floor gate in all three runs before dependencies are installed, and separately needs to compare a 3-component runtime version against a 2-component floor string that parse_version's exact anchoring would reject.
- One disclosed, minor behavior change: run.sh now fails clearly if both requirements.lock and requirements.txt are missing, instead of a prior silent no-op.

## Test plan
- [x] Full suite: 2349 passed, 1 skipped (unchanged from PR A baseline)
- [x] ruff format --check clean
- [x] bash -n clean on every touched shell file
- [x] Behavioral (not just syntax) test of curatarr_pip_install: 19 assertions across 6 scenarios (hash-verified success, hash-fail fallback, no-lock fallback, both-missing failure, two-lockfile-pair form, partial-lockfile-pair form)
- [x] Real docker build + container run of both run.sh (inside the image) and the web entrypoint (HTTP 200)
- [ ] run.ps1 changes are comment-only and UNEXECUTED/unverified (no Windows PowerShell available on this host)