### PR TITLE
refactor: hoist nested helpers and split process_user (2.10.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.28] - 2026-07-26
+
+### Changed
+
+- **Audit remediation batch E (PR3): hoisted nested helpers and split
+  `process_user`.** `generate_combined_html`
+  (`recommenders/external_render.py`) defined 4 helper functions INSIDE
+  itself (`collect_tmdb_ids_from_categorized`, `render_table_flat`,
+  `render_sequels_table`, `render_horizon_table`) - hoisted to module level
+  (now `_collect_tmdb_ids_from_categorized`/`_render_table_flat`/
+  `_render_sequels_table`/`_render_horizon_table`, matching this file's
+  existing underscore-prefix convention for internal helpers), taking
+  their previously-closure-captured variables (`imdb_cache`,
+  `all_imdb_ids`, `pending_lookups`, `now`, `movie_counts`, `show_counts`,
+  `total_users`) as explicit parameters instead.
+
+  `process_user` (`recommenders/external.py`, ~373 lines, 44 branches but
+  shallow/linear nesting) split into 9 named pipeline stages
+  (`_pu_resolve_context`, `_pu_load_libraries_and_caches`,
+  `_pu_clean_caches`, `_pu_build_profiles`, `_pu_plan_discovery`,
+  `_pu_discover_new_content`, `_pu_reconcile_caches`,
+  `_pu_categorize_and_stamp`, `_pu_finalize_output`), called in the exact
+  original order - existing tests assert on mocked dependencies' call
+  order (e.g. movie library/cache operations before tv), so stage
+  boundaries were chosen to never reorder a call relative to another.
+  `process_user`'s own signature and return contract are unchanged.
+
+  Evaluated but **skipped** two other audit-flagged candidates, per the
+  audit's own "skip and report if not reviewable" guidance:
+  `find_similar_content_with_profile` (~249 lines) has a discovery loop
+  with genuine cross-iteration mutable state (`quality_recs`, `seen_ids`,
+  `scored_cache`, early-exit counters) - splitting it out is materially
+  riskier than `process_user`'s linear pipeline and not attempted here.
+  `export_to_sonarr`/`export_to_radarr` (~230/227 lines) are structurally
+  parallel but not simple 1:1 substitutions - they use different exception
+  types (`SonarrAPIError`/`RadarrAPIError`), different client methods
+  (`get_series()`/`get_movies()`), different id fields (`tvdb_id`/
+  `tmdb_id`), and non-overlapping per-service settings
+  (`season_folder`/`series_type` vs `minimum_availability`) - factoring
+  the shared part safely would need a real abstraction layer, a
+  substantially bigger and harder-to-review diff than the rest of this
+  batch.
+
+  Verified behavior-preserving: `tests/harness.py` byte-identical
+  `PYTHONHASHSEED=0` output (this batch doesn't touch scoring, re-checked
+  anyway); a synthetic watchlist page byte-identical before/after; a full
+  `pyinstaller curatarr.spec` build + running the resulting frozen binary.
+  Added 11 new tests for the hoisted/extracted functions (2448 passed, up
+  from 2437).
+
 ## [2.10.27] - 2026-07-26
 
 ### Changed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -1921,20 +1921,9 @@ def load_ignore_list(display_name: str) -> Set[str]:
     return set()
 
 
-def process_user(config, plex, username, movie_library=None, tv_library=None):
-    """Process external recommendations for a single user.
-
-    Args:
-        config: Root configuration dictionary
-        plex: Connected PlexServer instance
-        username: Plex username to process
-        movie_library: Optional normalized movie library dict (#157 Phase 3,
-            see utils.config.get_libraries). None keeps the legacy
-            single-library behavior (config['plex'].movie_library).
-        tv_library: Optional normalized tv library dict (#157 Phase 3).
-            None keeps the legacy single-library behavior
-            (config['plex'].tv_library).
-    """
+def _pu_resolve_context(config, username, movie_library, tv_library):
+    """process_user stage: resolve display name/library section names/cache
+    lib-ids for this user (see process_user)."""
     user_prefs = config.get("users", {}).get("preferences", {}).get(username, {})
     display_name = user_prefs.get("display_name", username)
 
@@ -1952,6 +1941,14 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
     movie_cache_lib_id = movie_library["id"] if movie_is_multi else None
     tv_cache_lib_id = tv_library["id"] if tv_is_multi else None
 
+    return (user_prefs, display_name, movie_library_name, tv_library_name, movie_cache_lib_id, tv_cache_lib_id)
+
+
+def _pu_load_libraries_and_caches(
+    plex, display_name, movie_library_name, tv_library_name, movie_cache_lib_id, tv_cache_lib_id
+):
+    """process_user stage: fetch current library contents and load this
+    user's existing recommendation caches/ignore list (see process_user)."""
     library_movies = get_library_items(plex, movie_library_name, "movie")
     library_shows = get_library_items(plex, tv_library_name, "show")
 
@@ -1962,6 +1959,14 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
     show_cache = load_cache(display_name, "shows", lib_id=tv_cache_lib_id)
     ignore_list = load_ignore_list(display_name)
 
+    return (library_movies, library_shows, movie_cache, show_cache, ignore_list)
+
+
+def _pu_clean_caches(config, movie_cache, show_cache, library_movies, library_shows, ignore_list):
+    """process_user stage: mutate movie_cache/show_cache in place - drop
+    items that fail the configured language filter, are now in the
+    library (acquired), or are on the user's ignore list (see
+    process_user)."""
     # Get language filter from config
     external_config = config.get("external_recommendations", {})
     language_filter = external_config.get("language")
@@ -2018,6 +2023,11 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
     if removed_ignored:
         print(f"{YELLOW}Removed {removed_ignored} ignored items{RESET}")
 
+
+def _pu_build_profiles(plex, config, username):
+    """process_user stage: load (or build) this user's movie/show
+    preference profiles, then enhance them with Trakt watch history where
+    applicable (see process_user)."""
     # Load user profiles from cache (FAST) or build from scratch (SLOW)
     # Cache is pre-computed by internal recommenders with proper weighting
     movie_profile = load_user_profile_from_cache(config, username, "movie")
@@ -2049,6 +2059,14 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
         if show_profile:
             show_profile = enhance_profile_with_trakt(show_profile, config, tmdb_api_key, cache_dir, "tv")
 
+    return (movie_profile, show_profile, tmdb_api_key)
+
+
+def _pu_plan_discovery(config, user_prefs, movie_cache, show_cache):
+    """process_user stage: compute each cache's quality-item deficit
+    against its configured limit, the cached-id exclusion sets, and any
+    Trakt watchlist IMDB ids to exclude from discovery (see
+    process_user)."""
     # Find new recommendations using profile-based scoring
     external_config = config.get("external_recommendations", {})
     movie_limit = external_config.get("movie_limit", 50)
@@ -2088,6 +2106,43 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
                     f"Excluding {len(exclude_movie_imdb_ids)} movies, {len(exclude_show_imdb_ids)} shows from Trakt watchlist"
                 )
 
+    return (
+        movie_limit,
+        show_limit,
+        min_relevance,
+        exclude_genres,
+        quality_movies,
+        quality_shows,
+        movie_deficit,
+        show_deficit,
+        cached_movie_ids,
+        cached_show_ids,
+        exclude_movie_imdb_ids,
+        exclude_show_imdb_ids,
+    )
+
+
+def _pu_discover_new_content(
+    tmdb_api_key,
+    movie_profile,
+    show_profile,
+    library_movies,
+    library_shows,
+    movie_deficit,
+    show_deficit,
+    quality_movies,
+    quality_shows,
+    exclude_genres,
+    min_relevance,
+    config,
+    exclude_movie_imdb_ids,
+    exclude_show_imdb_ids,
+    cached_movie_ids,
+    cached_show_ids,
+):
+    """process_user stage: discover new movie/show recommendations to fill
+    each cache's deficit (skipped entirely when a cache is already at or
+    above its limit) (see process_user)."""
     # Movie discovery - skip if cache is full, otherwise find deficit items
     if movie_deficit == 0:
         print(f"{GREEN}Movie cache healthy ({len(quality_movies)} quality items), skipping discovery{RESET}")
@@ -2126,6 +2181,26 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
             exclude_cached_ids=cached_show_ids,  # Skip items already in cache
         )
 
+    return (new_movies, new_shows)
+
+
+def _pu_reconcile_caches(
+    movie_cache,
+    show_cache,
+    new_movies,
+    new_shows,
+    movie_limit,
+    show_limit,
+    display_name,
+    movie_cache_lib_id,
+    tv_cache_lib_id,
+    min_relevance,
+):
+    """process_user stage: merge newly-discovered items into the caches
+    (updating scores for items already present), trim each cache back down
+    to its configured limit (keeping the highest-scored items), persist
+    both caches, then build the final threshold-filtered, limit-backfilled
+    movie/show lists for this run's output (see process_user)."""
     # Merge with existing cache - UPDATE scores for existing items, ADD new ones
     for movie in new_movies:
         tmdb_id = str(movie["tmdb_id"])
@@ -2227,6 +2302,13 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
         f"{GREEN}Output: {len(shows_list)} shows ({len(high_shows)} above {int(min_relevance * 100)}% threshold){RESET}"
     )
 
+    return (movies_list, shows_list)
+
+
+def _pu_categorize_and_stamp(config, movies_list, shows_list, tmdb_api_key, movie_library, tv_library):
+    """process_user stage: categorize the final movie/show lists by
+    streaming-service availability and stamp each item with its source
+    library id (#157 Phase 3 provenance) (see process_user)."""
     # Get household streaming services from top-level config
     user_services = config.get("streaming_services", [])
 
@@ -2243,6 +2325,12 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
     _stamp_library_id(movies_categorized, movie_item_library_id)
     _stamp_library_id(shows_categorized, tv_item_library_id)
 
+    return (movies_categorized, shows_categorized, user_services)
+
+
+def _pu_finalize_output(username, display_name, movies_categorized, shows_categorized):
+    """process_user stage: write this user's markdown recommendations file
+    and print the final per-user summary (see process_user)."""
     # Generate markdown per user
     project_root = get_project_root()
     output_dir = os.path.join(project_root, "recommendations", "external")
@@ -2262,6 +2350,86 @@ def process_user(config, plex, username, movie_library=None, tv_library=None):
 
     print(f"{GREEN}Processed: {total_movies} movies, {total_shows} shows{RESET}")
     print(f"\nExternal recommendation process completed for {display_name}!")
+
+
+def process_user(config, plex, username, movie_library=None, tv_library=None):
+    """Process external recommendations for a single user.
+
+    Args:
+        config: Root configuration dictionary
+        plex: Connected PlexServer instance
+        username: Plex username to process
+        movie_library: Optional normalized movie library dict (#157 Phase 3,
+            see utils.config.get_libraries). None keeps the legacy
+            single-library behavior (config['plex'].movie_library).
+        tv_library: Optional normalized tv library dict (#157 Phase 3).
+            None keeps the legacy single-library behavior
+            (config['plex'].tv_library).
+    """
+    user_prefs, display_name, movie_library_name, tv_library_name, movie_cache_lib_id, tv_cache_lib_id = (
+        _pu_resolve_context(config, username, movie_library, tv_library)
+    )
+
+    library_movies, library_shows, movie_cache, show_cache, ignore_list = _pu_load_libraries_and_caches(
+        plex, display_name, movie_library_name, tv_library_name, movie_cache_lib_id, tv_cache_lib_id
+    )
+
+    _pu_clean_caches(config, movie_cache, show_cache, library_movies, library_shows, ignore_list)
+
+    movie_profile, show_profile, tmdb_api_key = _pu_build_profiles(plex, config, username)
+
+    (
+        movie_limit,
+        show_limit,
+        min_relevance,
+        exclude_genres,
+        quality_movies,
+        quality_shows,
+        movie_deficit,
+        show_deficit,
+        cached_movie_ids,
+        cached_show_ids,
+        exclude_movie_imdb_ids,
+        exclude_show_imdb_ids,
+    ) = _pu_plan_discovery(config, user_prefs, movie_cache, show_cache)
+
+    new_movies, new_shows = _pu_discover_new_content(
+        tmdb_api_key,
+        movie_profile,
+        show_profile,
+        library_movies,
+        library_shows,
+        movie_deficit,
+        show_deficit,
+        quality_movies,
+        quality_shows,
+        exclude_genres,
+        min_relevance,
+        config,
+        exclude_movie_imdb_ids,
+        exclude_show_imdb_ids,
+        cached_movie_ids,
+        cached_show_ids,
+    )
+
+    movies_list, shows_list = _pu_reconcile_caches(
+        movie_cache,
+        show_cache,
+        new_movies,
+        new_shows,
+        movie_limit,
+        show_limit,
+        display_name,
+        movie_cache_lib_id,
+        tv_cache_lib_id,
+        min_relevance,
+    )
+
+    movies_categorized, shows_categorized, user_services = _pu_categorize_and_stamp(
+        config, movies_list, shows_list, tmdb_api_key, movie_library, tv_library
+    )
+
+    _pu_finalize_output(username, display_name, movies_categorized, shows_categorized)
 
     # Return data for combined HTML generation and Trakt sync.
     #

--- a/recommenders/external_render.py
+++ b/recommenders/external_render.py
@@ -256,6 +256,126 @@ def generate_markdown(
     return output_file
 
 
+def _collect_tmdb_ids_from_categorized(categorized, media_type, imdb_cache, all_imdb_ids, pending_lookups):
+    """Helper to collect TMDB IDs from categorized items."""
+    items = categorized.get("all_items", [])
+    if not items:
+        for service_items in categorized.get("user_services", {}).values():
+            items.extend(service_items)
+        for service_items in categorized.get("other_services", {}).values():
+            items.extend(service_items)
+        items.extend(categorized.get("acquire", []))
+
+    for item in items:
+        tmdb_id = item.get("tmdb_id")
+        if not tmdb_id:
+            continue
+        # Check cache first
+        cache_key = f"{tmdb_id}_{media_type}"
+        if cache_key in imdb_cache:
+            all_imdb_ids[tmdb_id] = imdb_cache[cache_key]
+        elif tmdb_id not in all_imdb_ids and (tmdb_id, media_type) not in [(p[0], p[1]) for p in pending_lookups]:
+            pending_lookups.append((tmdb_id, media_type))
+
+
+def _render_table_flat(
+    items, media_type, user_id, user_services, all_imdb_ids, now, movie_counts, show_counts, total_users
+):
+    """Render HTML table with streaming icons column (score-sorted)"""
+    rows = []
+    counts = movie_counts if media_type == "movie" else show_counts
+    for item in items:
+        tmdb_id = item.get("tmdb_id", "")
+        imdb_id = all_imdb_ids.get(tmdb_id, "")
+        days_listed = (now - datetime.fromisoformat(item["added_date"])).days
+        # Show shared count if more than one user
+        user_count = counts.get(str(tmdb_id), 1)
+        shared_badge = (
+            f'<span class="shared-badge" title="{user_count} of {total_users} users want this">{user_count}/{total_users}</span>'
+            if total_users > 1
+            else ""
+        )
+        # Render streaming icons (with rent/buy fallback)
+        streaming_services = item.get("streaming_services", [])
+        rent_services = item.get("rent_services", [])
+        buy_services = item.get("buy_services", [])
+        streaming_html = render_streaming_icons(
+            streaming_services, user_services, rent_services, buy_services, item["title"]
+        )
+        # Add animated badge if applicable
+        genre_ids = item.get("genre_ids", [])
+        animated_badge = '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ""
+        rows.append(f'''
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="{_esc(media_type)}" data-user="{_esc(user_id)}">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>{_esc(item["title"])} {animated_badge}{shared_badge}</td>
+                    <td>{_esc(item["year"])}</td>
+                    <td>{item["rating"]:.1f}</td>
+                    <td>{item["score"]:.0%}</td>
+                    <td><div class="streaming-icons">{streaming_html}</div></td>
+                    <td>{days_listed}</td>
+                </tr>''')
+    return "\n".join(rows)
+
+
+def _render_sequels_table(items, user_services, all_imdb_ids):
+    """Render HTML table for missing sequels (Sequel Huntarr)"""
+    rows = []
+    for item in items:
+        tmdb_id = item.get("tmdb_id", "")
+        imdb_id = all_imdb_ids.get(tmdb_id, "")
+        collection_name = item.get("collection_name", "Unknown")
+        owned = item.get("owned_count", 0)
+        total = item.get("total_count", 0)
+        streaming_services = item.get("streaming_services", [])
+        rent_services = item.get("rent_services", [])
+        buy_services = item.get("buy_services", [])
+        streaming_html = render_streaming_icons(
+            streaming_services, user_services, rent_services, buy_services, item["title"]
+        )
+        # Add badges for TV Special and Animated
+        badges = ""
+        if item.get("is_animated"):
+            badges += '<span class="animated-badge">Animated</span>'
+        if item.get("is_tv_movie"):
+            badges += '<span class="tv-special-badge">TV Special</span>'
+        rows.append(f'''
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="sequel-huntarr">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>{_esc(item["title"])} {badges}</td>
+                    <td>{_esc(item.get("year", ""))}</td>
+                    <td>{_esc(collection_name)}</td>
+                    <td>{owned}/{total}</td>
+                    <td><div class="streaming-icons">{streaming_html}</div></td>
+                </tr>''')
+    return "\n".join(rows)
+
+
+def _render_horizon_table(items, all_imdb_ids):
+    """Render HTML table for upcoming movies (Horizon Huntarr)"""
+    rows = []
+    for item in items:
+        tmdb_id = item.get("tmdb_id", "")
+        imdb_id = all_imdb_ids.get(tmdb_id, "")
+        collection_name = item.get("collection_name", "Unknown")
+        release_date = item.get("release_date", "TBA")
+        status = item.get("status", "Unknown")
+        # Status badge styling
+        status_class = status.lower().replace(" ", "-")
+        # Add animated badge if applicable
+        genre_ids = item.get("genre_ids", [])
+        animated_badge = '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ""
+        rows.append(f'''
+                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="horizon-huntarr">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>{_esc(item["title"])} {animated_badge}</td>
+                    <td>{_esc(collection_name)}</td>
+                    <td>{_esc(release_date)}</td>
+                    <td><span class="status-badge {_esc(status_class)}">{_esc(status)}</span></td>
+                </tr>''')
+    return "\n".join(rows)
+
+
 def generate_combined_html(
     all_users_data: List[Dict],
     output_dir: str,
@@ -303,30 +423,13 @@ def generate_combined_html(
     all_imdb_ids = {}  # tmdb_id -> imdb_id
     pending_lookups = []  # [(tmdb_id, media_type), ...]
 
-    def collect_tmdb_ids_from_categorized(categorized, media_type):
-        """Helper to collect TMDB IDs from categorized items."""
-        items = categorized.get("all_items", [])
-        if not items:
-            for service_items in categorized.get("user_services", {}).values():
-                items.extend(service_items)
-            for service_items in categorized.get("other_services", {}).values():
-                items.extend(service_items)
-            items.extend(categorized.get("acquire", []))
-
-        for item in items:
-            tmdb_id = item.get("tmdb_id")
-            if not tmdb_id:
-                continue
-            # Check cache first
-            cache_key = f"{tmdb_id}_{media_type}"
-            if cache_key in imdb_cache:
-                all_imdb_ids[tmdb_id] = imdb_cache[cache_key]
-            elif tmdb_id not in all_imdb_ids and (tmdb_id, media_type) not in [(p[0], p[1]) for p in pending_lookups]:
-                pending_lookups.append((tmdb_id, media_type))
-
     for user_data in all_users_data:
-        collect_tmdb_ids_from_categorized(user_data["movies_categorized"], "movie")
-        collect_tmdb_ids_from_categorized(user_data["shows_categorized"], "tv")
+        _collect_tmdb_ids_from_categorized(
+            user_data["movies_categorized"], "movie", imdb_cache, all_imdb_ids, pending_lookups
+        )
+        _collect_tmdb_ids_from_categorized(
+            user_data["shows_categorized"], "tv", imdb_cache, all_imdb_ids, pending_lookups
+        )
 
     # Also collect from missing sequels (Sequel Huntarr)
     for item in missing_sequels:
@@ -369,103 +472,6 @@ def generate_combined_html(
     else:
         print(f"  {GREEN}All {len(all_imdb_ids)} IMDB IDs from cache{RESET}")
 
-    def render_table_flat(items, media_type, user_id, user_services):
-        """Render HTML table with streaming icons column (score-sorted)"""
-        rows = []
-        counts = movie_counts if media_type == "movie" else show_counts
-        for item in items:
-            tmdb_id = item.get("tmdb_id", "")
-            imdb_id = all_imdb_ids.get(tmdb_id, "")
-            days_listed = (now - datetime.fromisoformat(item["added_date"])).days
-            # Show shared count if more than one user
-            user_count = counts.get(str(tmdb_id), 1)
-            shared_badge = (
-                f'<span class="shared-badge" title="{user_count} of {total_users} users want this">{user_count}/{total_users}</span>'
-                if total_users > 1
-                else ""
-            )
-            # Render streaming icons (with rent/buy fallback)
-            streaming_services = item.get("streaming_services", [])
-            rent_services = item.get("rent_services", [])
-            buy_services = item.get("buy_services", [])
-            streaming_html = render_streaming_icons(
-                streaming_services, user_services, rent_services, buy_services, item["title"]
-            )
-            # Add animated badge if applicable
-            genre_ids = item.get("genre_ids", [])
-            animated_badge = (
-                '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ""
-            )
-            rows.append(f'''
-                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="{_esc(media_type)}" data-user="{_esc(user_id)}">
-                    <td><input type="checkbox" class="select-item"></td>
-                    <td>{_esc(item["title"])} {animated_badge}{shared_badge}</td>
-                    <td>{_esc(item["year"])}</td>
-                    <td>{item["rating"]:.1f}</td>
-                    <td>{item["score"]:.0%}</td>
-                    <td><div class="streaming-icons">{streaming_html}</div></td>
-                    <td>{days_listed}</td>
-                </tr>''')
-        return "\n".join(rows)
-
-    def render_sequels_table(items, user_services):
-        """Render HTML table for missing sequels (Sequel Huntarr)"""
-        rows = []
-        for item in items:
-            tmdb_id = item.get("tmdb_id", "")
-            imdb_id = all_imdb_ids.get(tmdb_id, "")
-            collection_name = item.get("collection_name", "Unknown")
-            owned = item.get("owned_count", 0)
-            total = item.get("total_count", 0)
-            streaming_services = item.get("streaming_services", [])
-            rent_services = item.get("rent_services", [])
-            buy_services = item.get("buy_services", [])
-            streaming_html = render_streaming_icons(
-                streaming_services, user_services, rent_services, buy_services, item["title"]
-            )
-            # Add badges for TV Special and Animated
-            badges = ""
-            if item.get("is_animated"):
-                badges += '<span class="animated-badge">Animated</span>'
-            if item.get("is_tv_movie"):
-                badges += '<span class="tv-special-badge">TV Special</span>'
-            rows.append(f'''
-                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="sequel-huntarr">
-                    <td><input type="checkbox" class="select-item"></td>
-                    <td>{_esc(item["title"])} {badges}</td>
-                    <td>{_esc(item.get("year", ""))}</td>
-                    <td>{_esc(collection_name)}</td>
-                    <td>{owned}/{total}</td>
-                    <td><div class="streaming-icons">{streaming_html}</div></td>
-                </tr>''')
-        return "\n".join(rows)
-
-    def render_horizon_table(items):
-        """Render HTML table for upcoming movies (Horizon Huntarr)"""
-        rows = []
-        for item in items:
-            tmdb_id = item.get("tmdb_id", "")
-            imdb_id = all_imdb_ids.get(tmdb_id, "")
-            collection_name = item.get("collection_name", "Unknown")
-            release_date = item.get("release_date", "TBA")
-            status = item.get("status", "Unknown")
-            # Status badge styling
-            status_class = status.lower().replace(" ", "-")
-            # Add animated badge if applicable
-            genre_ids = item.get("genre_ids", [])
-            animated_badge = (
-                '<span class="animated-badge">Animated</span>' if TMDB_ANIMATION_GENRE_ID in genre_ids else ""
-            )
-            rows.append(f'''
-                <tr data-tmdb="{_esc(tmdb_id)}" data-imdb="{_esc(imdb_id)}" data-type="movie" data-user="horizon-huntarr">
-                    <td><input type="checkbox" class="select-item"></td>
-                    <td>{_esc(item["title"])} {animated_badge}</td>
-                    <td>{_esc(collection_name)}</td>
-                    <td>{_esc(release_date)}</td>
-                    <td><span class="status-badge {_esc(status_class)}">{_esc(status)}</span></td>
-                </tr>''')
-        return "\n".join(rows)
-
     # Build tabs HTML
     tabs_html = ""
     panels_html = ""
@@ -488,13 +494,16 @@ def generate_combined_html(
         all_movies = movies_cat.get("all_items", [])
         if all_movies:
             panel_content += f"<h2>Movies to Watch ({len(all_movies)})</h2>"
+            movies_table_html = _render_table_flat(
+                all_movies, "movie", user_id, user_services, all_imdb_ids, now, movie_counts, show_counts, total_users
+            )
             panel_content += f"""
                 <table>
                     <thead>
                         <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Rating</th><th class="sortable desc">Score</th><th class="sortable">Streaming</th><th class="sortable">Days</th></tr>
                     </thead>
                     <tbody>
-                        {render_table_flat(all_movies, "movie", user_id, user_services)}
+                        {movies_table_html}
                     </tbody>
                 </table>"""
 
@@ -502,13 +511,16 @@ def generate_combined_html(
         all_shows = shows_cat.get("all_items", [])
         if all_shows:
             panel_content += f"<h2>TV Shows to Watch ({len(all_shows)})</h2>"
+            shows_table_html = _render_table_flat(
+                all_shows, "show", user_id, user_services, all_imdb_ids, now, movie_counts, show_counts, total_users
+            )
             panel_content += f"""
                 <table>
                     <thead>
                         <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Rating</th><th class="sortable desc">Score</th><th class="sortable">Streaming</th><th class="sortable">Days</th></tr>
                     </thead>
                     <tbody>
-                        {render_table_flat(all_shows, "show", user_id, user_services)}
+                        {shows_table_html}
                     </tbody>
                 </table>"""
 
@@ -537,7 +549,7 @@ def generate_combined_html(
                     <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Collection</th><th class="sortable">Owned</th><th class="sortable">Streaming</th></tr>
                 </thead>
                 <tbody>
-                    {render_sequels_table(missing_sequels, first_user_services)}
+                    {_render_sequels_table(missing_sequels, first_user_services, all_imdb_ids)}
                 </tbody>
             </table>"""
         panels_html += f'<div class="tab-panel {is_active}" data-user="sequel-huntarr">{sequels_content}</div>\n'
@@ -558,7 +570,7 @@ def generate_combined_html(
                     <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Collection</th><th class="sortable">Release Date</th><th class="sortable">Status</th></tr>
                 </thead>
                 <tbody>
-                    {render_horizon_table(horizon_movies)}
+                    {_render_horizon_table(horizon_movies, all_imdb_ids)}
                 </tbody>
             </table>"""
         panels_html += f'<div class="tab-panel {is_active}" data-user="horizon-huntarr">{horizon_content}</div>\n'

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -28,6 +28,8 @@ from recommenders.external import (
     _empty_categorized,
     _merge_categorized,
     _merge_user_runs,
+    _pu_plan_discovery,
+    _pu_resolve_context,
     _stamp_library_id,
     categorize_by_streaming_service,
     discover_popular_by_genre,
@@ -4736,3 +4738,91 @@ class TestEarlyTermination:
 
         # Should reset to 0
         assert consecutive_zero_iterations == 0
+
+
+class TestProcessUserResolveContext:
+    """Tests for _pu_resolve_context() - one of process_user's named
+    pipeline stages (#audit remediation batch E, PR3)."""
+
+    def test_legacy_config_resolves_section_names_and_none_lib_ids(self):
+        config = {"plex": {"movie_library": "Movies", "tv_library": "TV Shows"}, "users": {"preferences": {}}}
+        (
+            user_prefs,
+            display_name,
+            movie_library_name,
+            tv_library_name,
+            movie_cache_lib_id,
+            tv_cache_lib_id,
+        ) = _pu_resolve_context(config, "alice", None, None)
+
+        assert user_prefs == {}
+        assert display_name == "alice"
+        assert movie_library_name == "Movies"
+        assert tv_library_name == "TV Shows"
+        assert movie_cache_lib_id is None
+        assert tv_cache_lib_id is None
+
+    def test_display_name_prefers_configured_preference(self):
+        config = {
+            "plex": {"movie_library": "Movies", "tv_library": "TV Shows"},
+            "users": {"preferences": {"alice": {"display_name": "Alice A."}}},
+        }
+        user_prefs, display_name, *_ = _pu_resolve_context(config, "alice", None, None)
+        assert display_name == "Alice A."
+        assert user_prefs == {"display_name": "Alice A."}
+
+    @patch("recommenders.external.get_libraries_for_media_type")
+    def test_multi_library_qualifies_cache_lib_id(self, mock_get_libs):
+        mock_get_libs.return_value = [Mock(), Mock()]  # 2 libraries -> "is_multi"
+        config = {"plex": {}, "users": {"preferences": {}}}
+        movie_library = {"id": "movies-4k", "section": "Movies 4K"}
+        tv_library = {"id": "tv-shows", "section": "TV Shows"}
+
+        *_rest, movie_cache_lib_id, tv_cache_lib_id = _pu_resolve_context(config, "alice", movie_library, tv_library)
+
+        assert movie_cache_lib_id == "movies-4k"
+        assert tv_cache_lib_id == "tv-shows"
+
+
+class TestProcessUserPlanDiscovery:
+    """Tests for _pu_plan_discovery() - one of process_user's named
+    pipeline stages (#audit remediation batch E, PR3)."""
+
+    def test_healthy_cache_has_zero_deficit(self):
+        config = {
+            "external_recommendations": {"movie_limit": 2, "show_limit": 2, "min_relevance_score": 0.5},
+            "trakt": {},
+        }
+        movie_cache = {"1": {"score": 0.9}, "2": {"score": 0.8}}
+        show_cache = {}
+
+        result = _pu_plan_discovery(config, {}, movie_cache, show_cache)
+        (
+            movie_limit,
+            show_limit,
+            min_relevance,
+            exclude_genres,
+            quality_movies,
+            quality_shows,
+            movie_deficit,
+            show_deficit,
+            cached_movie_ids,
+            cached_show_ids,
+            exclude_movie_imdb_ids,
+            exclude_show_imdb_ids,
+        ) = result
+
+        assert movie_deficit == 0
+        assert show_deficit == 2
+        assert len(quality_movies) == 2
+        assert cached_movie_ids == {1, 2}
+        assert exclude_genres == []
+        assert exclude_movie_imdb_ids == set()
+        assert exclude_show_imdb_ids == set()
+
+    def test_excluded_genres_from_user_prefs(self):
+        config = {"external_recommendations": {"movie_limit": 5, "show_limit": 5}, "trakt": {}}
+        user_prefs = {"exclude_genres": ["Horror"]}
+
+        result = _pu_plan_discovery(config, user_prefs, {}, {})
+        assert result[3] == ["Horror"]

--- a/tests/test_external_render.py
+++ b/tests/test_external_render.py
@@ -10,12 +10,16 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from recommenders.external_render import (
     SERVICE_SHORT_NAMES,
+    _collect_tmdb_ids_from_categorized,
     _generate_html_template,
     _html_body_header,
     _html_head_and_style,
     _html_script,
     _html_tabs_and_panels,
     _load_imdb_cache,
+    _render_horizon_table,
+    _render_sequels_table,
+    _render_table_flat,
     _save_imdb_cache,
     generate_combined_html,
     generate_markdown,
@@ -1102,3 +1106,110 @@ class TestGenerateHtmlTemplateHelpers:
         )
         actual = _generate_html_template(tabs_html, panels_html, now)
         assert actual == expected
+
+
+class TestHoistedGenerateCombinedHtmlHelpers:
+    """Tests for the 4 helpers generate_combined_html used to define as
+    nested closures (collect_tmdb_ids_from_categorized, render_table_flat,
+    render_sequels_table, render_horizon_table) - hoisted to module level
+    (now underscore-prefixed) so they're reachable/testable in isolation."""
+
+    def test_collect_tmdb_ids_from_categorized_uses_cache_hit(self):
+        imdb_cache = {"123_movie": "tt000123"}
+        all_imdb_ids = {}
+        pending_lookups = []
+        categorized = {"all_items": [{"tmdb_id": 123, "title": "Cached Movie"}]}
+
+        _collect_tmdb_ids_from_categorized(categorized, "movie", imdb_cache, all_imdb_ids, pending_lookups)
+
+        assert all_imdb_ids == {123: "tt000123"}
+        assert pending_lookups == []
+
+    def test_collect_tmdb_ids_from_categorized_queues_cache_miss(self):
+        imdb_cache = {}
+        all_imdb_ids = {}
+        pending_lookups = []
+        categorized = {"all_items": [{"tmdb_id": 456, "title": "New Movie"}]}
+
+        _collect_tmdb_ids_from_categorized(categorized, "movie", imdb_cache, all_imdb_ids, pending_lookups)
+
+        assert all_imdb_ids == {}
+        assert pending_lookups == [(456, "movie")]
+
+    def test_collect_tmdb_ids_from_categorized_falls_back_to_service_buckets(self):
+        """When all_items is empty, falls back to user_services/other_services/acquire."""
+        imdb_cache = {}
+        all_imdb_ids = {}
+        pending_lookups = []
+        categorized = {
+            "all_items": [],
+            "user_services": {"netflix": [{"tmdb_id": 789, "title": "Bucketed Movie"}]},
+            "other_services": {},
+            "acquire": [],
+        }
+
+        _collect_tmdb_ids_from_categorized(categorized, "movie", imdb_cache, all_imdb_ids, pending_lookups)
+
+        assert pending_lookups == [(789, "movie")]
+
+    def test_render_table_flat_produces_row_with_tmdb_and_score(self):
+        items = [
+            {
+                "tmdb_id": 111,
+                "title": "Some Movie",
+                "year": "2022",
+                "rating": 7.0,
+                "score": 0.8,
+                "added_date": "2024-01-01T00:00:00",
+                "streaming_services": [],
+                "genre_ids": [],
+            }
+        ]
+        result = _render_table_flat(
+            items,
+            "movie",
+            "user1",
+            [],
+            all_imdb_ids={111: "tt000111"},
+            now=datetime(2024, 1, 2, 0, 0),
+            movie_counts={},
+            show_counts={},
+            total_users=1,
+        )
+        assert 'data-tmdb="111"' in result
+        assert 'data-imdb="tt000111"' in result
+        assert "Some Movie" in result
+        assert "80%" in result
+
+    def test_render_sequels_table_produces_row_with_collection(self):
+        items = [
+            {
+                "tmdb_id": 222,
+                "title": "Sequel Movie",
+                "year": "2023",
+                "collection_name": "Big Franchise",
+                "owned_count": 2,
+                "total_count": 5,
+                "streaming_services": [],
+            }
+        ]
+        result = _render_sequels_table(items, [], all_imdb_ids={222: "tt000222"})
+        assert 'data-tmdb="222"' in result
+        assert "Big Franchise" in result
+        assert "2/5" in result
+
+    def test_render_horizon_table_produces_row_with_status_badge(self):
+        items = [
+            {
+                "tmdb_id": 333,
+                "title": "Upcoming Movie",
+                "collection_name": "Future Franchise",
+                "release_date": "2027-01-01",
+                "status": "Post Production",
+                "genre_ids": [],
+            }
+        ]
+        result = _render_horizon_table(items, all_imdb_ids={333: "tt000333"})
+        assert 'data-tmdb="333"' in result
+        assert "Future Franchise" in result
+        assert 'status-badge post-production">Post Production</span>' in result

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.27"
+__version__ = "2.10.28"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Hoists generate_combined_html's (recommenders/external_render.py) 4 nested helper functions to module level: _collect_tmdb_ids_from_categorized, _render_table_flat, _render_sequels_table, _render_horizon_table - previously-captured closure variables (imdb_cache, all_imdb_ids, pending_lookups, now, movie_counts, show_counts, total_users) become explicit parameters.
- Splits process_user (recommenders/external.py, ~373 lines, 44 branches, shallow nesting) into 9 named pipeline stages, called in the exact original order (existing tests assert on mocked dependencies' call order, e.g. movie before tv). Signature/return contract unchanged.
- Evaluated and skipped two other audit-flagged candidates (documented in CHANGELOG): find_similar_content_with_profile (genuine cross-iteration mutable state in its discovery loop) and export_to_sonarr/export_to_radarr (structurally parallel but not simple 1:1 substitutions - different exception types/client methods/id fields/per-service settings).

## Verification
- tests/harness.py (PYTHONHASHSEED=0): byte-identical.
- Synthetic watchlist page generated via generate_combined_html: byte-identical diff before/after.
- Full pyinstaller curatarr.spec build succeeded; ran the resulting frozen binary (--version -> 2.10.28, --help) to confirm the split didn't break the frozen build.
- Full suite: 2437 passed (PR2 baseline) -> 2448 passed (+11 new tests), 1 skipped, 0 failures.
- ruff format --check: clean. ruff check: 126 findings, same as main (0 new).

## Test plan
- [x] tests/harness.py byte-identical
- [x] synthetic watchlist page byte-identical before/after
- [x] pyinstaller build + frozen binary --help/--version succeed
- [x] full pytest suite green
- [x] ruff format/check clean vs baseline