### PR TITLE
fix: audit remediation batch 2 - API client consolidation (2.10.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.21] - 2026-07-26
+
+### Changed
+
+- **Audit remediation: API client consolidation** (batch 2, PR C).
+  `TraktClient` and `SimklClient` now subclass `utils/api_client.py`'s
+  `BaseAPIClient` (`sonarr.py`/`tautulli.py`/`mdblist.py`/`radarr.py`
+  already did) instead of hand-rolling their own near-identical
+  `_rate_limit()` and 429-retry-with-backoff loop. `BaseAPIClient`
+  gained a new `_send_with_retries()` primitive (rate limiting + a
+  bounded, `Retry-After`-honoring 429 retry loop, opt-in via
+  `max_429_retries`/`max_retry_after_seconds` - default 0 retries, so
+  `_make_request_to_url` and every existing subclass built on it are
+  completely unchanged) that both clients now call, while keeping
+  their own status-code handling local (Trakt's security-sensitive
+  OAuth-refresh-on-401 retry, Simkl's 401/404 mapping) - migration
+  only, no behavior change. Verified against the real, live Trakt API
+  (not just mocks): identical response before/after for
+  `get_username()`/`get_trending()`.
+  `utils/tmdb.py`'s `fetch_tmdb_with_retry` was evaluated but left
+  as a documented third implementation: it's function-based (no
+  client instance to attach `BaseAPIClient` to without inventing a new
+  `TMDBClient` class and touching every call site across the
+  codebase) and its 429 backoff is linear (`2*(attempt+1)` seconds)
+  rather than `Retry-After`-header-driven like the shared path -
+  forcing it through would either change its effective backoff timing
+  or require a second retry style option, both a bigger structural
+  change and more regression risk than this migration's scope
+  justifies.
+
 ## [2.10.20] - 2026-07-26
 
 ### Changed

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -40,6 +40,22 @@ class BaseAPIClient:
     rate_limit_delay: float = 0.1
     request_timeout: int = 30
 
+    # Bounds a 429 (rate-limited) retry loop in _send_with_retries.
+    # 0 (default) preserves every existing subclass's behavior exactly
+    # (Radarr/Sonarr/Tautulli/MDBList never retried a 429, and don't
+    # call _send_with_retries at all - they use _make_request_to_url,
+    # unchanged here). Clients that DO need it (TraktClient/SimklClient
+    # - both talk to a real rate-limited cloud API, unlike the others'
+    # local network services) set this explicitly.
+    max_429_retries: int = 0
+
+    # Ceiling on how long a single 429 retry will ever sleep for,
+    # regardless of what the server's Retry-After header asks for -
+    # that header is server-controlled input, and a compromised/
+    # misbehaving endpoint could otherwise stall this process for an
+    # arbitrary/huge amount of time.
+    max_retry_after_seconds: int = 60
+
     def __init__(self):
         """Initialize base client state."""
         self._last_request_time = 0
@@ -50,6 +66,54 @@ class BaseAPIClient:
         if elapsed < self.rate_limit_delay:
             time.sleep(self.rate_limit_delay - elapsed)
         self._last_request_time = time.time()
+
+    def _send_with_retries(
+        self,
+        method: str,
+        url: str,
+        data: Optional[Dict] = None,
+        params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
+    ) -> requests.Response:
+        """Issue a rate-limited request with a bounded 429 (rate
+        limited) retry loop, honoring the server's Retry-After header
+        (capped at max_retry_after_seconds).
+
+        Returns the raw response whatever its status code - unlike
+        _make_request_to_url this never raises on a 4xx/5xx and never
+        runs the redirect-following/response-size-cap pipeline, so a
+        caller that needs to inspect the response before deciding how
+        to handle an error (e.g. TraktClient retrying with a refreshed
+        OAuth token on 401, which a raised exception here would
+        prevent) can do so itself. Callers that just want the shared
+        error-handling pipeline should use _make_request_to_url
+        instead - this only owns the rate-limit/429-retry loop.
+        """
+        response = None
+        for attempt in range(self.max_429_retries + 1):
+            self._rate_limit()
+            response = requests.request(
+                method=method,
+                url=url,
+                headers=headers,
+                json=data,
+                params=params,
+                timeout=self.request_timeout,
+                allow_redirects=False,
+            )
+
+            if response.status_code != 429 or attempt == self.max_429_retries:
+                break
+
+            retry_after = min(
+                int(response.headers.get("Retry-After", 1)),
+                self.max_retry_after_seconds,
+            )
+            logger.warning(
+                f"{self.api_name} rate limited, waiting {retry_after}s (retry {attempt + 1}/{self.max_429_retries})"
+            )
+            time.sleep(retry_after)
+        return response
 
     def _get_headers(self) -> Dict[str, str]:
         """Get headers for API requests. Override in subclass."""

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.20"
+__version__ = "2.10.21"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/simkl.py
+++ b/utils/simkl.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from .api_client import BaseAPIClient
 from .metrics import record_api_call
 
 logger = logging.getLogger("curatarr")
@@ -53,12 +54,19 @@ class SimklAPIError(Exception):
     pass
 
 
-class SimklClient:
+class SimklClient(BaseAPIClient):
     """
     Simkl API client with PIN authentication.
 
     PIN auth works in Docker/SSH environments without browser redirects.
     """
+
+    api_name = "Simkl"
+    exception_class = SimklAPIError
+    rate_limit_delay = SIMKL_RATE_LIMIT_DELAY
+    request_timeout = SIMKL_REQUEST_TIMEOUT
+    max_429_retries = SIMKL_MAX_429_RETRIES
+    max_retry_after_seconds = SIMKL_MAX_RETRY_AFTER_SECONDS
 
     def __init__(self, client_id: str, access_token: Optional[str] = None, token_callback: Optional[callable] = None):
         """
@@ -69,10 +77,10 @@ class SimklClient:
             access_token: Existing access token (optional)
             token_callback: Function to call when tokens are updated (for saving)
         """
+        super().__init__()
         self.client_id = client_id
         self.access_token = access_token
         self.token_callback = token_callback
-        self._last_request_time = 0
 
     @property
     def is_authenticated(self) -> bool:
@@ -86,12 +94,7 @@ class SimklClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         return headers
 
-    def _rate_limit(self) -> None:
-        """Enforce rate limiting between requests."""
-        elapsed = time.time() - self._last_request_time
-        if elapsed < SIMKL_RATE_LIMIT_DELAY:
-            time.sleep(SIMKL_RATE_LIMIT_DELAY - elapsed)
-        self._last_request_time = time.time()
+    # _rate_limit() inherited from BaseAPIClient (rate_limit_delay set above)
 
     def _make_request(
         self,
@@ -137,36 +140,12 @@ class SimklClient:
         request_start = time.time()
         outcome = "error"
         try:
-            response = None
-            # Bounded retry loop for 429s - see SIMKL_MAX_429_RETRIES's
-            # comment above for why this used to recurse unboundedly.
-            for attempt in range(SIMKL_MAX_429_RETRIES + 1):
-                self._rate_limit()
-                response = requests.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    json=data,
-                    params=params,
-                    timeout=SIMKL_REQUEST_TIMEOUT,
-                    # Never auto-follow redirects - requests only strips
-                    # the Authorization header on a cross-host hop, not
-                    # the custom simkl-api-key header this client also
-                    # sends (see _get_headers).
-                    allow_redirects=False,
-                )
-
-                if response.status_code != 429 or attempt == SIMKL_MAX_429_RETRIES:
-                    break
-
-                retry_after = min(
-                    int(response.headers.get("Retry-After", 1)),
-                    SIMKL_MAX_RETRY_AFTER_SECONDS,
-                )
-                logger.warning(
-                    f"Simkl rate limited, waiting {retry_after}s (retry {attempt + 1}/{SIMKL_MAX_429_RETRIES})"
-                )
-                time.sleep(retry_after)
+            # Rate-limited request with the shared bounded 429-retry
+            # loop (see BaseAPIClient._send_with_retries) - returns the
+            # raw response instead of raising, so the status handling
+            # below (401/404/error mapping specific to Simkl) stays
+            # unchanged.
+            response = self._send_with_retries(method, url, data=data, params=params, headers=headers)
 
             # Handle auth errors
             if response.status_code == 401:

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from .api_client import BaseAPIClient
 from .metrics import record_api_call
 
 logger = logging.getLogger("curatarr")
@@ -54,12 +55,19 @@ class TraktAPIError(Exception):
     pass
 
 
-class TraktClient:
+class TraktClient(BaseAPIClient):
     """
     Trakt API client with OAuth device authentication.
 
     Device auth flow works in Docker/SSH environments without browser redirects.
     """
+
+    api_name = "Trakt"
+    exception_class = TraktAPIError
+    rate_limit_delay = TRAKT_RATE_LIMIT_DELAY
+    request_timeout = TRAKT_REQUEST_TIMEOUT
+    max_429_retries = TRAKT_MAX_429_RETRIES
+    max_retry_after_seconds = TRAKT_MAX_RETRY_AFTER_SECONDS
 
     def __init__(
         self,
@@ -79,12 +87,12 @@ class TraktClient:
             refresh_token: Existing refresh token (optional)
             token_callback: Function to call when tokens are updated (for saving)
         """
+        super().__init__()
         self.client_id = client_id
         self.client_secret = client_secret
         self.access_token = access_token
         self.refresh_token = refresh_token
         self.token_callback = token_callback
-        self._last_request_time = 0
 
     @property
     def is_authenticated(self) -> bool:
@@ -98,12 +106,7 @@ class TraktClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         return headers
 
-    def _rate_limit(self) -> None:
-        """Enforce rate limiting between requests."""
-        elapsed = time.time() - self._last_request_time
-        if elapsed < TRAKT_RATE_LIMIT_DELAY:
-            time.sleep(TRAKT_RATE_LIMIT_DELAY - elapsed)
-        self._last_request_time = time.time()
+    # _rate_limit() inherited from BaseAPIClient (rate_limit_delay set above)
 
     def _make_request(
         self,
@@ -144,35 +147,13 @@ class TraktClient:
         request_start = time.time()
         outcome = "error"
         try:
-            response = None
-            # Bounded retry loop for 429s - see TRAKT_MAX_429_RETRIES's
-            # comment above for why this used to recurse unboundedly.
-            for attempt in range(TRAKT_MAX_429_RETRIES + 1):
-                self._rate_limit()
-                response = requests.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    json=data,
-                    timeout=TRAKT_REQUEST_TIMEOUT,
-                    # Never auto-follow redirects - requests only strips
-                    # the Authorization header on a cross-host hop, not
-                    # the custom trakt-api-key header this client also
-                    # sends (see _get_headers).
-                    allow_redirects=False,
-                )
-
-                if response.status_code != 429 or attempt == TRAKT_MAX_429_RETRIES:
-                    break
-
-                retry_after = min(
-                    int(response.headers.get("Retry-After", 1)),
-                    TRAKT_MAX_RETRY_AFTER_SECONDS,
-                )
-                logger.warning(
-                    f"Trakt rate limited, waiting {retry_after}s (retry {attempt + 1}/{TRAKT_MAX_429_RETRIES})"
-                )
-                time.sleep(retry_after)
+            # Rate-limited request with the shared bounded 429-retry
+            # loop (see BaseAPIClient._send_with_retries) - this
+            # returns the raw response instead of raising on an error
+            # status, so the 401-refresh-and-retry handling below (this
+            # client's own, security-sensitive OAuth logic) still gets
+            # to inspect it first.
+            response = self._send_with_retries(method, url, data=data, headers=headers)
 
             # Handle auth errors
             if response.status_code == 401 and retry_auth and self.refresh_token:


### PR DESCRIPTION
## Summary
- Migrate TraktClient and SimklClient onto utils/api_client.py's BaseAPIClient (sonarr/tautulli/mdblist/radarr already did) - eliminates duplicated _rate_limit()/429-retry-with-backoff code between the two clients.
- BaseAPIClient gains a new _send_with_retries() primitive (rate limiting + a bounded, Retry-After-honoring 429 retry loop). Opt-in via max_429_retries/max_retry_after_seconds (default 0 retries) so _make_request_to_url and every existing subclass built on it are completely unchanged.
- Trakt/Simkl keep their own status-code handling layered on top of _send_with_retries (Trakt's security-sensitive OAuth-refresh-on-401 retry; Simkl's 401/404 mapping) - preserves exact exception types/messages/control flow.
- utils/tmdb.py's fetch_tmdb_with_retry evaluated and left as a documented third implementation: function-based (no client instance) and linear backoff (2*(attempt+1)s) rather than Retry-After-driven - forcing it onto the shared path would change effective behavior or require inventing a new client class across many call sites, more risk than this migration's scope justifies.

Behavior-preserving migration only - no timeouts, retry counts, backoff timing, or auth headers changed.

## Test plan
- [x] Full suite: 2351 passed, 1 skipped (matches pre-refactor baseline)
- [x] ruff format --check clean
- [x] ruff check: identical finding count/content vs main (line-number shifts only)
- [x] Live smoke test against the real Trakt API (this install has trakt.yml configured/enabled): get_username()/get_trending() identical before/after migration
- [x] py_compile on all changed modules