### PR TITLE
feat: self-update E2E missing_asset scenario (2.10.22)

### DIFF
--- a/.github/workflows/selfupdate-e2e.yml
+++ b/.github/workflows/selfupdate-e2e.yml
@@ -170,6 +170,22 @@ jobs:
             --work-dir "$RUNNER_TEMP/selfupdate-e2e/runs/rollback" \
             --debug-log "$RUNNER_TEMP/selfupdate-e2e/debug-logs/rollback_handoff.log"
 
+      - name: Missing asset - requested filename 404s on an otherwise-real release (must refuse, old server keeps serving)
+        if: always()
+        shell: bash
+        env:
+          MANIFEST: ${{ runner.temp }}/selfupdate-e2e/fixtures/manifest.json
+        run: |
+          set -euo pipefail
+          eval "$(python scripts/selfupdate_e2e/print_manifest_env.py missing_asset)"
+          python scripts/selfupdate_e2e/run_scenario.py \
+            --scenario missing_asset \
+            --old-binary "$OLD_BINARY" --release-dir "$RELEASE_DIR" \
+            --old-version "$OLD_VERSION" --target-version "$NEW_VERSION" \
+            --ui-port 18791 --server-port 18804 \
+            --work-dir "$RUNNER_TEMP/selfupdate-e2e/runs/missing_asset" \
+            --debug-log "$RUNNER_TEMP/selfupdate-e2e/debug-logs/missing_asset_handoff.log"
+
       - name: Upload debug logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.22] - 2026-07-26
+
+### Added
+
+- **Self-update E2E: `missing_asset` scenario.** The real end-to-end
+  self-update harness (`scripts/selfupdate_e2e/`) had no coverage for
+  "the requested release asset doesn't exist" (a 404 on the platform
+  asset download) - the exact situation discussion #207 describes for
+  pre-2.10.0 macOS binaries once the transitional
+  `curatarr-macos-universal` duplicate is dropped from newer releases.
+  Added a `missing_asset` scenario: a fixture release directory whose
+  `SHA256SUMS.txt`/`.sig` are present and correctly signed (the
+  release itself is real) but never lists or ships the requested
+  platform asset filename, so the fake release server's existing
+  "file not on disk -> 404" path fires exactly as a real GitHub
+  release missing that one asset would. Asserts the update is refused
+  before signature/hash verification ever runs, the running binary's
+  SHA256 is byte-for-byte unchanged, no temp download artifact is left
+  behind, and `update_apply.log` shows the same `verify failed` refusal
+  line already asserted for `bad_sig`/`bad_hash`. Wired into
+  `.github/workflows/selfupdate-e2e.yml` alongside the four existing
+  scenarios. Also added a unit-level integration test in
+  `tests/test_self_update.py` (`TestDownloadAndVerifyUpdate`) covering
+  a 404 through the full `download_and_verify_update()` path - the
+  existing 404 coverage
+  (`TestDownloadToFile::test_http_error_status_raises_download_error`)
+  only exercised the low-level `_download_to_file` helper in isolation.
+
+  Verified this scenario has teeth: temporarily patching
+  `download_and_verify_update` to swap the binary in before
+  verification (bypassing the fail-closed download-error path)
+  reliably fails the scenario's own hash-unchanged assertion - not
+  just the E2E job, but a targeted local check of the same assertion
+  path.
+
 ## [2.10.21] - 2026-07-26
 
 ### Changed

--- a/scripts/selfupdate_e2e/build_fixtures.py
+++ b/scripts/selfupdate_e2e/build_fixtures.py
@@ -2,11 +2,14 @@
 (.github/workflows/selfupdate-e2e.yml) needs: two real PyInstaller
 binaries (the current version, "old", and a synthetic higher version,
 "new"), a non-functional "broken" placeholder asset for the
-new-binary-fails-to-boot rollback scenario, and four signed release
-fixture directories (good / bad_hash / bad_sig / rollback) - each a
-SHA256SUMS.txt + SHA256SUMS.txt.sig pair plus the asset they describe,
-exactly what utils.self_update.download_and_verify_update() expects to
-find on a real GitHub release.
+new-binary-fails-to-boot rollback scenario, and five signed release
+fixture directories (good / bad_hash / bad_sig / rollback /
+missing_asset) - each a SHA256SUMS.txt + SHA256SUMS.txt.sig pair plus
+(for every scenario except missing_asset - see
+build_missing_asset_release_dir's own docstring for why that one is
+different) the asset they describe, exactly what
+utils.self_update.download_and_verify_update() expects to find on a
+real GitHub release.
 
 CI-only, never used by the real release pipeline (scripts/release.sh,
 .github/workflows/release.yml) and never touches the real signing key:
@@ -266,6 +269,42 @@ def build_release_dir(release_dir, asset_name, asset_bytes_source_path, signing_
     return {"dir": release_dir, "asset": asset_dest, "real_hash": real_hash, "recorded_hash": recorded_hash}
 
 
+def build_missing_asset_release_dir(release_dir, requested_asset_name, signing_key_path):
+    """Models discussion #207's exact real-world situation: a release
+    that genuinely exists and publishes a validly-signed SHA256SUMS.txt
+    - it just never shipped the specific asset filename an OLDER
+    binary's self-updater still requests (e.g. the retired
+    'curatarr-macos-universal' name dropped once macOS binaries went
+    arm64-only - see utils/self_update.py's ASSET_MACOS_ARM64 comment).
+
+    Deliberately does NOT write `requested_asset_name` into this
+    directory at all, so fake_release_server.py's existing "file not
+    on disk -> 404" branch fires for it exactly as it would against a
+    real GitHub release missing that one asset - no changes needed to
+    that server. SHA256SUMS.txt/.sig are both present and correctly
+    signed (the release/tag itself is real) but list a DIFFERENT,
+    unrelated filename instead of requested_asset_name, mirroring a
+    real SHA256SUMS.txt regenerated for a release that simply never
+    published that name.
+
+    This deliberately never even reaches verify_downloaded_asset()'s
+    own "asset not listed in the verified sums file" check
+    (HashMismatchError) - the real failure this models happens one
+    step EARLIER, at the asset download itself (DownloadError), which
+    is what utils.self_update._download_and_verify_update_impl
+    actually hits first: it downloads SHA256SUMS.txt/.sig, THEN the
+    platform asset - see that function's docstring."""
+    os.makedirs(release_dir, exist_ok=True)
+    unrelated_name = "curatarr-some-other-platform-asset"
+    unrelated_bytes = b"stands in for a different release asset entirely - never downloaded by this scenario"
+    unrelated_hash = hashlib.sha256(unrelated_bytes).hexdigest()
+    sums_path = os.path.join(release_dir, "SHA256SUMS.txt")
+    with open(sums_path, "w", newline="\n") as f:
+        f.write(f"{unrelated_hash}  {unrelated_name}\n")
+    sign_sums_file(sums_path, signing_key_path)
+    return {"dir": release_dir}
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--repo-root", required=True)
@@ -358,6 +397,11 @@ def main():
         os.path.join(releases_dir, "rollback"),
         asset_name,
         broken_binary_path,
+        test_key["key_path"],
+    )
+    manifest["releases"]["missing_asset"] = build_missing_asset_release_dir(
+        os.path.join(releases_dir, "missing_asset"),
+        asset_name,
         test_key["key_path"],
     )
 

--- a/scripts/selfupdate_e2e/print_manifest_env.py
+++ b/scripts/selfupdate_e2e/print_manifest_env.py
@@ -12,7 +12,7 @@ escape handling at all, and shlex.quote() below makes the values this
 script prints safe to eval regardless of what characters a path
 contains.
 
-Usage: python print_manifest_env.py <bad_sig|bad_hash|rollback>
+Usage: python print_manifest_env.py <bad_sig|bad_hash|rollback|missing_asset>
 """
 
 import json

--- a/scripts/selfupdate_e2e/run_scenario.py
+++ b/scripts/selfupdate_e2e/run_scenario.py
@@ -18,6 +18,14 @@ Scenarios:
               "broken" binary) - expect the hand-off script's own
               fail-safe to detect that, restore the old binary, and
               relaunch it successfully.
+  missing_asset - the release itself is real (SHA256SUMS.txt/.sig
+              download fine) but the specific platform asset filename
+              this binary requests was never published to it (models
+              discussion #207: an old binary still requesting a
+              filename - e.g. the retired 'curatarr-macos-universal' -
+              that a later release dropped) - expect a 404 on the
+              asset download itself, refused before signature/hash
+              verification ever runs, old binary/version unchanged.
 
 Prints clear PASS/FAIL evidence; exits 1 on any unexpected outcome or
 timeout (a stuck/hung process must fail the CI job, never hang it
@@ -152,7 +160,7 @@ def kill_by_install_dir(install_dir):
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("--scenario", required=True, choices=["swap", "bad_sig", "bad_hash", "rollback"])
+    p.add_argument("--scenario", required=True, choices=["swap", "bad_sig", "bad_hash", "rollback", "missing_asset"])
     p.add_argument("--old-binary", required=True)
     p.add_argument("--release-dir", required=True)
     p.add_argument("--old-version", required=True)
@@ -274,14 +282,25 @@ def main():
                 flush=True,
             )
 
-        elif args.scenario in ("bad_sig", "bad_hash"):
+        elif args.scenario in ("bad_sig", "bad_hash", "missing_asset"):
             time.sleep(20)
             data = http_get_json(f"http://127.0.0.1:{args.ui_port}/healthz", timeout=3)
             assert data.get("version") == args.old_version, f"expected version to stay {args.old_version}, got {data}"
             final_hash = sha256_file(exe_path)
             assert final_hash == original_hash, "binary hash CHANGED - a bad update was applied!"
             log = read_update_log()
+            # web/update_apply.py's _run_frozen_verify_and_handoff wraps
+            # download_and_verify_update() in a single blanket `except
+            # Exception` and always logs this exact line regardless of
+            # WHICH *Error subclass it caught (SignatureVerificationError
+            # for bad_sig, HashMismatchError for bad_hash, DownloadError
+            # for missing_asset's 404) - same assertion covers all three.
             assert "verify failed" in log, f"update_apply.log does not show a verify failure: {log!r}"
+            # No stray temp download artifact left behind in the install
+            # directory (utils.self_update._download_and_verify_update_impl
+            # cleans up its own partial download on any failure).
+            leftover_temp_files = [n for n in os.listdir(install_dir) if ".curatarr-update-" in n]
+            assert leftover_temp_files == [], f"leftover temp download artifact(s): {leftover_temp_files}"
             print(
                 f"[{args.scenario}] PASS: update refused, binary hash unchanged "
                 f"({final_hash[:12]}), still serving v{args.old_version}",

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1412,6 +1412,57 @@ class TestDownloadAndVerifyUpdate:
         leftovers = [p for p in os.listdir(str(tmp_path)) if p.endswith(".tmp")]
         assert leftovers == []
 
+    def test_asset_404_raises_download_error_and_leaves_everything_untouched(self, tmp_path, monkeypatch):
+        """Models discussion #207's real-world case directly: a release
+        that genuinely exists (SHA256SUMS.txt/.sig download fine) but
+        the specific platform asset an older binary still requests was
+        dropped from it (e.g. the retired 'curatarr-macos-universal'
+        name - see utils/self_update.py's ASSET_MACOS_ARM64 comment) -
+        so its own download 404s. Deliberately does NOT monkeypatch
+        `_download_to_file` away (unlike every other test in this
+        class) - it patches `requests.get` instead, so this exercises
+        the REAL `_download_to_file` implementation and proves the
+        failure propagates all the way through
+        download_and_verify_update() exactly the way a genuine HTTPS
+        404 would, not just via a stand-in raising DownloadError
+        directly. See TestDownloadToFile::test_http_error_status_raises_download_error
+        for the lower-level version of this same check in isolation."""
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        current_exe = tmp_path / "curatarr"
+        current_exe.write_bytes(b"old binary")
+
+        monkeypatch.setattr(self_update, "current_binary_path", lambda: str(current_exe))
+        monkeypatch.setattr(self_update, "determine_update_target", lambda force_refresh=True: "2.9.0")
+        monkeypatch.setattr(self_update, "select_asset_name", lambda: "curatarr-macos-universal")
+
+        def _fake_get(url, timeout=None, stream=None):
+            mock_response = Mock()
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
+            if url.endswith("curatarr-macos-universal"):
+                # The dropped asset itself: a real GitHub 404.
+                mock_response.raise_for_status = Mock(
+                    side_effect=requests.HTTPError(f"404 Client Error: Not Found for url: {url}")
+                )
+            else:
+                # SHA256SUMS.txt / .sig: the release itself is real and
+                # serves those just fine - only the requested asset is
+                # gone.
+                mock_response.raise_for_status = Mock()
+                mock_response.iter_content = Mock(return_value=[b"irrelevant - never reached"])
+            return mock_response
+
+        monkeypatch.setattr(self_update.requests, "get", Mock(side_effect=_fake_get))
+
+        with pytest.raises(self_update.DownloadError, match="404"):
+            self_update.download_and_verify_update()
+
+        # Fail-closed: original binary on disk is completely untouched.
+        assert current_exe.read_bytes() == b"old binary"
+        # No stray temp asset file left behind in the install directory.
+        leftovers = [p for p in os.listdir(str(tmp_path)) if p.endswith(".tmp")]
+        assert leftovers == []
+
     def test_no_update_available_never_downloads_anything(self, tmp_path, monkeypatch):
         monkeypatch.setattr(sys, "frozen", True, raising=False)
         current_exe = tmp_path / "curatarr"

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.21"
+__version__ = "2.10.22"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Adds a `missing_asset` scenario to the self-update real E2E harness (`scripts/selfupdate_e2e/`) covering a 404 on the requested platform release asset - previously untested. Models discussion #207's real situation: the release itself exists and serves a validly-signed SHA256SUMS.txt/.sig, but the specific asset filename an older binary still requests (e.g. the retired `curatarr-macos-universal` duplicate) isn't there.
- Fixture: the fake release server's existing "file not on disk -> 404" path fires unmodified; SHA256SUMS.txt/.sig are present and correctly signed but list an unrelated filename, so the failure happens at asset DOWNLOAD time (DownloadError) rather than at hash/signature verification - matching what `utils/self_update.py` actually hits first.
- Adds a unit-level integration test in `tests/test_self_update.py` (`TestDownloadAndVerifyUpdate`) exercising a real 404 (via a URL-aware `requests.get` mock, not a monkeypatched `_download_to_file`) through the full `download_and_verify_update()` path - previous 404 coverage only exercised the low-level `_download_to_file` helper in isolation.
- Wired into `.github/workflows/selfupdate-e2e.yml` alongside the existing four scenarios.
- Version bump 2.10.21 -> 2.10.22 + CHANGELOG entry.

## Test plan
- [x] New scenario built and run locally on macOS: fixtures built via `build_fixtures.py`, `run_scenario.py --scenario missing_asset` PASSes (exit 0), binary hash unchanged, `update_apply.log` shows `verify failed`.
- [x] Proved the scenario has teeth: temporarily patched `web/update_apply.py` to swap in unverified bytes via `swap_binary()` on any `download_and_verify_update()` failure, rebuilt fixtures, reran the scenario - it correctly failed (`AssertionError: binary hash CHANGED`, exit 1). Reverted before committing (clean diff).
- [x] Full suite: 2352 passed, 1 skipped (baseline was 2351 passed, 1 skipped).
- [x] `ruff format --check` clean; no new `ruff check` findings in touched files (126 pre-existing repo-wide lint errors unchanged, confirmed against main).
- [ ] CI: Self-Update E2E workflow (path-filtered on `scripts/selfupdate_e2e/**`) + required checks (test/secret-scan/lint).