### PR TITLE
fix: web hardening - login rate limiting, conditional Secure cookie, static assets (2.10.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.30] - 2026-07-26
+
+### Changed
+
+- **Web hardening: login rate limiting, conditional Secure cookie, static assets.**
+
+  Three independent hardening fixes to `web/security.py`, found during
+  an audit pass:
+
+  - `POST /login` had no failed-attempt limiting at all - an attacker
+    (or a script) could hammer the endpoint as fast as the process
+    could handle requests. Added a per-source-IP failed-attempt
+    counter: 5 failures within a rolling 60-second window locks that
+    IP out (rejected outright, without even checking the token, so
+    continuing to hit the endpoint while locked out can't extend the
+    lockout). Never permanent - the window ages out on its own with no
+    operator intervention, and a single successful login clears the
+    IP's history immediately. In-process/in-memory, no new dependency
+    (flask-limiter is not already a requirement). Every failed attempt
+    is logged (source IP only, never the attempted token).
+  - The `curatarr_token` cookie always omitted `Secure`, on the
+    reasoning that this app is served over plain HTTP by design. That's
+    still true for the common case, but self-hosters commonly put a
+    TLS-terminating reverse proxy (nginx/Caddy/Traefik) in front of it.
+    `Secure` is now set whenever the request actually arrived over TLS
+    - directly, or via a trusted proxy's `X-Forwarded-Proto`, gated
+    behind an explicit `CURATARR_TRUST_PROXY_PROTO=true` opt-in (that
+    header is otherwise exactly as spoofable by a direct caller as any
+    other request header - unset by default, so every existing install
+    is unaffected).
+  - `_TOKEN_EXEMPT_PATHS` only exempted `/login` and `/healthz` - on a
+    non-loopback bind, the login page's own `/static/style.css` 401'd
+    before the browser had a token to present, breaking the login page
+    itself. Static assets are now exempt too (nothing else is).
+
 ## [2.10.29] - 2026-07-26
 
 ### Changed

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -8,7 +8,15 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pytest
 
 from web.app import create_app
-from web.security import _is_loopback_bind, is_allowed_host, redact, redact_lines, safe_join
+from web.security import (
+    _client_ip,
+    _is_loopback_bind,
+    _login_failures,
+    is_allowed_host,
+    redact,
+    redact_lines,
+    safe_join,
+)
 
 
 class TestRedact:
@@ -325,3 +333,254 @@ class TestRegisterTokenAuth:
         app.testing = True
         resp = app.test_client().get("/")
         assert resp.status_code == 401  # a configured token always wins
+
+
+class TestConditionalSecureCookie:
+    """PR2(b): the curatarr_token cookie's Secure attribute is set only
+    when the request actually arrived over TLS - directly
+    (request.is_secure) or, opt-in only, via a trusted reverse proxy's
+    X-Forwarded-Proto header - see web/security.py's
+    _request_is_secure. Never set on a plain-HTTP request with no
+    opt-in, matching this app's plain-HTTP-by-design default (see
+    TestRegisterTokenAuth.test_login_submit_with_correct_token_sets_cookie_and_redirects
+    above, unchanged)."""
+
+    NON_LOOPBACK_HOST = "0.0.0.0"
+    TOKEN = "a" * 32
+
+    def _client(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", self.TOKEN)
+        monkeypatch.delenv("CURATARR_TRUSTED_NETWORK", raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host=self.NON_LOOPBACK_HOST)
+        app.testing = True
+        return app.test_client()
+
+    def test_plain_http_request_gets_no_secure_flag(self, curatarr_web_root, monkeypatch):
+        monkeypatch.delenv("CURATARR_TRUST_PROXY_PROTO", raising=False)
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post("/login", data={"token": self.TOKEN}, follow_redirects=False)
+        assert "Secure" not in resp.headers.get("Set-Cookie", "")
+
+    def test_direct_tls_request_gets_secure_flag(self, curatarr_web_root, monkeypatch):
+        monkeypatch.delenv("CURATARR_TRUST_PROXY_PROTO", raising=False)
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"wsgi.url_scheme": "https"},
+        )
+        assert "Secure" in resp.headers.get("Set-Cookie", "")
+
+    def test_forwarded_proto_ignored_without_opt_in(self, curatarr_web_root, monkeypatch):
+        """A direct caller can set X-Forwarded-Proto to whatever it
+        wants - without CURATARR_TRUST_PROXY_PROTO=true, it must not be
+        trusted (see _request_is_secure's docstring)."""
+        monkeypatch.delenv("CURATARR_TRUST_PROXY_PROTO", raising=False)
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            headers={"X-Forwarded-Proto": "https"},
+        )
+        assert "Secure" not in resp.headers.get("Set-Cookie", "")
+
+    def test_forwarded_proto_honored_with_explicit_opt_in(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_TRUST_PROXY_PROTO", "true")
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            headers={"X-Forwarded-Proto": "https"},
+        )
+        assert "Secure" in resp.headers.get("Set-Cookie", "")
+
+    def test_forwarded_proto_http_with_opt_in_stays_insecure(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_TRUST_PROXY_PROTO", "true")
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            headers={"X-Forwarded-Proto": "http"},
+        )
+        assert "Secure" not in resp.headers.get("Set-Cookie", "")
+
+    def test_forwarded_proto_takes_last_value_in_chain(self, curatarr_web_root, monkeypatch):
+        """Only the nearest hop's appended value is trusted - see
+        _request_is_secure's docstring on single-hop trust."""
+        monkeypatch.setenv("CURATARR_TRUST_PROXY_PROTO", "true")
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            headers={"X-Forwarded-Proto": "https, http"},
+        )
+        assert "Secure" not in resp.headers.get("Set-Cookie", "")
+
+
+class TestStaticAssetsExemptFromToken:
+    """PR2(c): the login page's own static assets must be reachable
+    before a browser has a token - see web/security.py's
+    _TOKEN_EXEMPT_STATIC_PREFIX. Nothing else under /static-like paths
+    is exempted beyond that one prefix."""
+
+    NON_LOOPBACK_HOST = "0.0.0.0"
+    TOKEN = "a" * 32
+
+    def _client(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", self.TOKEN)
+        monkeypatch.delenv("CURATARR_TRUSTED_NETWORK", raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host=self.NON_LOOPBACK_HOST)
+        app.testing = True
+        return app.test_client()
+
+    def test_static_css_reachable_without_token(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.get("/static/style.css")
+        assert resp.status_code != 401
+
+    def test_other_paths_still_require_token(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        resp = c.get("/config/connections")
+        assert resp.status_code == 401
+
+
+class TestLoginRateLimiting:
+    """PR2(a): per-IP failed-attempt lockout on POST /login - see
+    web/security.py's _is_locked_out/_record_login_failure. Policy:
+    at most 5 failed attempts per source IP within a rolling 60-second
+    window; never permanent - see web/security.py's module docstring
+    above register_token_auth for the full rationale.
+    """
+
+    NON_LOOPBACK_HOST = "0.0.0.0"
+    TOKEN = "a" * 32
+    IP = "203.0.113.5"
+
+    def setup_method(self):
+        _login_failures.clear()
+
+    def teardown_method(self):
+        _login_failures.clear()
+
+    def _client(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", self.TOKEN)
+        monkeypatch.delenv("CURATARR_TRUSTED_NETWORK", raising=False)
+        app = create_app(project_root=curatarr_web_root, bind_host=self.NON_LOOPBACK_HOST)
+        app.testing = True
+        return app.test_client()
+
+    def _fail(self, c, times, ip=None):
+        for _ in range(times):
+            c.post(
+                "/login",
+                data={"token": "wrong"},
+                follow_redirects=False,
+                environ_overrides={"REMOTE_ADDR": ip or self.IP},
+            )
+
+    def test_below_threshold_still_gets_invalid_token_error(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 4)
+        resp = c.post(
+            "/login",
+            data={"token": "wrong"},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.headers["Location"] == "/login?error=1"
+
+    def test_reaching_threshold_locks_out(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 5)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},  # even the CORRECT token is rejected while locked out
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.headers["Location"] == "/login?error=locked"
+        assert "curatarr_token" not in resp.headers.get("Set-Cookie", "")
+
+    def test_lockout_is_scoped_per_ip(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 5, ip=self.IP)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": "198.51.100.9"},
+        )
+        assert resp.status_code == 303
+        assert "curatarr_token" in resp.headers.get("Set-Cookie", "")
+
+    def test_successful_login_clears_failure_history(self, curatarr_web_root, monkeypatch):
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 4)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert "curatarr_token" in resp.headers.get("Set-Cookie", "")
+        assert _client_ip.__module__ == "web.security"  # sanity the right module is under test
+        # A fresh run of failures now needs the full threshold again,
+        # not just one more (proves the history was actually cleared).
+        self._fail(c, 4)
+        resp = c.post(
+            "/login",
+            data={"token": "wrong"},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.headers["Location"] == "/login?error=1"
+
+    def test_lockout_expires_after_window(self, curatarr_web_root, monkeypatch):
+        """Never permanent - a rolling window that ages out on its
+        own. Simulated by monkeypatching time.monotonic rather than
+        actually sleeping 60s."""
+        import web.security as security_module
+
+        fake_now = [1000.0]
+        monkeypatch.setattr(security_module.time, "monotonic", lambda: fake_now[0])
+
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 5)
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.headers["Location"] == "/login?error=locked"
+
+        fake_now[0] += security_module._LOGIN_WINDOW_SECONDS + 1
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.status_code == 303
+        assert "curatarr_token" in resp.headers.get("Set-Cookie", "")
+
+    def test_failed_attempt_is_logged(self, curatarr_web_root, monkeypatch):
+        import web.security as security_module
+
+        logged = []
+        monkeypatch.setattr(security_module, "log_warning", lambda msg: logged.append(msg))
+
+        c = self._client(curatarr_web_root, monkeypatch)
+        c.post(
+            "/login",
+            data={"token": "wrong"},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert any(self.IP in msg for msg in logged)
+        assert not any("wrong" in msg for msg in logged)  # never log the attempted token

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.29"
+__version__ = "2.10.30"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/web/security.py
+++ b/web/security.py
@@ -19,7 +19,10 @@ violation). Re-exported here unchanged so every existing
 import hmac
 import os
 import re
+import threading
+import time
 
+from utils.display import log_warning
 from utils.redact import REDACTED, redact, redact_lines
 
 __all__ = [
@@ -226,6 +229,17 @@ def _is_loopback_bind(host: str) -> bool:
 #   way).
 _TOKEN_EXEMPT_PATHS = frozenset({"/login", "/healthz"})
 
+# Also exempt: the login page's own static assets (style.css etc, under
+# Flask's default static_url_path - web/app.py's Flask(__name__) never
+# sets a custom static_url_path). Without this, a non-loopback bind
+# 401s the login page's own CSS/JS before the browser has ever had a
+# chance to obtain the token cookie. These assets disclose nothing
+# (no config, no secrets - just the UI's own stylesheet/script), the
+# same risk profile as /login itself. Deliberately just this one
+# prefix, not a broader exemption - every other path still requires
+# the token.
+_TOKEN_EXEMPT_STATIC_PREFIX = "/static/"
+
 
 def _request_token(request) -> str:
     """Pull the caller-supplied token out of *request*, checking (in
@@ -253,6 +267,125 @@ def _valid_token(supplied: str) -> bool:
     if len(expected) < MIN_AUTH_TOKEN_LENGTH or not supplied:
         return False
     return hmac.compare_digest(supplied, expected)
+
+
+# Opt-in ack that this process is deployed behind a reverse proxy the
+# operator controls and trusts to set X-Forwarded-Proto accurately -
+# unset by default. See _request_is_secure below.
+TRUST_PROXY_PROTO_ENV_VAR = "CURATARR_TRUST_PROXY_PROTO"
+
+
+def _request_is_secure(request) -> bool:
+    """True if *request* arrived over TLS - either directly
+    (request.is_secure, i.e. the connection Werkzeug itself terminated
+    was HTTPS - never true for web/app.py's plain app.run(), by design)
+    or, only when the operator has explicitly set
+    CURATARR_TRUST_PROXY_PROTO=true, via a reverse proxy's
+    X-Forwarded-Proto: https header. Self-hosters commonly run this
+    app behind a TLS-terminating reverse proxy (nginx, Caddy, Traefik,
+    ...), where request.is_secure is always False - Werkzeug only ever
+    sees the proxy's own plain-HTTP hop to it.
+
+    X-Forwarded-Proto is a plain, unauthenticated request header any
+    direct caller can set to whatever they like - trusting it
+    unconditionally would let a caller who reaches this process
+    directly (bypassing the proxy entirely - e.g. on the same LAN)
+    simply lie their way into Secure-cookie treatment. Requiring the
+    explicit opt-in keeps every existing install (no proxy in front -
+    see web/app.py's default 127.0.0.1 bind) byte-for-byte unchanged,
+    and makes the ones that DO enable it trust only their OWN proxy's
+    header, a deliberate operator decision, not an arbitrary caller's.
+
+    Takes the LAST comma-separated value (nearest hop to this
+    process) if the header somehow contains more than one - a
+    single-hop trust model, matching the single explicit opt-in above:
+    only the proxy immediately in front of this process is trusted to
+    have appended its own accurate value, not whatever a client further
+    upstream may have prepended.
+    """
+    if request.is_secure:
+        return True
+    if os.environ.get(TRUST_PROXY_PROTO_ENV_VAR, "").strip().lower() != "true":
+        return False
+    forwarded = request.headers.get("X-Forwarded-Proto", "")
+    if not forwarded:
+        return False
+    return forwarded.split(",")[-1].strip().lower() == "https"
+
+
+# ---------------------------------------------------------------------------
+# Login rate limiting (POST /login only - see login_submit in
+# register_token_auth below).
+#
+# Policy: at most _LOGIN_MAX_ATTEMPTS failed attempts per source IP
+# within a rolling _LOGIN_WINDOW_SECONDS window; a locked-out IP is
+# rejected outright (without even checking the supplied token, so
+# hammering the endpoint while locked out can't extend the lockout -
+# see _is_locked_out). This is NEVER permanent: it's a rolling window,
+# not a persistent ban - the oldest recorded failure ages out of the
+# window on its own, and the IP regains the ability to try again
+# without any operator intervention (no admin unlock, no restart
+# needed). A single successful login immediately clears that IP's
+# history (see _clear_login_failures). Every failed attempt (locked-out
+# or not) is logged via log_warning - never the supplied token itself,
+# only the source IP - see login_submit.
+#
+# Intentionally in-process/in-memory, no new dependency (flask-limiter
+# is not already a requirement - see requirements-ui.txt): web/app.py's
+# main() and web/docker_server.py both run this as one long-lived
+# process (or one container) for the life of the server, so a plain
+# dict scoped to that process lifetime is sufficient. Resets on
+# restart - acceptable, since restarting the process already requires
+# whatever access restarting it requires. Guarded by a lock because
+# both app.run(threaded=True) (web/app.py) and the Docker waitress
+# server (web/docker_server.py) serve requests concurrently.
+# ---------------------------------------------------------------------------
+
+_LOGIN_MAX_ATTEMPTS = 5
+_LOGIN_WINDOW_SECONDS = 60
+
+_login_failures_lock = threading.Lock()
+_login_failures = {}  # {ip: [monotonic timestamp, ...]} of FAILED attempts only
+
+
+def _client_ip(request) -> str:
+    """Source IP bucket for login rate limiting - the immediate peer
+    address only (request.remote_addr), never X-Forwarded-For (that
+    header is exactly as spoofable as X-Forwarded-Proto - see
+    _request_is_secure above - and there's no equivalent opt-in for it
+    here). Behind a reverse proxy every client therefore shares one
+    bucket (the proxy's own address); that's an acceptable
+    simplification; it just means the rate limit is enforced
+    proxy-wide rather than per real client in that deployment, never
+    less strict than intended."""
+    return request.remote_addr or "unknown"
+
+
+def _prune_locked(ip: str, now: float) -> list:
+    """Attempts for *ip* still inside the rolling window, as of *now*
+    (a time.monotonic() reading) - must be called with
+    _login_failures_lock held."""
+    attempts = [t for t in _login_failures.get(ip, []) if now - t < _LOGIN_WINDOW_SECONDS]
+    _login_failures[ip] = attempts
+    return attempts
+
+
+def _is_locked_out(ip: str) -> bool:
+    with _login_failures_lock:
+        return len(_prune_locked(ip, time.monotonic())) >= _LOGIN_MAX_ATTEMPTS
+
+
+def _record_login_failure(ip: str) -> None:
+    with _login_failures_lock:
+        now = time.monotonic()
+        attempts = _prune_locked(ip, now)
+        attempts.append(now)
+        _login_failures[ip] = attempts
+
+
+def _clear_login_failures(ip: str) -> None:
+    with _login_failures_lock:
+        _login_failures.pop(ip, None)
 
 
 def register_token_auth(app, bind_host: str) -> None:
@@ -293,9 +426,16 @@ def register_token_auth(app, bind_host: str) -> None:
 
     @app.post("/login")
     def login_submit():
+        ip = _client_ip(request)
+        if _is_locked_out(ip):
+            log_warning(f"Login rejected for {ip} - too many failed attempts")
+            return redirect("/login?error=locked", code=303)
         supplied = request.form.get("token", "")
         if not _valid_token(supplied):
+            _record_login_failure(ip)
+            log_warning(f"Failed login attempt from {ip}")
             return redirect("/login?error=1", code=303)
+        _clear_login_failures(ip)
         response = make_response(redirect("/", code=303))
         response.set_cookie(
             AUTH_TOKEN_COOKIE_NAME,
@@ -303,10 +443,14 @@ def register_token_auth(app, bind_host: str) -> None:
             httponly=True,
             samesite="Strict",
             path="/",
-            # No secure=True: this app is served over plain HTTP on a
-            # LAN by design (see docs/DOCKER.md) - Secure would make the
-            # browser silently refuse to ever send the cookie back on
-            # any request, with no HTTPS path to switch to instead.
+            # Secure only when the request actually arrived over TLS
+            # (directly, or via a trusted reverse proxy's
+            # X-Forwarded-Proto - see _request_is_secure) - this app is
+            # also commonly served over plain HTTP on a LAN by design
+            # (see docs/DOCKER.md), where Secure would make the browser
+            # silently refuse to ever send the cookie back, with no
+            # HTTPS path to switch to instead.
+            secure=_request_is_secure(request),
         )
         return response
 
@@ -319,7 +463,7 @@ def register_token_auth(app, bind_host: str) -> None:
 
     @app.before_request
     def _token_auth_guard():
-        if request.path in _TOKEN_EXEMPT_PATHS:
+        if request.path in _TOKEN_EXEMPT_PATHS or request.path.startswith(_TOKEN_EXEMPT_STATIC_PREFIX):
             return
         if not _valid_token(_request_token(request)):
             abort(401)

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -11,7 +11,9 @@
     <main>
       <h1>Curatarr</h1>
       <p>This instance is not bound to loopback and requires an access token.</p>
-      {% if error %}
+      {% if error == 'locked' %}
+      <p class="banner error">Too many failed attempts. Try again in a minute.</p>
+      {% elif error %}
       <p class="banner error">Invalid token.</p>
       {% endif %}
       <form method="post" action="{{ url_for('login_submit') }}">


### PR DESCRIPTION
## Summary
- Per-IP failed-login rate limiting on POST /login (5 attempts / rolling 60s window, non-permanent, in-memory, no new dependency)
- curatarr_token cookie Secure flag now conditional on request.is_secure or an explicit CURATARR_TRUST_PROXY_PROTO=true opt-in for X-Forwarded-Proto
- /static/* assets exempted from the token guard so the login page's own CSS/JS load before a browser has a token

## Test plan
- [x] pytest tests/ (2462 passed, 1 skipped)
- [x] ruff check / ruff format --check clean
