### PR TITLE
fix: audit remediation batch 2 - eliminate duplication (2.10.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.20] - 2026-07-26
+
+### Changed
+
+- **Audit remediation: eliminated duplicated cache/recommender code**
+  (batch 2, PR B). Four hand-rolled JSON cache implementations
+  (`recommenders/external.py`'s `load_cache`/`save_cache`,
+  `load_huntarr_cache`/`save_huntarr_cache`,
+  `load_horizon_cache`/`save_horizon_cache`, and
+  `recommenders/external_render.py`'s `_load_imdb_cache`/`_save_imdb_cache`)
+  now route through the shared `utils/cache.py` helpers
+  (`load_json_cache`/`save_json_cache`) instead of duplicating
+  open/json.load/json.dump by hand - the huntarr/horizon caches also
+  gain `curatarr_cache_lookups_total` hit/miss metrics as a result,
+  previously invisible. Existing on-disk cache files verified to still
+  load correctly (version/staleness semantics unchanged - only the
+  raw I/O plumbing moved). `_load_imdb_cache`'s bare
+  `except (...): pass` (silently swallowing write failures) now logs
+  via the shared helper instead of hiding the error.
+- **`collect_tmdb_ids` deduplicated** in `recommenders/external_sync.py`
+  - was defined identically inside both `export_to_mdblist` and
+  `export_to_simkl`; hoisted to one module-level function.
+- **`_calculate_rating_multiplier`, `_save_cache`, and
+  `_print_similarity_breakdown` deduplicated** between
+  `recommenders/movie.py` and `recommenders/tv.py` - identical (or
+  differing only by the `self.media_type` literal) implementations
+  hoisted onto `recommenders/base.py`'s `BaseRecommender`.
+  `_print_similarity_breakdown` is no longer `@abstractmethod` (now a
+  concrete shared implementation); `BaseRecommender` still can't be
+  instantiated directly since other abstract methods remain.
+
 ## [2.10.19] - 2026-07-26
 
 ### Added

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -25,7 +25,16 @@ from plexapi.myplex import MyPlexAccount
 from utils import (
     CACHE_VERSION,
     CYAN,
+    DEFAULT_NEGATIVE_THRESHOLD,
     GREEN,
+    RATING_MULTIPLIER_2_STAR,
+    RATING_MULTIPLIER_3_STAR,
+    RATING_MULTIPLIER_4_STAR,
+    RATING_MULTIPLIER_5_STAR,
+    RATING_MULTIPLIER_UNRATED,
+    RATING_TIER_3_STAR,
+    RATING_TIER_4_STAR,
+    RATING_TIER_5_STAR,
     RED,
     RESET,
     TIER_DIVERSE_PERCENT,
@@ -50,6 +59,7 @@ from utils import (
     get_libraries_for_media_type,
     get_library_imdb_ids,
     get_max_rating_for_user,
+    get_negative_multiplier,
     get_project_root,
     get_tmdb_config,
     get_tmdb_id_for_item,
@@ -61,6 +71,7 @@ from utils import (
     log_error,
     log_warning,
     migrate_legacy_cache_dir,
+    print_similarity_breakdown,
     process_counters_from_cache,
     remove_labels_from_items,
     save_media_cache,
@@ -491,6 +502,45 @@ class BaseRecommender(ABC):
             Dict of weight names to values
         """
         pass
+
+    def _calculate_rating_multiplier(self, user_rating):
+        """Calculate rating multiplier based on user's star rating (0-10 scale in Plex)
+
+        With negative signals enabled, low ratings (0-3) return negative multipliers
+        to penalize similar content instead of weakly preferring it.
+
+        Rating scale (negative signals enabled):
+        - 9-10 (5 stars): 1.0x weight - love it, strong preference
+        - 7-8 (4 stars): 0.75x weight - like it, moderate preference
+        - 5-6 (3 stars): 0.5x weight - neutral, weak preference
+        - 4 (2 stars): 0.25x weight - dislike, very weak preference
+        - 0-3 (1-1.5 stars): NEGATIVE weight - hate it, penalize similar content
+        - None/0 (unrated): 0.6x weight - default, slightly lower than neutral
+        """
+        if not user_rating or user_rating == 0:
+            return RATING_MULTIPLIER_UNRATED
+
+        rating_int = int(round(user_rating))
+
+        # Check if negative signals are enabled
+        ns_config = self.config.get("negative_signals", {})
+        bad_ratings_config = ns_config.get("bad_ratings", {})
+        ns_enabled = ns_config.get("enabled", True) and bad_ratings_config.get("enabled", True)
+        threshold = bad_ratings_config.get("threshold", DEFAULT_NEGATIVE_THRESHOLD)
+
+        # Return negative multiplier for low ratings if enabled
+        if ns_enabled and rating_int <= threshold:
+            return get_negative_multiplier(rating_int)
+
+        # Positive multipliers for higher ratings
+        if user_rating >= RATING_TIER_5_STAR:
+            return RATING_MULTIPLIER_5_STAR
+        elif user_rating >= RATING_TIER_4_STAR:
+            return RATING_MULTIPLIER_4_STAR
+        elif user_rating >= RATING_TIER_3_STAR:
+            return RATING_MULTIPLIER_3_STAR
+        else:
+            return RATING_MULTIPLIER_2_STAR
 
     def _cache_library_prefix(self) -> str:
         """
@@ -1163,10 +1213,15 @@ class BaseRecommender(ABC):
         """Calculate similarity score for an item."""
         pass
 
-    @abstractmethod
     def _print_similarity_breakdown(self, item_info: Dict, score: float, breakdown: Dict):
-        """Print detailed breakdown of similarity score."""
-        pass
+        """Print detailed breakdown of similarity score calculation.
+
+        Concrete for both media types (movie.py/tv.py previously
+        duplicated this, differing only in the media_type literal
+        passed through to the shared print_similarity_breakdown
+        formatter - self.media_type already carries that).
+        """
+        print_similarity_breakdown(item_info, score, breakdown, self.media_type)
 
     @abstractmethod
     def _get_watched_data(self) -> Dict:
@@ -1200,6 +1255,14 @@ class BaseRecommender(ABC):
         Must be implemented by subclasses.
         """
         pass
+
+    def _save_cache(self):
+        """Save the recommender's caches. Concrete for both media types
+        (movie.py/tv.py previously duplicated this identical one-line
+        body) - just delegates to the abstract _save_watched_cache
+        subclasses must already implement.
+        """
+        self._save_watched_cache()
 
     def _enhance_profile_with_trakt(self):
         """

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -69,12 +69,14 @@ from utils import (
     get_tmdb_keywords,
     get_trakt_discovery_candidates,
     load_config,
+    load_json_cache,
     log_error,
     log_warning,
     normalize_genre,
     normalize_user_profile,
     record_recommender_run,
     record_unhandled_error,
+    save_json_cache,
     smart_open_html,
 )
 
@@ -823,18 +825,13 @@ HUNTARR_CACHE_VERSION = SEQUEL_HUNTARR_CACHE_VERSION
 
 def load_huntarr_cache(cache_path: str, stale_days: int = 7) -> Dict:
     """Load Huntarr cache from disk."""
-    try:
-        if os.path.exists(cache_path):
-            with open(cache_path, "r") as f:
-                cache = json.load(f)
-                if cache.get("version") == HUNTARR_CACHE_VERSION:
-                    # Check staleness
-                    cached_at = cache.get("cached_at", 0)
-                    age_days = (time.time() - cached_at) / 86400
-                    if age_days < stale_days:
-                        return cache
-    except (json.JSONDecodeError, IOError) as e:
-        logger.debug(f"Could not load Huntarr cache: {e}")
+    cache = load_json_cache(cache_path)
+    if cache and cache.get("version") == HUNTARR_CACHE_VERSION:
+        # Check staleness
+        cached_at = cache.get("cached_at", 0)
+        age_days = (time.time() - cached_at) / 86400
+        if age_days < stale_days:
+            return cache
     return {}
 
 
@@ -842,12 +839,8 @@ def save_huntarr_cache(cache_path: str, cache: Dict) -> None:
     """Save Huntarr cache to disk."""
     cache["version"] = HUNTARR_CACHE_VERSION
     cache["cached_at"] = time.time()
-    try:
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with open(cache_path, "w") as f:
-            json.dump(cache, f)
-    except IOError as e:
-        log_warning(f"Could not save Huntarr cache: {e}")
+    if not save_json_cache(cache_path, cache):
+        log_warning("Could not save Huntarr cache")
 
 
 def find_missing_sequels(
@@ -1175,17 +1168,12 @@ def get_movie_status(tmdb_api_key: str, tmdb_id: int) -> Tuple[str, str]:
 
 def load_horizon_cache(cache_path: str, stale_days: int = 7) -> Dict:
     """Load Horizon Huntarr cache from disk."""
-    try:
-        if os.path.exists(cache_path):
-            with open(cache_path, "r") as f:
-                cache = json.load(f)
-                if cache.get("version") == HORIZON_HUNTARR_CACHE_VERSION:
-                    cached_at = cache.get("cached_at", 0)
-                    age_days = (time.time() - cached_at) / 86400
-                    if age_days < stale_days:
-                        return cache
-    except (json.JSONDecodeError, IOError) as e:
-        logger.debug(f"Could not load Horizon Huntarr cache: {e}")
+    cache = load_json_cache(cache_path)
+    if cache and cache.get("version") == HORIZON_HUNTARR_CACHE_VERSION:
+        cached_at = cache.get("cached_at", 0)
+        age_days = (time.time() - cached_at) / 86400
+        if age_days < stale_days:
+            return cache
     return {}
 
 
@@ -1193,12 +1181,8 @@ def save_horizon_cache(cache_path: str, cache: Dict) -> None:
     """Save Horizon Huntarr cache to disk."""
     cache["version"] = HORIZON_HUNTARR_CACHE_VERSION
     cache["cached_at"] = time.time()
-    try:
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with open(cache_path, "w") as f:
-            json.dump(cache, f)
-    except IOError as e:
-        log_warning(f"Could not save Horizon Huntarr cache: {e}")
+    if not save_json_cache(cache_path, cache):
+        log_warning("Could not save Horizon Huntarr cache")
 
 
 def find_horizon_movies(tmdb_api_key: str, plex: Any, library_name: str, stale_days: int = 7) -> List[Dict]:
@@ -1856,37 +1840,35 @@ def load_cache(display_name: str, media_type: str, lib_id: Optional[str] = None)
     lib_prefix = f"{lib_id}_" if lib_id else ""
     cache_file = os.path.join(cache_dir, f"external_recs_{lib_prefix}{safe_name}_{media_type}.json")
 
-    if os.path.exists(cache_file):
-        with open(cache_file, "r") as f:
-            cache = json.load(f)
+    cache = load_json_cache(cache_file)
+    if cache is not None:
+        # Check cache version - invalidate old format
+        cache_version = cache.get("version", 0)
+        if cache_version < EXTERNAL_RECS_CACHE_VERSION:
+            print(f"  {YELLOW}External recs cache outdated (v{cache_version}), rebuilding...{RESET}")
+            return {}
 
-            # Check cache version - invalidate old format
-            cache_version = cache.get("version", 0)
-            if cache_version < EXTERNAL_RECS_CACHE_VERSION:
-                print(f"  {YELLOW}External recs cache outdated (v{cache_version}), rebuilding...{RESET}")
-                return {}
+        items = cache.get("items", {})
 
-            items = cache.get("items", {})
+        # Add tmdb_id to items that don't have it (backwards compatibility)
+        for tmdb_id_str, item in items.items():
+            if "tmdb_id" not in item:
+                item["tmdb_id"] = int(tmdb_id_str)
 
-            # Add tmdb_id to items that don't have it (backwards compatibility)
-            for tmdb_id_str, item in items.items():
-                if "tmdb_id" not in item:
-                    item["tmdb_id"] = int(tmdb_id_str)
+        # Filter out items without enough votes (match score filtering happens at output)
+        filtered = {}
+        removed_count = 0
+        for tmdb_id_str, item in items.items():
+            vote_count = item.get("vote_count", 0)  # Missing vote_count = needs re-fetch
+            if vote_count >= MIN_VOTE_COUNT:
+                filtered[tmdb_id_str] = item
+            else:
+                removed_count += 1
 
-            # Filter out items without enough votes (match score filtering happens at output)
-            filtered = {}
-            removed_count = 0
-            for tmdb_id_str, item in items.items():
-                vote_count = item.get("vote_count", 0)  # Missing vote_count = needs re-fetch
-                if vote_count >= MIN_VOTE_COUNT:
-                    filtered[tmdb_id_str] = item
-                else:
-                    removed_count += 1
+        if removed_count > 0:
+            print(f"  Filtered {removed_count} cached items with < {MIN_VOTE_COUNT} votes")
 
-            if removed_count > 0:
-                print(f"  Filtered {removed_count} cached items with < {MIN_VOTE_COUNT} votes")
-
-            return filtered
+        return filtered
     return {}
 
 
@@ -1906,8 +1888,8 @@ def save_cache(display_name: str, media_type: str, cache_data: Dict, lib_id: Opt
     cache_file = os.path.join(cache_dir, f"external_recs_{lib_prefix}{safe_name}_{media_type}.json")
 
     versioned_cache = {"version": EXTERNAL_RECS_CACHE_VERSION, "items": cache_data}
-    with open(cache_file, "w") as f:
-        json.dump(versioned_cache, f, indent=2)
+    if not save_json_cache(cache_file, versioned_cache):
+        log_warning(f"Could not save external recs cache for {display_name} ({media_type})")
 
 
 def _stamp_library_id(categorized: Dict, library_id: Optional[str]) -> None:

--- a/recommenders/external_render.py
+++ b/recommenders/external_render.py
@@ -4,12 +4,12 @@ Generates markdown watchlists and combined HTML views.
 """
 
 import html
-import json
 import os
 from datetime import datetime
 from typing import Dict, List
 from urllib.parse import quote_plus
 
+from utils.cache import load_json_cache, save_json_cache
 from utils.config import TMDB_ANIMATION_GENRE_ID
 
 
@@ -31,23 +31,12 @@ def _esc(value) -> str:
 
 def _load_imdb_cache(cache_path: str) -> Dict[str, str]:
     """Load IMDB ID cache from disk. IDs are permanent so no staleness check."""
-    try:
-        if os.path.exists(cache_path):
-            with open(cache_path, "r") as f:
-                return json.load(f)
-    except (json.JSONDecodeError, IOError):
-        pass
-    return {}
+    return load_json_cache(cache_path) or {}
 
 
 def _save_imdb_cache(cache_path: str, cache: Dict[str, str]) -> None:
     """Save IMDB ID cache to disk."""
-    try:
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with open(cache_path, "w") as f:
-            json.dump(cache, f)
-    except IOError:
-        pass
+    save_json_cache(cache_path, cache)
 
 
 # ANSI color codes

--- a/recommenders/external_sync.py
+++ b/recommenders/external_sync.py
@@ -65,6 +65,28 @@ def flatten_categorized(categorized: Dict) -> List[Dict]:
     return items
 
 
+def collect_tmdb_ids(categorized: Dict) -> List[int]:
+    """Extract TMDB IDs from categorized items, deduplicated in
+    first-seen order.
+
+    Handles both category shapes used across export_to_mdblist and
+    export_to_simkl: dict-of-lists (user_services/other_services, keyed
+    by streaming service) and flat lists (acquire).
+    """
+    tmdb_ids = []
+    for category_items in categorized.values():
+        if isinstance(category_items, dict):
+            for items in category_items.values():
+                for item in items:
+                    if item.get("tmdb_id"):
+                        tmdb_ids.append(item["tmdb_id"])
+        elif isinstance(category_items, list):
+            for item in category_items:
+                if item.get("tmdb_id"):
+                    tmdb_ids.append(item["tmdb_id"])
+    return list(dict.fromkeys(tmdb_ids))
+
+
 def get_imdb_id(tmdb_api_key: str, tmdb_id: int, media_type: str = "movie") -> Optional[str]:
     """Fetch IMDB ID from TMDB external IDs endpoint."""
     try:
@@ -880,21 +902,6 @@ def export_to_mdblist(config: Dict, all_users_data: List[Dict], tmdb_api_key: st
     else:
         users_to_export = all_users_data
 
-    # Helper to collect TMDB IDs from categorized data
-    def collect_tmdb_ids(categorized):
-        tmdb_ids = []
-        for category_items in categorized.values():
-            if isinstance(category_items, dict):
-                for items in category_items.values():
-                    for item in items:
-                        if item.get("tmdb_id"):
-                            tmdb_ids.append(item["tmdb_id"])
-            elif isinstance(category_items, list):
-                for item in category_items:
-                    if item.get("tmdb_id"):
-                        tmdb_ids.append(item["tmdb_id"])
-        return list(dict.fromkeys(tmdb_ids))
-
     # Handle combined mode
     if user_mode == "combined":
         all_movie_tmdb_ids = []
@@ -1026,22 +1033,6 @@ def export_to_simkl(config: Dict, all_users_data: List[Dict], tmdb_api_key: str)
             return
     else:
         users_to_export = all_users_data
-
-    # Collect TMDB IDs from categorized data
-    def collect_tmdb_ids(categorized):
-        """Extract TMDB IDs from categorized items."""
-        tmdb_ids = []
-        for category_items in categorized.values():
-            if isinstance(category_items, dict):
-                for items in category_items.values():
-                    for item in items:
-                        if item.get("tmdb_id"):
-                            tmdb_ids.append(item["tmdb_id"])
-            elif isinstance(category_items, list):
-                for item in category_items:
-                    if item.get("tmdb_id"):
-                        tmdb_ids.append(item["tmdb_id"])
-        return list(dict.fromkeys(tmdb_ids))
 
     # Collect all recommendations
     all_movie_tmdb_ids = []

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -14,16 +14,7 @@ from utils import (
     COLLECTION_BONUS_BASE,
     COLLECTION_BONUS_CAP,
     COLLECTION_BONUS_LOG_FACTOR,
-    DEFAULT_NEGATIVE_THRESHOLD,
     GREEN,
-    RATING_MULTIPLIER_2_STAR,
-    RATING_MULTIPLIER_3_STAR,
-    RATING_MULTIPLIER_4_STAR,
-    RATING_MULTIPLIER_5_STAR,
-    RATING_MULTIPLIER_UNRATED,
-    RATING_TIER_3_STAR,
-    RATING_TIER_4_STAR,
-    RATING_TIER_5_STAR,
     RED,
     RESET,
     TOP_CAST_COUNT,
@@ -40,14 +31,12 @@ from utils import (
     fetch_tautulli_movie_history,
     find_plex_movie,
     format_media_output,
-    get_negative_multiplier,
     get_plex_account_ids,
     get_project_root,
     get_watched_movie_count,
     log_error,
     log_warning,
     merge_movie_history,
-    print_similarity_breakdown,
     process_counters_from_cache,
     run_recommender_main,
     setup_log_file,
@@ -225,44 +214,7 @@ class PlexMovieRecommender(BaseRecommender):
         users_to_check = [self.single_user] if self.single_user else self.users["plex_users"]
         return get_watched_movie_count(self.config, users_to_check)
 
-    def _calculate_rating_multiplier(self, user_rating):
-        """Calculate rating multiplier based on user's star rating (0-10 scale in Plex)
-
-        With negative signals enabled, low ratings (0-3) return negative multipliers
-        to penalize similar content instead of weakly preferring it.
-
-        Rating scale (negative signals enabled):
-        - 9-10 (5 stars): 1.0x weight - love it, strong preference
-        - 7-8 (4 stars): 0.75x weight - like it, moderate preference
-        - 5-6 (3 stars): 0.5x weight - neutral, weak preference
-        - 4 (2 stars): 0.25x weight - dislike, very weak preference
-        - 0-3 (1-1.5 stars): NEGATIVE weight - hate it, penalize similar content
-        - None/0 (unrated): 0.6x weight - default, slightly lower than neutral
-        """
-        if not user_rating or user_rating == 0:
-            return RATING_MULTIPLIER_UNRATED
-
-        rating_int = int(round(user_rating))
-
-        # Check if negative signals are enabled
-        ns_config = self.config.get("negative_signals", {})
-        bad_ratings_config = ns_config.get("bad_ratings", {})
-        ns_enabled = ns_config.get("enabled", True) and bad_ratings_config.get("enabled", True)
-        threshold = bad_ratings_config.get("threshold", DEFAULT_NEGATIVE_THRESHOLD)
-
-        # Return negative multiplier for low ratings if enabled
-        if ns_enabled and rating_int <= threshold:
-            return get_negative_multiplier(rating_int)
-
-        # Positive multipliers for higher ratings
-        if user_rating >= RATING_TIER_5_STAR:
-            return RATING_MULTIPLIER_5_STAR
-        elif user_rating >= RATING_TIER_4_STAR:
-            return RATING_MULTIPLIER_4_STAR
-        elif user_rating >= RATING_TIER_3_STAR:
-            return RATING_MULTIPLIER_3_STAR
-        else:
-            return RATING_MULTIPLIER_2_STAR
+    # _calculate_rating_multiplier() inherited from BaseRecommender
 
     def _get_plex_watched_data(self) -> Dict:
         """Get watched movie data from Plex's native history (using Plex API)"""
@@ -390,8 +342,7 @@ class PlexMovieRecommender(BaseRecommender):
         """Save watched movie cache using base class utility."""
         self._do_save_watched_cache()
 
-    def _save_cache(self):
-        self._save_watched_cache()
+    # _save_cache() inherited from BaseRecommender
 
     def _get_media_cache(self):
         """Return the movie cache instance."""
@@ -534,11 +485,8 @@ class PlexMovieRecommender(BaseRecommender):
 
         return score, breakdown
 
-    def _print_similarity_breakdown(self, movie_info: Dict, score: float, breakdown: Dict):
-        """Print detailed breakdown of similarity score calculation"""
-        print_similarity_breakdown(movie_info, score, breakdown, "movie")
-
-    # get_recommendations() and manage_plex_labels() are inherited from BaseRecommender
+    # _print_similarity_breakdown(), get_recommendations() and
+    # manage_plex_labels() are inherited from BaseRecommender
 
 
 # ------------------------------------------------------------------------

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -15,16 +15,7 @@ from utils import (
     COLLECTION_BONUS_BASE,
     COLLECTION_BONUS_CAP,
     COLLECTION_BONUS_LOG_FACTOR,
-    DEFAULT_NEGATIVE_THRESHOLD,
     GREEN,
-    RATING_MULTIPLIER_2_STAR,
-    RATING_MULTIPLIER_3_STAR,
-    RATING_MULTIPLIER_4_STAR,
-    RATING_MULTIPLIER_5_STAR,
-    RATING_MULTIPLIER_UNRATED,
-    RATING_TIER_3_STAR,
-    RATING_TIER_4_STAR,
-    RATING_TIER_5_STAR,
     RED,
     RESET,
     TOP_CAST_COUNT,
@@ -42,7 +33,6 @@ from utils import (
     fetch_show_completion_data,
     fetch_tautulli_show_watched_data,
     format_media_output,
-    get_negative_multiplier,
     get_plex_account_ids,
     get_project_root,
     get_watched_show_count,
@@ -50,7 +40,6 @@ from utils import (
     log_error,
     log_warning,
     merge_show_watched_data,
-    print_similarity_breakdown,
     process_counters_from_cache,
     run_recommender_main,
     setup_log_file,
@@ -226,44 +215,7 @@ class PlexTVRecommender(BaseRecommender):
         # Use shared utility function
         return get_watched_show_count(self.config, users_to_check)
 
-    def _calculate_rating_multiplier(self, user_rating):
-        """Calculate rating multiplier based on user's star rating (0-10 scale in Plex)
-
-        With negative signals enabled, low ratings (0-3) return negative multipliers
-        to penalize similar content instead of weakly preferring it.
-
-        Rating scale (negative signals enabled):
-        - 9-10 (5 stars): 1.0x weight - love it, strong preference
-        - 7-8 (4 stars): 0.75x weight - like it, moderate preference
-        - 5-6 (3 stars): 0.5x weight - neutral, weak preference
-        - 4 (2 stars): 0.25x weight - dislike, very weak preference
-        - 0-3 (1-1.5 stars): NEGATIVE weight - hate it, penalize similar content
-        - None/0 (unrated): 0.6x weight - default, slightly lower than neutral
-        """
-        if not user_rating or user_rating == 0:
-            return RATING_MULTIPLIER_UNRATED
-
-        rating_int = int(round(user_rating))
-
-        # Check if negative signals are enabled
-        ns_config = self.config.get("negative_signals", {})
-        bad_ratings_config = ns_config.get("bad_ratings", {})
-        ns_enabled = ns_config.get("enabled", True) and bad_ratings_config.get("enabled", True)
-        threshold = bad_ratings_config.get("threshold", DEFAULT_NEGATIVE_THRESHOLD)
-
-        # Return negative multiplier for low ratings if enabled
-        if ns_enabled and rating_int <= threshold:
-            return get_negative_multiplier(rating_int)
-
-        # Positive multipliers for higher ratings
-        if user_rating >= RATING_TIER_5_STAR:
-            return RATING_MULTIPLIER_5_STAR
-        elif user_rating >= RATING_TIER_4_STAR:
-            return RATING_MULTIPLIER_4_STAR
-        elif user_rating >= RATING_TIER_3_STAR:
-            return RATING_MULTIPLIER_3_STAR
-        else:
-            return RATING_MULTIPLIER_2_STAR
+    # _calculate_rating_multiplier() inherited from BaseRecommender
 
     def _get_plex_account_ids(self):
         """Get Plex account IDs for configured users with flexible name matching"""
@@ -433,8 +385,7 @@ class PlexTVRecommender(BaseRecommender):
         """Save watched show cache using base class utility."""
         self._do_save_watched_cache()
 
-    def _save_cache(self):
-        self._save_watched_cache()
+    # _save_cache() inherited from BaseRecommender
 
     def _get_media_cache(self):
         """Return the show cache instance."""
@@ -586,11 +537,8 @@ class PlexTVRecommender(BaseRecommender):
 
         return score, breakdown
 
-    def _print_similarity_breakdown(self, show_info: Dict, score: float, breakdown: Dict):
-        """Print detailed breakdown of similarity score calculation"""
-        print_similarity_breakdown(show_info, score, breakdown, "tv")
-
-    # get_recommendations() and manage_plex_labels() are inherited from BaseRecommender
+    # _print_similarity_breakdown(), get_recommendations() and
+    # manage_plex_labels() are inherited from BaseRecommender
 
 
 # ------------------------------------------------------------------------

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.19"
+__version__ = "2.10.20"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Route the 4 hand-rolled JSON cache implementations in recommenders/external.py and recommenders/external_render.py onto the shared utils/cache.py helpers (load_json_cache/save_json_cache) - same on-disk format/versioning/staleness semantics, verified via load-then-save round-trip against the real cache files. Huntarr/horizon caches gain hit/miss metrics as a side effect.
- Hoist collect_tmdb_ids (identical nested closure in export_to_mdblist and export_to_simkl) to one module-level function in recommenders/external_sync.py.
- Hoist _calculate_rating_multiplier, _save_cache, and _print_similarity_breakdown off movie.py/tv.py onto BaseRecommender - _print_similarity_breakdown is no longer abstract (all subclasses used self.media_type as the only differing literal).

Behavior-preserving refactor only - no scoring/ranking logic touched.

## Test plan
- [x] Full suite: 2351 passed, 1 skipped (matches pre-refactor baseline)
- [x] ruff format --check clean
- [x] ruff check: identical finding count/content vs main (line-number shifts only, no new findings)
- [x] Cache round-trip verified against real on-disk huntarr_cache.json/horizon_huntarr_cache.json/external_recs_*.json (keys, version, item content preserved; only the expected cached_at timestamp refresh differs, same as the original implementation always did)
- [x] py_compile on all changed modules