### PR TITLE
refactor: remove dead divergently-defaulted display keys from adapt_config_for_media_type (2.10.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.37] - 2026-07-26
+
+### Changed
+
+- **Removed `adapt_config_for_media_type()`'s dead, divergently-defaulted display-option output (audit remediation, PR4).**
+
+  - Since the 2.10.23 config fix, `recommenders/base.py` resolves
+    `movies:`/`tv:` `show_summary`/`show_cast`/`show_language`/`show_rating`
+    overrides itself, directly from `self.media_config` (defaulting to
+    `False` for all four when unset). `utils/config.py`'s
+    `adapt_config_for_media_type()` still independently flattened the
+    same four keys onto its returned dict with a **different default**
+    (`True`).
+  - Verified "read nowhere outside `utils/config.py`" myself with an
+    exhaustive grep (including every test file) before touching anything:
+    the only reads of these four specific keys are `recommenders/base.py`'s
+    own, separate `self.media_config`-based resolution (unrelated code
+    path, never touches this function's output) and this function's own
+    definition - not a single caller anywhere (`utils/cli.py`'s
+    `run_recommender_main`, `recommenders/movie.py`/`tv.py`'s
+    `process_recommendations`, or any test) ever reads
+    `result["show_summary"]` etc. from `adapt_config_for_media_type()`'s
+    return value.
+  - The rest of the function is NOT dead: `run_recommender_main` reads
+    the returned `general`/`plex`/`plex_users`/`users`/`libraries` keys
+    (passthroughs of the same root-config values, not media-specific
+    adaptations) for log retention, the Plex token, the configured user
+    list, and per-library-per-user looping - kept those untouched.
+    `limit_results`/`randomize_recommendations`/`normalize_counters`/
+    quality-filter/weights/radarr-sonarr/`add_label` keys are also
+    unread outside this function's own tests, same as the four removed
+    keys, but were **left in place** - out of this PR's explicitly-scoped
+    finding (which named only the four *divergently-defaulted* display
+    keys), and none of them have a different-default divergence risk
+    from the live path the way show_summary/cast/language/rating did
+    (e.g. `limit_results`'s 50/20 default here already matches
+    `recommenders/base.py`'s, post-PR1).
+  - Removed the four keys entirely rather than just fixing their default
+    to match - fixing the default wouldn't make the output any less dead,
+    and would leave the exact same "looks like it matters, doesn't" trap
+    for a future maintainer.
+  - Added a test locking in that `adapt_config_for_media_type()` no
+    longer produces these four keys, so a future change can't silently
+    reintroduce them.
+
 ## [2.10.36] - 2026-07-26
 
 ### Changed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -255,6 +255,22 @@ class TestAdaptConfigForMediaType:
         assert len(libs) == 1
         assert libs[0]["section"] == "Movies"
 
+    def test_does_not_produce_dead_divergently_defaulted_display_keys(self):
+        """PR4 audit remediation: show_summary/show_cast/show_language/
+        show_rating used to be flattened onto the returned dict here with
+        a default (True) that silently diverged from
+        recommenders/base.py's real, live resolution (default False) -
+        while never actually being read from this function's output
+        anywhere. Removed rather than fixed-in-place, since fixing the
+        default wouldn't make the output any less dead. Locks in that a
+        future change doesn't silently reintroduce the same trap."""
+        result = adapt_config_for_media_type({}, "movies")
+
+        assert "show_summary" not in result
+        assert "show_cast" not in result
+        assert "show_language" not in result
+        assert "show_rating" not in result
+
 
 class TestNegativeSignalsConstants:
     """Tests for negative signals constants"""

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.36"
+__version__ = "2.10.37"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus
@@ -505,10 +505,15 @@ def adapt_config_for_media_type(root_config: Dict, media_type: str = "movies") -
     config["limit_results"] = media_config.get("limit_results", 50 if media_type == "movies" else 20)
     config["randomize_recommendations"] = media_config.get("randomize_recommendations", False)
     config["normalize_counters"] = media_config.get("normalize_counters", True)
-    config["show_summary"] = media_config.get("show_summary", True)
-    config["show_cast"] = media_config.get("show_cast", True)
-    config["show_language"] = media_config.get("show_language", True)
-    config["show_rating"] = media_config.get("show_rating", True)
+    # NOTE: show_summary/show_cast/show_language/show_rating deliberately
+    # NOT flattened here (removed 2026-07, audit remediation PR4) -
+    # recommenders/base.py resolves these itself directly from
+    # self.media_config (see its __init__), with a DIFFERENT default
+    # (False) than this function used to produce (True) for all four.
+    # This function's output for these specific keys was never read
+    # anywhere outside its own tests (see CHANGELOG) - do not re-add a
+    # flattened copy here; it would only reintroduce the same dead,
+    # misleadingly-defaulted trap for a future maintainer.
     config["show_imdb_link"] = media_config.get("show_imdb_link", False)
 
     # Quality filters


### PR DESCRIPTION
## Summary
- `utils/config.py`'s `adapt_config_for_media_type()` still flattened `show_summary`/`show_cast`/`show_language`/`show_rating` onto its returned dict with a default (`True`) that silently diverged from `recommenders/base.py`'s real, live resolution (default `False`) - while never being read anywhere outside this function's own tests.
- Verified the "read nowhere" claim with an exhaustive grep (including every test file) before removing anything.
- Removed only the four divergently-defaulted keys; the rest of the function (general/plex/plex_users/users/libraries passthrough) is still live, read by `utils/cli.py`'s `run_recommender_main`, and untouched.

## Test plan
- [x] `pytest tests/` - 2481 passed, 1 skipped (prior 2480/1 + 1 new)
- [x] `tests/harness.py` output byte-identical to baseline
- [x] `ruff check .` clean, `ruff format --check .` clean
