### PR TITLE
fix: retry cosign verify to close post-release smoke test race (2.10.25)

### DIFF
--- a/.github/workflows/post-release-smoke-test.yml
+++ b/.github/workflows/post-release-smoke-test.yml
@@ -522,6 +522,36 @@ jobs:
   # command docs/DOCKER.md tells operators to run, against the
   # bare-semver tag docker/metadata-action's `type=semver,pattern=
   # {{version}}` produces for a `vX.Y.Z` tag push (no leading 'v').
+  #
+  # Bounded-retry, not a hard dependency on docker.yml (#233 audit
+  # remediation): docker.yml is a *separate* workflow, triggered
+  # independently by the same `vX.Y.Z` tag push that starts release.yml
+  # (this workflow's own trigger chain - see the top-of-file comment -
+  # is release.yml's finalize-checksums job finishing, then a maintainer
+  # manually running scripts/sign-release-checksums.sh, which dispatches
+  # this workflow). There is no `needs:`/`workflow_run` link connecting
+  # a manually `workflow_dispatch`-triggered workflow to a specific run
+  # of a *different*, independently tag-triggered workflow - and even if
+  # there were, correlating "which docker.yml run matches this release"
+  # by ref is strictly less reliable than just checking whether the
+  # actual artifact this job needs (a signed image manifest) exists yet.
+  # docker.yml's multi-arch (QEMU) build+push+cosign-sign can easily
+  # still be in flight when the maintainer's signing step completes
+  # (their manual step has no ordering relationship to docker.yml at
+  # all) - this raced and produced three false-alarm auto-filed issues
+  # (#214, #220, #225) before this fix, always the same MANIFEST_UNKNOWN
+  # shape: the image/signature genuinely wasn't published *yet*, not a
+  # real signing failure.
+  #
+  # Retries the exact same `cosign verify` command/flags (identity
+  # regexp + OIDC issuer) unchanged - this never weakens what "verified"
+  # means. A genuinely unsigned image or one signed by the wrong
+  # identity fails cosign verify identically on every attempt (there is
+  # nothing time-dependent about that failure), so it still fails for
+  # real once MAX_ATTEMPTS is exhausted; only the "not published yet"
+  # race gets a chance to resolve itself first. Bound: 20 attempts x 30s
+  # = 10 minutes, comfortably longer than docker.yml's typical
+  # multi-arch build+push+sign time.
   # -------------------------------------------------------------------
   cosign-verify:
     name: cosign verify published image
@@ -533,13 +563,38 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: cosign verify ghcr.io/orchestratedchaos/curatarr:${{ needs.resolve-inputs.outputs.version }}
+      - name: cosign verify ghcr.io/orchestratedchaos/curatarr:${{ needs.resolve-inputs.outputs.version }} (bounded retry)
         run: |
-          set -euo pipefail
-          cosign verify \
-            --certificate-identity-regexp '^https://github\.com/OrchestratedChaos/curatarr/\.github/workflows/docker\.yml@refs/' \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "ghcr.io/orchestratedchaos/curatarr:${VERSION}"
+          set -uo pipefail
+
+          IMAGE="ghcr.io/orchestratedchaos/curatarr:${VERSION}"
+          MAX_ATTEMPTS=20
+          SLEEP_SECONDS=30
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            OUTPUT="$(cosign verify \
+              --certificate-identity-regexp '^https://github\.com/OrchestratedChaos/curatarr/\.github/workflows/docker\.yml@refs/' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "$IMAGE" 2>&1)"
+            STATUS=$?
+
+            if [ "$STATUS" -eq 0 ]; then
+              echo "$OUTPUT"
+              echo "Verified $IMAGE on attempt ${attempt}/${MAX_ATTEMPTS}."
+              exit 0
+            fi
+
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS} failed:"
+            echo "$OUTPUT"
+
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::cosign verify never succeeded for $IMAGE after $MAX_ATTEMPTS attempts ($((MAX_ATTEMPTS * SLEEP_SECONDS / 60)) minutes). This is either a genuine signature/identity problem, or docker.yml (a separate workflow - see this job's own comment) is taking longer than usual to build+push+sign. See the last attempt's output above."
+              exit 1
+            fi
+
+            echo "docker.yml's build+push+sign may still be in flight - retrying in ${SLEEP_SECONDS}s..."
+            sleep "$SLEEP_SECONDS"
+          done
 
   # -------------------------------------------------------------------
   # Loud failure path. A silent red X on a workflow nobody watches is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.25] - 2026-07-26
+
+### Fixed
+
+- **Post-release smoke test's `cosign verify` job raced
+  `.github/workflows/docker.yml`'s image build+push+sign, producing
+  three false-alarm auto-filed issues (#214, #220, #225 - all
+  `MANIFEST_UNKNOWN`, never a real signing problem).**
+  `post-release-smoke-test.yml` is dispatched manually (by
+  `scripts/sign-release-checksums.sh`, after `release.yml`'s own chain
+  finishes) with no ordering relationship to `docker.yml`, a separate
+  workflow independently triggered by the same tag push - its
+  multi-arch (QEMU) build+push+cosign-sign can still be in flight when
+  the smoke test's `cosign verify` step runs. There's no
+  `needs:`/`workflow_run` link between a manually-dispatched workflow
+  and a specific run of a different, independently-triggered one, and
+  even if there were, matching runs by ref would be less reliable than
+  just checking whether the artifact this job actually needs (a signed
+  image manifest) exists yet. Fixed by retrying the exact same `cosign
+  verify` command/flags (identity regexp + OIDC issuer, unchanged) up
+  to 20 times with a 30s sleep (10 minutes total) instead of failing on
+  the first attempt. This never weakens verification: a genuinely
+  unsigned image or wrong signing identity fails identically on every
+  attempt (nothing about that failure is time-dependent), so it still
+  fails for real once the budget is exhausted - retrying only gives the
+  "not published yet" race a chance to resolve itself. Verified the
+  retry/give-up control flow directly (a fake `cosign` that fails twice
+  then succeeds, and one that always fails).
+
 ## [2.10.24] - 2026-07-26
 
 ### Changed

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.24"
+__version__ = "2.10.25"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- post-release-smoke-test.yml's cosign-verify job raced docker.yml's independent multi-arch build+push+sign - three false-alarm auto-filed issues (#214, #220, #225), all MANIFEST_UNKNOWN, never a real signing problem.
- No workflow_run/needs mechanism connects this manually-dispatched workflow to a separate, independently tag-triggered one, so cosign verify now retries the identical command/flags (identity regexp + OIDC issuer, unchanged) up to 20x / 30s apart (10 min bound) instead of failing on the first attempt.
- Does not weaken verification: a genuinely unsigned image or wrong identity fails identically on every attempt (nothing about that failure is time-dependent), so it still fails for real once the retry budget is exhausted.
- Closes #220 (comment explaining root cause + linking this PR).

## Test plan
- [x] actionlint clean on the modified workflow (and the whole .github/workflows/ directory)
- [x] YAML syntax validated
- [x] Retry/give-up control flow verified directly: extracted the loop and ran it against a fake cosign that fails twice then succeeds (exits 0 on attempt 3) and one that always fails (exhausts all attempts, exits 1 with a clear error)
- [x] Full test suite unaffected (2395 passed, 1 skipped - no Python changes)