### PR TITLE
fix: cosign-verify retry loop never retried due to inherited errexit (2.10.33)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,8 +50,21 @@ jobs:
 
           git config gpg.ssh.allowedSignersFile .github/allowed_signers
 
-          VERIFY_OUTPUT="$(git verify-tag "$GITHUB_REF_NAME" 2>&1 1>/dev/null)"
-          VERIFY_EXIT=$?
+          # The assignment lives in the `if` condition itself (not a bare
+          # `VERIFY_OUTPUT=$(...)` followed by a separate `VERIFY_EXIT=$?`)
+          # because GitHub Actions runs this script as `bash -e {0}` and
+          # this step's own `set -uo pipefail` does not clear that
+          # inherited -e - a bare failing assignment here would abort the
+          # script on the spot, silently skipping both the diagnostic
+          # `echo "$VERIFY_OUTPUT"` below and the `::error::` annotation,
+          # even though the step would still (correctly) fail red. Same
+          # class of bug fixed in post-release-smoke-test.yml's
+          # cosign-verify job; see that job's comment for the full story.
+          if VERIFY_OUTPUT="$(git verify-tag "$GITHUB_REF_NAME" 2>&1 1>/dev/null)"; then
+            VERIFY_EXIT=0
+          else
+            VERIFY_EXIT=$?
+          fi
           echo "$VERIFY_OUTPUT"
 
           if [ "$VERIFY_EXIT" -ne 0 ]; then

--- a/.github/workflows/post-release-smoke-test.yml
+++ b/.github/workflows/post-release-smoke-test.yml
@@ -571,14 +571,26 @@ jobs:
           MAX_ATTEMPTS=20
           SLEEP_SECONDS=30
 
+          # `if OUTPUT=$(...); then` (NOT `OUTPUT=$(...); STATUS=$?` followed
+          # by a separate `if`) is load-bearing here, not stylistic: GitHub
+          # Actions runs every `run:` step's script as `bash -e {0}` by
+          # default, and this step's own `set -uo pipefail` does not (and
+          # cannot) clear that inherited -e. A bare `VAR=$(failing_cmd)`
+          # statement is a simple command for errexit's purposes - if it's
+          # not already inside an `if`/`while`/`&&`/`||`/`!` condition,
+          # errexit kills the whole script on the spot, before a
+          # never-reached `STATUS=$?` line or the retry loop below it ever
+          # runs. That exact bug shipped in 2.10.25-2.10.32: this job died
+          # in under a second on the first MANIFEST_UNKNOWN with zero
+          # "Attempt N/20 failed" diagnostics, looking like a hung/instant
+          # failure instead of a retrying one. Putting the assignment
+          # directly in the `if` condition is what actually suppresses
+          # errexit for it - see `help set` / bash's "Compound Commands".
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            OUTPUT="$(cosign verify \
+            if OUTPUT="$(cosign verify \
               --certificate-identity-regexp '^https://github\.com/OrchestratedChaos/curatarr/\.github/workflows/docker\.yml@refs/' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              "$IMAGE" 2>&1)"
-            STATUS=$?
-
-            if [ "$STATUS" -eq 0 ]; then
+              "$IMAGE" 2>&1)"; then
               echo "$OUTPUT"
               echo "Verified $IMAGE on attempt ${attempt}/${MAX_ATTEMPTS}."
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,22 @@ jobs:
           # body/message (which `-v` would print to stdout — we never pass
           # `-v`) can never end up in VERIFY_OUTPUT regardless of git
           # version.
-          VERIFY_OUTPUT="$(git verify-tag "$GITHUB_REF_NAME" 2>&1 1>/dev/null)"
-          VERIFY_EXIT=$?
+          #
+          # The assignment lives in the `if` condition itself (not a bare
+          # `VERIFY_OUTPUT=$(...)` followed by a separate `VERIFY_EXIT=$?`)
+          # because GitHub Actions runs this script as `bash -e {0}` and
+          # this step's own `set -uo pipefail` does not clear that
+          # inherited -e - a bare failing assignment here would abort the
+          # script on the spot, silently skipping both the diagnostic
+          # `echo "$VERIFY_OUTPUT"` below and the `::error::` annotation,
+          # even though the step would still (correctly) fail red. Same
+          # class of bug fixed in post-release-smoke-test.yml's
+          # cosign-verify job; see that job's comment for the full story.
+          if VERIFY_OUTPUT="$(git verify-tag "$GITHUB_REF_NAME" 2>&1 1>/dev/null)"; then
+            VERIFY_EXIT=0
+          else
+            VERIFY_EXIT=$?
+          fi
           echo "$VERIFY_OUTPUT"
 
           if [ "$VERIFY_EXIT" -ne 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.33] - 2026-07-26
+
+### Fixed
+
+- **`post-release-smoke-test.yml`'s `cosign-verify` bounded retry never
+  retried, and the same broken pattern existed in two other workflows
+  (#243).**
+
+  - The `cosign-verify` job's retry loop (added in 2.10.25 to survive
+    the race where this smoke test runs before `docker.yml` finishes
+    pushing and signing the image) never executed a single retry.
+    GitHub Actions runs every `run:` step as `bash -e {0}`; the step's
+    own `set -uo pipefail` does not (and cannot) clear that inherited
+    `-e`. `OUTPUT="$(cosign verify ...)"` is a bare command-substitution
+    assignment, not inside any conditional - so on the very first
+    `MANIFEST_UNKNOWN` failure, errexit killed the script immediately,
+    before the following `STATUS=$?` line or any retry logic ever ran.
+    Confirmed in the real v2.10.32 run: the job died in well under a
+    second with zero "Attempt N/20 failed" diagnostics.
+  - `release.yml` and `docker.yml`'s "Verify tag is signed by the
+    trusted release key" steps had the identical shape
+    (`VERIFY_OUTPUT="$(git verify-tag ...)"; VERIFY_EXIT=$?`) - lower
+    severity there (the step still failed the job either way, since
+    errexit's own exit code propagates), but the diagnostic
+    `git verify-tag` output and the `::error::` annotation explaining
+    *why* were both silently lost on every failure.
+  - Fixed all three by moving the failing command substitution directly
+    into the `if` condition (`if OUTPUT="$(...)"; then ... else ...
+    fi`), which is the one context bash's errexit does not apply to -
+    confirmed with a fake `cosign` on PATH covering fails-twice-then-
+    succeeds (retries and passes), always-fails (exhausts its budget
+    and fails non-zero, loudly, with every attempt's output printed),
+    and succeeds-immediately (no spurious retry delay).
+  - v2.10.32 itself was not affected - a manual re-dispatch of the
+    smoke test after `docker.yml` finished passed every check (cosign
+    verify, glibc floor, all 8 distro/arch starts, real self-update).
+    The auto-filed failure was this bug plus the pre-existing
+    not-published-yet race it was supposed to survive.
+
 ## [2.10.32] - 2026-07-26
 
 ### Fixed

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.32"
+__version__ = "2.10.33"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary

- `post-release-smoke-test.yml`'s `cosign-verify` bounded retry (added 2.10.25) never actually retried: GitHub Actions runs every `run:` step as `bash -e {0}`, and the step's own `set -uo pipefail` never cleared that inherited `-e`. The bare `OUTPUT="$(cosign verify ...)"` assignment triggered errexit on the very first `MANIFEST_UNKNOWN`, killing the script before `STATUS=$?` or any retry logic ever ran - confirmed in the real v2.10.32 run (died in well under a second, zero "Attempt N/20 failed" diagnostics).
- `release.yml` and `docker.yml`'s "Verify tag is signed by the trusted release key" steps had the identical shape (`VERIFY_OUTPUT="$(git verify-tag ...)"; VERIFY_EXIT=$?`) - lower severity since the step still failed the job either way, but the diagnostic output and `::error::` annotation were silently dropped.
- Fixed all three by moving the failing command substitution directly into the `if` condition (`if OUTPUT="$(...)"; then ... else ... fi`), the one context bash's errexit does not apply to.
- v2.10.32 itself is unaffected - a manual re-dispatch of the smoke test after `docker.yml` finished passed every check.

Closes #243.

## Test plan

- [x] Reproduced the original bug with a trivial `bash -e` script (dies silently, prints nothing, before reaching any retry/diagnostic line)
- [x] Fake `cosign` on PATH, fails twice then succeeds -> loop retries, job passes
- [x] Fake `cosign` on PATH, always fails -> loop exhausts budget, exits non-zero, prints every attempt's output plus a final `::error::`
- [x] Fake `cosign` on PATH, succeeds immediately -> no spurious retry delay
- [x] `actionlint` clean on all three edited workflow files
- [x] `python3 -m py_compile utils/config.py`
- [x] YAML parses on all three edited workflow files