### PR TITLE
fix: lint and test-hygiene debt - ruff clean, mypy reduced, cache-dir test leak fixed (2.10.31)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,14 +57,21 @@ jobs:
     # violation and got `ruff format --check` clean on main, so that
     # step's continue-on-error was removed below - a real formatting
     # regression now fails this job for real, not just in the log.
-    # `ruff check` stays non-blocking: 128 violations remain that are
-    # deliberately NOT auto-fixed (removing them either changes
-    # behavior - see CHANGELOG.md's [2.10.14] entry on the six
-    # cross-module "unused" imports that are actually re-exports relied
-    # on elsewhere - or needs a human judgment call ruff can't make
-    # safely, e.g. an ambiguous variable rename or an `except:` that
-    # legitimately shouldn't chain `from`). `mypy` also stays
-    # non-blocking (255 pre-existing errors, unrelated to this pass -
+    #
+    # A later pass (lint/test-hygiene debt cleanup) worked the
+    # remaining 126 `ruff check` violations down to zero rule-by-rule -
+    # six cross-module "unused" imports that are actually live
+    # re-exports got explicit `__all__` (not deletion - see
+    # recommenders/external.py and web/config_test_connection.py),
+    # genuinely unfixable ones (embedded HTML/PowerShell/shell template
+    # content whose "long lines" are markup/script, not Python) got a
+    # one-line-justified per-file ignore in ruff.toml instead of
+    # sprinkling `# noqa` everywhere, and everything else (unused
+    # variables, ambiguous single-letter names, missing `raise ... from
+    # err`, etc.) was fixed for real. `ruff check`'s continue-on-error
+    # is removed below to match - a real regression now fails this job
+    # for real. `mypy` stays non-blocking (180 pre-existing errors,
+    # reduced from 255 but still unrelated to most day-to-day changes -
     # this codebase is only partially annotated).
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -81,7 +88,6 @@ jobs:
           pip install ruff mypy
 
       - name: ruff check
-        continue-on-error: true
         run: ruff check .
 
       - name: ruff format --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,86 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.31] - 2026-07-26
+
+### Changed
+
+- **Lint and test-hygiene debt: `ruff check` clean, mypy reduced, real cache-dir test leak fixed.**
+
+  - `ruff check` was at 126 violations; all fixed or explicitly disabled
+    with a documented reason, and CI's `lint` job's `ruff check` step is
+    now blocking (its `continue-on-error` is removed, matching `ruff
+    format --check`'s own precedent from 2.10.14):
+    - `F401` (6 - the DANGEROUS ones): every one confirmed live by
+      grepping all callers, including tests, before touching anything -
+      `recommenders/external.py`'s `sync_watch_history_to_trakt`
+      (imported by `trakt_sync.py`'s entry point),
+      `SERVICE_DISPLAY_NAMES`/`get_tmdb_id_from_imdb` (imported by
+      `tests/test_external.py`), and `web/config_test_connection.py`'s
+      `RadarrAPIError`/`SonarrAPIError`/`TautulliAPIError` (imported by
+      `tests/test_web_config_test_connection.py` via its `cc` alias) are
+      all cross-module re-exports. Fixed with an explicit `__all__` in
+      each module (not deletion - see the [2.10.14] entry on a prior
+      `ruff --fix` pass that deleted six "unused" imports outright and
+      broke the suite).
+    - `E501` (57): mechanically split long `print()`/`log_warning()`/
+      `logger.debug()` f-string messages across adjacent string
+      literals (identical message content, just wrapped). The
+      `recommenders/external_render.py` (embedded HTML/CSS/JS template
+      strings) and `utils/self_update_handoff.py` (embedded PowerShell/
+      shell handoff scripts) cases are markup/script content, not
+      Python - wrapping those to fit the 120-column convention risks
+      altering the generated output for no readability gain, so both
+      get a one-line-justified `ruff.toml` per-file ignore instead. Two
+      `# pragma: no cover` explanatory comments (`curatarr_app.py` x2,
+      `web/update_apply.py`) that must stay on their annotated line get
+      a targeted `# noqa: E501` instead, matching `tests/harness.py`'s
+      existing precedent - a per-file ignore would be too broad for two
+      one-off lines in otherwise fully-compliant files.
+    - `F841`, `E402`, `B904`, `E731`, `B007`, `E741`, `B017`: fixed for
+      real (dropped pointless variable assignments while keeping the
+      exercised call, added `from e`/`from None` exception chaining,
+      rewrote test-only lambdas as `def`s, renamed genuinely-unused loop
+      variables to `_`-prefixed, renamed ambiguous `l` to a descriptive
+      name, narrowed one `pytest.raises(Exception)` to the specific
+      type actually raised).
+  - `mypy` (non-strict, still non-blocking in CI): reduced from 233 to
+    180 errors by adding explicit type annotations to every `[var-
+    annotated]` finding (44 of them) - a purely additive fix (no
+    runtime behavior change) that mypy can't infer on its own for a
+    dict/list/set literal. The remaining ~180 (mostly `[assignment]`/
+    `[attr-defined]`/`[str]`) are left for a future pass; this codebase
+    is only partially annotated by design.
+  - Tests were leaking fake per-user cache files (`tv_watched_cache_
+    plex_bob.json`, `tv_watched_cache_plex_user1.json`, `tv_watched_
+    cache_anime_plex_user1.json`) into the REAL `cache/` directory:
+    `recommenders/base.py`'s `BaseRecommender.__init__` and several
+    `recommenders/external.py` functions resolve `cache_dir` via
+    `get_project_root()` (`@lru_cache`'d), and most tests never
+    override `CURATARR_CONFIG_DIR` or mock it - `tests/test_tv.py` in
+    particular never did at all. Fixed with an autouse
+    `_isolated_recommender_cache_dir` fixture in `tests/conftest.py`,
+    matching the existing `_isolated_update_dismissal_dir`/
+    `_isolated_metrics_dir` pattern (patches the *consuming* module's
+    own `get_project_root` name binding, not the shared origin - each
+    importer copied its own reference at import time). Still honors an
+    explicitly-set `CURATARR_CONFIG_DIR` so it can't break the two
+    tests that deliberately exercise the real resolution logic against
+    one. Also discovered and fixed a related, more serious bug while
+    building this: with only `get_project_root` faked out,
+    `recommenders/base.py`'s `migrate_legacy_cache_dir` call (whose
+    `legacy_dir` argument bypasses `get_project_root()` by design, so it
+    still resolved to the REAL repo `cache/` directory) would treat that
+    real directory as "legacy" relative to the fixture's fake `new_dir`
+    and `shutil.move()` every real file out of it into a throwaway
+    `tmp_path` on every test run - silently deleting real cache/
+    contents, not just stopping new writes. The fixture also no-ops
+    `recommenders.base.migrate_legacy_cache_dir` during tests to close
+    that. Verified with a planted canary file that survives a full test
+    run. The three leaked fake-user files above were removed from the
+    real `cache/` directory (confirmed fake by content and username -
+    real users' cache files were never touched).
+
 ## [2.10.30] - 2026-07-26
 
 ### Changed

--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -87,7 +87,7 @@ import sys
 
 def _suppress_windows_crash_dialogs() -> (
     None
-):  # pragma: no cover - real Windows API call, same category as _attach_or_setup_console below (not unit-testable on non-Windows CI)
+):  # pragma: no cover - real Windows API call, same category as _attach_or_setup_console below (not unit-testable on non-Windows CI)  # noqa: E501
     """Call SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX)
     as the very first thing this process does, on every frozen Windows
     invocation - the normal UI launch, the self-update worker, and any
@@ -149,7 +149,7 @@ def _configure_windowed_launch() -> None:
 
 def _attach_or_setup_console(
     debug: bool,
-) -> None:  # pragma: no cover - real Windows console/ctypes API, exercised by the Windows build test in the release PR, not unit-testable on Linux CI
+) -> None:  # pragma: no cover - real Windows console/ctypes API, exercised by the Windows build test in the release PR, not unit-testable on Linux CI  # noqa: E501
     """Three cases, in order:
 
     1. Launched from an existing cmd/PowerShell: AttachConsole finds

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -16,7 +16,7 @@ import time
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import plexapi.exceptions
 import requests
@@ -177,7 +177,8 @@ class BaseCache(ABC):
             print(f"Found {len(new_items)} new {self.media_key} to analyze")
 
             for i, item in enumerate(new_items, 1):
-                msg = f"\r{CYAN}Processing {self.media_type} {i}/{len(new_items)} ({int((i / len(new_items)) * 100)}%){RESET}"
+                pct_done = int((i / len(new_items)) * 100)
+                msg = f"\r{CYAN}Processing {self.media_type} {i}/{len(new_items)} ({pct_done}%){RESET}"
                 sys.stdout.write(msg)
                 sys.stdout.flush()
 
@@ -233,7 +234,7 @@ class BaseCache(ABC):
         print(f"\n{CYAN}Backfilling collection data for {total} movies (one-time migration)...{RESET}")
 
         updated = 0
-        for i, (item_id, info) in enumerate(movies_needing_collection, 1):
+        for i, (_item_id, info) in enumerate(movies_needing_collection, 1):
             pct = int((i / total) * 100)
             sys.stdout.write(f"\r{CYAN}Processing {i}/{total} ({pct}%) - Found {updated} collections{RESET}")
             sys.stdout.flush()
@@ -326,7 +327,7 @@ class BaseCache(ABC):
         Returns:
             Dict with 'tmdb_id', 'imdb_id', 'keywords', 'rating', 'vote_count'
         """
-        result = {
+        result: Dict[str, Any] = {
             "tmdb_id": None,
             "imdb_id": None,
             "keywords": [],
@@ -446,10 +447,10 @@ class BaseRecommender(ABC):
 
         # Initialize counters and caches
         self.cached_watched_count = 0
-        self.watched_data_counters = {}
-        self.plex_tmdb_cache = {}
-        self.tmdb_keywords_cache = {}
-        self.label_dates = {}
+        self.watched_data_counters: Dict[str, Any] = {}
+        self.plex_tmdb_cache: Dict[str, Any] = {}
+        self.tmdb_keywords_cache: Dict[str, Any] = {}
+        self.label_dates: Dict[str, Any] = {}
         self.users = get_configured_users(self.config)
 
         # Set for tracking watched item IDs
@@ -800,7 +801,8 @@ class BaseRecommender(ABC):
             print(f"Excluded {excluded_count} {self.media_key} based on genre filters")
         if quality_filtered_count > 0:
             log_warning(
-                f"Filtered {quality_filtered_count} {self.media_key} below quality thresholds (rating: {min_rating}+, votes: {min_vote_count}+)"
+                f"Filtered {quality_filtered_count} {self.media_key} below quality thresholds "
+                f"(rating: {min_rating}+, votes: {min_vote_count}+)"
             )
 
         if not unwatched_items:
@@ -924,7 +926,7 @@ class BaseRecommender(ABC):
         if total_labeled > 0:
             print(f"  Scoring {total_labeled} existing labeled items...", end="", flush=True)
 
-        for i, item in enumerate(unwatched_labeled, 1):
+        for _i, item in enumerate(unwatched_labeled, 1):
             item_id = int(item.ratingKey)
             item_info = media_cache.cache[self.media_key].get(str(item_id))
             if item_info:

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -24,11 +24,10 @@ import urllib3
 from plexapi.myplex import MyPlexAccount
 from plexapi.server import PlexServer
 
-# Module-level logger
-logger = logging.getLogger("curatarr")
-
 # Import shared utilities - same as internal recommenders
 # Import export functions
+# Import output generation
+from recommenders.external_render import SERVICE_DISPLAY_NAMES, generate_combined_html, generate_markdown
 from recommenders.external_sync import (
     export_to_mdblist,
     export_to_radarr,
@@ -38,9 +37,6 @@ from recommenders.external_sync import (
     get_imdb_id,
     sync_watch_history_to_trakt,
 )
-
-# Import output generation
-from recommenders.external_render import SERVICE_DISPLAY_NAMES, generate_combined_html, generate_markdown
 from utils import (
     CYAN,
     DEFAULT_RATING_MULTIPLIERS,
@@ -79,6 +75,26 @@ from utils import (
     save_json_cache,
     smart_open_html,
 )
+
+# Module-level logger
+logger = logging.getLogger("curatarr")
+
+# Names imported above but never referenced in this module - re-exported
+# for other modules to import FROM here (not from their own original
+# definition module), so ruff would otherwise flag them F401
+# ("imported but unused"). Confirmed live by grepping every caller,
+# including tests, before listing here - see CHANGELOG.md's [2.10.14]
+# entry on a prior ruff --fix pass that deleted six of these outright
+# and broke the suite:
+#   - sync_watch_history_to_trakt: trakt_sync.py's entry point imports
+#     it from here (recommenders.external), not recommenders.external_sync.
+#   - SERVICE_DISPLAY_NAMES, get_tmdb_id_from_imdb: imported from here
+#     by tests/test_external.py.
+__all__ = [
+    "sync_watch_history_to_trakt",
+    "SERVICE_DISPLAY_NAMES",
+    "get_tmdb_id_from_imdb",
+]
 
 # TMDB Genre ID mappings
 TMDB_MOVIE_GENRES = {
@@ -240,7 +256,7 @@ def discover_candidates_by_profile(
     else:
         print(f"  Discovery iteration {iteration + 1}: expanding search...")
 
-    candidates = {}  # tmdb_id -> basic info
+    candidates: Dict[int, Dict] = {}  # tmdb_id -> basic info
     media = "movie" if media_type == "movie" else "tv"
 
     # Get genres for this iteration's range
@@ -383,7 +399,8 @@ def discover_candidates_by_profile(
                     similar_count += 1
 
     print(
-        f"    Iteration {iteration + 1}: {genre_count} from genres, {keyword_count} from keywords, {similar_count} from similar"
+        f"    Iteration {iteration + 1}: {genre_count} from genres, "
+        f"{keyword_count} from keywords, {similar_count} from similar"
     )
     return candidates
 
@@ -421,7 +438,7 @@ def discover_popular_by_genre(
     genre_id_map = TMDB_MOVIE_GENRE_IDS if media_type == "movie" else TMDB_TV_GENRE_IDS
     library_ids = set(library_data.keys()) if library_data else set()
 
-    recommendations = []
+    recommendations: List[Dict] = []
     seen_ids = set()
 
     # Fetch popular content for each genre
@@ -530,7 +547,8 @@ def load_user_profile_from_cache(config: Dict, username: str, media_type: str = 
 
         watched_count = cache_data.get("watched_count", len(profile["genres"]))
         print(
-            f"  {GREEN}Loaded {media_type} profile from cache: {watched_count} watched, {len(profile['keywords'])} keywords{RESET}"
+            f"  {GREEN}Loaded {media_type} profile from cache: {watched_count} watched, "
+            f"{len(profile['keywords'])} keywords{RESET}"
         )
 
         return profile
@@ -560,7 +578,7 @@ def build_user_profile(plex: Any, config: Dict, username: str, media_type: str =
     recency_config = config.get("recency_decay", {})
     recency_enabled = recency_config.get("enabled", True)
 
-    counters = {
+    counters: Dict[str, Any] = {
         "genres": Counter(),
         "directors": Counter(),  # movies
         "studios": Counter(),  # TV shows
@@ -570,8 +588,10 @@ def build_user_profile(plex: Any, config: Dict, username: str, media_type: str =
         "tmdb_ids": set(),
     }
 
-    # Get account for user checking
-    account = MyPlexAccount(token=config["plex"]["token"])
+    # Get account for user checking - construction alone validates the
+    # token (raises if invalid), same as before; the account object
+    # itself was never used past this point.
+    MyPlexAccount(token=config["plex"]["token"])
     tmdb_api_key = get_tmdb_config(config)["api_key"]
 
     watched_count = 0
@@ -698,7 +718,7 @@ def get_watch_providers(tmdb_api_key: str, tmdb_id: int, media_type: str = "movi
         - rent: rental providers (iTunes, Amazon, etc.)
         - buy: purchase providers
     """
-    empty_result = {"streaming": [], "rent": [], "buy": []}
+    empty_result: Dict[str, List] = {"streaming": [], "rent": [], "buy": []}
 
     # Check cache first
     cache_key = (tmdb_id, media_type)
@@ -905,7 +925,7 @@ def find_missing_sequels(
     print(f"{CYAN}  Scanning {total_items} movies for collections...{RESET}")
 
     # Step 1: Find all movies with collection IDs and track which are owned
-    collection_owned = {}  # collection_id -> set of owned tmdb_ids
+    collection_owned: Dict[int, Set[int]] = {}  # collection_id -> set of owned tmdb_ids
 
     # Use cached movie->collection mapping if available
     movie_collections = cache.get("movie_collections", {})
@@ -981,7 +1001,7 @@ def find_missing_sequels(
 
     print(f"{CYAN}  Checking collections for missing movies...{RESET}")
 
-    for i, (coll_id, owned_ids) in enumerate(collection_owned.items()):
+    for i, (coll_id, _owned_ids) in enumerate(collection_owned.items()):
         if i % 5 == 0:
             show_progress("  Checking collections", i + 1, total_collections)
 
@@ -1137,7 +1157,8 @@ def find_missing_sequels(
     )
 
     print(
-        f"{GREEN}  Found {len(missing_sequels)} missing movies across {collections_with_gaps} incomplete collections{RESET}"
+        f"{GREEN}  Found {len(missing_sequels)} missing movies across "
+        f"{collections_with_gaps} incomplete collections{RESET}"
     )
     return missing_sequels
 
@@ -1249,7 +1270,7 @@ def find_horizon_movies(tmdb_api_key: str, plex: Any, library_name: str, stale_d
     total_items = len(items)
     print(f"{CYAN}  Scanning {total_items} movies for collections...{RESET}")
 
-    collection_owned = {}
+    collection_owned: Dict[int, Set[int]] = {}
 
     for i, item in enumerate(items):
         if i % 50 == 0:
@@ -1306,7 +1327,7 @@ def find_horizon_movies(tmdb_api_key: str, plex: Any, library_name: str, stale_d
 
     print(f"{CYAN}  Checking collections for upcoming releases...{RESET}")
 
-    for i, (coll_id, owned_ids) in enumerate(collection_owned.items()):
+    for i, (coll_id, _owned_ids) in enumerate(collection_owned.items()):
         if i % 5 == 0:
             show_progress("  Checking collections", i + 1, total_collections)
 
@@ -1449,7 +1470,7 @@ def categorize_by_streaming_service(
         'all_items': [all items sorted by score with streaming info]
     }
     """
-    result = {"user_services": {}, "other_services": {}, "acquire": [], "all_items": []}
+    result: Dict[str, Any] = {"user_services": {}, "other_services": {}, "acquire": [], "all_items": []}
 
     for item in recommendations:
         tmdb_id = item["tmdb_id"]
@@ -1503,7 +1524,7 @@ def get_genre_distribution(plex: Any, config: Dict, username: str, media_type: s
         library_name = config["plex"].get("movie_library" if media_type == "movie" else "tv_library")
         library = plex.library.section(library_name)
 
-        genre_counts = {}
+        genre_counts: Dict[str, int] = {}
         total_items = 0
 
         # For admin user, check watched items directly
@@ -1652,7 +1673,7 @@ def find_similar_content_with_profile(
         print(f"  {CYAN}Language filter: {language_filter.upper()} only{RESET}")
 
     # Track state across iterations
-    quality_recs = []  # Items meeting quality bar
+    quality_recs: List[Dict] = []  # Items meeting quality bar
     seen_ids = set(exclude_cached_ids or set())  # Include cached IDs to skip
     scored_cache = {}  # tmdb_id -> scored item (avoid re-scoring)
     consecutive_zero_iterations = 0  # Track for early termination
@@ -1796,7 +1817,8 @@ def find_similar_content_with_profile(
         quality_recs.sort(key=lambda x: (x["score"], x["rating"]), reverse=True)
 
         print(
-            f"  {CYAN}Iteration {iteration + 1} ({iteration_threshold:.0%} threshold): {new_quality_this_iteration} new quality items, {len(quality_recs)} total{RESET}"
+            f"  {CYAN}Iteration {iteration + 1} ({iteration_threshold:.0%} threshold): "
+            f"{new_quality_this_iteration} new quality items, {len(quality_recs)} total{RESET}"
         )
 
         # Early termination check - only if we're close to target
@@ -1806,7 +1828,8 @@ def find_similar_content_with_profile(
             progress_pct = len(quality_recs) / limit if limit > 0 else 1.0
             if consecutive_zero_iterations >= 2 and progress_pct >= 0.8:
                 print(
-                    f"  {CYAN}Early exit: 2 consecutive iterations with no new matches ({len(quality_recs)}/{limit}){RESET}"
+                    f"  {CYAN}Early exit: 2 consecutive iterations with no new matches "
+                    f"({len(quality_recs)}/{limit}){RESET}"
                 )
                 break
         else:
@@ -1988,7 +2011,8 @@ def _pu_clean_caches(config, movie_cache, show_cache, library_movies, library_sh
                 filtered_shows += 1
         if filtered_movies or filtered_shows:
             print(
-                f"{CYAN}Filtered {filtered_movies} movies and {filtered_shows} shows (not {language_filter.upper()}){RESET}"
+                f"{CYAN}Filtered {filtered_movies} movies and {filtered_shows} shows "
+                f"(not {language_filter.upper()}){RESET}"
             )
 
     # Remove acquired items from cache (now in library) - check TMDB IDs AND titles
@@ -2103,7 +2127,8 @@ def _pu_plan_discovery(config, user_prefs, movie_cache, show_cache):
             exclude_show_imdb_ids = trakt_client.get_watchlist_imdb_ids("shows")
             if exclude_movie_imdb_ids or exclude_show_imdb_ids:
                 print(
-                    f"Excluding {len(exclude_movie_imdb_ids)} movies, {len(exclude_show_imdb_ids)} shows from Trakt watchlist"
+                    f"Excluding {len(exclude_movie_imdb_ids)} movies, "
+                    f"{len(exclude_show_imdb_ids)} shows from Trakt watchlist"
                 )
 
     return (
@@ -2296,7 +2321,8 @@ def _pu_reconcile_caches(
         shows_list.extend(low_shows[: show_limit - len(shows_list)])
 
     print(
-        f"{GREEN}Output: {len(movies_list)} movies ({len(high_movies)} above {int(min_relevance * 100)}% threshold){RESET}"
+        f"{GREEN}Output: {len(movies_list)} movies "
+        f"({len(high_movies)} above {int(min_relevance * 100)}% threshold){RESET}"
     )
     print(
         f"{GREEN}Output: {len(shows_list)} shows ({len(high_shows)} above {int(min_relevance * 100)}% threshold){RESET}"
@@ -2647,7 +2673,8 @@ def process_user_movie_library(config, plex, username, library):
         movies_list.extend(low_movies[: movie_limit - len(movies_list)])
 
     print(
-        f"{GREEN}Output: {len(movies_list)} movies ({len(high_movies)} above {int(min_relevance * 100)}% threshold){RESET}"
+        f"{GREEN}Output: {len(movies_list)} movies "
+        f"({len(high_movies)} above {int(min_relevance * 100)}% threshold){RESET}"
     )
 
     user_services = config.get("streaming_services", [])

--- a/recommenders/external_render.py
+++ b/recommenders/external_render.py
@@ -6,7 +6,7 @@ Generates markdown watchlists and combined HTML views.
 import html
 import os
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from urllib.parse import quote_plus
 
 from utils.cache import load_json_cache, save_json_cache
@@ -420,8 +420,8 @@ def generate_combined_html(
     imdb_cache = _load_imdb_cache(imdb_cache_path)
 
     # Collect all unique TMDB IDs that need IMDB lookup
-    all_imdb_ids = {}  # tmdb_id -> imdb_id
-    pending_lookups = []  # [(tmdb_id, media_type), ...]
+    all_imdb_ids: Dict[int, str] = {}  # tmdb_id -> imdb_id
+    pending_lookups: List[Tuple[int, str]] = []  # [(tmdb_id, media_type), ...]
 
     for user_data in all_users_data:
         _collect_tmdb_ids_from_categorized(

--- a/recommenders/external_sync.py
+++ b/recommenders/external_sync.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 import requests
 
@@ -56,7 +56,7 @@ def flatten_categorized(categorized: Dict) -> List[Dict]:
     Returns a flat list of all items.
     """
     items = []
-    for key, value in categorized.items():
+    for _key, value in categorized.items():
         if isinstance(value, dict):  # user_services or other_services
             for service_items in value.values():
                 items.extend(service_items)
@@ -1133,8 +1133,8 @@ def sync_watch_history_to_trakt(
         return
 
     # Load TMDB IDs from cache files (fast - no API calls)
-    all_movie_tmdb_ids = set()
-    all_show_tmdb_ids = set()
+    all_movie_tmdb_ids: Set[int] = set()
+    all_show_tmdb_ids: Set[int] = set()
 
     if load_profile_func is None:
         print("  No profile loader provided - cannot load cached watch history")

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -7,7 +7,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import logging
 import math
 import traceback
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# Import base classes
+from recommenders.base import BaseCache, BaseRecommender
 
 # Import shared utilities
 from utils import (
@@ -46,9 +49,6 @@ from utils import (
 
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger("curatarr")
-
-# Import base classes
-from recommenders.base import BaseCache, BaseRecommender
 
 
 class MovieCache(BaseCache):
@@ -150,9 +150,9 @@ class PlexMovieRecommender(BaseRecommender):
         # Movie-specific initialization
         self.cached_unwatched_count = 0
         self.cached_library_movie_count = 0
-        self.synced_movie_ids = set()
-        self.cached_unwatched_movies = []
-        self.plex_watched_rating_keys = set()
+        self.synced_movie_ids: Set[int] = set()
+        self.cached_unwatched_movies: List[Any] = []
+        self.plex_watched_rating_keys: Set[int] = set()
         # movies.show_director: is the documented location (config/tuning.example.yml);
         # fall back to the legacy root-level general.show_director for back-compat.
         self.show_director = self.media_config.get(
@@ -247,9 +247,9 @@ class PlexMovieRecommender(BaseRecommender):
 
         movies_section = self.plex.library.section(self.library_title)
         counters = create_empty_counters("movie")
-        watched_ids = set()
-        watched_movie_dates = {}  # Store watch timestamps for recency decay
-        user_ratings = {}  # Store user ratings for each movie
+        watched_ids: Set[int] = set()
+        watched_movie_dates: Dict[int, Any] = {}  # Store watch timestamps for recency decay
+        user_ratings: Dict[int, float] = {}  # Store user ratings for each movie
         watched_movie_views = {}  # Store view counts for rewatch weighting
         not_found_count = 0
 
@@ -340,7 +340,8 @@ class PlexMovieRecommender(BaseRecommender):
                 if multiplier < 0:
                     negative_signal_count += 1
                     logger.debug(
-                        f"Negative signal: {movie_info.get('title')} (rating: {user_ratings.get(movie_id)}, weight: {multiplier:.2f})"
+                        f"Negative signal: {movie_info.get('title')} "
+                        f"(rating: {user_ratings.get(movie_id)}, weight: {multiplier:.2f})"
                     )
 
                 # Process with weighted counters
@@ -504,7 +505,8 @@ class PlexMovieRecommender(BaseRecommender):
             score = min(1.0, score * (1 + bonus))
             breakdown["collection_bonus"] = round(bonus, 3)
             breakdown["details"]["collection"] = (
-                f"{movie_info.get('collection_name', 'Unknown')} (watched: {collection_count:.1f}, bonus: {round(bonus * 100, 1)}%)"
+                f"{movie_info.get('collection_name', 'Unknown')} "
+                f"(watched: {collection_count:.1f}, bonus: {round(bonus * 100, 1)}%)"
             )
 
         return score, breakdown

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -8,7 +8,10 @@ import logging
 import math
 import re
 import traceback
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# Import base classes
+from recommenders.base import BaseCache, BaseRecommender
 
 # Import shared utilities
 from utils import (
@@ -49,9 +52,6 @@ from utils import (
 
 # Module-level logger - configured by setup_logging() in main()
 logger = logging.getLogger("curatarr")
-
-# Import base classes
-from recommenders.base import BaseCache, BaseRecommender
 
 
 class ShowCache(BaseCache):
@@ -141,9 +141,9 @@ class PlexTVRecommender(BaseRecommender):
         # TV-specific initialization
         self.cached_unwatched_count = 0
         self.cached_library_show_count = 0
-        self.synced_show_ids = set()
-        self.cached_unwatched_shows = []
-        self.plex_watched_rating_keys = set()
+        self.synced_show_ids: Set[int] = set()
+        self.cached_unwatched_shows: List[Any] = []
+        self.plex_watched_rating_keys: Set[int] = set()
 
         # Create show cache
         self.show_cache = ShowCache(self.cache_dir, recommender=self)
@@ -248,7 +248,7 @@ class PlexTVRecommender(BaseRecommender):
 
         shows_section = self.plex.library.section(self.library_title)
         counters = create_empty_counters("tv")
-        watched_ids = set()
+        watched_ids: Set[int] = set()
         not_found_count = 0
 
         log_warning("Querying Plex watch history directly...")
@@ -296,7 +296,9 @@ class PlexTVRecommender(BaseRecommender):
                     if show_id in show_completion_data:
                         data = show_completion_data[show_id]
                         logger.debug(
-                            f"Dropped: {data.get('title')} ({data['watched_episodes']}/{data['total_episodes']} eps, {data['completion_percent']:.0f}%)"
+                            f"Dropped: {data.get('title')} "
+                            f"({data['watched_episodes']}/{data['total_episodes']} eps, "
+                            f"{data['completion_percent']:.0f}%)"
                         )
 
         # Build rewatch data and user ratings for shows
@@ -332,11 +334,12 @@ class PlexTVRecommender(BaseRecommender):
         normal_watched = watched_ids - dropped_show_ids
         print("")
         print(
-            f"Processing {len(normal_watched)} watched shows with recency decay (excluding {len(dropped_show_ids)} dropped):"
+            f"Processing {len(normal_watched)} watched shows with recency decay "
+            f"(excluding {len(dropped_show_ids)} dropped):"
         )
 
         # Track production companies for franchise/spinoff bonus
-        production_companies = {}  # production_company_id -> weighted count
+        production_companies: Dict[int, float] = {}  # production_company_id -> weighted count
 
         for i, show_id in enumerate(normal_watched, 1):
             show_progress("Processing", i, len(normal_watched))

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,6 +46,24 @@ select = [
 # workaround.
 "utils/__init__.py" = ["F401"]
 
+# recommenders/external_render.py generates the external watchlist's HTML
+# page (recommenders/movie.py's/tv.py's counterparts render markdown, not
+# markup) via large embedded HTML/CSS/JS template strings - those lines
+# are markup, not Python control flow, and splitting a long <label>/
+# <button>/... tag across lines to satisfy the 120-column convention
+# would risk altering the generated HTML (e.g. injecting whitespace into
+# an inline onclick=/style= attribute) for zero readability benefit.
+"recommenders/external_render.py" = ["E501"]
+
+# utils/self_update_handoff.py generates the self-update swap+relaunch
+# handoff scripts (a PowerShell script on Windows, a POSIX shell script
+# elsewhere) as embedded string templates - those lines are shell/
+# PowerShell source, not Python, and the same reasoning as
+# external_render.py above applies: wrapping them to fit Python's line
+# length convention doesn't make the generated script more readable and
+# risks subtly changing it.
+"utils/self_update_handoff.py" = ["E501"]
+
 [lint.isort]
 # This codebase already groups "stdlib, then blank line, then
 # third-party/local" without stdlib/third-party/first-party

--- a/scripts/selfupdate_e2e/run_scenario.py
+++ b/scripts/selfupdate_e2e/run_scenario.py
@@ -201,7 +201,8 @@ def main():
         server_log_file.close()
         with open(server_log_path) as f:
             print(
-                f"[{args.scenario}] fake release server exited immediately (code {server_proc.returncode}):\n{f.read()}",
+                f"[{args.scenario}] fake release server exited immediately "
+                f"(code {server_proc.returncode}):\n{f.read()}",
                 flush=True,
             )
         raise SystemExit(f"[{args.scenario}] FAIL: fake release server never started")

--- a/scripts/selfupdate_stub_e2e/run_stub_cycle.py
+++ b/scripts/selfupdate_stub_e2e/run_stub_cycle.py
@@ -107,7 +107,7 @@ def launch_handoff_script(old_pid, current_exe_path, new_asset_path, port, targe
 
     env = dict(os.environ)
     if debug_log:
-        with open(debug_log, "ab") as f:
+        with open(debug_log, "ab"):
             pass
         popen_kwargs["stdout"] = open(debug_log, "ab")
         popen_kwargs["stderr"] = subprocess.STDOUT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,74 @@ def _isolated_metrics_dir(tmp_path_factory, monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_recommender_cache_dir(tmp_path_factory, monkeypatch):
+    """Same reasoning as _isolated_metrics_dir above, for
+    recommenders/base.py's BaseRecommender.__init__ (self.cache_dir =
+    get_project_root() + config['cache_dir']) and recommenders/
+    external.py's several standalone functions that resolve cache_dir
+    the same way - both hold their OWN `from utils import
+    get_project_root` name binding (same reason the three fixtures
+    above each patch their own consuming module rather than
+    utils.helpers.get_project_root itself - patching the origin
+    wouldn't touch a binding another module already copied at import
+    time).
+
+    Without this, any test that constructs a real (unmocked)
+    PlexMovieRecommender/PlexTVRecommender, or calls one of
+    recommenders/external.py's real cache-dir-resolving functions,
+    writes REAL watched_cache_plex_<user>.json /
+    tv_watched_cache_plex_<user>.json / external_recs_*.json files into
+    the real repo's cache/ directory - this is exactly how fake test
+    usernames (plex_bob, plex_user1, anime_plex_user1) ended up in the
+    live cache/ dir: tests/test_tv.py in particular never overrode
+    get_project_root at all before this fixture existed.
+
+    Still honors CURATARR_CONFIG_DIR (falls through to the real
+    override-branch behavior) rather than unconditionally replacing
+    get_project_root with a fixed path, so this can't break the tests
+    that deliberately exercise the REAL cache_dir resolution logic
+    against an explicit CURATARR_CONFIG_DIR (tests/test_base.py's
+    TestBaseRecommenderCacheDirResolution, tests/test_movie.py's
+    TestLibraryFetchedOnceNotSixTimes) - those still get the directory
+    THEY set, not this fixture's fallback tmp_path. Tests that
+    specifically exercise recommenders/external.py's own cache-dir
+    handling already patch recommenders.external.get_project_root
+    themselves per-test (see tests/test_external.py); this is a
+    safety net for the many that don't.
+
+    ALSO no-ops recommenders.base.migrate_legacy_cache_dir - discovered
+    the hard way while building this exact fixture: with get_project_root
+    faked out but migrate_legacy_cache_dir left real,
+    BaseRecommender.__init__'s own legacy_cache_dir (computed straight
+    off recommenders/base.py's __file__, bypassing get_project_root
+    entirely by design - see that function's docstring) still resolves
+    to the REAL repo cache/ directory, which the real
+    migrate_legacy_cache_dir would then treat as "legacy" relative to
+    this fixture's fake new_dir and shutil.move() every real file in it
+    into a throwaway tmp_path - silently DELETING real cache/ contents
+    on every test run that constructs a recommender, not just
+    preventing new writes. tests/test_helpers.py's own
+    migrate_legacy_cache_dir tests call the function directly (a
+    different name binding - see above), so they're unaffected;
+    tests/test_base.py already mocks this itself in every test that
+    needs to (its own @patch layers on top of this, same convention as
+    every other fixture here).
+    """
+    fallback_root = str(tmp_path_factory.mktemp("recommender_cache"))
+
+    def _fake_get_project_root():
+        override = os.environ.get("CURATARR_CONFIG_DIR")
+        if override:
+            os.makedirs(override, exist_ok=True)
+            return override
+        return fallback_root
+
+    monkeypatch.setattr("recommenders.base.get_project_root", _fake_get_project_root)
+    monkeypatch.setattr("recommenders.external.get_project_root", _fake_get_project_root)
+    monkeypatch.setattr("recommenders.base.migrate_legacy_cache_dir", lambda legacy_dir, new_dir: None)
+
+
 _FAKE_MOVIE_PY = """\
 import os
 import sys

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -307,7 +307,7 @@ class TestBaseCacheGetLanguage:
         mock_show = Mock()
         mock_show.episodes.return_value = [mock_episode]
 
-        result = cache._get_language(mock_show)
+        cache._get_language(mock_show)
 
         mock_show.episodes.assert_called_once()
 
@@ -468,7 +468,7 @@ class TestBaseRecommenderInit:
         mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
         mock_plex.return_value = Mock()
 
-        recommender = ConcreteRecommender("/path/to/config.yml")
+        ConcreteRecommender("/path/to/config.yml")
 
         mock_load.assert_called_once_with("/path/to/config.yml")
 
@@ -488,7 +488,7 @@ class TestBaseRecommenderInit:
         mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
         mock_plex.return_value = Mock()
 
-        recommender = ConcreteRecommender("/path/to/config.yml")
+        ConcreteRecommender("/path/to/config.yml")
 
         mock_plex.assert_called_once()
 
@@ -536,7 +536,7 @@ class TestBaseRecommenderInit:
             def _load_weights(self, weights_config):
                 return {"genre": 0.3, "actor": 0.3}
 
-        recommender = BadWeightsRecommender("/path/to/config.yml")
+        BadWeightsRecommender("/path/to/config.yml")
 
         mock_warn.assert_called()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -628,8 +628,8 @@ class TestGetLibraries:
             "sonarr": {"enabled": True, "root_folder": "/data/tv", "series_type": "anime"},
         }
         libraries = get_libraries(config)
-        movie_lib = next(l for l in libraries if l["media_type"] == MEDIA_TYPE_MOVIE)
-        tv_lib = next(l for l in libraries if l["media_type"] == MEDIA_TYPE_TV)
+        movie_lib = next(lib for lib in libraries if lib["media_type"] == MEDIA_TYPE_MOVIE)
+        tv_lib = next(lib for lib in libraries if lib["media_type"] == MEDIA_TYPE_TV)
 
         movie_arr = get_effective_arr_config(config, movie_lib)
         assert movie_arr["enabled"] is True

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -60,7 +60,7 @@ class TestColoredFormatter:
             name="test", level=logging.DEBUG, pathname="", lineno=0, msg="Test message", args=(), exc_info=None
         )
 
-        formatted = formatter.format(record)
+        formatter.format(record)
 
         assert CYAN in record.levelname
 
@@ -71,7 +71,7 @@ class TestColoredFormatter:
             name="test", level=logging.INFO, pathname="", lineno=0, msg="Test message", args=(), exc_info=None
         )
 
-        formatted = formatter.format(record)
+        formatter.format(record)
 
         assert GREEN in record.levelname
 
@@ -82,7 +82,7 @@ class TestColoredFormatter:
             name="test", level=logging.WARNING, pathname="", lineno=0, msg="Test message", args=(), exc_info=None
         )
 
-        formatted = formatter.format(record)
+        formatter.format(record)
 
         assert YELLOW in record.levelname
 
@@ -93,7 +93,7 @@ class TestColoredFormatter:
             name="test", level=logging.ERROR, pathname="", lineno=0, msg="Test message", args=(), exc_info=None
         )
 
-        formatted = formatter.format(record)
+        formatter.format(record)
 
         assert RED in record.levelname
 
@@ -104,7 +104,7 @@ class TestColoredFormatter:
             name="test", level=logging.CRITICAL, pathname="", lineno=0, msg="Test message", args=(), exc_info=None
         )
 
-        formatted = formatter.format(record)
+        formatter.format(record)
 
         assert RED in record.levelname
 
@@ -115,7 +115,7 @@ class TestTeeLogger:
     def test_write_to_file_strips_ansi(self):
         """Test that file output has ANSI codes stripped."""
         mock_logfile = StringIO()
-        tee = TeeLogger(mock_logfile)
+        TeeLogger(mock_logfile)
 
         # Directly manipulate to test file writing
         colored_text = f"{GREEN}Success{RESET}"

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -39,6 +39,7 @@ from recommenders.external import (
     generate_combined_html,
     get_collection_details,
     get_imdb_id,
+    get_library_items,
     get_movie_genre_ids,
     get_movie_status,
     get_tmdb_id_from_imdb,
@@ -48,6 +49,7 @@ from recommenders.external import (
     load_cache,
     load_horizon_cache,
     load_huntarr_cache,
+    load_ignore_list,
     process_user,
     process_user_movie_library,
     process_user_tv_library,
@@ -274,7 +276,8 @@ class TestGenerateCombinedHtml:
     """Tests for generate_combined_html function"""
 
     def test_generates_html_file(self):
-        mock_get_imdb = lambda api_key, tmdb_id, media_type: "tt1234567"
+        def mock_get_imdb(api_key, tmdb_id, media_type):
+            return "tt1234567"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             test_movie = {
@@ -315,7 +318,8 @@ class TestGenerateCombinedHtml:
                 assert "Watchlist" in content
 
     def test_html_contains_tabs_for_multiple_users(self):
-        mock_get_imdb = lambda api_key, tmdb_id, media_type: "tt1234567"
+        def mock_get_imdb(api_key, tmdb_id, media_type):
+            return "tt1234567"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             all_users_data = [
@@ -342,7 +346,8 @@ class TestGenerateCombinedHtml:
                 assert "tab-btn" in content
 
     def test_html_contains_export_buttons(self):
-        mock_get_imdb = lambda api_key, tmdb_id, media_type: "tt1234567"
+        def mock_get_imdb(api_key, tmdb_id, media_type):
+            return "tt1234567"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             all_users_data = [
@@ -364,7 +369,8 @@ class TestGenerateCombinedHtml:
                 assert "exportSonarr()" in content
 
     def test_html_checkboxes_unchecked_by_default(self):
-        mock_get_imdb = lambda api_key, tmdb_id, media_type: "tt1234567"
+        def mock_get_imdb(api_key, tmdb_id, media_type):
+            return "tt1234567"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             test_movie = {
@@ -463,13 +469,6 @@ class TestTmdbProviders:
     def test_contains_disney_plus(self):
         assert 337 in TMDB_PROVIDERS
         assert TMDB_PROVIDERS[337] == "disney_plus"
-
-
-# Import additional functions for testing
-from recommenders.external import (
-    get_library_items,
-    load_ignore_list,
-)
 
 
 class TestGetLibraryItems:

--- a/tests/test_external_sync.py
+++ b/tests/test_external_sync.py
@@ -2267,7 +2267,9 @@ class TestSyncWatchHistoryToTrakt:
             "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}},
             "cache_dir": tmp_cache,
         }
-        load_profile_func = lambda cfg, u, mt: {"tmdb_ids": {100}} if mt == "movie" else None
+
+        def load_profile_func(cfg, u, mt):
+            return {"tmdb_ids": {100}} if mt == "movie" else None
 
         sync_watch_history_to_trakt(config, "tmdb-key", users=["jason"], load_profile_func=load_profile_func)
 
@@ -2291,7 +2293,9 @@ class TestSyncWatchHistoryToTrakt:
             "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}},
             "cache_dir": tmp_cache,
         }
-        load_profile_func = lambda cfg, u, mt: {"tmdb_ids": {100}} if mt == "movie" else None
+
+        def load_profile_func(cfg, u, mt):
+            return {"tmdb_ids": {100}} if mt == "movie" else None
 
         sync_watch_history_to_trakt(config, "tmdb-key", users=["jason"], load_profile_func=load_profile_func)
 
@@ -2310,7 +2314,9 @@ class TestSyncWatchHistoryToTrakt:
             "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}},
             "cache_dir": tmp_cache,
         }
-        load_profile_func = lambda cfg, u, mt: {"tmdb_ids": {100}} if mt == "movie" else None
+
+        def load_profile_func(cfg, u, mt):
+            return {"tmdb_ids": {100}} if mt == "movie" else None
 
         sync_watch_history_to_trakt(config, "tmdb-key", users=["jason"], load_profile_func=load_profile_func)
 
@@ -2329,7 +2335,9 @@ class TestSyncWatchHistoryToTrakt:
             "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}},
             "cache_dir": tmp_cache,
         }
-        load_profile_func = lambda cfg, u, mt: {"tmdb_ids": {100}} if mt == "movie" else None
+
+        def load_profile_func(cfg, u, mt):
+            return {"tmdb_ids": {100}} if mt == "movie" else None
 
         sync_watch_history_to_trakt(config, "tmdb-key", users=["jason"], load_profile_func=load_profile_func)
 
@@ -2352,7 +2360,9 @@ class TestSyncWatchHistoryToTrakt:
             "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}},
             "cache_dir": tmp_cache,
         }
-        load_profile_func = lambda cfg, u, mt: {"tmdb_ids": {100}} if mt == "movie" else None
+
+        def load_profile_func(cfg, u, mt):
+            return {"tmdb_ids": {100}} if mt == "movie" else None
 
         sync_watch_history_to_trakt(config, "tmdb-key", users=["jason"], load_profile_func=load_profile_func)
 

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -391,7 +391,7 @@ class TestMDBListClientAddItems:
         mock_request.return_value = {"added": 4, "existing": 0, "not_found": 0}
 
         client = MDBListClient("key")
-        result = client.add_items(123, movies=[1, 2], shows=[10, 20])
+        client.add_items(123, movies=[1, 2], shows=[10, 20])
 
         call_data = mock_request.call_args[1]["data"]
         assert len(call_data["movies"]) == 2

--- a/tests/test_migrate_config.py
+++ b/tests/test_migrate_config.py
@@ -399,8 +399,8 @@ class TestMigrateConfigLibraries:
 
         assert "libraries" in migrated
         assert len(migrated["libraries"]) == 2
-        movie_lib = next(l for l in migrated["libraries"] if l["media_type"] == "movie")
-        tv_lib = next(l for l in migrated["libraries"] if l["media_type"] == "tv")
+        movie_lib = next(lib for lib in migrated["libraries"] if lib["media_type"] == "movie")
+        tv_lib = next(lib for lib in migrated["libraries"] if lib["media_type"] == "tv")
         assert movie_lib["arr"]["root_folder"] == "/data/movies"
         assert movie_lib["arr"]["quality_profile"] == "4K"
         assert tv_lib["arr"]["root_folder"] == "/data/tv"

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -165,7 +165,7 @@ class TestPlexMovieRecommenderInit:
         mock_plex.return_value = Mock()
         mock_cache.return_value = Mock(cache={"movies": {}})
 
-        recommender = PlexMovieRecommender("/path/to/config.yml")
+        PlexMovieRecommender("/path/to/config.yml")
 
         mock_cache.assert_called_once()
 

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -636,7 +636,7 @@ class TestInitPlex:
 
         config = {"plex": {"url": "http://localhost:32400", "token": "test_token"}}
 
-        with pytest.raises(Exception):
+        with pytest.raises(requests.RequestException, match="Connection refused"):
             init_plex(config)
 
         mock_log.assert_called_once()

--- a/tests/test_trakt_auth.py
+++ b/tests/test_trakt_auth.py
@@ -78,10 +78,6 @@ class TestTraktAuthSaveTokens:
             yaml.dump(initial_config, f)
 
         # Patch the path resolution
-        import utils.trakt_auth as trakt_auth_module
-
-        original_func = trakt_auth_module.save_tokens
-
         def patched_save_tokens(access_token, refresh_token):
             with open(config_path, "r") as f:
                 config = yaml.safe_load(f)

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -198,7 +198,7 @@ class TestPlexTVRecommenderInit:
         mock_plex.return_value = mock_plex_inst
         mock_cache.return_value = Mock(cache={"shows": {}})
 
-        recommender = PlexTVRecommender("/path/to/config.yml")
+        PlexTVRecommender("/path/to/config.yml")
 
         mock_cache.assert_called_once()
 

--- a/tests/test_user_migration.py
+++ b/tests/test_user_migration.py
@@ -242,7 +242,7 @@ class TestRenameUserInUsersList:
         new_text, changed = rename_user_in_users_list(SAMPLE_CONFIG_TEXT, "testuser_alpha", "jsmith_new")
 
         assert changed is True
-        list_line = [l for l in new_text.splitlines() if l.strip().startswith("list:")][0]
+        list_line = [line for line in new_text.splitlines() if line.strip().startswith("list:")][0]
         assert "jsmith_new" in list_line
         assert "testuser_alpha" not in list_line
         # Other users on the same line preserved, formatting/commas intact

--- a/tests/test_web_config_libraries.py
+++ b/tests/test_web_config_libraries.py
@@ -29,7 +29,7 @@ def _read_config(root):
 
 
 def _lib(libs, lib_id):
-    return next(l for l in libs if l["id"] == lib_id)
+    return next(lib for lib in libs if lib["id"] == lib_id)
 
 
 # Base form for the two libraries seeded by tests/conftest.py's
@@ -123,7 +123,7 @@ class TestSave:
         c.post("/config/libraries", data=form)
 
         core = _read_config(root)
-        assert any(l["id"] == "movies" and l["name"] == "Feature Films" for l in core["libraries"])
+        assert any(lib["id"] == "movies" and lib["name"] == "Feature Films" for lib in core["libraries"])
 
     def test_adds_new_library(self, client):
         c, app, root = client

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -309,16 +309,16 @@ class BaseAPIClient:
             try:
                 read_response_capped(response)
             except ValueError as e:
-                raise self.exception_class(f"{self.api_name} response rejected: {e}")
+                raise self.exception_class(f"{self.api_name} response rejected: {e}") from e
             result = self._handle_response(response)
             outcome = "success"
             return result
 
-        except requests.exceptions.Timeout:
-            raise self.exception_class(f"Request timeout after {self.request_timeout}s")
-        except requests.exceptions.ConnectionError:
-            raise self.exception_class(f"Could not connect to {self.api_name}")
+        except requests.exceptions.Timeout as e:
+            raise self.exception_class(f"Request timeout after {self.request_timeout}s") from e
+        except requests.exceptions.ConnectionError as e:
+            raise self.exception_class(f"Could not connect to {self.api_name}") from e
         except requests.exceptions.RequestException as e:
-            raise self.exception_class(f"Request failed: {e}")
+            raise self.exception_class(f"Request failed: {e}") from e
         finally:
             record_api_call(self.api_name.lower(), outcome, time.time() - request_start)

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -9,7 +9,7 @@ import logging
 import os
 import tempfile
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from .config import CACHE_VERSION, check_cache_version
 from .display import log_warning
@@ -94,7 +94,12 @@ def load_media_cache(cache_path: str, media_key: str = "movies") -> Dict:
     Returns:
         Cache dictionary with media items, or empty structure if invalid/missing
     """
-    empty_cache = {media_key: {}, "last_updated": None, "library_count": 0, "cache_version": CACHE_VERSION}
+    empty_cache: Dict[str, Any] = {
+        media_key: {},
+        "last_updated": None,
+        "library_count": 0,
+        "cache_version": CACHE_VERSION,
+    }
 
     if not check_cache_version(cache_path, f"{media_key.title()} cache"):
         record_cache_lookup("miss")

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.30"
+__version__ = "2.10.31"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/utils/counters.py
+++ b/utils/counters.py
@@ -4,7 +4,7 @@ Handles preference counting and profile building.
 """
 
 from collections import Counter
-from typing import Dict
+from typing import Any, Dict
 
 from .config import DEFAULT_NEGATIVE_THRESHOLD, get_negative_multiplier, get_rating_multipliers
 from .display import log_warning
@@ -21,7 +21,7 @@ def create_empty_counters(media_type: str = "movie") -> Dict:
     Returns:
         Dictionary with Counter objects for each category
     """
-    counters = {
+    counters: Dict[str, Any] = {
         "genres": Counter(),
         "actors": Counter(),
         "languages": Counter(),

--- a/utils/display.py
+++ b/utils/display.py
@@ -8,7 +8,7 @@ import logging
 import re
 import sys
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from .redact import redact
 
@@ -493,7 +493,7 @@ def user_select_recommendations(recommendations: List[Dict], operation_label: st
         return recommendations
 
     # Parse selection
-    selected_indices = set()
+    selected_indices: Set[int] = set()
     for part in choice.replace(" ", "").split(","):
         if "-" in part:
             try:

--- a/utils/labels.py
+++ b/utils/labels.py
@@ -6,7 +6,7 @@ Handles adding, removing, and categorizing Plex labels.
 import logging
 import re
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from .display import GREEN, RESET, log_info
 
@@ -67,7 +67,7 @@ def categorize_labeled_items(
     # Convert to list to allow multiple iterations (MediaContainer is single-use)
     labeled_items = list(labeled_items)
 
-    result = {
+    result: Dict[str, List[Any]] = {
         "fresh": [],
         "watched": [],
         "stale": [],  # Always empty now - score-based eviction handles rotation

--- a/utils/migrate_config.py
+++ b/utils/migrate_config.py
@@ -332,7 +332,7 @@ def migrate_config(config_path: str, dry_run: bool = False) -> dict:
         print(f"config.yml (slimmed to {len(core_config)} sections)")
         if tuning_config:
             print(f"tuning.yml ({len(tuning_config)} sections)")
-        for feature, cfg in feature_configs.items():
+        for feature, _cfg in feature_configs.items():
             print(f"{feature}.yml")
         if libraries:
             print(f"config.yml would gain a 'libraries' section ({len(libraries)} entries)")

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -22,16 +22,15 @@ import plexapi.exceptions
 import plexapi.server
 import requests
 import urllib3
-
-# Module-level logger
-logger = logging.getLogger("curatarr")
-
 from plexapi.myplex import MyPlexAccount
 
 from .config import PLEX_LONG_REQUEST_TIMEOUT, PLEX_REQUEST_TIMEOUT
 from .display import GREEN, RED, RESET, YELLOW, log_error, log_warning
 from .helpers import normalize_title, read_response_capped
 from .metrics import record_api_call
+
+# Module-level logger
+logger = logging.getLogger("curatarr")
 
 
 def _resolve_verify_ssl(config: dict) -> bool:
@@ -312,7 +311,7 @@ def fetch_plex_watch_history_movies(
 
         owner_id = "1"
         all_history_items = []
-        watched_movie_dates = {}
+        watched_movie_dates: Dict[str, Any] = {}
 
         for i, account_id in enumerate(account_ids, 1):
             print(f"  [{i}/{len(account_ids)}] Fetching history for account ID {account_id}...", end="")
@@ -390,8 +389,8 @@ def fetch_plex_watch_history_shows(
     print("")
     print(f"{GREEN}Fetching Plex watch history for {len(account_ids)} user(s)...{RESET}")
 
-    watched_show_ids = set()
-    show_timestamps = {}  # show_id -> latest viewedAt timestamp
+    watched_show_ids: Set[str] = set()
+    show_timestamps: Dict[str, Any] = {}  # show_id -> latest viewedAt timestamp
 
     for account_id in account_ids:
         print("")
@@ -466,9 +465,9 @@ def fetch_show_completion_data(config: Dict, account_ids: List[str], tv_section:
             'last_watched': int (timestamp),
         }
     """
-    show_data = {}
-    show_episodes = {}  # show_id -> set of episode rating keys
-    show_last_watched = {}  # show_id -> most recent viewedAt
+    show_data: Dict[str, Any] = {}
+    show_episodes: Dict[str, Set[int]] = {}  # show_id -> set of episode rating keys
+    show_last_watched: Dict[str, Any] = {}  # show_id -> most recent viewedAt
 
     # Fetch watched episode data from history
     for account_id in account_ids:
@@ -729,7 +728,7 @@ def update_plex_collection(
             try:
                 # Convert Recommended_username to PrivateCollection_username
                 private_label = label_name.replace("Recommended_", "PrivateCollection_")
-                current_labels = [l.tag for l in target_collection.labels]
+                current_labels = [label.tag for label in target_collection.labels]
                 if private_label not in current_labels:
                     target_collection.addLabel(private_label)
             except plexapi.exceptions.PlexApiException as e:
@@ -955,7 +954,7 @@ def extract_genres(item) -> List[str]:
     Returns:
         List of lowercase genre strings
     """
-    genres = []
+    genres: List[str] = []
     try:
         if not hasattr(item, "genres") or not item.genres:
             return genres

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -170,7 +170,7 @@ def apply_user_label_restrictions(
         logger.debug(f"Plex users available for restrictions: {list(plex_users.keys())}")
 
         all_success = True
-        for username, user_label in all_user_labels.items():
+        for username, _user_label in all_user_labels.items():
             # Admin can't have restrictions
             if username.lower() == admin_username:
                 logger.debug(f"Skipping restrictions for admin user: {username}")

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -360,7 +360,7 @@ def _normalize_user_genre_counts(user_genre_counter: Counter) -> Tuple[Dict[str,
     1 when the user has no genre data, matching
     calculate_similarity_score()'s pre-existing fallback.
     """
-    normalized_user_genres = {}
+    normalized_user_genres: Dict[str, int] = {}
     for genre, count in user_genre_counter.items():
         norm_genre = normalize_genre(genre)
         if norm_genre in normalized_user_genres:
@@ -412,7 +412,8 @@ def _score_genre_component(
                 penalty = rarity * TFIDF_GENRE_PENALTY
                 genre_penalty += penalty
                 details.append(
-                    f"{genre} (TF-IDF: count {genre_count:.1f} < threshold {tfidf_threshold_count:.1f}, penalty: {round(penalty, 2)})"
+                    f"{genre} (TF-IDF: count {genre_count:.1f} < threshold {tfidf_threshold_count:.1f}, "
+                    f"penalty: {round(penalty, 2)})"
                 )
             else:
                 # Genre is common in user's profile - good match
@@ -646,7 +647,8 @@ def _score_keyword_component(
                 penalty = rarity * TFIDF_KEYWORD_PENALTY
                 keyword_penalty += penalty
                 details.append(
-                    f"{kw} (TF-IDF: count {count:.1f} < threshold {tfidf_kw_threshold:.1f}, penalty: {round(penalty, 2)})"
+                    f"{kw} (TF-IDF: count {count:.1f} < threshold {tfidf_kw_threshold:.1f}, "
+                    f"penalty: {round(penalty, 2)})"
                 )
             else:
                 # Keyword is common in user's profile - good match
@@ -704,7 +706,7 @@ def _apply_active_weight_redistribution(
     if lost_weight > 0 and active_weights:
         total_active_weight = sum(w for w, _ in active_weights.values())
         if total_active_weight > 0:
-            for comp, (weight, ratio) in active_weights.items():
+            for _comp, (weight, ratio) in active_weights.items():
                 extra_weight = lost_weight * (weight / total_active_weight)
                 extra_score = extra_weight * ratio
                 score += extra_score

--- a/utils/simkl.py
+++ b/utils/simkl.py
@@ -167,12 +167,12 @@ class SimklClient(BaseAPIClient):
 
             return response.json()
 
-        except requests.exceptions.Timeout:
-            raise SimklAPIError(f"Request timeout after {SIMKL_REQUEST_TIMEOUT}s")
-        except requests.exceptions.ConnectionError:
-            raise SimklAPIError("Could not connect to Simkl API")
+        except requests.exceptions.Timeout as e:
+            raise SimklAPIError(f"Request timeout after {SIMKL_REQUEST_TIMEOUT}s") from e
+        except requests.exceptions.ConnectionError as e:
+            raise SimklAPIError("Could not connect to Simkl API") from e
         except requests.exceptions.RequestException as e:
-            raise SimklAPIError(f"Simkl request failed: {e}")
+            raise SimklAPIError(f"Simkl request failed: {e}") from e
         finally:
             record_api_call("simkl", outcome, time.time() - request_start)
 
@@ -210,7 +210,7 @@ class SimklClient(BaseAPIClient):
             }
 
         except requests.RequestException as e:
-            raise SimklAuthError(f"Failed to get PIN code: {e}")
+            raise SimklAuthError(f"Failed to get PIN code: {e}") from e
 
     def poll_for_token(self, user_code: str, interval: int = 5, expires_in: int = 900) -> bool:
         """

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -177,7 +177,7 @@ class TraktClient(BaseAPIClient):
             return response.json()
 
         except requests.RequestException as e:
-            raise TraktAPIError(f"Trakt request failed: {e}")
+            raise TraktAPIError(f"Trakt request failed: {e}") from e
         finally:
             record_api_call("trakt", outcome, time.time() - request_start)
 

--- a/utils/trakt_discovery.py
+++ b/utils/trakt_discovery.py
@@ -337,7 +337,7 @@ def discover_from_trakt(
     anticipated_limit = discovery_config.get("anticipated_limit", DEFAULT_ANTICIPATED_LIMIT)
     recommendations_limit = discovery_config.get("recommendations_limit", DEFAULT_RECOMMENDATIONS_LIMIT)
 
-    results = {"trending": [], "popular": [], "anticipated": [], "recommendations": []}
+    results: Dict[str, List[Dict]] = {"trending": [], "popular": [], "anticipated": [], "recommendations": []}
 
     def filter_items(items: List[Dict]) -> List[Dict]:
         """Remove excluded items."""
@@ -413,7 +413,7 @@ def get_trakt_discovery_candidates(
         config, media_type, cache_dir, exclude_tmdb_ids=library_tmdb_ids, exclude_imdb_ids=exclude_imdb_ids
     )
 
-    candidates = {}
+    candidates: Dict[int, Any] = {}
 
     # Process each source with source attribution and tier priority
     for source, items in discovery.items():

--- a/web/config_connections.py
+++ b/web/config_connections.py
@@ -17,7 +17,7 @@ existing installs keep working without this screen ever writing those
 two fields again.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from flask import jsonify, redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
@@ -161,7 +161,7 @@ def _existing_secret_lookup(data: Dict[str, CommentedMap], service: str) -> Dict
     if service in ("sonarr", "radarr"):
         return {"api_key": (data[service] or {}).get("api_key", "")}
     if service == "trakt":
-        trakt = data["trakt"] or {}
+        trakt: Dict[str, Any] = data["trakt"] or {}
         return {
             "client_secret": trakt.get("client_secret", ""),
             "access_token": trakt.get("access_token", ""),
@@ -175,9 +175,9 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
     on-disk values (or, after a failed submission, *overrides* merged
     over them) plus masked secret-status strings - never a raw secret."""
     core = data["core"]
-    sonarr = data["sonarr"] or {}
-    radarr = data["radarr"] or {}
-    trakt = data["trakt"] or {}
+    sonarr: Dict[str, Any] = data["sonarr"] or {}
+    radarr: Dict[str, Any] = data["radarr"] or {}
+    trakt: Dict[str, Any] = data["trakt"] or {}
     plex = core.get("plex") or {}
     tmdb = core.get("tmdb") or {}
     tautulli = core.get("tautulli") or {}

--- a/web/config_test_connection.py
+++ b/web/config_test_connection.py
@@ -25,6 +25,15 @@ from utils.trakt import TraktClient
 
 from .security import redact
 
+# RadarrAPIError/SonarrAPIError/TautulliAPIError: imported above but never
+# referenced in this module - re-exported for tests to import FROM here
+# (web.config_test_connection, aliased as cc in
+# tests/test_web_config_test_connection.py) rather than from each
+# client's own utils.* module. Confirmed live by grepping every caller
+# before listing here, same convention as recommenders/external.py's
+# own __all__.
+__all__ = ["RadarrAPIError", "SonarrAPIError", "TautulliAPIError"]
+
 logger = logging.getLogger("curatarr")
 
 

--- a/web/security.py
+++ b/web/security.py
@@ -21,6 +21,7 @@ import os
 import re
 import threading
 import time
+from typing import Dict, List
 
 from utils.display import log_warning
 from utils.redact import REDACTED, redact, redact_lines
@@ -345,7 +346,7 @@ _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW_SECONDS = 60
 
 _login_failures_lock = threading.Lock()
-_login_failures = {}  # {ip: [monotonic timestamp, ...]} of FAILED attempts only
+_login_failures: Dict[str, List[float]] = {}  # {ip: [monotonic timestamp, ...]} of FAILED attempts only
 
 
 def _client_ip(request) -> str:

--- a/web/update_apply.py
+++ b/web/update_apply.py
@@ -887,6 +887,6 @@ def run_self_update_worker(argv) -> None:
 
 if (
     __name__ == "__main__"
-):  # pragma: no cover - detached-process entry point; the decision logic it calls (_run_worker and everything it calls) is exercised directly by tests/test_web_update_apply.py, but actually spawning/killing real processes from a unit test is neither safe nor meaningful - see that file's module docstring, matching this repo's existing precedent for excluding OS-process-boundary code (e.g. curatarr_app.py's _attach_or_setup_console).
+):  # pragma: no cover - detached-process entry point; the decision logic it calls (_run_worker and everything it calls) is exercised directly by tests/test_web_update_apply.py, but actually spawning/killing real processes from a unit test is neither safe nor meaningful - see that file's module docstring, matching this repo's existing precedent for excluding OS-process-boundary code (e.g. curatarr_app.py's _attach_or_setup_console).  # noqa: E501
     _args = _parse_worker_args(sys.argv[1:])
     _run_worker(_args.project_root, _args.pid, _args.host, _args.port)


### PR DESCRIPTION
## Summary
- `ruff check` 126 -> 0 findings, fixed rule-by-rule (F401 via explicit `__all__`, not deletion - all six confirmed live by grepping callers); CI `lint` job's `ruff check` step is now blocking
- Genuinely unfixable E501s (embedded HTML/PowerShell/shell template content) get a documented `ruff.toml` per-file ignore instead of reformatting markup; two one-off pragma-comment lines get a targeted `# noqa: E501`
- mypy 233 -> 180 errors (all `[var-annotated]` findings fixed with explicit type hints); left non-blocking in CI
- Fixed tests leaking fake per-user cache files into the real `cache/` directory via an autouse conftest fixture; also fixed a related bug (`migrate_legacy_cache_dir` evacuating real cache/ files during test runs) discovered while building the fix

## Test plan
- [x] pytest tests/ (2462 passed, 1 skipped)
- [x] ruff check / ruff format --check clean
- [x] PyInstaller build succeeds and the frozen binary runs (`--help`/`--version` verified)
- [x] Planted a canary file in cache/ and confirmed it survives a full test run
