### PR TITLE
fix: bound login rate limiter memory growth under distributed floods (2.10.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.38] - 2026-07-26
+
+### Fixed
+
+- **Login rate limiter (`web/security.py`'s `_login_failures`) could grow without bound under a distributed attack (audit remediation, PR5).**
+
+  - `_login_failures` was only pruned when the offending IP made another
+    request (`_prune_locked`, called from `_is_locked_out`/
+    `_record_login_failure` for that one IP only). A distributed
+    attack sending exactly one request per source IP never revisits any
+    of its own IPs, so nothing ever reclaimed those one-shot entries -
+    the dict grows by one entry per unique attacking IP forever.
+  - Added `_LOGIN_FAILURES_MAX_TRACKED_IPS` (10,000) and
+    `_sweep_login_failures_locked()`, triggered from
+    `_record_login_failure` only once the dict exceeds that cap (no new
+    background thread/timer - stays in keeping with this module's
+    existing "in-process/in-memory, no new dependency" design). The
+    sweep first drops every entry that's aged out of the rolling window
+    on its own (the common case for a one-shot flood), then, only if
+    still over cap, evicts the least-recently-active entries - but never
+    an actively locked-out IP (`>= _LOGIN_MAX_ATTEMPTS` within the
+    window) while any non-locked-out entry remains to evict instead.
+  - **Must not weaken lockout, must not let a flood evict a legitimate
+    lockout**: this is why locked-out entries are excluded from eviction
+    whenever a non-locked-out alternative exists - a flood of throwaway
+    IPs can only evict *other throwaway/expired* entries, never force out
+    a genuine attacker's (or a real user's, if they collide behind a
+    shared proxy) active lockout early. Only falls back to evicting a
+    locked-out entry in the pathological case where the cap is entirely
+    saturated by simultaneously-locked IPs (requires
+    `_LOGIN_FAILURES_MAX_TRACKED_IPS * _LOGIN_MAX_ATTEMPTS` failed
+    requests inside one `_LOGIN_WINDOW_SECONDS` window - already its own
+    denial-of-service on the process regardless of this dict) - logged
+    via `log_warning` if it ever happens.
+  - Tests added to `tests/test_web_security.py`: dict size stays bounded
+    under a 50-unique-IP flood with the cap monkeypatched down to 5,
+    an active lockout survives an unrelated flood of throwaway IPs (via
+    the real `/login` route), a legitimate under-threshold user still
+    logs in successfully after the same flood, and naturally-expired
+    entries are pruned before any eviction is even considered.
+  - No change to the existing lockout/window behavior for the ordinary
+    case - all 66 pre-existing tests in this file pass unchanged.
+
 ## [2.10.37] - 2026-07-26
 
 ### Changed

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -584,3 +584,83 @@ class TestLoginRateLimiting:
         )
         assert any(self.IP in msg for msg in logged)
         assert not any("wrong" in msg for msg in logged)  # never log the attempted token
+
+    def test_dict_size_bounded_under_distributed_flood(self, monkeypatch):
+        """PR5: a distributed one-request-per-IP flood (each IP hits the
+        endpoint exactly once, never revisiting itself) must not grow
+        _login_failures without bound - nothing else would ever prune
+        those one-shot entries (see _sweep_login_failures_locked)."""
+        import web.security as security_module
+
+        monkeypatch.setattr(security_module, "_LOGIN_FAILURES_MAX_TRACKED_IPS", 5)
+
+        for i in range(50):
+            security_module._record_login_failure(f"203.0.113.{i}")
+
+        assert len(_login_failures) <= 5
+
+    def test_active_lockout_survives_flood_of_other_ips(self, curatarr_web_root, monkeypatch):
+        """An attacker cannot use a flood of throwaway one-shot IPs to
+        push a DIFFERENT, already-locked-out IP's entry out of the
+        tracker and let it straight back in early."""
+        import web.security as security_module
+
+        monkeypatch.setattr(security_module, "_LOGIN_FAILURES_MAX_TRACKED_IPS", 5)
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 5, ip=self.IP)  # locks out self.IP
+
+        for i in range(50):
+            security_module._record_login_failure(f"198.51.100.{i}")
+
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.headers["Location"] == "/login?error=locked"
+
+    def test_legitimate_user_still_succeeds_after_unrelated_ip_flood(self, curatarr_web_root, monkeypatch):
+        """A flood of unrelated one-shot IPs filling up the tracker must
+        not prevent a normal user (under the failure threshold) from
+        logging in with the correct token afterward - eviction may or may
+        not remove their own (not-locked-out) entry, and either outcome
+        must still let them through."""
+        import web.security as security_module
+
+        monkeypatch.setattr(security_module, "_LOGIN_FAILURES_MAX_TRACKED_IPS", 5)
+        c = self._client(curatarr_web_root, monkeypatch)
+        self._fail(c, 2, ip=self.IP)  # under threshold
+
+        for i in range(50):
+            security_module._record_login_failure(f"198.51.100.{i}")
+
+        resp = c.post(
+            "/login",
+            data={"token": self.TOKEN},
+            follow_redirects=False,
+            environ_overrides={"REMOTE_ADDR": self.IP},
+        )
+        assert resp.status_code == 303
+        assert "curatarr_token" in resp.headers.get("Set-Cookie", "")
+
+    def test_expired_entries_pruned_before_evicting_active_ones(self, monkeypatch):
+        """The sweep drops naturally-expired entries first, before ever
+        considering eviction - a batch of one-shot IPs that has simply
+        aged out of the window costs nothing once the window has passed,
+        even without a fresh request from any of them."""
+        import web.security as security_module
+
+        fake_now = [1000.0]
+        monkeypatch.setattr(security_module.time, "monotonic", lambda: fake_now[0])
+        monkeypatch.setattr(security_module, "_LOGIN_FAILURES_MAX_TRACKED_IPS", 5)
+
+        for i in range(5):
+            security_module._record_login_failure(f"198.51.100.{i}")
+        assert len(_login_failures) == 5
+
+        fake_now[0] += security_module._LOGIN_WINDOW_SECONDS + 1  # everything above ages out
+
+        security_module._record_login_failure("203.0.113.1")  # triggers a sweep (6 > 5)
+
+        assert set(_login_failures.keys()) == {"203.0.113.1"}

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.37"
+__version__ = "2.10.38"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus

--- a/web/security.py
+++ b/web/security.py
@@ -340,10 +340,22 @@ def _request_is_secure(request) -> bool:
 # whatever access restarting it requires. Guarded by a lock because
 # both app.run(threaded=True) (web/app.py) and the Docker waitress
 # server (web/docker_server.py) serve requests concurrently.
+#
+# Memory is bounded independently of the rolling window above (PR5):
+# a distributed attack that sends exactly one request per source IP
+# never revisits any of its own IPs, so the per-IP window pruning above
+# would otherwise never reclaim those one-shot entries - see
+# _LOGIN_FAILURES_MAX_TRACKED_IPS and _sweep_login_failures_locked.
 # ---------------------------------------------------------------------------
 
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW_SECONDS = 60
+
+# Caps how many source IPs _login_failures tracks, against a distributed
+# one-request-per-IP flood (audit remediation, PR5) - see
+# _sweep_login_failures_locked below for how the cap is enforced without
+# weakening a genuine lockout.
+_LOGIN_FAILURES_MAX_TRACKED_IPS = 10_000
 
 _login_failures_lock = threading.Lock()
 _login_failures: Dict[str, List[float]] = {}  # {ip: [monotonic timestamp, ...]} of FAILED attempts only
@@ -376,12 +388,68 @@ def _is_locked_out(ip: str) -> bool:
         return len(_prune_locked(ip, time.monotonic())) >= _LOGIN_MAX_ATTEMPTS
 
 
+def _sweep_login_failures_locked(now: float) -> None:
+    """Bound _login_failures' memory footprint - must be called with
+    _login_failures_lock held. Only called from _record_login_failure
+    once the dict has grown past _LOGIN_FAILURES_MAX_TRACKED_IPS - a
+    distributed flood (one request from each of many source IPs) never
+    re-visits any single one of its own IPs, so nothing would otherwise
+    ever prune those one-shot entries: _prune_locked above only rewrites
+    the CURRENTLY-REQUESTING ip's own list, never every other ip's list.
+
+    First drops every entry that's aged out of the rolling window on its
+    own - the common case, since most of a one-shot flood's IPs will
+    already be stale by the time the cap is hit. If that alone isn't
+    enough, evicts the least-recently-active entries next, but NEVER an
+    IP that is currently locked out (>= _LOGIN_MAX_ATTEMPTS within the
+    window) while any non-locked-out entry remains to evict instead -
+    otherwise a flood of throwaway IPs could evict a genuine attacker's
+    (or a legitimate user's, if they happen to collide behind a shared
+    proxy - see _client_ip) active lockout and let them straight back in.
+    Only falls back to evicting a locked-out entry in the pathological
+    case where the cap is entirely full of simultaneously-locked IPs -
+    sustaining that requires _LOGIN_FAILURES_MAX_TRACKED_IPS *
+    _LOGIN_MAX_ATTEMPTS failed requests inside one _LOGIN_WINDOW_SECONDS
+    window, itself already a denial-of-service on the process regardless
+    of this dict.
+    """
+    for ip in list(_login_failures.keys()):
+        _prune_locked(ip, now)
+    for ip in [ip for ip, attempts in _login_failures.items() if not attempts]:
+        del _login_failures[ip]
+
+    overflow = len(_login_failures) - _LOGIN_FAILURES_MAX_TRACKED_IPS
+    if overflow <= 0:
+        return
+
+    def _last_activity(candidate_ip: str) -> float:
+        return max(_login_failures[candidate_ip])
+
+    not_locked = sorted(
+        (ip for ip, attempts in _login_failures.items() if len(attempts) < _LOGIN_MAX_ATTEMPTS),
+        key=_last_activity,
+    )
+    locked = sorted((ip for ip in _login_failures if ip not in set(not_locked)), key=_last_activity)
+
+    for ip in (not_locked + locked)[:overflow]:
+        del _login_failures[ip]
+
+    if overflow > len(not_locked):
+        log_warning(
+            f"Login failure tracker exceeded {_LOGIN_FAILURES_MAX_TRACKED_IPS} "
+            "simultaneously locked-out IPs - evicted the oldest active "
+            "lockouts to bound memory."
+        )
+
+
 def _record_login_failure(ip: str) -> None:
     with _login_failures_lock:
         now = time.monotonic()
         attempts = _prune_locked(ip, now)
         attempts.append(now)
         _login_failures[ip] = attempts
+        if len(_login_failures) > _LOGIN_FAILURES_MAX_TRACKED_IPS:
+            _sweep_login_failures_locked(now)
 
 
 def _clear_login_failures(ip: str) -> None:


### PR DESCRIPTION
## Summary
- `_login_failures` was only pruned when the offending IP made another request - a distributed one-request-per-IP attack (never revisiting its own IPs) grew it without bound.
- Added a size cap (`_LOGIN_FAILURES_MAX_TRACKED_IPS = 10,000`) and an on-demand sweep triggered once the dict exceeds it: drop naturally-expired entries first, then evict least-recently-active ones - but never an actively locked-out IP while a non-locked-out entry remains to evict instead.
- A flood of throwaway IPs can only evict other throwaway/expired entries, never force out a genuine lockout early.
- No change to existing lockout/window behavior for the ordinary case - all 66 pre-existing tests in `tests/test_web_security.py` pass unchanged.

## Test plan
- [x] `pytest tests/` - 2485 passed, 1 skipped (prior 2481/1 + 4 new)
- [x] New tests: dict size bounded under a 50-IP flood, active lockout survives an unrelated flood (via the real `/login` route), legitimate under-threshold user still logs in after the same flood, expired entries pruned before any eviction
- [x] `tests/harness.py` output byte-identical to baseline
- [x] `ruff check .` clean, `ruff format --check .` clean
