### PR TITLE
fix: audit remediation batch D - Plex fetch dedup, cache prune, cross-container lock (2.10.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.24] - 2026-07-26
+
+### Changed
+
+- **Audit remediation batch D (PR1): fewer redundant Plex fetches per run.**
+  `recommenders/movie.py`/`tv.py`'s init path called Plex's
+  `section.all()` up to 6 times per user per run - once each from
+  `MovieCache`/`ShowCache.update_cache`, `_get_library_movies_set`
+  (itself called twice back-to-back for a byte-identical result),
+  `_get_library_movie_titles`/`_get_library_shows_set`,
+  `_get_library_imdb_ids`, and again inside `_get_plex_watched_data`/
+  `_get_plex_watched_shows_data` for view counts - and `utils/cli.py`'s
+  library-outer/user-inner loop constructed a fresh recommender per
+  user with nothing shared across them either. `BaseRecommender` now
+  fetches the full library once via a new `_get_all_library_items()`
+  and every one of those consumers reuses it; `utils/cli.py` shares one
+  fetch across every user processed against the same library in a run
+  too. Measured before/after (instrumented mock call count, see
+  `tests/test_movie.py::TestLibraryFetchedOnceNotSixTimes`): 6 calls to
+  `section.all()` down to 1 for a single user's instantiation.
+  Behavior is unchanged - only fewer Plex round trips.
+
+### Added
+
+- **Audit remediation batch D (PR1): prune orphaned per-user cache
+  files.** `cache/` had no equivalent of `logs/`'s `cleanup_old_logs` -
+  nothing ever removed a per-user cache file for a user no longer
+  configured (a real example found in a live install: a joined
+  multi-user `watched_cache_plex_<many-usernames>.json` left over from
+  before every run became strictly single-user, plus
+  `external_recs_<removed-user>_*.json`). New `utils/cache_prune.py`
+  diffs the four known per-user cache filename patterns (shared with
+  `utils/user_migration.py`'s rename-migration, now exported as
+  `CACHE_FILENAME_PATTERNS`) against the run's actual resolved
+  usernames. Conservative by design: a file that doesn't match one of
+  those exact patterns is never touched, and the new
+  `general.cache_prune` config (`enabled: true` by default) only logs
+  candidates - nothing is deleted until `dry_run: false` is also set
+  explicitly.
+- **Audit remediation batch D (PR1): cross-container run lock.**
+  `docker-compose.yml`'s `curatarr` (web UI) and `curatarr-recommend`
+  services share the same bind-mounted `./cache` volume, but only the
+  web UI's `job_runner.py` ever took a run lock (in-process +
+  PID-lockfile, meaningless across two containers' separate PID
+  namespaces) - `docker-entrypoint.sh`'s `recommend` mode had no
+  locking at all. Both now take the identical `flock` on a
+  `cache/.recommender_run.lock` file shared by both containers -
+  `job_runner.py` via a new `utils/run_lock.py` (POSIX only; a
+  documented no-op on Windows, where this race can't happen),
+  `docker-entrypoint.sh` via the `flock` command directly. Verified
+  against real Docker containers (not just mocks): a `recommend`
+  invocation correctly refuses to start while the lock is held by a
+  separate container, and the web UI's job runner correctly refuses to
+  launch a subprocess while `docker-entrypoint.sh` holds it. Residual
+  risk: a direct `python3 recommenders/movie.py` invocation bypassing
+  both of those paths still isn't covered - threading the lock through
+  every recommender entry point was judged too invasive for this pass
+  (see `utils/run_lock.py`'s docstring). Cache writes were already
+  atomic (temp file + `os.replace()`, added in 2.10.9) - verified still
+  true across every cache write path (`utils/cache.py`'s
+  `_atomic_write_json`).
+
 ## [2.10.23] - 2026-07-26
 
 ### Fixed

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -45,6 +45,17 @@ general:
   #   (source installs only - see run.sh/run.ps1).
   # off: never check for updates.
   update_mode: notify
+  # Prunes cache/ files left behind by users no longer in your
+  # users.list (removed-user watched caches, external_recs_<user>_*
+  # exports, etc.) - see utils/cache_prune.py. enabled: true just logs
+  # what it *would* remove every run; nothing is deleted until you also
+  # set dry_run: false. Conservative on purpose: only ever considers
+  # the exact per-user cache filename patterns curatarr itself
+  # generates (never all_movies_cache.json/all_shows_cache.json or
+  # anything it doesn't recognize).
+  # cache_prune:
+  #   enabled: true
+  #   dry_run: true
 
 # Huntarr: Find missing/upcoming movies from collections
 huntarr:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,6 +41,19 @@ NC='\033[0m'
 CONFIG_DIR="${CURATARR_CONFIG_DIR:-/data}"
 CONFIG_YML="${CONFIG_DIR}/config/config.yml"
 
+# Cross-container run lock (#233 audit remediation batch D / PR1(c)):
+# docker-compose.yml can run this `recommend` mode (in the
+# curatarr-recommend service, normally on a host cron/Task Scheduler
+# timer - see docs/DOCKER.md "Scheduling") at the same time the
+# curatarr (web UI) service's own job_runner.py triggers a run - both
+# mutate the same bind-mounted ./cache volume, which is a real
+# interleaved-write hazard, not just a "friendly error" problem.
+# job_runner.py (see utils/run_lock.py) takes the identical flock on
+# this identical path before spawning its own subprocess - same
+# kernel-level lock on the same inode either way, so whichever side
+# gets there first wins and the other fails fast instead of racing.
+RUN_LOCK_FILE="${CONFIG_DIR}/cache/.recommender_run.lock"
+
 _require_config() {
     if [ ! -f "$CONFIG_YML" ]; then
         echo -e "${RED}ERROR: ${CONFIG_YML} not found${NC}"
@@ -79,6 +92,25 @@ case "$MODE" in
         shift
         ENGINE="${1:-full}"
         [ $# -gt 0 ] && shift
+
+        # Acquire the cross-container run lock (see the RUN_LOCK_FILE
+        # comment above) on fd 9 before running anything. Held open for
+        # the rest of this script/process - including across `exec`,
+        # which replaces this process image but does not close
+        # already-open file descriptors - so it stays held for the
+        # *entire* recommender subprocess's lifetime, not just until
+        # this shell would otherwise have exited, and is released
+        # automatically (by the kernel) whenever this process exits,
+        # however it exits.
+        mkdir -p "$(dirname "$RUN_LOCK_FILE")"
+        exec 9>"$RUN_LOCK_FILE"
+        if ! flock -n 9; then
+            echo -e "${RED}ERROR: another recommender run is already in progress${NC} (lock: ${RUN_LOCK_FILE})" >&2
+            echo "This can happen if the web UI triggered a run at the same time as this" >&2
+            echo "scheduled 'recommend' invocation. Wait for the other run to finish and retry." >&2
+            exit 1
+        fi
+
         case "$ENGINE" in
             full)
                 echo -e "${YELLOW}=== Movie recommendations ===${NC}"

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -57,7 +57,7 @@ from utils import (
     get_excluded_genres_for_user,
     get_full_language_name,
     get_libraries_for_media_type,
-    get_library_imdb_ids,
+    get_library_imdb_ids_from_items,
     get_max_rating_for_user,
     get_negative_multiplier,
     get_project_root,
@@ -123,7 +123,9 @@ class BaseCache(ABC):
         self.cache["cache_version"] = CACHE_VERSION
         save_media_cache(self.cache_path, self.cache, self.media_key)
 
-    def update_cache(self, plex, library_title: str, tmdb_api_key: Optional[str] = None) -> bool:
+    def update_cache(
+        self, plex, library_title: str, tmdb_api_key: Optional[str] = None, all_items: Optional[List] = None
+    ) -> bool:
         """
         Update cache with current library contents and TMDB metadata.
 
@@ -131,12 +133,21 @@ class BaseCache(ABC):
             plex: PlexServer instance
             library_title: Name of the library section
             tmdb_api_key: Optional TMDB API key for fetching additional metadata
+            all_items: Optional pre-fetched section.all() result. When
+                provided, this skips the library fetch entirely instead of
+                re-querying Plex - callers that already hold a full-library
+                snapshot (see BaseRecommender._get_all_library_items(), #233
+                audit remediation batch D / PR1(a)) should pass it here so a
+                single run only fetches the library once, not once per
+                consumer. Falls back to fetching it here (unchanged
+                behavior) when omitted.
 
         Returns:
             bool: True if cache was updated, False if already up to date
         """
-        section = plex.library.section(library_title)
-        all_items = section.all()
+        if all_items is None:
+            section = plex.library.section(library_title)
+            all_items = section.all()
         current_count = len(all_items)
 
         if current_count == self.cache["library_count"]:
@@ -385,7 +396,13 @@ class BaseRecommender(ABC):
     library_config_key: str = None  # e.g., 'movie_library_title'
     default_library_name: str = None  # e.g., 'Movies'
 
-    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
+    def __init__(
+        self,
+        config_path: str,
+        single_user: str = None,
+        library: Optional[Dict] = None,
+        library_items_cache: Optional[Dict[str, List]] = None,
+    ):
         """
         Initialize the recommender.
 
@@ -397,10 +414,21 @@ class BaseRecommender(ABC):
                 provided, the recommender operates against this library's
                 Plex section. When None, falls back to the legacy
                 library_config_key/default_library_name resolution.
+            library_items_cache: Optional dict shared across every
+                recommender instance processed against the same library in
+                a single run (utils.cli.run_recommender_main creates one per
+                run and threads it through movie.py/tv.py's
+                process_recommendations -> here). Keyed by library_title;
+                see _get_all_library_items(). When None (direct/test
+                instantiation), a fresh per-instance dict is used instead -
+                this still dedupes the up-to-6x-per-user Plex fetches within
+                one instantiation (#233 audit remediation batch D / PR1(a)),
+                it just doesn't share across users/instances.
         """
         self.single_user = single_user
         self.config = load_config(config_path)
         self.library = library
+        self._library_items_cache: Dict[str, List] = library_items_cache if library_items_cache is not None else {}
 
         if self.library:
             self.library_id = self.library["id"]
@@ -1223,9 +1251,31 @@ class BaseRecommender(ABC):
             self._save_watched_cache()
         return set(keywords)
 
+    def _get_all_library_items(self) -> List:
+        """Fetch this run's full library item list from Plex exactly once,
+        then reuse it for every consumer that needs a full library scan -
+        cache update, ID/title-set derivation, and view-count lookups all
+        used to call section.all() independently, up to 6 Plex round trips
+        per user per run (#233 audit remediation batch D / PR1(a)).
+
+        Cached per library_title in self._library_items_cache. When that
+        dict is the one utils.cli.run_recommender_main shares across every
+        user processed against this library in a single run, this also
+        collapses the fetch to once per library per run, not once per user
+        - see __init__'s library_items_cache docstring. Only a *successful*
+        fetch is cached; a Plex error here propagates to the caller (which
+        already has its own try/except and log message) without poisoning
+        the cache, so the next consumer simply retries instead of being
+        stuck with a cached failure.
+        """
+        if self.library_title not in self._library_items_cache:
+            section = self.plex.library.section(self.library_title)
+            self._library_items_cache[self.library_title] = section.all()
+        return self._library_items_cache[self.library_title]
+
     def _get_library_imdb_ids(self) -> Set[str]:
         """Get set of all IMDb IDs in the library."""
-        return get_library_imdb_ids(self.plex.library.section(self.library_title))
+        return get_library_imdb_ids_from_items(self._get_all_library_items())
 
     @abstractmethod
     def _find_plex_item(self, section, rec: Dict):

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -126,16 +126,26 @@ class PlexMovieRecommender(BaseRecommender):
             "language": weights_config.get("language", weights_config.get("language_weight", 0.0)),
         }
 
-    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
+    def __init__(
+        self,
+        config_path: str,
+        single_user: str = None,
+        library: Optional[Dict] = None,
+        library_items_cache: Optional[Dict] = None,
+    ):
         """Initialize the movie recommender.
 
         Args:
             config_path: Path to the config.yml configuration file
             single_user: Optional username to generate recommendations for a single user
             library: Optional normalized library dict (#157 Phase 3 per-library loop)
+            library_items_cache: Optional dict shared across every user's
+                recommender instance for this library in one run (see
+                BaseRecommender.__init__ / _get_all_library_items - #233
+                audit remediation batch D / PR1(a))
         """
         # Initialize base class (config, plex, display options, weights, etc.)
-        super().__init__(config_path, single_user, library=library)
+        super().__init__(config_path, single_user, library=library, library_items_cache=library_items_cache)
 
         # Movie-specific initialization
         self.cached_unwatched_count = 0
@@ -151,7 +161,12 @@ class PlexMovieRecommender(BaseRecommender):
 
         # Create movie cache
         self.movie_cache = MovieCache(self.cache_dir, recommender=self)
-        self.movie_cache.update_cache(self.plex, self.library_title, self.tmdb_api_key)
+        # Pass the run's (or run+library-shared) library snapshot in
+        # rather than letting update_cache() re-fetch it - see
+        # _get_all_library_items() (#233 audit remediation batch D / PR1(a)).
+        self.movie_cache.update_cache(
+            self.plex, self.library_title, self.tmdb_api_key, all_items=self._get_all_library_items()
+        )
 
         # Verify Plex user configuration
         if self.users["plex_users"]:
@@ -209,7 +224,12 @@ class PlexMovieRecommender(BaseRecommender):
         self.profile_hash = compute_profile_hash(self.watched_data_counters)
 
         print("Fetching library metadata (for existing Movies checks)...")
-        self.library_movies = self._get_library_movies_set()
+        # current_library_ids (above) and this were previously two
+        # independent _get_library_movies_set() calls producing a
+        # byte-identical result (same library, no reload/filter change
+        # between them) - confirmed redundant, so this just reuses it
+        # instead of re-fetching (#233 audit remediation batch D / PR1(a)).
+        self.library_movies = current_library_ids
         self.library_movie_titles = self._get_library_movie_titles()
         self.library_imdb_ids = self._get_library_imdb_ids()
 
@@ -275,9 +295,11 @@ class PlexMovieRecommender(BaseRecommender):
                 if movie_id not in user_ratings or user_rating > user_ratings[movie_id]:
                     user_ratings[movie_id] = user_rating
 
-        # Get view counts from library (history API doesn't provide this)
+        # Get view counts from library (history API doesn't provide this).
+        # Reuses this run's shared library snapshot instead of a fresh
+        # section.all() (#233 audit remediation batch D / PR1(a)).
         try:
-            for movie in movies_section.all():
+            for movie in self._get_all_library_items():
                 movie_id = int(movie.ratingKey)
                 if movie_id in watched_ids and hasattr(movie, "viewCount") and movie.viewCount:
                     watched_movie_views[movie_id] = int(movie.viewCount)
@@ -368,8 +390,7 @@ class PlexMovieRecommender(BaseRecommender):
     def _get_library_movies_set(self) -> Set[int]:
         """Get set of all movie IDs in the library"""
         try:
-            movies = self.plex.library.section(self.library_title)
-            return {int(movie.ratingKey) for movie in movies.all()}
+            return {int(movie.ratingKey) for movie in self._get_all_library_items()}
         except Exception as e:
             log_error(f"Error getting library movies: {e}")
             return set()
@@ -377,8 +398,7 @@ class PlexMovieRecommender(BaseRecommender):
     def _get_library_movie_titles(self) -> Set[Tuple[str, Optional[int]]]:
         """Get set of (title, year) tuples for all movies in the library"""
         try:
-            movies = self.plex.library.section(self.library_title)
-            return {(movie.title.lower(), getattr(movie, "year", None)) for movie in movies.all()}
+            return {(movie.title.lower(), getattr(movie, "year", None)) for movie in self._get_all_library_items()}
         except Exception as e:
             log_error(f"Error getting library movie titles: {e}")
             return set()
@@ -533,14 +553,18 @@ def adapt_root_config_to_legacy(root_config):
 # ------------------------------------------------------------------------
 # MAIN
 # ------------------------------------------------------------------------
-def process_recommendations(config, config_path, log_retention_days, single_user=None, library=None):
+def process_recommendations(
+    config, config_path, log_retention_days, single_user=None, library=None, library_items_cache=None
+):
     original_stdout = sys.stdout
     log_dir = os.path.join(get_project_root(), "logs")
     setup_log_file(log_dir, log_retention_days, single_user, "recommendations")
 
     try:
         # Create recommender with single user context
-        recommender = PlexMovieRecommender(config_path, single_user=single_user, library=library)
+        recommender = PlexMovieRecommender(
+            config_path, single_user=single_user, library=library, library_items_cache=library_items_cache
+        )
 
         # Check for debug mode
         if config.get("general", {}).get("debug", False):

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -117,16 +117,26 @@ class PlexTVRecommender(BaseRecommender):
             "language": weights_config.get("language", weights_config.get("language_weight", 0.05)),
         }
 
-    def __init__(self, config_path: str, single_user: str = None, library: Optional[Dict] = None):
+    def __init__(
+        self,
+        config_path: str,
+        single_user: str = None,
+        library: Optional[Dict] = None,
+        library_items_cache: Optional[Dict] = None,
+    ):
         """Initialize the TV show recommender.
 
         Args:
             config_path: Path to the config.yml configuration file
             single_user: Optional username to generate recommendations for a single user
             library: Optional normalized library dict (#157 Phase 3 per-library loop)
+            library_items_cache: Optional dict shared across every user's
+                recommender instance for this library in one run (see
+                BaseRecommender.__init__ / _get_all_library_items - #233
+                audit remediation batch D / PR1(a))
         """
         # Initialize base class (config, plex, display options, weights, etc.)
-        super().__init__(config_path, single_user, library=library)
+        super().__init__(config_path, single_user, library=library, library_items_cache=library_items_cache)
 
         # TV-specific initialization
         self.cached_unwatched_count = 0
@@ -137,7 +147,12 @@ class PlexTVRecommender(BaseRecommender):
 
         # Create show cache
         self.show_cache = ShowCache(self.cache_dir, recommender=self)
-        self.show_cache.update_cache(self.plex, self.library_title, self.tmdb_api_key)
+        # Pass the run's (or run+library-shared) library snapshot in
+        # rather than letting update_cache() re-fetch it - see
+        # _get_all_library_items() (#233 audit remediation batch D / PR1(a)).
+        self.show_cache.update_cache(
+            self.plex, self.library_title, self.tmdb_api_key, all_items=self._get_all_library_items()
+        )
 
         # Verify Plex user configuration
         if self.users["plex_users"]:
@@ -154,9 +169,10 @@ class PlexTVRecommender(BaseRecommender):
         # Load watched cache using base class method
         watched_cache = self._load_watched_cache()
 
-        # Get library rating keys for filtering (must be ints to match watched_ids)
-        shows_section = self.plex.library.section(self.library_title)
-        current_library_rating_keys = {int(show.ratingKey) for show in shows_section.all()}
+        # Get library rating keys for filtering (must be ints to match watched_ids).
+        # Reuses this run's shared library snapshot instead of a fresh
+        # section.all() (#233 audit remediation batch D / PR1(a)).
+        current_library_rating_keys = {int(show.ratingKey) for show in self._get_all_library_items()}
 
         # Clean up both watched show tracking mechanisms
         self.plex_watched_rating_keys = {
@@ -288,8 +304,10 @@ class PlexTVRecommender(BaseRecommender):
         # Only apply rewatch bonus if user actually rewatched episodes
         show_rewatch_counts = {}
         user_ratings = {}  # Store user ratings for each show
+        # Reuses this run's shared library snapshot instead of a fresh
+        # section.all() (#233 audit remediation batch D / PR1(a)).
         try:
-            for show in shows_section.all():
+            for show in self._get_all_library_items():
                 show_id = int(show.ratingKey)
                 if show_id in watched_ids:
                     # Get rewatch count
@@ -400,9 +418,8 @@ class PlexTVRecommender(BaseRecommender):
     # ------------------------------------------------------------------------
     def _get_library_shows_set(self) -> Set[Tuple[str, Optional[int]]]:
         try:
-            shows = self.plex.library.section(self.library_title)
             library_shows = set()
-            for show in shows.all():
+            for show in self._get_all_library_items():
                 # Handle both normal titles and titles with embedded years
                 title = show.title.lower()
                 year = show.year
@@ -585,7 +602,9 @@ def main():
     )
 
 
-def process_recommendations(config, config_path, log_retention_days, single_user=None, library=None):
+def process_recommendations(
+    config, config_path, log_retention_days, single_user=None, library=None, library_items_cache=None
+):
     """Process and display TV show recommendations for configured users."""
     original_stdout = sys.stdout
     log_dir = os.path.join(get_project_root(), "logs")
@@ -593,7 +612,9 @@ def process_recommendations(config, config_path, log_retention_days, single_user
 
     try:
         # Create recommender with single user context
-        recommender = PlexTVRecommender(config_path, single_user, library=library)
+        recommender = PlexTVRecommender(
+            config_path, single_user, library=library, library_items_cache=library_items_cache
+        )
         recommendations = recommender.get_recommendations()
 
         print(f"\n{GREEN}=== Recommended Unwatched Shows in Your Library ==={RESET}")

--- a/tests/test_cache_prune.py
+++ b/tests/test_cache_prune.py
@@ -1,0 +1,174 @@
+"""Tests for utils/cache_prune.py - orphaned per-user cache file pruning
+(#233 audit remediation batch D / PR1(b)).
+
+Every test here uses tmp_path - never the real cache/ directory.
+"""
+
+from utils.cache_prune import find_orphaned_cache_files, prune_orphaned_cache_files
+
+
+class TestFindOrphanedCacheFiles:
+    def test_no_files_returns_empty(self, tmp_path):
+        assert find_orphaned_cache_files(str(tmp_path), ["alice", "bob"]) == []
+
+    def test_missing_dir_returns_empty_not_raises(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        assert find_orphaned_cache_files(str(missing), ["alice"]) == []
+
+    def test_configured_user_cache_is_not_orphaned(self, tmp_path):
+        (tmp_path / "watched_cache_plex_alice.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tv_watched_cache_plex_alice.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "external_recs_alice_movies.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "external_recs_alice_shows.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice", "bob"])
+
+        assert result == []
+
+    def test_removed_user_cache_is_orphaned(self, tmp_path):
+        (tmp_path / "watched_cache_plex_charlie.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice", "bob"])
+
+        assert len(result) == 1
+        assert result[0].username == "charlie"
+        assert result[0].filename == "watched_cache_plex_charlie.json"
+        assert result[0].path == str(tmp_path / "watched_cache_plex_charlie.json")
+
+    def test_external_recs_for_removed_user_is_orphaned(self, tmp_path):
+        (tmp_path / "external_recs_departed_movies.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "external_recs_departed_shows.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice"])
+
+        filenames = {o.filename for o in result}
+        assert filenames == {"external_recs_departed_movies.json", "external_recs_departed_shows.json"}
+
+    def test_empty_username_cache_is_orphaned(self, tmp_path):
+        """Real example from a live install: watched_cache_plex_.json -
+        an empty username from an old bug. Must be caught, not silently
+        skipped just because the captured group would be empty."""
+        (tmp_path / "watched_cache_plex_.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tv_watched_cache_plex_.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice", "bob"])
+
+        usernames = {o.username for o in result}
+        assert usernames == {""}
+        assert len(result) == 2
+
+    def test_joined_multi_user_legacy_file_is_orphaned(self, tmp_path):
+        """Real example from a live install: a joined-multi-user
+        watched_cache_plex_<many-usernames>.json left over from before
+        every run became strictly single-user (see
+        recommenders/base.py's _get_user_context). The current code
+        never writes or reads this shape, so even if every individual
+        name in the blob is still configured, the file as a whole isn't
+        a valid single-user cache filename and must be flagged."""
+        (tmp_path / "watched_cache_plex_alice_bob_charlie.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice", "bob", "charlie"])
+
+        assert len(result) == 1
+        assert result[0].username == "alice_bob_charlie"
+
+    def test_non_matching_files_are_never_flagged(self, tmp_path):
+        """Whole-library caches, huntarr caches, and anything else not
+        matching one of the four known per-user patterns must never be
+        considered, let alone flagged - this module has no positive
+        evidence any of these are per-user."""
+        for name in (
+            "all_movies_cache.json",
+            "all_shows_cache.json",
+            "horizon_huntarr_cache.json",
+            "sequel_huntarr_cache.json",
+            "user_id_map.json",
+            "some_unrelated_file.txt",
+        ):
+            (tmp_path / name).write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice"])
+
+        assert result == []
+
+    def test_mixed_valid_and_orphaned(self, tmp_path):
+        (tmp_path / "watched_cache_plex_alice.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "watched_cache_plex_charlie.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "all_movies_cache.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), ["alice"])
+
+        assert len(result) == 1
+        assert result[0].username == "charlie"
+
+    def test_results_sorted_by_filename(self, tmp_path):
+        (tmp_path / "watched_cache_plex_zeta.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "watched_cache_plex_alpha.json").write_text("{}", encoding="utf-8")
+
+        result = find_orphaned_cache_files(str(tmp_path), [])
+
+        assert [o.filename for o in result] == ["watched_cache_plex_alpha.json", "watched_cache_plex_zeta.json"]
+
+
+class TestPruneOrphanedCacheFiles:
+    def test_dry_run_removes_nothing(self, tmp_path):
+        target = tmp_path / "watched_cache_plex_charlie.json"
+        target.write_text("{}", encoding="utf-8")
+
+        removed = prune_orphaned_cache_files(str(tmp_path), ["alice"], dry_run=True)
+
+        assert removed == []
+        assert target.exists()
+
+    def test_dry_run_is_the_default(self, tmp_path):
+        target = tmp_path / "watched_cache_plex_charlie.json"
+        target.write_text("{}", encoding="utf-8")
+
+        removed = prune_orphaned_cache_files(str(tmp_path), ["alice"])
+
+        assert removed == []
+        assert target.exists()
+
+    def test_non_dry_run_removes_orphans(self, tmp_path):
+        target = tmp_path / "watched_cache_plex_charlie.json"
+        target.write_text("{}", encoding="utf-8")
+        kept = tmp_path / "watched_cache_plex_alice.json"
+        kept.write_text("{}", encoding="utf-8")
+
+        removed = prune_orphaned_cache_files(str(tmp_path), ["alice"], dry_run=False)
+
+        assert removed == [str(target)]
+        assert not target.exists()
+        assert kept.exists()
+
+    def test_non_dry_run_survives_removal_failure(self, tmp_path, monkeypatch):
+        """A single file's removal failure must not stop the rest or
+        raise out of the function."""
+        target = tmp_path / "watched_cache_plex_charlie.json"
+        target.write_text("{}", encoding="utf-8")
+        other = tmp_path / "watched_cache_plex_dave.json"
+        other.write_text("{}", encoding="utf-8")
+
+        real_remove = __import__("os").remove
+
+        def _flaky_remove(path):
+            if "charlie" in path:
+                raise OSError("permission denied")
+            real_remove(path)
+
+        monkeypatch.setattr("utils.cache_prune.os.remove", _flaky_remove)
+
+        removed = prune_orphaned_cache_files(str(tmp_path), ["alice"], dry_run=False)
+
+        assert removed == [str(other)]
+        assert target.exists()  # the flaky one was left alone, not partially removed
+        assert not other.exists()
+
+    def test_never_touches_non_matching_files(self, tmp_path):
+        keep = tmp_path / "all_movies_cache.json"
+        keep.write_text("{}", encoding="utf-8")
+
+        removed = prune_orphaned_cache_files(str(tmp_path), [], dry_run=False)
+
+        assert removed == []
+        assert keep.exists()

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -561,7 +561,9 @@ class TestProcessRecommendationsLibraryParam:
         library = {"id": "movies-4k", "name": "Movies 4K", "section": "Movies 4K", "media_type": "movie"}
         process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice", library=library)
 
-        mock_recommender_cls.assert_called_once_with("/path/to/config.yml", single_user="alice", library=library)
+        mock_recommender_cls.assert_called_once_with(
+            "/path/to/config.yml", single_user="alice", library=library, library_items_cache=None
+        )
 
     @patch("recommenders.movie.PlexMovieRecommender")
     @patch("recommenders.movie.teardown_log_file")
@@ -575,7 +577,9 @@ class TestProcessRecommendationsLibraryParam:
 
         process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
 
-        mock_recommender_cls.assert_called_once_with("/path/to/config.yml", single_user="alice", library=None)
+        mock_recommender_cls.assert_called_once_with(
+            "/path/to/config.yml", single_user="alice", library=None, library_items_cache=None
+        )
 
 
 class TestMainMediaTypeKey:
@@ -1132,7 +1136,7 @@ class TestFormatMovieOutputExtended:
 class TestPlexMovieRecommenderLibraryImdbIds:
     """Tests for PlexMovieRecommender._get_library_imdb_ids method (inherited from BaseRecommender)."""
 
-    @patch("recommenders.base.get_library_imdb_ids")
+    @patch("recommenders.base.get_library_imdb_ids_from_items")
     @patch("recommenders.movie.MovieCache")
     @patch("recommenders.base.init_plex")
     @patch("recommenders.base.get_configured_users")
@@ -1502,3 +1506,77 @@ class TestProcessRecommendationsMovie:
             process_recommendations({"general": {}}, "/path/to/config.yml", 0)
 
         mock_exit.assert_not_called()
+
+
+class TestLibraryFetchedOnceNotSixTimes:
+    """#233 audit remediation batch D / PR1(a) regression coverage.
+
+    Before this fix, PlexMovieRecommender.__init__ called
+    section.all() independently from up to 6 places for a single
+    user's instantiation: MovieCache.update_cache, _get_library_movies_set
+    (itself called twice back-to-back for a byte-identical result),
+    _get_library_movie_titles, _get_library_imdb_ids, and the view-count
+    loop inside _get_plex_watched_data. All six now share one fetch via
+    BaseRecommender._get_all_library_items().
+
+    Runs a real (unmocked) MovieCache/update_cache - not a mocked
+    stand-in - so this exercises the actual code path, not just the
+    call site. get_project_root() is @lru_cache'd, so CURATARR_CONFIG_DIR
+    is pointed at tmp_path and the cache cleared before/after, same
+    convention as TestBaseRecommenderCacheDirResolution in
+    test_base.py - this must never resolve to the real project's own
+    cache/ directory.
+    """
+
+    def setup_method(self):
+        from utils.helpers import get_project_root
+
+        get_project_root.cache_clear()
+
+    def teardown_method(self):
+        from utils.helpers import get_project_root
+
+        get_project_root.cache_clear()
+
+    @patch("recommenders.movie.fetch_plex_watch_history_movies", return_value=([], {}))
+    @patch("recommenders.movie.get_plex_account_ids", return_value=["acct1"])
+    @patch("recommenders.movie.get_watched_movie_count", return_value=0)
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    def test_section_all_called_exactly_once(
+        self,
+        mock_load,
+        mock_tmdb,
+        mock_users,
+        mock_plex,
+        mock_watched_count,
+        mock_account_ids,
+        mock_history,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("CURATARR_CONFIG_DIR", str(tmp_path))
+
+        mock_load.return_value = {
+            "plex": {"url": "http://localhost", "token": "abc"},
+            "general": {},
+            "weights": {"genre": 0.3, "director": 0.2, "actor": 0.2, "language": 0.1, "keyword": 0.2},
+        }
+        mock_users.return_value = {"plex_users": ["user1"], "managed_users": [], "admin_user": "admin"}
+        # No TMDB key - keeps MovieCache._process_item on its no-TMDB
+        # branch so this test only measures Plex round trips.
+        mock_tmdb.return_value = {"use_keywords": False, "api_key": None}
+
+        mock_movie = Mock(ratingKey=1, year=2020, guids=[], directors=[], genres=[], roles=[], viewCount=0)
+        mock_movie.title = "Test Movie"
+        mock_section = Mock()
+        mock_section.all.return_value = [mock_movie]
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+
+        PlexMovieRecommender("/path/to/config.yml")
+
+        assert mock_section.all.call_count == 1

--- a/tests/test_run_lock.py
+++ b/tests/test_run_lock.py
@@ -1,0 +1,83 @@
+"""Tests for utils/run_lock.py - the cross-container recommender run
+lock (#233 audit remediation batch D / PR1(c)).
+"""
+
+import fcntl
+import os
+
+import pytest
+
+from utils.run_lock import PosixRunLock, run_lock_path
+
+
+class TestRunLockPath:
+    def test_path_is_under_cache_dir(self, tmp_path):
+        path = run_lock_path(str(tmp_path))
+
+        assert path == os.path.join(str(tmp_path), "cache", ".recommender_run.lock")
+
+
+class TestPosixRunLock:
+    def test_acquire_creates_lock_file_and_cache_dir(self, tmp_path):
+        lock_path = run_lock_path(str(tmp_path))
+        lock = PosixRunLock(lock_path)
+
+        lock.acquire()
+        try:
+            assert os.path.exists(lock_path)
+        finally:
+            lock.release()
+
+    def test_second_acquire_from_same_process_fails(self, tmp_path):
+        """A second, independent file descriptor on the same path must
+        fail to acquire while the first is held - this is the actual
+        mechanism that makes two containers bind-mounting the same
+        ./cache volume correctly contend with each other."""
+        lock_path = run_lock_path(str(tmp_path))
+        first = PosixRunLock(lock_path)
+        second = PosixRunLock(lock_path)
+
+        first.acquire()
+        try:
+            with pytest.raises(OSError):
+                second.acquire()
+        finally:
+            first.release()
+
+    def test_lock_available_again_after_release(self, tmp_path):
+        lock_path = run_lock_path(str(tmp_path))
+        first = PosixRunLock(lock_path)
+        first.acquire()
+        first.release()
+
+        second = PosixRunLock(lock_path)
+        second.acquire()
+        second.release()  # must not raise
+
+    def test_release_without_acquire_is_a_safe_noop(self, tmp_path):
+        lock = PosixRunLock(run_lock_path(str(tmp_path)))
+        lock.release()  # must not raise
+
+    def test_release_is_idempotent(self, tmp_path):
+        lock = PosixRunLock(run_lock_path(str(tmp_path)))
+        lock.acquire()
+        lock.release()
+        lock.release()  # must not raise a second time
+
+    def test_contends_with_a_raw_flock_held_by_another_fd(self, tmp_path):
+        """Simulates docker-entrypoint.sh's `recommend` mode, which
+        holds this same lock via the flock(1) *command* (a plain
+        fcntl.flock on an independently-opened fd, not a PosixRunLock
+        instance) - proves the two mechanisms genuinely contend on the
+        same underlying kernel lock, not just within this Python class."""
+        lock_path = run_lock_path(str(tmp_path))
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        raw_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(raw_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            lock = PosixRunLock(lock_path)
+            with pytest.raises(OSError):
+                lock.acquire()
+        finally:
+            fcntl.flock(raw_fd, fcntl.LOCK_UN)
+            os.close(raw_fd)

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1097,7 +1097,9 @@ class TestProcessRecommendationsLibraryParam:
         library = {"id": "anime", "name": "Anime", "section": "Anime", "media_type": "tv"}
         process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice", library=library)
 
-        mock_recommender_cls.assert_called_once_with("/path/to/config.yml", "alice", library=library)
+        mock_recommender_cls.assert_called_once_with(
+            "/path/to/config.yml", "alice", library=library, library_items_cache=None
+        )
 
     @patch("recommenders.tv.PlexTVRecommender")
     @patch("recommenders.tv.teardown_log_file")
@@ -1111,7 +1113,9 @@ class TestProcessRecommendationsLibraryParam:
 
         process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
 
-        mock_recommender_cls.assert_called_once_with("/path/to/config.yml", "alice", library=None)
+        mock_recommender_cls.assert_called_once_with(
+            "/path/to/config.yml", "alice", library=None, library_items_cache=None
+        )
 
 
 class TestMainMediaTypeKey:
@@ -1427,6 +1431,12 @@ class TestGetLibraryShowsSetError:
 
     def test_returns_empty_set_on_error(self):
         recommender = _make_tv_recommender()
+        # __init__ already populated the shared library-items cache (see
+        # BaseRecommender._get_all_library_items, #233 audit remediation
+        # batch D / PR1(a)) with a successful (if empty) fetch, so force a
+        # cache miss here to actually re-exercise a *fresh* Plex failure
+        # rather than silently reusing that cached result.
+        recommender._library_items_cache.clear()
         recommender.plex.library.section.side_effect = Exception("boom")
 
         result = recommender._get_library_shows_set()

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -284,6 +284,98 @@ class TestPopenFailure:
         assert manager.current_job() is None
 
 
+class TestCrossContainerLock:
+    """Tests for the cross-container run lock (#233 audit remediation
+    batch D / PR1(c)) - docker-compose.yml's curatarr (web UI) and
+    curatarr-recommend services share the same bind-mounted ./cache
+    volume; JobManager.start() must refuse to launch a subprocess while
+    that lock is held by *anything* else, not just another run this
+    same JobManager instance already knows about."""
+
+    def test_start_rejected_while_lock_held_by_another_container(self, curatarr_web_root):
+        """Simulates docker-entrypoint.sh's `recommend` mode already
+        running in the sibling curatarr-recommend container: a raw
+        flock on the identical path, held by an fd this JobManager
+        instance has no in-memory knowledge of at all (unlike
+        is_running()/_foreign_run_in_progress(), which only ever see
+        runs *this* process triggered)."""
+        import fcntl
+
+        from utils.run_lock import run_lock_path
+
+        lock_path = run_lock_path(curatarr_web_root)
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        raw_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(raw_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            manager = _manager(curatarr_web_root)
+            with pytest.raises(JobAlreadyRunningError):
+                manager.start("movie", "alice", ["alice"])
+            assert manager.is_running() is False
+            assert manager.current_job() is None
+        finally:
+            fcntl.flock(raw_fd, fcntl.LOCK_UN)
+            os.close(raw_fd)
+
+    def test_start_succeeds_once_the_other_container_releases(self, curatarr_web_root):
+        import fcntl
+
+        from utils.run_lock import run_lock_path
+
+        lock_path = run_lock_path(curatarr_web_root)
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        raw_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(raw_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(raw_fd, fcntl.LOCK_UN)
+        os.close(raw_fd)
+
+        manager = _manager(curatarr_web_root)
+        job = manager.start("movie", "alice", ["alice"])
+        _wait_until_done(job)
+
+        assert job.returncode == 0
+
+    def test_lock_released_after_job_completes_so_a_second_run_is_allowed(self, curatarr_web_root):
+        """The lock must not leak past one job's lifetime - otherwise
+        every run after the first would falsely look like a
+        cross-container collision forever."""
+        manager = _manager(curatarr_web_root)
+        job1 = manager.start("movie", "alice", ["alice", "bob"])
+        _wait_until_done(job1)
+
+        job2 = manager.start("movie", "bob", ["alice", "bob"])
+        _wait_until_done(job2)
+
+        assert job2.returncode == 0
+
+    def test_lock_released_even_when_popen_itself_fails(self, curatarr_web_root, monkeypatch):
+        """A Popen failure (M3) must not leave the cross-container lock
+        stuck held forever - see start()'s except OSError branch."""
+
+        def _boom(*args, **kwargs):
+            raise FileNotFoundError("[Errno 2] No such file or directory: 'bash'")
+
+        monkeypatch.setattr(job_runner_mod.subprocess, "Popen", _boom)
+        manager = _manager(curatarr_web_root)
+
+        with pytest.raises(JobError):
+            manager.start("full", "all", ["alice"])
+
+        # The lock must be free again - a plain flock probe proves it,
+        # independent of any JobManager state.
+        import fcntl
+
+        from utils.run_lock import run_lock_path
+
+        lock_path = run_lock_path(curatarr_web_root)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # must not raise
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 class TestTerminateRunning:
     """Tests for H3 - terminating an in-flight run on server shutdown."""
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -165,6 +165,7 @@ from .plex import (
     get_current_users,
     get_excluded_genres_for_user,
     get_library_imdb_ids,
+    get_library_imdb_ids_from_items,
     get_max_rating_for_user,
     get_plex_account_ids,
     get_plex_user_ids,
@@ -481,6 +482,7 @@ __all__ = [
     "extract_ids_from_guids",
     "extract_rating",
     "get_library_imdb_ids",
+    "get_library_imdb_ids_from_items",
     "get_plex_user_ids",
     # User migration (stable Plex id -> username)
     "USER_ID_MAP_FILENAME",

--- a/utils/cache_prune.py
+++ b/utils/cache_prune.py
@@ -1,0 +1,157 @@
+"""Prunes cache/ files orphaned by no-longer-configured users.
+
+cache/ has no equivalent of logs/'s cleanup_old_logs (see utils.helpers)
+- nothing here ever removes a per-user cache file once that user is no
+longer configured. Real examples found in a live install (#233 audit
+remediation batch D / PR1(b)): watched_cache_plex_.json (an empty
+username - an old bug), a joined-multi-user
+watched_cache_plex_<many-usernames>.json (a legacy naming convention
+from before every recommender run became strictly single-user - see
+recommenders/base.py's _get_user_context - so the current code never
+writes or reads that shape, only ever left it behind), and
+external_recs_<removed-user>_*.json for a user no longer in users.list
+at all.
+
+Deliberately conservative:
+  - Only ever considers the four exact per-user filename patterns
+    utils.user_migration's rename-migration already uses
+    (CACHE_FILENAME_PATTERNS) - a file this doesn't recognize is left
+    alone entirely, not even logged. This never touches
+    all_movies_cache.json/all_shows_cache.json (whole-library, not
+    per-user), huntarr caches, user_id_map.json, or anything else this
+    module has no positive evidence is a per-user cache.
+  - prune_orphaned_cache_files() defaults to dry_run=True: logging
+    candidates, removing nothing, until a caller explicitly opts into
+    deletion. Deleting a live cache forces an expensive full Plex
+    re-scan for that user on their next run, so this only ever acts on
+    files it can positively identify as orphaned, and only when asked.
+"""
+
+import logging
+import os
+import re
+from typing import Iterable, List, NamedTuple, Pattern
+
+from .display import log_warning
+from .user_migration import CACHE_FILENAME_PATTERNS
+
+logger = logging.getLogger("curatarr")
+
+
+class OrphanedCacheFile(NamedTuple):
+    """One cache file whose embedded username doesn't match any
+    currently-configured user."""
+
+    path: str
+    filename: str
+    username: str
+
+
+def _pattern_to_regex(pattern: str) -> Pattern:
+    """Turn a "{username}"-templated filename pattern (see
+    utils.user_migration.CACHE_FILENAME_PATTERNS) into a regex that
+    captures the username portion back out of a real filename.
+
+    Uses .* (not .+) for the captured group deliberately - an empty
+    username portion (e.g. "watched_cache_plex_.json", a real example
+    found in a live install) is exactly the kind of orphan this is
+    meant to catch, not silently skip.
+    """
+    prefix, _, suffix = pattern.partition("{username}")
+    return re.compile(f"^{re.escape(prefix)}(?P<username>.*){re.escape(suffix)}$")
+
+
+_PATTERN_REGEXES = [_pattern_to_regex(p) for p in CACHE_FILENAME_PATTERNS]
+
+
+def find_orphaned_cache_files(cache_dir: str, configured_usernames: Iterable[str]) -> List[OrphanedCacheFile]:
+    """
+    Find cache/ files matching one of the known per-user filename
+    patterns (see utils.user_migration.CACHE_FILENAME_PATTERNS) whose
+    embedded username isn't in configured_usernames.
+
+    A file that doesn't match one of those four exact patterns is left
+    alone entirely - not even logged - so this never flags/removes
+    anything this codebase doesn't have positive evidence is a
+    per-user cache file. A file whose embedded "username" is actually
+    several usernames joined with '_' (the legacy pre-single-user-mode
+    naming convention - see module docstring) can't exact-match any
+    single configured username either, so it's correctly flagged here
+    too without needing any special-case joined-name parsing.
+
+    Args:
+        cache_dir: Directory to scan (never the real cache/ during
+            development/tests - see this module's own test suite,
+            which only ever scans a tmp_path fixture)
+        configured_usernames: Every username this run currently
+            considers valid - already resolved (e.g. 'admin' already
+            mapped to the real account username - see
+            utils.cli.resolve_admin_username), not the raw config
+            string, so a config that still says 'admin' doesn't
+            false-flag that user's real cache file as orphaned.
+
+    Returns:
+        List of OrphanedCacheFile candidates, sorted by filename.
+    """
+    valid = set(configured_usernames)
+    orphans = []
+
+    try:
+        entries = sorted(os.listdir(cache_dir))
+    except OSError as e:
+        logger.debug(f"Could not list cache dir {cache_dir} for orphan pruning: {e}")
+        return []
+
+    for filename in entries:
+        for regex in _PATTERN_REGEXES:
+            match = regex.match(filename)
+            if not match:
+                continue
+            username = match.group("username")
+            if username not in valid:
+                orphans.append(
+                    OrphanedCacheFile(path=os.path.join(cache_dir, filename), filename=filename, username=username)
+                )
+            break  # matched one pattern - don't also test the others against this filename
+
+    return orphans
+
+
+def prune_orphaned_cache_files(cache_dir: str, configured_usernames: Iterable[str], dry_run: bool = True) -> List[str]:
+    """
+    Find and (unless dry_run) remove orphaned per-user cache files - see
+    find_orphaned_cache_files() for what counts as orphaned.
+
+    Conservative by default: dry_run=True (the default) only logs what
+    *would* be removed and deletes nothing.
+
+    Args:
+        cache_dir: Directory to scan
+        configured_usernames: Every currently-valid (resolved) username
+        dry_run: If True (default), only log candidates - remove
+            nothing. If False, actually remove each file (best-effort;
+            one file's removal failure is logged and does not stop the
+            rest).
+
+    Returns:
+        Paths of files that were actually removed (always empty in
+        dry_run mode).
+    """
+    orphans = find_orphaned_cache_files(cache_dir, configured_usernames)
+    removed = []
+
+    for orphan in orphans:
+        if dry_run:
+            logger.info(
+                f"[dry-run] Would remove orphaned cache file: {orphan.filename} "
+                f"(user '{orphan.username}' not in configured users)"
+            )
+            continue
+        try:
+            os.remove(orphan.path)
+            logger.info(f"Removed orphaned cache file: {orphan.filename} (user '{orphan.username}' not configured)")
+            removed.append(orphan.path)
+        except OSError as e:
+            log_warning(f"Could not remove orphaned cache file {orphan.filename}: {e}")
+
+    return removed

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -14,6 +14,7 @@ from typing import Callable, Dict, List, Optional
 import yaml
 from plexapi.myplex import MyPlexAccount
 
+from .cache_prune import prune_orphaned_cache_files
 from .config import __version__, get_libraries_for_media_type, get_update_mode
 from .display import (
     CYAN,
@@ -251,7 +252,7 @@ def run_recommender_main(
     media_type: str,
     description: str,
     adapt_config_func: Callable[[Dict], Dict],
-    process_func: Callable[[Dict, str, int, Optional[str], Optional[Dict]], None],
+    process_func: Callable[[Dict, str, int, Optional[str], Optional[Dict], Optional[Dict]], None],
     media_type_key: str = "movie",
 ):
     """
@@ -268,7 +269,8 @@ def run_recommender_main(
         description: argparse description
         adapt_config_func: Function to adapt root config to media-specific format
         process_func: Function to process recommendations for a user. Receives
-            (user_config, config_path, log_retention_days, resolved_user, library)
+            (user_config, config_path, log_retention_days, resolved_user,
+            library, library_items_cache)
         media_type_key: 'movie' or 'tv' - selects which libraries to loop over
             (see utils.config.get_libraries_for_media_type)
     """
@@ -363,6 +365,12 @@ def run_recommender_main(
 
         multi_library = len(libraries) > 1
 
+        # Collected across the whole library x user loop below, then used
+        # to prune orphaned per-user cache files at the end of this run
+        # (#233 audit remediation batch D / PR1(b)) - see
+        # utils.cache_prune.prune_orphaned_cache_files.
+        resolved_usernames = set()
+
         # Process each library x user
         plex_token = base_config.get("plex", {}).get("token", "")
         for library in libraries:
@@ -370,17 +378,40 @@ def run_recommender_main(
                 print(f"\n{CYAN}=== Library: {library['name']} ==={RESET}")
                 print("-" * 50)
 
+            # Shared across every user processed against *this* library
+            # below - each recommender's BaseRecommender._get_all_library_items()
+            # fetches Plex's section.all() into this dict on first access and
+            # every subsequent user reuses that same list, so one library
+            # scan serves the whole library's user loop instead of one scan
+            # per user (#233 audit remediation batch D / PR1(a)). A fresh
+            # dict per library (not per run) because two libraries never
+            # share a section, so there's nothing to gain from a wider scope
+            # - and it keeps a library's cache from outliving that library's
+            # own iteration below.
+            library_items_cache: Dict = {}
+
             for user in all_users:
                 print(f"\n{GREEN}Processing recommendations for user: {user}{RESET}")
                 print("-" * 50)
 
                 resolved_user = resolve_admin_username(user, plex_token)
                 user_config = update_config_for_user(base_config, resolved_user)
+                resolved_usernames.add(resolved_user)
 
-                process_func(user_config, config_path, log_retention_days, resolved_user, library)
+                process_func(user_config, config_path, log_retention_days, resolved_user, library, library_items_cache)
 
                 print(f"\n{GREEN}Completed processing for user: {resolved_user}{RESET}")
                 print("-" * 50)
+
+        # Prune cache/ files left behind by users no longer configured -
+        # cache/ has no equivalent of logs/'s cleanup_old_logs above this
+        # run never had (#233 audit remediation batch D / PR1(b)).
+        # Conservative by default: dry_run only *logs* candidates, so this
+        # never deletes anything unless a config explicitly opts in via
+        # general.cache_prune.dry_run: false.
+        cache_prune_config = general.get("cache_prune", {}) or {}
+        if cache_prune_config.get("enabled", True):
+            prune_orphaned_cache_files(cache_dir, resolved_usernames, dry_run=cache_prune_config.get("dry_run", True))
 
         outcome = "success"
     except SystemExit:

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.23"
+__version__ = "2.10.24"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -1099,9 +1099,34 @@ def get_library_imdb_ids(plex_section: Any) -> Set[str]:
     Returns:
         Set of IMDb ID strings
     """
+    try:
+        items = plex_section.all()
+    except (plexapi.exceptions.PlexApiException, TypeError) as e:
+        log_warning(f"Error retrieving IMDb IDs from library: {e}")
+        return set()
+    return get_library_imdb_ids_from_items(items)
+
+
+def get_library_imdb_ids_from_items(items: Any) -> Set[str]:
+    """
+    Extract IMDb IDs from an already-fetched list/iterable of Plex
+    library items (e.g. a section.all() result a caller already holds).
+
+    Shares the guid-parsing logic with get_library_imdb_ids() so a
+    caller that's already fetched the full library once (see
+    recommenders/base.py's _get_all_library_items(), #233 audit
+    remediation batch D / PR1(a)) doesn't have to re-query Plex just to
+    derive this set too.
+
+    Args:
+        items: Iterable of Plex media items (already fetched)
+
+    Returns:
+        Set of IMDb ID strings
+    """
     imdb_ids = set()
     try:
-        for item in plex_section.all():
+        for item in items:
             if hasattr(item, "guids"):
                 for guid in item.guids:
                     if guid.id.startswith("imdb://"):

--- a/utils/run_lock.py
+++ b/utils/run_lock.py
@@ -1,0 +1,113 @@
+"""Cross-process advisory lock for recommender runs (#233 audit
+remediation batch D / PR1(c)).
+
+docker-compose.yml can run two separate containers sharing the same
+bind-mounted ./cache volume: the long-running `curatarr` web UI (which
+triggers runs via web/job_runner.py's JobManager, as a subprocess) and
+the one-shot `curatarr-recommend` service, meant to be triggered by a
+host cron/Task Scheduler entry (see docs/DOCKER.md "Scheduling") via
+docker-entrypoint.sh's `recommend` mode. A recommender run mutates
+cache/*.json files (and Plex collections) in place - two of them
+racing on that shared volume at once is a real interleaved-write
+hazard, not just a "friendly error message" problem.
+
+JobManager's existing single-run lock (in-process threading.Lock + a
+PID lockfile - see web/job_runner.py) only ever gets taken when a run
+is *triggered from the web UI*; docker-entrypoint.sh's `recommend` mode
+execs the recommender scripts directly with no locking at all, and
+PIDs aren't even comparable across two containers' separate PID
+namespaces anyway.
+
+This module is the actual fix for that specific gap: a real OS-level
+advisory lock (flock(2)) on a file inside the shared cache/ directory.
+docker-entrypoint.sh wraps its own `recommend` invocations with the
+`flock` *command* (util-linux, present in the python:3.12-slim/Debian
+base image - see Dockerfile) on the identical path;
+JobManager.start() (web/job_runner.py) acquires the identical lock via
+PosixRunLock below before spawning its subprocess and holds it for
+that subprocess's entire lifetime. Both are the same kernel-level lock
+on the same inode (bind-mounted into both containers), so they
+correctly contend with each other regardless of which side goes
+first - flock is exactly the "e.g. flock on a file in the shared
+volume" fix this was scoped to.
+
+POSIX only (Linux/macOS - what every actual deployment of the two
+compose services runs; fcntl.flock works fine on macOS too, not just
+Linux). On Windows (native, non-Docker desktop install - os.name ==
+'nt') this is intentionally a no-op: Windows installs don't run
+docker-compose's two-container setup, so JobManager's existing
+in-process Lock + PID lockfile already covers the one race that can
+actually happen there (a second web UI process on the same machine).
+
+Residual risk (documented, not silently accepted): this only protects
+the two paths docker-compose.yml actually wires up (job_runner.py's
+subprocess launch and docker-entrypoint.sh's own `recommend` mode). A
+user who execs `python3 recommenders/movie.py` directly inside a
+container's shell, bypassing both of those, still bypasses this lock
+too - threading it through every recommender entry point
+(utils/cli.py's run_recommender_main, recommenders/external.py) as
+well was judged too invasive for this pass (many existing tests
+construct those entry points against fake, non-existent paths and
+would need real-filesystem mocking added purely for this lock - see
+PR description), so that residual gap is accepted rather than forced.
+"""
+
+import os
+
+RUN_LOCK_FILENAME = ".recommender_run.lock"
+
+
+def run_lock_path(project_root: str) -> str:
+    """Path to the shared cross-container run lock file.
+
+    Always <project_root>/cache/.recommender_run.lock, independent of
+    a config-level cache_dir: override - kept deliberately simple
+    rather than parsing config.yml here too (see module docstring). A
+    custom cache_dir just means this lock file lives in the default
+    ./cache alongside the (possibly relocated) real cache files, which
+    is harmless - it doesn't need to be *the* cache directory, just
+    *a* directory both containers have bind-mounted in common.
+    """
+    return os.path.join(project_root, "cache", RUN_LOCK_FILENAME)
+
+
+class PosixRunLock:
+    """Non-blocking fcntl.flock() wrapper on run_lock_path().
+
+    acquire() raises OSError immediately (never blocks/waits) if
+    another process already holds it - matches JobManager's existing
+    fail-fast-with-a-clear-error behavior rather than silently queueing
+    a run behind an unbounded wait. Safe to construct and call
+    acquire()/release() on any POSIX platform; callers on Windows
+    should simply not use this class (see module docstring).
+    """
+
+    def __init__(self, lock_path: str):
+        self._lock_path = lock_path
+        self._fd = None
+
+    def acquire(self) -> None:
+        """Acquire the lock or raise OSError if already held elsewhere."""
+        import fcntl
+
+        os.makedirs(os.path.dirname(self._lock_path), exist_ok=True)
+        fd = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            raise
+        self._fd = fd
+
+    def release(self) -> None:
+        """Release the lock. Safe to call even if acquire() was never
+        called or already failed (a no-op in that case)."""
+        if self._fd is None:
+            return
+        import fcntl
+
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._fd)
+            self._fd = None

--- a/utils/user_migration.py
+++ b/utils/user_migration.py
@@ -36,7 +36,7 @@ USER_ID_MAP_FILENAME = "user_id_map.json"
 # Cache filename patterns keyed on username. Kept explicit (rather than a
 # filesystem glob) so migration only ever touches files curatarr itself
 # generates for a given user.
-_CACHE_FILENAME_PATTERNS = [
+CACHE_FILENAME_PATTERNS = [
     "watched_cache_plex_{username}.json",
     "tv_watched_cache_plex_{username}.json",
     "external_recs_{username}_movies.json",
@@ -252,7 +252,7 @@ def _safe_cache_path(cache_dir: str, filename: str) -> Optional[str]:
     Why this matters here specifically: old_username/new_username come
     from a live Plex account's own username/title field - set by
     whoever owns that account, not something curatarr controls - and
-    get interpolated directly into _CACHE_FILENAME_PATTERNS. A username
+    get interpolated directly into CACHE_FILENAME_PATTERNS. A username
     containing a path separator (e.g. '../../etc/passwd') would
     otherwise make the "cache filename" resolve OUTSIDE cache_dir
     entirely, and migrate_cache_files below calls os.rename/os.remove
@@ -274,7 +274,7 @@ def _safe_cache_path(cache_dir: str, filename: str) -> Optional[str]:
 def migrate_cache_files(cache_dir: str, old_username: str, new_username: str) -> None:
     """Rename (or drop, if a file for the new name already exists) known
     per-user cache files so a rename doesn't leave stale/orphaned caches."""
-    for pattern in _CACHE_FILENAME_PATTERNS:
+    for pattern in CACHE_FILENAME_PATTERNS:
         old_path = _safe_cache_path(cache_dir, pattern.format(username=old_username))
         new_path = _safe_cache_path(cache_dir, pattern.format(username=new_username))
         if old_path is None or new_path is None:

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -9,6 +9,10 @@ short-lived CLI invocation, unsafe inside a long-running Flask process.
 Only one job may run at a time (a run mutates shared caches under
 cache/ and Plex collections), enforced by JobManager's lock (in-process)
 and a PID lockfile (cross-process - see _foreign_run_in_progress).
+Neither of those is cross-container-aware (PIDs aren't even comparable
+across two containers' separate PID namespaces) - see utils/run_lock.py
+for the actual fix covering docker-compose.yml's two services, wired in
+below (POSIX only; a no-op on Windows, see that module's docstring).
 
 Frozen (PyInstaller onefile) binary note: `sys.executable
 recommenders/<x>.py` doesn't exist once packaged - there is no
@@ -33,6 +37,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from utils.helpers import no_window_kwargs
+from utils.run_lock import PosixRunLock, run_lock_path
 
 from .security import redact
 
@@ -131,6 +136,11 @@ class Job:
         self.finished_at: Optional[datetime] = None
         self.returncode: Optional[int] = None
         self.process: Optional[subprocess.Popen] = None
+        # Cross-container run lock (see utils/run_lock.py) held for this
+        # job's subprocess lifetime, None on Windows (that lock is POSIX
+        # only - see that module's docstring). Released in _pump()'s
+        # finally alongside the existing PID lockfile cleanup.
+        self._run_lock: Optional[PosixRunLock] = None
 
         self._data_lock = threading.Lock()
         self.lines: List[str] = []
@@ -258,11 +268,31 @@ class JobManager:
             if self._foreign_run_in_progress():
                 raise JobAlreadyRunningError("A run started by a previous server process is still in progress")
 
+            # Cross-container run lock (see utils/run_lock.py): a
+            # docker-entrypoint.sh `recommend` invocation in the sibling
+            # curatarr-recommend container holds the identical flock on
+            # the identical path while it runs - this is what actually
+            # detects that case (the checks above only ever see runs
+            # *this* process/container triggered). POSIX only; a no-op
+            # on Windows, where this race can't happen (see that
+            # module's docstring).
+            run_lock = None
+            if os.name != "nt":
+                run_lock = PosixRunLock(run_lock_path(self.project_root))
+                try:
+                    run_lock.acquire()
+                except OSError as exc:
+                    raise JobAlreadyRunningError(
+                        "A recommender run is already in progress in another container/process "
+                        f"(cross-container lock held): {exc}"
+                    ) from exc
+
             cmd, env, log_name = self._build_command(engine, user)
             os.makedirs(self.logs_dir, exist_ok=True)
             log_path = os.path.join(self.logs_dir, log_name)
 
             job = Job(engine, user, cmd, log_path)
+            job._run_lock = run_lock
             popen_kwargs = dict(
                 cwd=self.project_root,
                 stdout=subprocess.PIPE,
@@ -298,6 +328,8 @@ class JobManager:
                 # surface as a normal, friendly JobError - the /run route
                 # already turns that into a redirect with an error
                 # message - not an unhandled 500.
+                if run_lock is not None:
+                    run_lock.release()
                 raise JobError(f"Could not start the {engine} run: {exc}") from exc
 
             job.process = process
@@ -371,7 +403,8 @@ class JobManager:
         wasn't reliably captured either way, and (this is what actually
         matters operationally) job._finish() is now *always* reached
         even on that path, so the job never gets stuck "running"
-        forever and the single-run lock is always released.
+        forever and both the PID lockfile and the cross-container
+        run_lock (see utils/run_lock.py) are always released.
         """
         log_file = None
         returncode: Optional[int] = None
@@ -412,6 +445,8 @@ class JobManager:
                     job.process.kill()
                     job.process.wait()
             self._remove_lock()
+            if job._run_lock is not None:
+                job._run_lock.release()
             job._finish(returncode if returncode is not None else -1)
 
     def terminate_running(self) -> None:


### PR DESCRIPTION
## Summary
- Full Plex library re-fetched up to 6x per user per run in movie.py/tv.py's init path - collapsed to a single shared fetch via a new BaseRecommender._get_all_library_items(), reused across every user processed against the same library in utils/cli.py's loop too. Measured 6 -> 1 (see tests/test_movie.py::TestLibraryFetchedOnceNotSixTimes).
- cache/ never pruned orphaned per-user files (unlike logs/'s cleanup_old_logs). New utils/cache_prune.py diffs the four known per-user cache filename patterns against a run's resolved usernames. Conservative: only exact known patterns are ever considered, and the new general.cache_prune config defaults to dry_run (log-only, deletes nothing until explicitly opted in).
- docker-compose.yml's curatarr (web UI) and curatarr-recommend services shared the ./cache volume with no cross-container lock - docker-entrypoint.sh's recommend mode had no locking at all, and job_runner.py's existing lock (in-process + PID file) can't see across containers. Both now take the identical flock on cache/.recommender_run.lock.

## Test plan
- [x] Full suite: 2395 passed, 1 skipped (baseline 2368/1, +27 new tests)
- [x] ruff format --check clean; ruff check finding count unchanged (126, same as main)
- [x] New test demonstrates the Plex call-count reduction concretely (6 -> 1)
- [x] Cross-container lock verified against real Docker containers (python:3.12-slim, same base as Dockerfile): a recommend invocation correctly refuses to start while a sibling container holds the lock, and correctly proceeds once released
- [x] Verified cache writes are already atomic (temp + os.replace, since 2.10.9) across every write path