### PR TITLE
fix: single-user cache prune orphan scope (2.10.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.32] - 2026-07-26
+
+### Fixed
+
+- **Single-user runs could delete every other configured user's cache
+  (#233 audit remediation batch D / PR1(b) follow-up, found in
+  pre-release review).**
+
+  - `utils.cli.run_recommender_main`'s cache-orphan pruning (added in
+    2.10.31 alongside per-library caching) collected `resolved_usernames`
+    only from the users actually processed *this run*, then pruned
+    `cache/` against that set unconditionally. Single-user mode (`python3
+    recommenders/movie.py alice`, or any web-UI-triggered per-user job)
+    narrows the processed-user list to just that one user, so every
+    OTHER configured user's cache was misclassified as orphaned - logged
+    as a false "would remove" candidate under the `dry_run: true`
+    default, and actually deleted the first time an admin flipped
+    `general.cache_prune.dry_run` to `false` (a reasonable next step
+    after reviewing dry-run output), forcing a full Plex re-scan for
+    every user but the one just run.
+  - Fixed by skipping the prune step entirely on single-user runs -
+    `resolved_usernames` only ever reflects every currently-configured
+    user on a full run (cron, the web UI's "full" engine, or a bare
+    `python3 recommenders/movie.py` with no username), which is the only
+    case this feature can tell "removed from config" apart from "just
+    not in this run". A user genuinely removed from config is still
+    caught on the next full run, so the feature keeps working exactly as
+    designed for its actual purpose.
+  - Considered instead passing every configured user (not just this
+    run's) into the prune call, but that requires re-deriving each
+    user's *resolved* form (e.g. `admin` -> the real Plex account
+    username - see `utils.cache_prune.find_orphaned_cache_files`'s own
+    docstring on why the caller must pass resolved, not raw config,
+    names) for users never actually processed this run, without
+    duplicating `resolve_admin_username`'s Plex API call for every
+    configured user on every single-user run. Skipping is simpler and
+    carries none of that risk of inverting into the same bug the other
+    direction (deleting a live cache because its raw config name doesn't
+    match its resolved cache-file name).
+  - Added regression coverage: a single-user run leaves another
+    configured user's cache untouched even with `dry_run: false`; a full
+    run still prunes a user genuinely removed from `users.list`; and a
+    full run classifies by the *resolved* admin username, not the raw
+    `admin` config string, so this can't silently invert into deleting a
+    live cache in a future change.
+
 ## [2.10.31] - 2026-07-26
 
 ### Changed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -873,3 +873,169 @@ class TestPrintUpdateNotice:
         assert "docker pull" in out
         assert "run.sh" not in out
         assert "--self-update" not in out
+
+
+class TestRunRecommenderMainCachePruneScope:
+    """Tests for the resolved_usernames -> prune_orphaned_cache_files
+    wiring at the end of run_recommender_main (#233 audit remediation
+    batch D / PR1(b)), and the single-user-mode false-orphan bug found
+    in pre-release review: single_user narrows all_users to just the one
+    user being processed, so resolved_usernames would only ever contain
+    that one user - pruning against it would misclassify every OTHER
+    configured user's still-live cache as orphaned. Every cache_dir here
+    is tmp_path/cache - never the real cache/ directory - and every test
+    sets dry_run: false so a regression would actually delete files, not
+    just log a false candidate.
+    """
+
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_single_user_run_does_not_orphan_other_configured_users(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        tmp_path,
+    ):
+        """A single-user run for 'bob' must never treat 'alice' (still
+        configured, just not processed this run) as orphaned - even with
+        cache_prune.dry_run: false, which would delete it if this run
+        pruned using only the current run's resolved_usernames."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        alice_cache = cache_dir / "watched_cache_plex_alice.json"
+        alice_cache.write_text("{}", encoding="utf-8")
+
+        mock_parse_args.return_value = Mock(username="bob", debug=False, library_id=None)
+        mock_root.return_value = str(tmp_path)
+        config = {
+            "plex": {"token": "abc"},
+            "users": {"list": "alice, bob"},
+            "general": {"cache_prune": {"enabled": True, "dry_run": False}},
+        }
+        mock_yaml.return_value = config
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(return_value=config)
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+
+        assert alice_cache.exists()
+
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_full_run_still_prunes_a_user_removed_from_config(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        tmp_path,
+    ):
+        """A full run (no username arg) must still prune 'charlie', who
+        is no longer in users.list - this is the legitimate case the
+        feature exists to handle, and scoping pruning to full-run-only
+        must not break it."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        alice_cache = cache_dir / "watched_cache_plex_alice.json"
+        alice_cache.write_text("{}", encoding="utf-8")
+        removed_cache = cache_dir / "watched_cache_plex_charlie.json"
+        removed_cache.write_text("{}", encoding="utf-8")
+
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
+        mock_root.return_value = str(tmp_path)
+        config = {
+            "plex": {"token": "abc"},
+            "users": {"list": "alice"},
+            "general": {"cache_prune": {"enabled": True, "dry_run": False}},
+        }
+        mock_yaml.return_value = config
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(return_value=config)
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+
+        assert alice_cache.exists()
+        assert not removed_cache.exists()
+
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_full_run_prunes_by_resolved_not_raw_admin_username(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        tmp_path,
+    ):
+        """The real per-user cache filename is written under the
+        RESOLVED account username (e.g. 'realadmin'), never the raw
+        config string 'admin' - see utils.cache_prune.find_orphaned_
+        cache_files's own docstring on this contract. Pruning must keep
+        classifying by that same resolved form: if a future change fed
+        the raw config string into prune_orphaned_cache_files instead,
+        a config that still says 'admin' would misclassify its own live
+        cache as orphaned and delete it - the exact inverse of this
+        bug."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        real_admin_cache = cache_dir / "watched_cache_plex_realadmin.json"
+        real_admin_cache.write_text("{}", encoding="utf-8")
+
+        mock_parse_args.return_value = Mock(username=None, debug=False, library_id=None)
+        mock_root.return_value = str(tmp_path)
+        config = {
+            "plex": {"token": "abc"},
+            "users": {"list": "admin"},
+            "general": {"cache_prune": {"enabled": True, "dry_run": False}},
+        }
+        mock_yaml.return_value = config
+        mock_migrate.return_value = {}
+
+        mock_adapt = Mock(return_value=config)
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: "realadmin" if u.lower() == "admin" else u
+
+        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+
+        assert real_admin_cache.exists()

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -409,8 +409,25 @@ def run_recommender_main(
         # Conservative by default: dry_run only *logs* candidates, so this
         # never deletes anything unless a config explicitly opts in via
         # general.cache_prune.dry_run: false.
+        # Single-user runs narrow all_users to just the one user being
+        # processed (see the `if single_user: all_users = [single_user]`
+        # above), so resolved_usernames here only ever contains that one
+        # user - never every other currently-configured user. Pruning
+        # against that narrowed set would misclassify every OTHER
+        # configured user's still-live cache as orphaned (found in
+        # pre-release review: a single-user run - e.g. a web-UI-triggered
+        # per-user job, or `python3 recommenders/movie.py alice` - would
+        # log false "would remove" candidates for every other user under
+        # the dry_run default, and actually delete them the first time an
+        # admin flips general.cache_prune.dry_run to false). Scoped to
+        # full runs only: a user genuinely removed from config is still
+        # caught on the next full run (cron / web UI's "full" engine /
+        # a bare `python3 recommenders/movie.py` with no username) - that
+        # is the only case where resolved_usernames reflects every
+        # currently-configured user, which is what this feature actually
+        # needs to tell "removed" apart from "just not in this run".
         cache_prune_config = general.get("cache_prune", {}) or {}
-        if cache_prune_config.get("enabled", True):
+        if not single_user and cache_prune_config.get("enabled", True):
             prune_orphaned_cache_files(cache_dir, resolved_usernames, dry_run=cache_prune_config.get("dry_run", True))
 
         outcome = "success"

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.31"
+__version__ = "2.10.32"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Single-user runs (python3 recommenders/movie.py alice, or any web-UI-triggered per-user job) fed a one-user resolved_usernames set into the unconditional cache-orphan prune added in 2.10.31, misclassifying every OTHER configured user's cache as orphaned.
- Under the dry_run: true default this only logged false "would remove" candidates, but flipping general.cache_prune.dry_run to false (a reasonable next step) would delete every other user's cache on the next single-user run, forcing a full Plex re-scan.
- Fix scopes pruning to full runs only (no username arg), the only case where resolved_usernames actually reflects every currently-configured user. A user genuinely removed from config is still pruned on the next full run (cron / web UI's "full" engine).

## Test plan
- [x] test_single_user_run_does_not_orphan_other_configured_users - proven to fail against pre-fix code (deletes alice's cache), passes against the fix
- [x] test_full_run_still_prunes_a_user_removed_from_config - full-run pruning still works for the legitimate removed-user case
- [x] test_full_run_prunes_by_resolved_not_raw_admin_username - locks in that pruning classifies by resolved username, not raw config string, so this can't invert into deleting a live cache
- [x] Full suite: 2465 passed, 1 skipped (baseline 2462/1 + 3 new tests)
- [x] ruff check / ruff format --check clean
- [x] tests/harness.py byte-identical
