### PR TITLE
fix: unify movies:/tv: config resolution into one live path (2.10.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.39] - 2026-07-26
+
+### Fixed
+
+- **Deleted the second, dead `movies:`/`tv:` config-resolution path that caused the 2.10.23 bug and left the architecture that produced it unfixed (audit remediation).**
+
+  - `utils/config.py`'s `adapt_config_for_media_type()` and
+    `recommenders/base.py`'s inline `self.media_config` resolution were
+    two fully independent implementations of the same `movies:`/`tv:`
+    override resolution, computed from two separate `load_config()`
+    reads. Only the `base.py` one was ever live - `adapt_config_for_media_type()`'s
+    output fed `utils/cli.py`'s `run_recommender_main()` as `base_config`,
+    but nothing downstream (`process_recommendations()` in
+    `recommenders/movie.py`/`tv.py`) ever read its media-type-resolved
+    keys, only root-level passthroughs (`general`, `plex`, `users`,
+    `libraries`) that were identical either way. This is exactly the
+    architecture that let the 2.10.23 bug happen and stay invisible for
+    months - a future key added to one implementation had no way to end
+    up in the other.
+  - Replaced both with one function, `utils/config.py`'s
+    `resolve_media_type_overrides(config, media_type)` (plus
+    `load_resolved_config(config_path, media_type)`, the `load_config()`
+    + `resolve_media_type_overrides()` one-call convenience most callers
+    want). It takes the FULL root config and only overlays the specific
+    resolved keys on top - unlike the deleted function, there is no
+    cherry-picked reconstruction that can silently drop an unrelated
+    root-level key (see below).
+  - `recommenders/base.py`, `movie.py`, and `utils/cli.py` now call this
+    directly instead of hand-resolving `movies:`/`tv:` overrides
+    themselves. `utils/cli.py`'s `run_recommender_main()` no longer takes
+    an `adapt_config_func` parameter - it never needed a media-type-
+    resolved config for its own bookkeeping (users/libraries/general.*/
+    plex.token are all root-level, media-type-independent values), so it
+    now reads `root_config` directly.
+  - **Defaults are unchanged for every key this touches** - verified by
+    reconstructing the OLD inline `base.py` resolution logic exactly and
+    diffing it key-for-key against the new function across 6 config
+    shapes (no `tuning.yml`, `movies:`-only, `tv:`-only, both, unknown/
+    extra keys, and the production install's actual config shape) x 2
+    media types = 12 scenarios, all matching. Where the deleted dead
+    path's computed defaults disagreed with the live one (documented
+    explicitly so a future maintainer doesn't "fix" the wrong one back
+    in): `randomize_recommendations` (dead path defaulted to `false`,
+    live/kept default is `true`), TV `weights` (dead path's `genre`
+    0.25/`actor` 0.20/`studio` 0.10/`keyword` 0.50/`language` 0.0 -
+    doesn't even sum to 1.0 - vs. the live, kept
+    `PlexTVRecommender._load_weights()` defaults of `genre` 0.20/`actor`
+    0.15/`studio` 0.15/`keyword` 0.45/`language` 0.05), and movies
+    `quality_filters` (dead path defaulted `min_rating`/`min_vote_count`
+    to 5.0/50 when unset; the live, kept default - shared with TV - is
+    0.0/0, resolved unchanged directly in
+    `BaseRecommender.get_recommendations()`, never migrated into the new
+    function since it was never divergent there).
+  - Added `tests/test_config.py`'s
+    `TestResolveMediaTypeOverridesKeyEnumeration`: parses the real,
+    committed `config/tuning.example.yml` and asserts every documented
+    `movies:`/`tv:` key actually resolves, plus a closed-set membership
+    check that fails loudly if a future edit to that file adds a key
+    neither test method accounts for - the standing guard against this
+    bug class recurring for a new key.
+  - `tests/harness.py` untouched (byte-identical - it only imports
+    `utils/scoring.py`, never `utils/config.py` or `recommenders/base.py`)
+    and its own test (`tests/test_harness.py`) still passes, confirming
+    no scoring drift.
+
 ## [2.10.38] - 2026-07-26
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -26,7 +26,6 @@ from utils import (
     CACHE_VERSION,
     CANDIDATE_BUFFER_MULTIPLIER,
     CYAN,
-    DEFAULT_LIMIT_RESULTS,
     DEFAULT_NEGATIVE_THRESHOLD,
     GREEN,
     RATING_MULTIPLIER_2_STAR,
@@ -76,6 +75,7 @@ from utils import (
     print_similarity_breakdown,
     process_counters_from_cache,
     remove_labels_from_items,
+    resolve_media_type_overrides,
     save_media_cache,
     save_watched_cache,
     select_tiered_recommendations,
@@ -429,7 +429,13 @@ class BaseRecommender(ABC):
                 it just doesn't share across users/instances.
         """
         self.single_user = single_user
-        self.config = load_config(config_path)
+        # load_config() (modular merge + auto-migration + env-var
+        # overrides) followed by resolve_media_type_overrides() (the
+        # movies:/tv: per-media-type resolution - see its docstring in
+        # utils/config.py for exactly which keys this adds/overwrites and
+        # why) - the one resolution path every recommender now shares
+        # with utils/cli.py.
+        self.config = resolve_media_type_overrides(load_config(config_path), self.media_type)
         self.library = library
         self._library_items_cache: Dict[str, List] = library_items_cache if library_items_cache is not None else {}
 
@@ -470,16 +476,11 @@ class BaseRecommender(ABC):
         # Media-specific section (movies:/tv: in tuning.yml) - the
         # documented, web-UI-writable location for display options,
         # randomize_recommendations, normalize_counters, quality_filters,
-        # and weights (see config/tuning.example.yml). Historically this
-        # class read all of these from `general_config` above instead,
-        # which meant a user's movies:/tv: overrides were silently never
-        # applied - randomize_recommendations, quality_filters, and
-        # several display options resolved to their code-level defaults
-        # no matter what was configured (see CHANGELOG). Every read below checks
-        # media_config first and falls back to the old general_config/
-        # root-level read so back-compat installs that (for whatever
-        # undocumented reason) set these under general: or root level
-        # keep behaving exactly as before.
+        # and weights (see config/tuning.example.yml). Kept as a direct
+        # reference to the raw section (not the resolved keys above) for
+        # get_recommendations()'s own quality_filters read further down,
+        # which resolves that key fresh at call time rather than once
+        # here - see its comment there for why.
         media_section = "movies" if self.media_type == "movie" else "tv"
         self.media_config = self.config.get(media_section, self.config.get(media_section.upper(), {})) or {}
 
@@ -510,7 +511,10 @@ class BaseRecommender(ABC):
         # CHANGELOG). This is now the single source of truth for how many
         # items end up in the recommendation collection - manage_plex_labels()
         # below reads self.limit_results directly as its target_count.
-        self.limit_results = self.media_config.get("limit_results", DEFAULT_LIMIT_RESULTS[self.media_type])
+        # Resolved once, up front, by resolve_media_type_overrides() (see
+        # its docstring in utils/config.py) - this class no longer hand-
+        # resolves movies:/tv: overrides itself.
+        self.limit_results = self.config["limit_results"]
 
         # Internal candidate-scoring buffer: generate CANDIDATE_BUFFER_MULTIPLIER x
         # limit_results scoring candidates per run, so the best-scoring items can
@@ -523,18 +527,14 @@ class BaseRecommender(ABC):
         # existing documented/tested behavior for installs that already set it.
         default_limit = self.limit_results * CANDIDATE_BUFFER_MULTIPLIER
         self.limit_plex_results = general_config.get("limit_plex_results", default_limit)
-        self.randomize_recommendations = self.media_config.get(
-            "randomize_recommendations", general_config.get("randomize_recommendations", True)
-        )
-        self.normalize_counters = self.media_config.get(
-            "normalize_counters", general_config.get("normalize_counters", True)
-        )
-        self.show_summary = self.media_config.get("show_summary", general_config.get("show_summary", False))
-        self.show_genres = self.media_config.get("show_genres", general_config.get("show_genres", True))
-        self.show_cast = self.media_config.get("show_cast", general_config.get("show_cast", False))
-        self.show_language = self.media_config.get("show_language", general_config.get("show_language", False))
-        self.show_rating = self.media_config.get("show_rating", general_config.get("show_rating", False))
-        self.show_imdb_link = self.media_config.get("show_imdb_link", general_config.get("show_imdb_link", False))
+        self.randomize_recommendations = self.config["randomize_recommendations"]
+        self.normalize_counters = self.config["normalize_counters"]
+        self.show_summary = self.config["show_summary"]
+        self.show_genres = self.config["show_genres"]
+        self.show_cast = self.config["show_cast"]
+        self.show_language = self.config["show_language"]
+        self.show_rating = self.config["show_rating"]
+        self.show_imdb_link = self.config["show_imdb_link"]
 
         # Load excluded genres
         exclude_genre_str = general_config.get("exclude_genre", "")
@@ -547,9 +547,12 @@ class BaseRecommender(ABC):
 
         # Load weights - movies:/tv: weights: (documented location, see
         # config/tuning.example.yml) take priority over the legacy
-        # root-level `weights` key some back-compat installs/tests still use.
-        weights_config = self.media_config.get("weights", self.config.get("weights", {}))
-        self.weights = self._load_weights(weights_config)
+        # root-level `weights` key some back-compat installs/tests still
+        # use; that fallback chain is resolved once by
+        # resolve_media_type_overrides() (self.config["weights"]) -
+        # _load_weights() below only applies the media-type-specific
+        # per-field defaults (director vs studio, etc.), unchanged.
+        self.weights = self._load_weights(self.config["weights"])
 
         # Validate weights sum
         total_weight = sum(self.weights.values())

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -21,7 +21,6 @@ from utils import (
     RED,
     RESET,
     TOP_CAST_COUNT,
-    adapt_config_for_media_type,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
     calculate_similarity_score,
@@ -155,9 +154,9 @@ class PlexMovieRecommender(BaseRecommender):
         self.plex_watched_rating_keys: Set[int] = set()
         # movies.show_director: is the documented location (config/tuning.example.yml);
         # fall back to the legacy root-level general.show_director for back-compat.
-        self.show_director = self.media_config.get(
-            "show_director", self.config.get("general", {}).get("show_director", False)
-        )
+        # Resolved once, up front, by resolve_media_type_overrides() (see
+        # its docstring in utils/config.py) via BaseRecommender.__init__.
+        self.show_director = self.config["show_director"]
 
         # Create movie cache
         self.movie_cache = MovieCache(self.cache_dir, recommender=self)
@@ -545,14 +544,6 @@ def format_movie_output(
 
 
 # ------------------------------------------------------------------------
-# CONFIG ADAPTER
-# ------------------------------------------------------------------------
-def adapt_root_config_to_legacy(root_config):
-    """Convert root config.yml format to legacy MRFP format"""
-    return adapt_config_for_media_type(root_config, "movies")
-
-
-# ------------------------------------------------------------------------
 # MAIN
 # ------------------------------------------------------------------------
 def process_recommendations(
@@ -620,7 +611,6 @@ def main():
     run_recommender_main(
         media_type="Movie",
         description="Movie Recommendations for Plex",
-        adapt_config_func=adapt_root_config_to_legacy,
         process_func=process_recommendations,
         media_type_key="movie",
     )

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -23,7 +23,6 @@ from utils import (
     RESET,
     TOP_CAST_COUNT,
     YELLOW,
-    adapt_config_for_media_type,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
     calculate_similarity_score,
@@ -586,20 +585,11 @@ def format_show_output(
     )
 
 
-# ------------------------------------------------------------------------
-# CONFIG ADAPTER
-# ------------------------------------------------------------------------
-def adapt_root_config_to_legacy(root_config):
-    """Convert root config.yml format to legacy TRFP format"""
-    return adapt_config_for_media_type(root_config, "tv")
-
-
 def main():
     """Entry point for TV show recommendations."""
     run_recommender_main(
         media_type="TV Show",
         description="TV Show Recommendations for Plex",
-        adapt_config_func=adapt_root_config_to_legacy,
         process_func=process_recommendations,
         media_type_key="tv",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -399,11 +399,10 @@ class TestRunRecommenderMain:
         mock_root.return_value = "/fake/root"
         mock_open.side_effect = FileNotFoundError("No config")
 
-        mock_adapt = Mock()
         mock_process = Mock()
 
         with pytest.raises(SystemExit) as exc_info:
-            run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+            run_recommender_main("Movie", "Test", mock_process)
 
         assert exc_info.value.code == 1
 
@@ -424,12 +423,11 @@ class TestRunRecommenderMain:
         mock_yaml.return_value = {"plex": {"token": "abc"}}  # No users
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value={"plex": {"token": "abc"}, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
 
         with pytest.raises(SystemExit) as exc_info:
-            run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+            run_recommender_main("Movie", "Test", mock_process)
 
         assert exc_info.value.code == 1
 
@@ -450,12 +448,11 @@ class TestRunRecommenderMain:
         mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "alice, bob"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value={"plex": {"token": "abc"}, "users": {"list": "alice, bob"}, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u  # Return unchanged
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert mock_process.call_count == 2
 
@@ -476,14 +473,11 @@ class TestRunRecommenderMain:
         mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "alice, bob, charlie"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(
-            return_value={"plex": {"token": "abc"}, "users": {"list": "alice, bob, charlie"}, "general": {}}
-        )
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert mock_process.call_count == 1
 
@@ -504,13 +498,12 @@ class TestRunRecommenderMain:
         mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "alice"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value={"plex": {"token": "abc"}, "users": {"list": "alice"}, "general": {}})
         mock_process = Mock()
         mock_logger = Mock()
         mock_setup_log.return_value = mock_logger
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         mock_setup_log.assert_called_once()
         call_kwargs = mock_setup_log.call_args
@@ -538,12 +531,11 @@ class TestRunRecommenderMain:
         ]
         mock_migrate.return_value = {"oldname": "newname"}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         mock_migrate.assert_called_once()
         # Config was re-read after migration, so the adapted config (and
@@ -569,12 +561,11 @@ class TestRunRecommenderMain:
         mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "alice"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert mock_yaml.call_count == 1
 
@@ -602,18 +593,11 @@ class TestRunRecommenderMainLibraryMatrixLoop:
         mock_yaml.return_value = {"plex": {"token": "abc", "movie_library": "Movies"}, "users": {"list": "alice, bob"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(
-            return_value={
-                "plex": {"token": "abc", "movie_library": "Movies"},
-                "users": {"list": "alice, bob"},
-                "general": {},
-            }
-        )
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process, media_type_key="movie")
+        run_recommender_main("Movie", "Test", mock_process, media_type_key="movie")
 
         assert mock_process.call_count == 2
         for call in mock_process.call_args_list:
@@ -649,12 +633,11 @@ class TestRunRecommenderMainLibraryMatrixLoop:
         mock_yaml.return_value = root_cfg
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process, media_type_key="movie")
+        run_recommender_main("Movie", "Test", mock_process, media_type_key="movie")
 
         assert mock_process.call_count == 4
         seen = set()
@@ -695,12 +678,11 @@ class TestRunRecommenderMainLibraryMatrixLoop:
         mock_yaml.return_value = root_cfg
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("TV Show", "Test", mock_adapt, mock_process, media_type_key="tv")
+        run_recommender_main("TV Show", "Test", mock_process, media_type_key="tv")
 
         assert mock_process.call_count == 2
         lib_ids = {call[0][4]["id"] for call in mock_process.call_args_list}
@@ -731,12 +713,11 @@ class TestRunRecommenderMainLibraryMatrixLoop:
         mock_yaml.return_value = root_cfg
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process, media_type_key="movie")
+        run_recommender_main("Movie", "Test", mock_process, media_type_key="movie")
 
         assert mock_process.call_count == 1
         assert mock_process.call_args[0][4]["id"] == "movies-4k"
@@ -759,13 +740,12 @@ class TestRunRecommenderMainLibraryMatrixLoop:
         mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "alice"}}
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(side_effect=lambda cfg: {**cfg, "general": {}})
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
         with pytest.raises(SystemExit) as exc_info:
-            run_recommender_main("Movie", "Test", mock_adapt, mock_process, media_type_key="movie")
+            run_recommender_main("Movie", "Test", mock_process, media_type_key="movie")
 
         assert exc_info.value.code == 1
         mock_process.assert_not_called()
@@ -927,12 +907,11 @@ class TestRunRecommenderMainCachePruneScope:
         mock_yaml.return_value = config
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value=config)
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert alice_cache.exists()
 
@@ -977,12 +956,11 @@ class TestRunRecommenderMainCachePruneScope:
         mock_yaml.return_value = config
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value=config)
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert alice_cache.exists()
         assert not removed_cache.exists()
@@ -1031,11 +1009,10 @@ class TestRunRecommenderMainCachePruneScope:
         mock_yaml.return_value = config
         mock_migrate.return_value = {}
 
-        mock_adapt = Mock(return_value=config)
         mock_process = Mock()
         mock_setup_log.return_value = Mock()
         mock_resolve.side_effect = lambda u, t: "realadmin" if u.lower() == "admin" else u
 
-        run_recommender_main("Movie", "Test", mock_adapt, mock_process)
+        run_recommender_main("Movie", "Test", mock_process)
 
         assert real_admin_cache.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,8 @@ import json
 import os
 import tempfile
 
+import yaml
+
 from utils.config import (
     CACHE_VERSION,
     DEFAULT_NEGATIVE_MULTIPLIERS,
@@ -12,7 +14,6 @@ from utils.config import (
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_TV,
     UPDATE_MODES,
-    adapt_config_for_media_type,
     check_cache_version,
     get_config_section,
     get_effective_arr_config,
@@ -24,6 +25,8 @@ from utils.config import (
     get_tmdb_config,
     get_update_mode,
     load_config,
+    load_resolved_config,
+    resolve_media_type_overrides,
 )
 
 
@@ -177,99 +180,351 @@ class TestGetRatingMultipliers:
         assert result[6] == 1.5  # Midpoint
 
 
-class TestAdaptConfigForMediaType:
-    """Tests for adapt_config_for_media_type function"""
+class TestResolveMediaTypeOverrides:
+    """Tests for resolve_media_type_overrides() - the single, live
+    movies:/tv: resolution path (see its docstring in utils/config.py for
+    the architecture history: this replaces two independent, drifted
+    implementations - recommenders/base.py's inline resolution, which was
+    always the real, live one, and this module's now-deleted
+    adapt_config_for_media_type(), which was never actually read by the
+    recommendation-generation path). Defaults asserted here are the LIVE
+    ones (matching recommenders/base.py's pre-refactor behavior exactly),
+    NOT the old dead path's - see CHANGELOG for every case where the two
+    disagreed and which one won."""
 
-    def test_movies_gets_director_weight(self):
-        config = {"movies": {"weights": {"director": 0.10}}}
-        result = adapt_config_for_media_type(config, "movies")
-        assert "director" in result["weights"]
-        assert result["weights"]["director"] == 0.10
-
-    def test_tv_gets_studio_weight(self):
-        config = {"tv": {"weights": {"studio": 0.15}}}
-        result = adapt_config_for_media_type(config, "tv")
-        assert "studio" in result["weights"]
-        assert result["weights"]["studio"] == 0.15
-
-    def test_movies_default_limit_50(self):
-        config = {}
-        result = adapt_config_for_media_type(config, "movies")
+    def test_movies_limit_results_default_50(self):
+        result = resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)
         assert result["limit_results"] == 50
 
-    def test_tv_default_limit_20(self):
-        config = {}
-        result = adapt_config_for_media_type(config, "tv")
+    def test_tv_limit_results_default_20(self):
+        result = resolve_media_type_overrides({}, MEDIA_TYPE_TV)
         assert result["limit_results"] == 20
 
-    def test_inherits_plex_config(self):
-        config = {"plex": {"url": "http://localhost:32400"}}
-        result = adapt_config_for_media_type(config, "movies")
-        assert result["plex"]["url"] == "http://localhost:32400"
+    def test_movies_limit_results_overridden(self):
+        config = {"movies": {"limit_results": 15}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["limit_results"] == 15
 
-    def test_movies_quality_defaults(self):
-        config = {}
-        result = adapt_config_for_media_type(config, "movies")
-        assert result["min_rating"] == 5.0
-        assert result["min_vote_count"] == 50
+    def test_randomize_recommendations_defaults_true(self):
+        """Live default is True (recommenders/base.py) - the old, dead
+        adapt_config_for_media_type() computed False here and nothing
+        ever read it; True is the one that must be preserved."""
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)["randomize_recommendations"] is True
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_TV)["randomize_recommendations"] is True
 
-    def test_tv_quality_defaults(self):
-        config = {}
-        result = adapt_config_for_media_type(config, "tv")
-        assert result["min_rating"] == 0.0
-        assert result["min_vote_count"] == 0
+    def test_randomize_recommendations_media_section_overrides_general(self):
+        config = {"general": {"randomize_recommendations": True}, "movies": {"randomize_recommendations": False}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["randomize_recommendations"] is False
+
+    def test_randomize_recommendations_falls_back_to_general_when_media_section_absent(self):
+        config = {"general": {"randomize_recommendations": False}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["randomize_recommendations"] is False
+
+    def test_normalize_counters_defaults_true(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_TV)["normalize_counters"] is True
+
+    def test_show_summary_defaults_false(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)["show_summary"] is False
+
+    def test_show_genres_defaults_true(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)["show_genres"] is True
+
+    def test_show_cast_defaults_false(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)["show_cast"] is False
+
+    def test_show_language_defaults_false(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_TV)["show_language"] is False
+
+    def test_show_rating_defaults_false(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_TV)["show_rating"] is False
+
+    def test_show_imdb_link_defaults_false(self):
+        assert resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)["show_imdb_link"] is False
+
+    def test_display_options_honor_movies_section_override(self):
+        config = {
+            "movies": {
+                "show_summary": True,
+                "show_cast": True,
+                "show_language": True,
+                "show_rating": True,
+                "show_imdb_link": True,
+                "show_genres": False,
+            }
+        }
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["show_summary"] is True
+        assert result["show_cast"] is True
+        assert result["show_language"] is True
+        assert result["show_rating"] is True
+        assert result["show_imdb_link"] is True
+        assert result["show_genres"] is False
+
+    def test_show_director_only_resolved_for_movies(self):
+        result = resolve_media_type_overrides({}, MEDIA_TYPE_MOVIE)
+        assert result["show_director"] is False
+
+        tv_result = resolve_media_type_overrides({}, MEDIA_TYPE_TV)
+        assert "show_director" not in tv_result
+
+    def test_show_director_honors_movies_section_and_general_fallback(self):
+        config = {"movies": {"show_director": True}}
+        assert resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)["show_director"] is True
+
+        config2 = {"general": {"show_director": True}}
+        assert resolve_media_type_overrides(config2, MEDIA_TYPE_MOVIE)["show_director"] is True
+
+    def test_weights_movies_section_overrides_legacy_root_weights(self):
+        config = {"weights": {"genre": 0.9, "actor": 0.1}, "movies": {"weights": {"genre": 0.1, "actor": 0.9}}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["weights"] == {"genre": 0.1, "actor": 0.9}
+
+    def test_weights_falls_back_to_legacy_root_weights_when_media_section_absent(self):
+        config = {"weights": {"genre": 0.9, "actor": 0.1}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["weights"] == {"genre": 0.9, "actor": 0.1}
+
+    def test_weights_defaults_to_empty_dict(self):
+        result = resolve_media_type_overrides({}, MEDIA_TYPE_TV)
+        assert result["weights"] == {}
 
     def test_handles_uppercase_media_section(self):
         config = {"MOVIES": {"limit_results": 100}}
-        result = adapt_config_for_media_type(config, "movies")
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
         assert result["limit_results"] == 100
 
-    def test_collection_settings_inherited(self):
-        config = {"collections": {"add_label": False}}
-        result = adapt_config_for_media_type(config, "movies")
-        assert result["add_label"] is False
+    def test_quality_filters_min_rating_min_vote_count_not_resolved_here(self):
+        """Deliberately out of scope: quality_filters is resolved by
+        BaseRecommender.get_recommendations() at call time, directly from
+        self.media_config/self.config (already the one correct, live
+        implementation - see this function's docstring). Locks in that a
+        future change doesn't reintroduce a second, competing computation
+        of these two keys here."""
+        result = resolve_media_type_overrides({"movies": {"quality_filters": {"min_rating": 5.0}}}, MEDIA_TYPE_MOVIE)
+        assert "min_rating" not in result
+        assert "min_vote_count" not in result
+
+    def test_arbitrary_root_level_keys_pass_through_unchanged(self):
+        """Strict-superset contract: every root-level key not explicitly
+        resolved here (plex_users, tautulli, huntarr, negative_signals,
+        radarr, sonarr, an arbitrary future key) survives completely
+        untouched - there is no cherry-picked reconstruction that could
+        silently drop one (see CHANGELOG for the plex_users key the old,
+        deleted adapt_config_for_media_type() used to drop)."""
+        config = {
+            "plex_users": {"users": "alice,bob"},
+            "tautulli": {"enabled": True, "url": "http://tautulli"},
+            "huntarr": {"sequel_huntarr": False},
+            "negative_signals": {"enabled": False},
+            "radarr": {"enabled": True, "url": "http://radarr"},
+            "sonarr": {"enabled": True, "url": "http://sonarr"},
+            "some_future_key": {"nested": "value"},
+        }
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result["plex_users"] == {"users": "alice,bob"}
+        assert result["tautulli"] == {"enabled": True, "url": "http://tautulli"}
+        assert result["huntarr"] == {"sequel_huntarr": False}
+        assert result["negative_signals"] == {"enabled": False}
+        assert result["radarr"] == {"enabled": True, "url": "http://radarr"}
+        assert result["sonarr"] == {"enabled": True, "url": "http://sonarr"}
+        assert result["some_future_key"] == {"nested": "value"}
 
     def test_libraries_passed_through(self):
-        """#157 Phase 3: the adapted config must carry 'libraries' through so
-        utils/cli.py's per-library loop (which calls
-        get_libraries_for_media_type against the adapted config) sees a
-        real multi-library setup instead of always falling back to the
-        synthesized single-library default."""
+        """#157 Phase 3: 'libraries' must carry through so utils/cli.py's
+        per-library loop sees a real multi-library setup instead of
+        always falling back to the synthesized single-library default."""
         config = {
             "libraries": [
                 {"id": "movies", "name": "Movies", "media_type": "movie"},
                 {"id": "movies-4k", "name": "Movies 4K", "media_type": "movie"},
             ]
         }
-        result = adapt_config_for_media_type(config, "movies")
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
         assert result["libraries"] == config["libraries"]
 
-    def test_libraries_absent_passes_through_none(self):
-        """No 'libraries' key in root config -> adapted config's 'libraries'
-        is None, so get_libraries_for_media_type falls back to synthesis."""
+    def test_libraries_absent_stays_absent(self):
+        """No 'libraries' key in root config -> resolved config has none
+        either, so get_libraries_for_media_type falls back to synthesis."""
         config = {"plex": {"movie_library": "Movies"}}
-        result = adapt_config_for_media_type(config, "movies")
-        assert result["libraries"] is None
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result.get("libraries") is None
 
         libs = get_libraries_for_media_type(result, "movie")
         assert len(libs) == 1
         assert libs[0]["section"] == "Movies"
 
-    def test_does_not_produce_dead_divergently_defaulted_display_keys(self):
-        """PR4 audit remediation: show_summary/show_cast/show_language/
-        show_rating used to be flattened onto the returned dict here with
-        a default (True) that silently diverged from
-        recommenders/base.py's real, live resolution (default False) -
-        while never actually being read from this function's output
-        anywhere. Removed rather than fixed-in-place, since fixing the
-        default wouldn't make the output any less dead. Locks in that a
-        future change doesn't silently reintroduce the same trap."""
-        result = adapt_config_for_media_type({}, "movies")
+    def test_mutates_and_returns_same_dict(self):
+        config = {"plex": {"url": "http://localhost"}}
+        result = resolve_media_type_overrides(config, MEDIA_TYPE_MOVIE)
+        assert result is config
 
-        assert "show_summary" not in result
-        assert "show_cast" not in result
-        assert "show_language" not in result
-        assert "show_rating" not in result
+
+class TestLoadResolvedConfig:
+    """Tests for load_resolved_config() - load_config() +
+    resolve_media_type_overrides() in one call, the single function most
+    callers (recommenders/base.py, utils/cli.py) need."""
+
+    def test_combines_modular_merge_and_media_type_resolution(self):
+        import shutil
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            tuning_path = os.path.join(config_dir, "tuning.yml")
+            with open(tuning_path, "w") as f:
+                f.write("movies:\n  limit_results: 15\n  randomize_recommendations: false\n")
+
+            result = load_resolved_config(config_path, MEDIA_TYPE_MOVIE)
+
+            assert result["plex"]["url"] == "http://localhost:32400"
+            assert result["limit_results"] == 15
+            assert result["randomize_recommendations"] is False
+        finally:
+            shutil.rmtree(config_dir)
+
+    def test_env_var_override_still_applies(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("plex:\n  url: http://localhost:32400\n  token: file_token\n")
+            path = f.name
+        try:
+            os.environ["PLEX_TOKEN"] = "env_token"
+            result = load_resolved_config(path, MEDIA_TYPE_TV)
+            assert result["plex"]["token"] == "env_token"
+            # media-type resolution still applied on top
+            assert result["limit_results"] == 20
+        finally:
+            del os.environ["PLEX_TOKEN"]
+            os.unlink(path)
+
+    def test_movie_and_tv_resolve_independently_from_same_file(self):
+        """Same on-disk config, two media types -> two independently
+        resolved results, each media-type-correct."""
+        import shutil
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            tuning_path = os.path.join(config_dir, "tuning.yml")
+            with open(tuning_path, "w") as f:
+                f.write("movies:\n  limit_results: 15\ntv:\n  limit_results: 7\n")
+
+            movie_result = load_resolved_config(config_path, MEDIA_TYPE_MOVIE)
+            tv_result = load_resolved_config(config_path, MEDIA_TYPE_TV)
+
+            assert movie_result["limit_results"] == 15
+            assert tv_result["limit_results"] == 7
+        finally:
+            shutil.rmtree(config_dir)
+
+
+class TestResolveMediaTypeOverridesKeyEnumeration:
+    """Standing guard (audit remediation): enumerates every movies:/tv:
+    key documented in config/tuning.example.yml and asserts each one
+    actually reaches a real recommender attribute (or, for
+    quality_filters/weights per-field values, the actual scoring/
+    filtering behavior) - not just that some function computes a
+    plausible-looking value nothing reads. This is the test that makes
+    the "two divergent resolution paths" bug class this PR fixes
+    impossible to silently reintroduce: a future key added only to
+    resolve_media_type_overrides() (or only read inline somewhere else)
+    without a corresponding case here should fail loudly instead of
+    silently doing nothing for users who set it.
+
+    Uses the real, committed config/tuning.example.yml - not a hand-rolled
+    fixture - so it also catches the example file and the resolution code
+    drifting apart from each other.
+    """
+
+    @staticmethod
+    def _load_example_tuning():
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        example_path = os.path.join(repo_root, "config", "tuning.example.yml")
+        with open(example_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def test_every_documented_movies_key_resolves(self):
+        tuning = self._load_example_tuning()
+        movies = tuning["movies"]
+        result = resolve_media_type_overrides({"movies": movies}, MEDIA_TYPE_MOVIE)
+
+        assert result["limit_results"] == movies["limit_results"]
+        assert result["randomize_recommendations"] == movies["randomize_recommendations"]
+        assert result["show_summary"] == movies["show_summary"]
+        assert result["show_cast"] == movies["show_cast"]
+        assert result["show_director"] == movies["show_director"]
+        assert result["show_genres"] == movies["show_genres"]
+        assert result["show_language"] == movies["show_language"]
+        assert result["show_rating"] == movies["show_rating"]
+        assert result["show_imdb_link"] == movies["show_imdb_link"]
+        assert result["weights"] == movies["weights"]
+        # quality_filters is resolved by BaseRecommender.get_recommendations(),
+        # not here (see TestResolveMediaTypeOverrides) - assert the raw
+        # section itself is at least present and unmodified, so a caller
+        # reading it directly (as get_recommendations() does) sees it.
+        assert result["movies"]["quality_filters"] == movies["quality_filters"]
+
+    def test_every_documented_tv_key_resolves(self):
+        tuning = self._load_example_tuning()
+        tv = tuning["tv"]
+        result = resolve_media_type_overrides({"tv": tv}, MEDIA_TYPE_TV)
+
+        assert result["limit_results"] == tv["limit_results"]
+        assert result["randomize_recommendations"] == tv["randomize_recommendations"]
+        assert result["normalize_counters"] == tv["normalize_counters"]
+        assert result["show_summary"] == tv["show_summary"]
+        assert result["show_cast"] == tv["show_cast"]
+        assert result["show_language"] == tv["show_language"]
+        assert result["show_rating"] == tv["show_rating"]
+        assert result["show_imdb_link"] == tv["show_imdb_link"]
+        assert "show_director" not in result
+        assert result["weights"] == tv["weights"]
+        assert result["tv"]["quality_filters"] == tv["quality_filters"]
+
+    def test_movies_and_tv_documented_keys_are_all_covered_by_this_class(self):
+        """Belt-and-braces: fails loudly (instead of silently passing) if
+        a future tuning.example.yml edit adds a movies:/tv: key that
+        neither test method above accounts for."""
+        tuning = self._load_example_tuning()
+        covered_movie_keys = {
+            "limit_results",
+            "randomize_recommendations",
+            "show_summary",
+            "show_cast",
+            "show_director",
+            "show_genres",
+            "show_language",
+            "show_rating",
+            "show_imdb_link",
+            "quality_filters",
+            "weights",
+        }
+        covered_tv_keys = {
+            "limit_results",
+            "randomize_recommendations",
+            "normalize_counters",
+            "show_summary",
+            "show_cast",
+            "show_language",
+            "show_rating",
+            "show_imdb_link",
+            "quality_filters",
+            "weights",
+        }
+        assert set(tuning["movies"].keys()) <= covered_movie_keys, (
+            f"tuning.example.yml movies: has undocumented-here keys: "
+            f"{set(tuning['movies'].keys()) - covered_movie_keys}"
+        )
+        assert set(tuning["tv"].keys()) <= covered_tv_keys, (
+            f"tuning.example.yml tv: has undocumented-here keys: {set(tuning['tv'].keys()) - covered_tv_keys}"
+        )
 
 
 class TestNegativeSignalsConstants:
@@ -576,30 +831,6 @@ trakt:
             assert os.path.exists(os.path.join(config_dir, "trakt.yml"))
         finally:
             shutil.rmtree(config_dir)
-
-
-class TestAdaptConfigRadarrSonarr:
-    """Tests for radarr/sonarr config handling in adapt_config_for_media_type"""
-
-    def test_radarr_from_root_level(self):
-        # New modular format - radarr at root level
-        config = {
-            "radarr": {"enabled": True, "url": "http://radarr:7878"},
-            "movies": {},
-        }
-        result = adapt_config_for_media_type(config, "movies")
-        assert result["radarr"]["enabled"] is True
-        assert result["radarr"]["url"] == "http://radarr:7878"
-
-    def test_sonarr_from_root_level(self):
-        # New modular format - sonarr at root level
-        config = {
-            "sonarr": {"enabled": True, "url": "http://sonarr:8989"},
-            "tv": {},
-        }
-        result = adapt_config_for_media_type(config, "tv")
-        assert result["sonarr"]["enabled"] is True
-        assert result["sonarr"]["url"] == "http://sonarr:8989"
 
 
 class TestGetLibraries:

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -11,7 +11,6 @@ import pytest
 from recommenders.movie import (
     MovieCache,
     PlexMovieRecommender,
-    adapt_root_config_to_legacy,
     format_movie_output,
     main,
     process_recommendations,
@@ -521,27 +520,6 @@ class TestFormatMovieOutput:
 
         assert "imdb.com" in result
         assert "tt1234567" in result
-
-
-class TestAdaptRootConfigToLegacy:
-    """Tests for adapt_root_config_to_legacy function."""
-
-    def test_adapt_preserves_plex_key(self):
-        """Test that config with 'plex' key preserves it."""
-        config = {"plex": {"url": "http://localhost", "token": "abc"}}
-
-        result = adapt_root_config_to_legacy(config)
-
-        assert "plex" in result
-        assert result["plex"]["url"] == "http://localhost"
-
-    def test_adapt_returns_dict(self):
-        """Test that function returns a dict."""
-        config = {"plex": {"url": "http://localhost"}}
-
-        result = adapt_root_config_to_legacy(config)
-
-        assert isinstance(result, dict)
 
 
 class TestProcessRecommendationsLibraryParam:

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -11,7 +11,6 @@ import pytest
 from recommenders.tv import (
     PlexTVRecommender,
     ShowCache,
-    adapt_root_config_to_legacy,
     format_show_output,
     main,
     process_recommendations,
@@ -841,27 +840,6 @@ class TestFormatShowOutput:
         result = format_show_output(show, index=1, show_summary=True)
 
         assert "chemistry" in result.lower() or "meth" in result.lower()
-
-
-class TestAdaptRootConfigToLegacy:
-    """Tests for adapt_root_config_to_legacy function."""
-
-    def test_adapt_preserves_plex_key(self):
-        """Test that config with 'plex' key preserves it."""
-        config = {"plex": {"url": "http://localhost", "token": "abc"}}
-
-        result = adapt_root_config_to_legacy(config)
-
-        assert "plex" in result
-        assert result["plex"]["url"] == "http://localhost"
-
-    def test_adapt_returns_dict(self):
-        """Test that function returns a dict."""
-        config = {"plex": {"url": "http://localhost"}}
-
-        result = adapt_root_config_to_legacy(config)
-
-        assert isinstance(result, dict)
 
 
 class TestPlexTVRecommenderShowDetails:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -64,7 +64,6 @@ from .config import (
     UPDATE_MODES,
     WEIGHT_SUM_TOLERANCE,
     __version__,
-    adapt_config_for_media_type,
     check_cache_version,
     get_config_section,
     get_effective_arr_config,
@@ -76,6 +75,8 @@ from .config import (
     get_tmdb_config,
     get_update_mode,
     load_config,
+    load_resolved_config,
+    resolve_media_type_overrides,
 )
 
 # Counter utilities
@@ -359,8 +360,9 @@ __all__ = [
     "get_config_section",
     "get_tmdb_config",
     "load_config",
+    "load_resolved_config",
+    "resolve_media_type_overrides",
     "get_rating_multipliers",
-    "adapt_config_for_media_type",
     "get_libraries",
     "get_libraries_for_media_type",
     "get_effective_arr_config",

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -251,7 +251,6 @@ def print_runtime(start_time: datetime):
 def run_recommender_main(
     media_type: str,
     description: str,
-    adapt_config_func: Callable[[Dict], Dict],
     process_func: Callable[[Dict, str, int, Optional[str], Optional[Dict], Optional[Dict]], None],
     media_type_key: str = "movie",
 ):
@@ -264,10 +263,19 @@ def run_recommender_main(
     one library of this media type) synthesize a single library entry, so
     this collapses back to the original one-loop-per-user behavior.
 
+    Reads root_config directly (no per-media-type adaptation) for every
+    value this loop itself needs (users, libraries, general.*, plex.token)
+    - all root-level passthroughs with a single meaning regardless of
+    media type. The actual movies:/tv: media-type-resolved config (used
+    for scoring/display/etc.) is resolved exactly once, inside each
+    recommender's own __init__ (see recommenders/base.py's
+    BaseRecommender, utils.config.load_resolved_config) - this function
+    never needs a second, parallel resolution of those same keys (see
+    CHANGELOG for the architecture history this replaces).
+
     Args:
         media_type: 'Movie' or 'TV Show' for display
         description: argparse description
-        adapt_config_func: Function to adapt root config to media-specific format
         process_func: Function to process recommendations for a user. Receives
             (user_config, config_path, log_retention_days, resolved_user,
             library, library_items_cache)
@@ -319,7 +327,6 @@ def run_recommender_main(
                 with open(config_path, "r") as f:
                     root_config = yaml.safe_load(f)
 
-            base_config = adapt_config_func(root_config)
         except Exception as e:
             log_error(f"Could not load config.yml from project root: {e}")
             log_warning(f"Looking for config at: {config_path}")
@@ -329,7 +336,7 @@ def run_recommender_main(
         logger = setup_logging(debug=args.debug, config=root_config)
         logger.debug("Debug logging enabled")
 
-        general = base_config.get("general", {})
+        general = root_config.get("general", {})
         log_retention_days = general.get("log_retention_days", 7)
 
         # Advisory update notice - printed right after the version banner
@@ -343,7 +350,7 @@ def run_recommender_main(
             log_warning(f"Single user mode: {single_user}")
 
         # Get users to process
-        all_users = get_users_from_config(base_config)
+        all_users = get_users_from_config(root_config)
         if single_user:
             all_users = [single_user]
 
@@ -355,7 +362,7 @@ def run_recommender_main(
         # install (no 'libraries:' config, or exactly one explicit library of
         # this media type) always resolves to exactly one entry here, so the
         # loop below collapses to the original one-pass-per-user behavior.
-        libraries = get_libraries_for_media_type(base_config, media_type_key)
+        libraries = get_libraries_for_media_type(root_config, media_type_key)
 
         if args.library_id:
             libraries = [lib for lib in libraries if lib.get("id") == args.library_id]
@@ -372,7 +379,7 @@ def run_recommender_main(
         resolved_usernames = set()
 
         # Process each library x user
-        plex_token = base_config.get("plex", {}).get("token", "")
+        plex_token = root_config.get("plex", {}).get("token", "")
         for library in libraries:
             if multi_library:
                 print(f"\n{CYAN}=== Library: {library['name']} ==={RESET}")
@@ -395,7 +402,7 @@ def run_recommender_main(
                 print("-" * 50)
 
                 resolved_user = resolve_admin_username(user, plex_token)
-                user_config = update_config_for_user(base_config, resolved_user)
+                user_config = update_config_for_user(root_config, resolved_user)
                 resolved_usernames.add(resolved_user)
 
                 process_func(user_config, config_path, log_retention_days, resolved_user, library, library_items_cache)

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.38"
+__version__ = "2.10.39"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus
@@ -465,90 +465,109 @@ def get_negative_multiplier(rating: int, config: dict = None) -> float:
     return DEFAULT_NEGATIVE_MULTIPLIERS.get(rating, -0.3)
 
 
-def adapt_config_for_media_type(root_config: Dict, media_type: str = "movies") -> Dict:
+def resolve_media_type_overrides(config: Dict, media_type: str) -> Dict:
     """
-    Adapt root configuration for a specific media type (movies or TV).
+    Overlay resolved `movies:`/`tv:` (config/tuning.yml) per-media-type
+    overrides onto an already-loaded root config (see load_config()).
 
-    Creates a unified config dict by merging media-specific settings
-    with global settings, handling key variations for backwards compatibility.
+    This is THE single resolution path for these keys - it replaces two
+    formerly-independent implementations that had quietly drifted apart
+    (see CHANGELOG 2.10.23/2.10.37/2.10.39 and this module's git history):
+    `recommenders/base.py`'s own inline `self.media_config` resolution
+    (LIVE - this is what every install's actual recommendations used),
+    and this module's now-deleted `adapt_config_for_media_type()` (DEAD -
+    computed a plausible-looking, differently-defaulted result that
+    nothing in the recommendation-generation path ever read). Consolidated
+    here so a future new `movies:`/`tv:` key only needs wiring up once,
+    with a standing test (see tests/test_config.py's
+    TestResolveMediaTypeOverridesKeyEnumeration) asserting every key
+    documented in config/tuning.example.yml actually resolves.
+
+    Mutates and returns `config` in place (matching load_config()'s own
+    `_load_module_configs()` merge convention) with these additional/
+    overwritten top-level keys: `limit_results`, `randomize_recommendations`,
+    `normalize_counters`, `show_summary`, `show_genres`, `show_cast`,
+    `show_language`, `show_rating`, `show_imdb_link`, `weights`, and
+    (movies only) `show_director`.
+
+    Every other root-level section (`plex`, `tmdb`, `users`, `plex_users`,
+    `collections`, `recency_decay`, `rating_multipliers`, `general`,
+    `cache_dir`, `libraries`, `negative_signals`, `radarr`, `sonarr`,
+    `quality_filters`, and anything else) passes through completely
+    untouched, because `config` itself (not a cherry-picked
+    reconstruction of it) is what gets returned - there is no way for
+    this function to silently drop a root-level key the way the old
+    `adapt_config_for_media_type()` dropped `plex_users` (see CHANGELOG).
+
+    Deliberately NOT resolved here (left exactly where they already
+    correctly, non-divergently live):
+      - `quality_filters` (`min_rating`/`min_vote_count`): still resolved
+        by `BaseRecommender.get_recommendations()` at call time, straight
+        from `self.media_config`/`self.config` - that was always the one
+        correct, live implementation (the old dead path's 5.0/50 movies
+        default never matched it - see CHANGELOG for which one won).
+      - Per-field weight *defaults* (`director` vs `studio`, and their
+        values): still resolved by `PlexMovieRecommender`/
+        `PlexTVRecommender._load_weights()` - already the single,
+        non-divergent source once the dead path is gone. Only the
+        `movies:`/`tv:` -> legacy-root-level `weights:` fallback *chain*
+        is centralized here (that part WAS duplicated, and divergently -
+        the old dead path never checked the legacy root-level tier).
 
     Args:
-        root_config: Root configuration dictionary from config.yml
-        media_type: 'movies' or 'tv'
+        config: Root config dict, as returned by load_config()
+        media_type: MEDIA_TYPE_MOVIE ('movie') or MEDIA_TYPE_TV ('tv')
 
     Returns:
-        Unified config dict with all needed settings for the media type
+        The same `config` dict, with the keys above added/overwritten
     """
-    # Get media-specific section
-    media_section = media_type.lower()
-    media_config = root_config.get(media_section, root_config.get(media_section.upper(), {}))
+    general_config = config.get("general", {}) or {}
+    media_section = MEDIA_KEY_MOVIES if media_type == MEDIA_TYPE_MOVIE else "tv"
+    media_config = config.get(media_section, config.get(media_section.upper(), {})) or {}
 
-    # Build unified config
-    config = {
-        "plex": root_config.get("plex", {}),
-        "tmdb": root_config.get("tmdb", root_config.get("TMDB", {})),
-        "users": root_config.get("users", {}),
-        "collections": root_config.get("collections", {}),
-        "recency_decay": root_config.get("recency_decay", {}),
-        "rating_multipliers": root_config.get("rating_multipliers", {}),
-        "general": root_config.get("general", {}),
-        "cache_dir": root_config.get("cache_dir", "cache"),
-        # #157 Phase 3: pass through the raw multi-library config so
-        # get_libraries()/get_libraries_for_media_type() (called against this
-        # adapted config from utils/cli.py's per-library recommendation loop)
-        # see the real 'libraries' block instead of always falling back to
-        # the synthesized single-library default.
-        "libraries": root_config.get("libraries"),
-    }
+    config["limit_results"] = media_config.get("limit_results", DEFAULT_LIMIT_RESULTS[media_type])
+    config["randomize_recommendations"] = media_config.get(
+        "randomize_recommendations", general_config.get("randomize_recommendations", True)
+    )
+    config["normalize_counters"] = media_config.get(
+        "normalize_counters", general_config.get("normalize_counters", True)
+    )
+    config["show_summary"] = media_config.get("show_summary", general_config.get("show_summary", False))
+    config["show_genres"] = media_config.get("show_genres", general_config.get("show_genres", True))
+    config["show_cast"] = media_config.get("show_cast", general_config.get("show_cast", False))
+    config["show_language"] = media_config.get("show_language", general_config.get("show_language", False))
+    config["show_rating"] = media_config.get("show_rating", general_config.get("show_rating", False))
+    config["show_imdb_link"] = media_config.get("show_imdb_link", general_config.get("show_imdb_link", False))
 
-    # Add media-specific settings
-    config["limit_results"] = media_config.get("limit_results", 50 if media_type == "movies" else 20)
-    config["randomize_recommendations"] = media_config.get("randomize_recommendations", False)
-    config["normalize_counters"] = media_config.get("normalize_counters", True)
-    # NOTE: show_summary/show_cast/show_language/show_rating deliberately
-    # NOT flattened here (removed 2026-07, audit remediation PR4) -
-    # recommenders/base.py resolves these itself directly from
-    # self.media_config (see its __init__), with a DIFFERENT default
-    # (False) than this function used to produce (True) for all four.
-    # This function's output for these specific keys was never read
-    # anywhere outside its own tests (see CHANGELOG) - do not re-add a
-    # flattened copy here; it would only reintroduce the same dead,
-    # misleadingly-defaulted trap for a future maintainer.
-    config["show_imdb_link"] = media_config.get("show_imdb_link", False)
+    if media_type == MEDIA_TYPE_MOVIE:
+        # movies-only: recommenders/movie.py's self.show_director (TV has
+        # no director-equivalent display option).
+        config["show_director"] = media_config.get("show_director", general_config.get("show_director", False))
 
-    # Quality filters
-    quality = media_config.get("quality_filters", {})
-    config["min_rating"] = quality.get("min_rating", 5.0 if media_type == "movies" else 0.0)
-    config["min_vote_count"] = quality.get("min_vote_count", 50 if media_type == "movies" else 0)
-
-    # Weights - handle both old and new key names
-    weights = media_config.get("weights", {})
-    config["weights"] = {
-        "genre": weights.get("genre", weights.get("genre_weight", 0.25)),
-        "actor": weights.get("actor", weights.get("actor_weight", 0.20)),
-        "keyword": weights.get("keyword", weights.get("keyword_weight", 0.50)),
-        "language": weights.get("language", weights.get("language_weight", 0.0)),
-    }
-
-    # Media-specific weights
-    if media_type == "movies":
-        config["weights"]["director"] = weights.get("director", weights.get("director_weight", 0.05))
-    else:
-        config["weights"]["studio"] = weights.get("studio", weights.get("studio_weight", 0.10))
-
-    # Radarr/Sonarr integration - check root level first (new modular format),
-    # then fall back to nested under movies/tv (legacy format)
-    arr_key = "radarr" if media_type == "movies" else "sonarr"
-    config[arr_key] = root_config.get(arr_key, media_config.get(arr_key, {}))
-
-    # Collection settings
-    collections = root_config.get("collections", {})
-    config["add_label"] = collections.get("add_label", True)
-
-    # Negative signals configuration
-    config["negative_signals"] = get_negative_signals_config(root_config)
+    # Weights - only the movies:/tv: -> legacy-root-level `weights:`
+    # fallback CHAIN is resolved here (see docstring above for why the
+    # per-field defaults deliberately stay in _load_weights()).
+    config["weights"] = media_config.get("weights", config.get("weights", {})) or {}
 
     return config
+
+
+def load_resolved_config(config_path: str, media_type: str) -> Dict:
+    """
+    The one function a caller needs for a fully media-type-resolved
+    config: load_config() (modular merge + auto-migration + env-var
+    overrides) followed by resolve_media_type_overrides() (movies:/tv:
+    per-media-type overrides) - see that function's docstring for exactly
+    which keys this adds/overwrites and why the rest is untouched.
+
+    Args:
+        config_path: Path to config.yml file
+        media_type: MEDIA_TYPE_MOVIE ('movie') or MEDIA_TYPE_TV ('tv')
+
+    Returns:
+        Parsed, merged, and media-type-resolved config dictionary
+    """
+    return resolve_media_type_overrides(load_config(config_path), media_type)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `utils/config.py`'s `adapt_config_for_media_type()` and `recommenders/base.py`'s inline `self.media_config` resolution were two independent implementations of the same `movies:`/`tv:` override resolution, fed by two separate `load_config()` reads - only the `base.py` one was ever live, which is exactly the architecture that caused the 2.10.23 bug and left it able to recur for any future key.
- Replaced both with one function: `resolve_media_type_overrides(config, media_type)` + `load_resolved_config(config_path, media_type)`. It overlays resolved keys onto the FULL root config instead of cherry-picking a reconstruction, so a root-level key can no longer be silently dropped the way the old function dropped `plex_users`.
- `recommenders/base.py`, `movie.py`, and `utils/cli.py` migrated onto it; `utils/cli.py`'s `run_recommender_main()` no longer takes an `adapt_config_func` param (it never needed a media-type-resolved config for its own bookkeeping).
- Defaults verified unchanged for every key via a 6-config-shape x 2-media-type parity check against the reconstructed OLD live logic (see CHANGELOG for the 3 cases where the two old paths actually disagreed and which default was kept).
- Added `TestResolveMediaTypeOverridesKeyEnumeration` - a standing guard that parses the real `config/tuning.example.yml` and asserts every documented key resolves, plus a closed-set check that fails if a future key isn't covered.
- `tests/harness.py` untouched (byte-identical, confirmed via git diff) - it only depends on `utils/scoring.py`, never the config-resolution code touched here.

## Test plan
- [x] Full suite: 2498 passed, 1 skipped (baseline 2485 passed, 1 skipped)
- [x] `ruff check .` - all checks passed
- [x] `ruff format --check .` - all files already formatted
- [x] `tests/test_harness.py` - 3 passed, harness.py byte-identical to origin/main
- [x] Standalone before/after parity script: old inline resolution vs new function, key-for-key, across fresh-install/movies-only/tv-only/both/unknown-keys/real-config-shape x movie/tv = 12 scenarios, all match