### PR TITLE
test: golden-output equivalence harness for external.py decomposition (2.10.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.41] - 2026-07-26
+
+### Added
+
+- **Golden-output equivalence harness for the upcoming `recommenders/external.py` architecture decomposition (PR2 prep, no production code touched).**
+
+  - `tests/golden_external_harness.py`: runs `find_missing_sequels()`
+    (Sequel Huntarr), `find_horizon_movies()` (Horizon Huntarr),
+    `categorize_by_streaming_service()`, and the
+    `generate_markdown()`/`generate_combined_html()` render pipeline
+    against fixed synthetic Plex/TMDB fixtures (no real watch history),
+    and compares the result byte-for-byte against committed golden
+    files (`tests/fixtures/external_golden/`). `datetime.now()` is
+    pinned (both render functions embed a live "generated at" timestamp)
+    so any two runs against unchanged code are byte-identical.
+  - `tests/test_golden_external_harness.py` is the actual CI-enforced
+    gate: every subsequent PR in the external.py decomposition sequence
+    must leave it passing, or stop and report the diff rather than
+    merge - a failure means moved/refactored code produced different
+    output than current main did.
+  - Deliberately does NOT exercise `find_similar_content_with_profile()`'s
+    iterative TMDB-Discover candidate loop or `build_user_profile()`'s
+    Plex watch-history scan - neither is a relocation target in this PR
+    sequence; see the harness's own docstring for the full reasoning.
+
 ## [2.10.40] - 2026-07-26
 
 ### Fixed

--- a/tests/fixtures/external_golden/golden_categorized.json
+++ b/tests/fixtures/external_golden/golden_categorized.json
@@ -1,0 +1,158 @@
+{
+  "movies": {
+    "acquire": [
+      {
+        "added_date": "2026-01-01T09:00:00",
+        "buy_services": [],
+        "on_user_services": [],
+        "original_language": "en",
+        "rating": 6.1,
+        "rent_services": [],
+        "score": 0.69,
+        "streaming_services": [],
+        "title": "Quiet Static",
+        "tmdb_id": 12,
+        "vote_count": 500,
+        "year": "2022"
+      }
+    ],
+    "all_items": [
+      {
+        "added_date": "2026-01-01T09:00:00",
+        "buy_services": [],
+        "on_user_services": [
+          "netflix"
+        ],
+        "original_language": "en",
+        "rating": 7.2,
+        "rent_services": [],
+        "score": 0.81,
+        "streaming_services": [
+          "netflix"
+        ],
+        "title": "Signal Drift",
+        "tmdb_id": 10,
+        "vote_count": 500,
+        "year": "2024"
+      },
+      {
+        "added_date": "2026-01-01T09:00:00",
+        "buy_services": [],
+        "on_user_services": [],
+        "original_language": "en",
+        "rating": 6.8,
+        "rent_services": [],
+        "score": 0.77,
+        "streaming_services": [
+          "max"
+        ],
+        "title": "Glass Horizon",
+        "tmdb_id": 11,
+        "vote_count": 500,
+        "year": "2023"
+      },
+      {
+        "added_date": "2026-01-01T09:00:00",
+        "buy_services": [],
+        "on_user_services": [],
+        "original_language": "en",
+        "rating": 6.1,
+        "rent_services": [],
+        "score": 0.69,
+        "streaming_services": [],
+        "title": "Quiet Static",
+        "tmdb_id": 12,
+        "vote_count": 500,
+        "year": "2022"
+      }
+    ],
+    "other_services": {
+      "max": [
+        {
+          "added_date": "2026-01-01T09:00:00",
+          "buy_services": [],
+          "on_user_services": [],
+          "original_language": "en",
+          "rating": 6.8,
+          "rent_services": [],
+          "score": 0.77,
+          "streaming_services": [
+            "max"
+          ],
+          "title": "Glass Horizon",
+          "tmdb_id": 11,
+          "vote_count": 500,
+          "year": "2023"
+        }
+      ]
+    },
+    "user_services": {
+      "netflix": [
+        {
+          "added_date": "2026-01-01T09:00:00",
+          "buy_services": [],
+          "on_user_services": [
+            "netflix"
+          ],
+          "original_language": "en",
+          "rating": 7.2,
+          "rent_services": [],
+          "score": 0.81,
+          "streaming_services": [
+            "netflix"
+          ],
+          "title": "Signal Drift",
+          "tmdb_id": 10,
+          "vote_count": 500,
+          "year": "2024"
+        }
+      ]
+    }
+  },
+  "shows": {
+    "acquire": [],
+    "all_items": [
+      {
+        "added_date": "2026-01-01T09:00:00",
+        "buy_services": [],
+        "on_user_services": [
+          "netflix"
+        ],
+        "original_language": "en",
+        "rating": 8.0,
+        "rent_services": [],
+        "score": 0.85,
+        "streaming_services": [
+          "netflix"
+        ],
+        "title": "Nightfall Station",
+        "tmdb_id": 20,
+        "vote_count": 500,
+        "year": "2021"
+      }
+    ],
+    "other_services": {},
+    "user_services": {
+      "netflix": [
+        {
+          "added_date": "2026-01-01T09:00:00",
+          "buy_services": [],
+          "on_user_services": [
+            "netflix"
+          ],
+          "original_language": "en",
+          "rating": 8.0,
+          "rent_services": [],
+          "score": 0.85,
+          "streaming_services": [
+            "netflix"
+          ],
+          "title": "Nightfall Station",
+          "tmdb_id": 20,
+          "vote_count": 500,
+          "year": "2021"
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/external_golden/golden_horizon.json
+++ b/tests/fixtures/external_golden/golden_horizon.json
@@ -1,0 +1,13 @@
+[
+  {
+    "collection_id": 100,
+    "collection_name": "Rogue Chronicles Collection",
+    "genre_ids": [
+      12
+    ],
+    "release_date": "2027-06-01",
+    "status": "In Production",
+    "title": "Rogue Chronicles: Horizon",
+    "tmdb_id": 4
+  }
+]

--- a/tests/fixtures/external_golden/golden_huntarr.json
+++ b/tests/fixtures/external_golden/golden_huntarr.json
@@ -1,0 +1,22 @@
+[
+  {
+    "buy_services": [],
+    "collection_id": 100,
+    "collection_name": "Rogue Chronicles Collection",
+    "is_animated": false,
+    "is_tv_movie": false,
+    "on_user_services": [
+      "netflix"
+    ],
+    "owned_count": 1,
+    "release_date": "2018-07-04",
+    "rent_services": [],
+    "streaming_services": [
+      "netflix"
+    ],
+    "title": "Rogue Chronicles: Ascension",
+    "tmdb_id": 3,
+    "total_count": 2,
+    "year": "2018"
+  }
+]

--- a/tests/fixtures/external_golden/golden_watchlist.html
+++ b/tests/fixtures/external_golden/golden_watchlist.html
@@ -1,0 +1,1469 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Curatarr Watchlist</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <style>
+        * { box-sizing: border-box; }
+
+        html {
+            background: #080808;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 50px 70px 40px;
+            background: linear-gradient(180deg, #0c0c0c 0%, #111 50%, #0c0c0c 100%);
+            color: #e0e0e0;
+            min-height: 100vh;
+            position: relative;
+            line-height: 1.6;
+        }
+
+        /* Draped curtain left */
+        body::before {
+            content: '';
+            position: fixed;
+            left: 0;
+            top: 0;
+            width: 60px;
+            height: 100%;
+            background:
+                radial-gradient(ellipse 80% 50% at 100% 0%, transparent 40%, rgba(0,0,0,0.4) 100%),
+                linear-gradient(90deg,
+                    #2a0000 0%,
+                    #4a0000 15%,
+                    #6b0000 30%,
+                    #8b0000 45%,
+                    #7a0000 55%,
+                    #5a0000 70%,
+                    #3a0000 85%,
+                    #1a0000 100%);
+            box-shadow:
+                inset -15px 0 40px rgba(0,0,0,0.6),
+                8px 0 30px rgba(0,0,0,0.5);
+            z-index: 100;
+            border-radius: 0 0 40% 0;
+        }
+
+        /* Draped curtain right */
+        body::after {
+            content: '';
+            position: fixed;
+            right: 0;
+            top: 0;
+            width: 60px;
+            height: 100%;
+            background:
+                radial-gradient(ellipse 80% 50% at 0% 0%, transparent 40%, rgba(0,0,0,0.4) 100%),
+                linear-gradient(270deg,
+                    #2a0000 0%,
+                    #4a0000 15%,
+                    #6b0000 30%,
+                    #8b0000 45%,
+                    #7a0000 55%,
+                    #5a0000 70%,
+                    #3a0000 85%,
+                    #1a0000 100%);
+            box-shadow:
+                inset 15px 0 40px rgba(0,0,0,0.6),
+                -8px 0 30px rgba(0,0,0,0.5);
+            z-index: 100;
+            border-radius: 0 0 0 40%;
+        }
+
+        /* Draped valance top */
+        .curtain-top {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 30px;
+            background: linear-gradient(180deg,
+                #5a0000 0%,
+                #7b0000 40%,
+                #6a0000 70%,
+                #4a0000 100%);
+            box-shadow: 0 8px 30px rgba(0,0,0,0.6);
+            z-index: 101;
+        }
+        .curtain-top::after {
+            content: '';
+            position: absolute;
+            bottom: -20px;
+            left: 0;
+            right: 0;
+            height: 20px;
+            background:
+                radial-gradient(ellipse 60px 20px at 30px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 90px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 150px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 210px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 270px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 330px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 390px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 450px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 510px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 570px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 630px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 690px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 750px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 810px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 870px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 930px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 990px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1050px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1110px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1170px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1230px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1290px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1350px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1410px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1470px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1530px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1590px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1650px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1710px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1770px 0px, #4a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1830px 0px, #5a0000 70%, transparent 70%),
+                radial-gradient(ellipse 60px 20px at 1890px 0px, #4a0000 70%, transparent 70%);
+            filter: drop-shadow(0 3px 4px rgba(0,0,0,0.4));
+        }
+
+        .page-wrapper {
+            position: relative;
+            z-index: 1;
+        }
+
+        /* Branding */
+        .brand {
+            text-align: center;
+            margin-bottom: 40px;
+            padding-top: 20px;
+        }
+        .brand h1 {
+            font-family: 'Playfair Display', Georgia, serif;
+            font-size: 3.2em;
+            margin: 0;
+            background: linear-gradient(180deg, #ffd700 0%, #d4af37 30%, #b8960c 60%, #d4af37 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            letter-spacing: 8px;
+            font-weight: 700;
+            filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+        }
+        .brand .subtitle {
+            color: #999;
+            font-size: 0.9em;
+            letter-spacing: 6px;
+            text-transform: uppercase;
+            margin-top: 8px;
+            font-weight: 500;
+        }
+        .brand .timestamp {
+            color: #666;
+            font-size: 0.8em;
+            margin-top: 12px;
+        }
+
+        h2 {
+            background: linear-gradient(135deg, #8b0000 0%, #6a0000 50%, #580000 100%);
+            color: #f0d060;
+            padding: 16px 22px;
+            border-radius: 12px;
+            margin-top: 40px;
+            border: none;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            font-size: 0.95em;
+            font-weight: 600;
+            box-shadow:
+                0 8px 25px rgba(0,0,0,0.4),
+                inset 0 1px 0 rgba(255,255,255,0.1),
+                inset 0 -2px 5px rgba(0,0,0,0.2);
+        }
+        h3 {
+            background: linear-gradient(135deg, #1e1e1e 0%, #282828 100%);
+            color: #ccc;
+            padding: 14px 18px;
+            border-radius: 10px;
+            border: 1px solid #333;
+            font-size: 0.9em;
+            font-weight: 600;
+            box-shadow:
+                0 4px 15px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.05);
+        }
+        h4 {
+            color: #d4af37;
+            margin: 20px 0 12px 0;
+            font-size: 0.85em;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            font-weight: 600;
+        }
+
+        .header-actions {
+            display: flex;
+            justify-content: center;
+            gap: 16px;
+            margin-bottom: 35px;
+            flex-wrap: wrap;
+        }
+        .export-btn {
+            background: linear-gradient(180deg, #a01010 0%, #8b0000 40%, #6a0000 100%);
+            color: #ffd700;
+            border: none;
+            padding: 14px 32px;
+            border-radius: 50px;
+            cursor: pointer;
+            font-family: 'Inter', sans-serif;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow:
+                0 6px 20px rgba(139, 0, 0, 0.4),
+                0 2px 5px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.15),
+                inset 0 -2px 10px rgba(0,0,0,0.2);
+            position: relative;
+            overflow: hidden;
+        }
+        .export-btn::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+            transition: left 0.5s ease;
+        }
+        .export-btn:hover {
+            transform: translateY(-3px);
+            box-shadow:
+                0 10px 30px rgba(139, 0, 0, 0.5),
+                0 4px 10px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.2);
+        }
+        .export-btn:hover::before {
+            left: 100%;
+        }
+        .export-btn:active {
+            transform: translateY(-1px);
+            box-shadow:
+                0 4px 15px rgba(139, 0, 0, 0.4),
+                inset 0 2px 5px rgba(0,0,0,0.2);
+        }
+        .export-btn.sonarr {
+            background: linear-gradient(180deg, #404040 0%, #2d2d2d 40%, #1a1a1a 100%);
+            color: #e0e0e0;
+            box-shadow:
+                0 6px 20px rgba(0, 0, 0, 0.4),
+                0 2px 5px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.1),
+                inset 0 -2px 10px rgba(0,0,0,0.2);
+        }
+        .export-btn.sonarr:hover {
+            box-shadow:
+                0 10px 30px rgba(0, 0, 0, 0.5),
+                0 4px 10px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.15);
+        }
+        .export-btn.trakt {
+            background: linear-gradient(180deg, #ff3333 0%, #ed1c24 40%, #c41920 100%);
+            color: #fff;
+            box-shadow:
+                0 6px 20px rgba(237, 28, 36, 0.4),
+                0 2px 5px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.2),
+                inset 0 -2px 10px rgba(0,0,0,0.2);
+        }
+        .export-btn.trakt:hover {
+            box-shadow:
+                0 10px 30px rgba(237, 28, 36, 0.5),
+                0 4px 10px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.25);
+        }
+
+        .tabs-wrapper {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin-bottom: 35px;
+            gap: 12px;
+        }
+        .tabs {
+            display: inline-flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            justify-content: center;
+            background: linear-gradient(180deg, #0a0a0a 0%, #0f0f0f 100%);
+            padding: 12px 20px;
+            border-radius: 16px;
+            box-shadow:
+                inset 0 2px 10px rgba(0,0,0,0.6),
+                0 4px 15px rgba(0,0,0,0.3);
+        }
+        .huntarr-tabs {
+            display: inline-flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            justify-content: center;
+            background: linear-gradient(180deg, #0a0808 0%, #0c0808 100%);
+            padding: 10px 16px;
+            border-radius: 12px;
+            box-shadow:
+                inset 0 2px 8px rgba(0,0,0,0.5),
+                0 3px 12px rgba(0,0,0,0.2);
+        }
+        .tab-btn {
+            background: linear-gradient(180deg, #1c1c1c 0%, #151515 100%);
+            color: #888;
+            border: none;
+            padding: 14px 28px;
+            border-radius: 12px;
+            cursor: pointer;
+            font-family: 'Inter', sans-serif;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        }
+        .tab-btn:hover {
+            background: linear-gradient(180deg, #282828 0%, #1f1f1f 100%);
+            color: #bbb;
+            transform: translateY(-1px);
+        }
+        .tab-btn.active {
+            background: linear-gradient(180deg, #a01010 0%, #8b0000 40%, #6a0000 100%);
+            color: #ffd700;
+            box-shadow:
+                0 6px 20px rgba(139, 0, 0, 0.5),
+                inset 0 1px 0 rgba(255,255,255,0.1);
+        }
+        .tab-panel { display: none; }
+        .tab-panel.active { display: block; animation: fadeIn 0.4s ease; }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(15px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 15px 0 35px 0;
+            background: linear-gradient(180deg, #181818 0%, #141414 50%, #111 100%);
+            border-radius: 16px;
+            overflow: hidden;
+            box-shadow:
+                0 10px 40px rgba(0,0,0,0.5),
+                0 2px 10px rgba(0,0,0,0.3),
+                inset 0 1px 0 rgba(255,255,255,0.03);
+        }
+        th, td {
+            padding: 16px 14px;
+            text-align: left;
+            border-bottom: 1px solid rgba(255,255,255,0.05);
+        }
+        th {
+            background: linear-gradient(180deg, #222 0%, #1a1a1a 100%);
+            color: #d4af37;
+            font-size: 0.7em;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            font-weight: 600;
+        }
+        th.sortable {
+            cursor: pointer;
+            user-select: none;
+            transition: color 0.2s ease;
+            white-space: nowrap;
+        }
+        th.sortable:hover {
+            color: #ffd700;
+        }
+        th.sortable::after {
+            content: ' \25B2\25BC';
+            opacity: 0.3;
+            font-size: 0.6em;
+            margin-left: 4px;
+            vertical-align: middle;
+        }
+        th.sortable.asc::after {
+            content: ' \25B2';
+            opacity: 1;
+            font-size: 0.7em;
+        }
+        th.sortable.desc::after {
+            content: ' \25BC';
+            opacity: 1;
+            font-size: 0.7em;
+        }
+        th:first-child { border-radius: 16px 0 0 0; }
+        th:last-child { border-radius: 0 16px 0 0; }
+        tr {
+            transition: all 0.2s ease;
+        }
+        tr:hover {
+            background: rgba(139, 0, 0, 0.1);
+        }
+        tr:last-child td {
+            border-bottom: none;
+        }
+        tr:last-child td:first-child { border-radius: 0 0 0 16px; }
+        tr:last-child td:last-child { border-radius: 0 0 16px 0; }
+        td:first-child, th:first-child { width: 50px; text-align: center; }
+        input[type="checkbox"] {
+            width: 18px;
+            height: 18px;
+            cursor: pointer;
+            accent-color: #8b0000;
+            border-radius: 4px;
+        }
+        .shared-badge {
+            display: inline-block;
+            background: linear-gradient(135deg, #8b0000, #a00);
+            color: #fff;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 12px;
+            margin-left: 8px;
+            vertical-align: middle;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        }
+        .tv-special-badge {
+            display: inline-block;
+            background: linear-gradient(135deg, #6b46c1, #805ad5);
+            color: #fff;
+            font-size: 10px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 8px;
+            vertical-align: middle;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        }
+        .animated-badge {
+            display: inline-block;
+            background: linear-gradient(135deg, #0891b2, #06b6d4);
+            color: #fff;
+            font-size: 10px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 8px;
+            vertical-align: middle;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        }
+
+        /* Status badges for Horizon Huntarr */
+        .status-badge {
+            display: inline-block;
+            font-size: 10px;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        }
+        .status-badge.post-production {
+            background: linear-gradient(135deg, #059669, #10b981);
+            color: #fff;
+        }
+        .status-badge.in-production {
+            background: linear-gradient(135deg, #0284c7, #0ea5e9);
+            color: #fff;
+        }
+        .status-badge.planned {
+            background: linear-gradient(135deg, #7c3aed, #8b5cf6);
+            color: #fff;
+        }
+        .status-badge.rumored {
+            background: linear-gradient(135deg, #475569, #64748b);
+            color: #fff;
+        }
+        .status-badge.unknown {
+            background: linear-gradient(135deg, #374151, #4b5563);
+            color: #9ca3af;
+        }
+
+        /* Streaming service icons */
+        .streaming-icons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 3px;
+            max-width: 280px;
+        }
+        .streaming-icon {
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 600;
+            white-space: nowrap;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            max-width: 260px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+            cursor: pointer;
+        }
+        .streaming-icon.user-service {
+            border: 2px solid #d4af37;
+            box-shadow: 0 0 6px rgba(212, 175, 55, 0.4);
+        }
+        .streaming-icon.netflix { background: #e50914; color: #fff; }
+        .streaming-icon.hulu { background: #1ce783; color: #000; }
+        .streaming-icon.disney_plus { background: #113ccf; color: #fff; }
+        .streaming-icon.amazon_prime { background: #00a8e1; color: #fff; }
+        .streaming-icon.paramount_plus { background: #0064ff; color: #fff; }
+        .streaming-icon.apple_tv_plus { background: #000; color: #fff; }
+        .streaming-icon.max { background: #002be7; color: #fff; }
+        .streaming-icon.peacock { background: #000; color: #fff; }
+        .streaming-icon.crunchyroll { background: #f47521; color: #fff; }
+        .streaming-icon.crackle { background: #f36f21; color: #fff; }
+        .streaming-icon.tubi { background: #fa382f; color: #fff; }
+        .streaming-icon.mubi { background: #0b0c0f; color: #fff; }
+        .streaming-icon.shudder { background: #000; color: #fff; }
+        .streaming-icon.acquire { background: #444; color: #aaa; font-style: italic; }
+        .streaming-icon.rent { background: linear-gradient(135deg, #004B93, #0066CC); color: #FFD700; font-weight: 600; }
+        .streaming-icon.buy { background: linear-gradient(135deg, #2563eb, #3b82f6); color: #fff; }
+
+        .streaming-link {
+            text-decoration: none;
+        }
+        .streaming-link:hover .streaming-icon {
+            transform: scale(1.1);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+        }
+
+        .instructions {
+            background: linear-gradient(180deg, #181818 0%, #121212 100%);
+            padding: 30px 35px;
+            border-radius: 20px;
+            margin-top: 60px;
+            border: 1px solid rgba(255,255,255,0.05);
+            box-shadow:
+                0 10px 40px rgba(0,0,0,0.4),
+                inset 0 1px 0 rgba(255,255,255,0.03);
+        }
+        .instructions h3 {
+            background: none;
+            border: none;
+            padding: 0;
+            color: #d4af37;
+            margin-bottom: 20px;
+            box-shadow: none;
+            font-size: 1.1em;
+        }
+        .instructions ul {
+            margin: 0;
+            padding-left: 24px;
+            color: #999;
+        }
+        .instructions li {
+            margin-bottom: 12px;
+            line-height: 1.7;
+        }
+        .instructions strong {
+            color: #ccc;
+            font-weight: 600;
+        }
+
+        .footer {
+            text-align: center;
+            margin-top: 50px;
+            padding-top: 30px;
+            border-top: 1px solid rgba(255,255,255,0.05);
+            color: #555;
+            font-size: 0.8em;
+            letter-spacing: 1px;
+        }
+        .footer a {
+            color: #8b0000;
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.3s ease;
+        }
+        .footer a:hover {
+            color: #d4af37;
+        }
+
+        /* Filter bar - Art Deco Cinema style */
+        .filter-bar {
+            display: flex;
+            gap: 20px;
+            align-items: flex-end;
+            justify-content: center;
+            background: linear-gradient(180deg, #1a1714 0%, #141210 100%);
+            padding: 22px 35px 18px;
+            border-radius: 6px;
+            margin-bottom: 30px;
+            border: 2px solid #3d3428;
+            box-shadow:
+                0 10px 40px rgba(0,0,0,0.5),
+                inset 0 1px 0 rgba(212, 175, 55, 0.15),
+                inset 0 -1px 0 rgba(0,0,0,0.3);
+            position: relative;
+        }
+        /* Top gold pinstripe */
+        .filter-bar::before {
+            content: '';
+            position: absolute;
+            top: -2px;
+            left: 30px;
+            right: 30px;
+            height: 3px;
+            background: linear-gradient(90deg, transparent, #b8960c 15%, #d4af37 35%, #f0d060 50%, #d4af37 65%, #b8960c 85%, transparent);
+            border-radius: 0 0 2px 2px;
+        }
+        /* Film strip sprocket holes - left */
+        .filter-bar::after {
+            content: '';
+            position: absolute;
+            left: 10px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 6px;
+            height: 60%;
+            background: repeating-linear-gradient(
+                180deg,
+                transparent 0px,
+                transparent 4px,
+                #2a2520 4px,
+                #2a2520 10px,
+                transparent 10px,
+                transparent 14px
+            );
+            opacity: 0.6;
+        }
+        .filter-group {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .filter-group label {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            color: #d4af37;
+            font-weight: 600;
+            font-variant: small-caps;
+        }
+        .filter-group input[type="text"],
+        .filter-group input[type="number"] {
+            background: linear-gradient(180deg, #0c0b09 0%, #100f0d 100%);
+            border: 1px solid #4a4030;
+            border-top-color: #2a2520;
+            border-left-color: #2a2520;
+            color: #e8dcc8;
+            padding: 10px 12px;
+            border-radius: 3px;
+            font-family: 'Inter', sans-serif;
+            font-size: 13px;
+            width: 75px;
+            transition: all 0.2s ease;
+            box-shadow:
+                inset 1px 1px 3px rgba(0,0,0,0.5),
+                0 1px 0 rgba(212, 175, 55, 0.1);
+        }
+        .filter-group input[type="text"] {
+            width: 140px;
+        }
+        .filter-group input:focus {
+            outline: none;
+            border-color: #d4af37;
+            box-shadow:
+                inset 1px 1px 3px rgba(0,0,0,0.5),
+                0 0 8px rgba(212, 175, 55, 0.4);
+        }
+        .filter-group input::placeholder {
+            color: #5a5040;
+            font-style: italic;
+            font-size: 12px;
+        }
+        /* Year inputs side by side */
+        .year-inputs {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .year-inputs input {
+            width: 65px;
+        }
+        .year-separator {
+            color: #5a5040;
+            font-size: 14px;
+        }
+        .streaming-filter {
+            position: relative;
+        }
+        .streaming-dropdown {
+            position: relative;
+        }
+        .dropdown-toggle {
+            background: linear-gradient(180deg, #0c0b09 0%, #100f0d 100%);
+            border: 1px solid #4a4030;
+            border-top-color: #2a2520;
+            border-left-color: #2a2520;
+            color: #e8dcc8;
+            padding: 10px 12px;
+            border-radius: 3px;
+            font-family: 'Inter', sans-serif;
+            font-size: 13px;
+            cursor: pointer;
+            min-width: 135px;
+            text-align: left;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            transition: all 0.2s ease;
+            box-shadow:
+                inset 1px 1px 3px rgba(0,0,0,0.5),
+                0 1px 0 rgba(212, 175, 55, 0.1);
+        }
+        .dropdown-toggle:hover {
+            border-color: #5a4a30;
+        }
+        .dropdown-toggle .arrow {
+            font-size: 10px;
+            color: #d4af37;
+        }
+        .dropdown-menu {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: -20px;
+            width: 180px;
+            background: linear-gradient(180deg, #1c1a16 0%, #14120f 100%);
+            border: 2px solid #3d3428;
+            border-radius: 4px;
+            margin-top: 6px;
+            padding: 8px 6px;
+            z-index: 1000;
+            max-height: 320px;
+            overflow-y: auto;
+            box-shadow:
+                0 15px 45px rgba(0,0,0,0.7),
+                inset 0 1px 0 rgba(212, 175, 55, 0.1);
+        }
+        /* Art deco corner accents on dropdown */
+        .dropdown-menu::before {
+            content: '';
+            position: absolute;
+            top: 4px;
+            left: 4px;
+            width: 12px;
+            height: 12px;
+            border-left: 2px solid #d4af37;
+            border-top: 2px solid #d4af37;
+        }
+        .dropdown-menu::after {
+            content: '';
+            position: absolute;
+            top: 4px;
+            right: 4px;
+            width: 12px;
+            height: 12px;
+            border-right: 2px solid #d4af37;
+            border-top: 2px solid #d4af37;
+        }
+        .dropdown-menu.show {
+            display: block;
+            animation: dropIn 0.2s ease;
+        }
+        @keyframes dropIn {
+            from { opacity: 0; transform: translateY(-8px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .dropdown-menu label {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 10px;
+            margin: 2px 0;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 500;
+            border-radius: 3px;
+            text-transform: none;
+            letter-spacing: 0;
+            font-variant: normal;
+            transition: all 0.15s ease;
+            border: 1px solid transparent;
+        }
+        /* Service-specific colors */
+        .dropdown-menu label[data-service="user-service"] {
+            color: #ffd700;
+            background: linear-gradient(90deg, rgba(212, 175, 55, 0.1) 0%, transparent 100%);
+            border-left: 3px solid #d4af37;
+        }
+        .dropdown-menu label[data-service="netflix"] {
+            color: #ff6b6b;
+            background: linear-gradient(90deg, rgba(229, 9, 20, 0.15) 0%, transparent 100%);
+            border-left: 3px solid #e50914;
+        }
+        .dropdown-menu label[data-service="hulu"] {
+            color: #6ee7a0;
+            background: linear-gradient(90deg, rgba(28, 231, 131, 0.12) 0%, transparent 100%);
+            border-left: 3px solid #1ce783;
+        }
+        .dropdown-menu label[data-service="disney_plus"] {
+            color: #7da0e0;
+            background: linear-gradient(90deg, rgba(17, 60, 207, 0.15) 0%, transparent 100%);
+            border-left: 3px solid #113ccf;
+        }
+        .dropdown-menu label[data-service="amazon_prime"] {
+            color: #6dcff6;
+            background: linear-gradient(90deg, rgba(0, 168, 225, 0.12) 0%, transparent 100%);
+            border-left: 3px solid #00a8e1;
+        }
+        .dropdown-menu label[data-service="max"] {
+            color: #8080ff;
+            background: linear-gradient(90deg, rgba(0, 43, 231, 0.15) 0%, transparent 100%);
+            border-left: 3px solid #002be7;
+        }
+        .dropdown-menu label[data-service="paramount_plus"] {
+            color: #6699ff;
+            background: linear-gradient(90deg, rgba(0, 100, 255, 0.12) 0%, transparent 100%);
+            border-left: 3px solid #0064ff;
+        }
+        .dropdown-menu label[data-service="apple_tv_plus"] {
+            color: #e0e0e0;
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.08) 0%, transparent 100%);
+            border-left: 3px solid #888;
+        }
+        .dropdown-menu label[data-service="peacock"] {
+            color: #e0e0e0;
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.06) 0%, transparent 100%);
+            border-left: 3px solid #666;
+        }
+        .dropdown-menu label[data-service="crunchyroll"] {
+            color: #ffa060;
+            background: linear-gradient(90deg, rgba(244, 117, 33, 0.12) 0%, transparent 100%);
+            border-left: 3px solid #f47521;
+        }
+        .dropdown-menu label[data-service="tubi"] {
+            color: #ff7070;
+            background: linear-gradient(90deg, rgba(250, 56, 47, 0.12) 0%, transparent 100%);
+            border-left: 3px solid #fa382f;
+        }
+        .dropdown-menu label[data-service="rent"] {
+            color: #ffd700;
+            background: linear-gradient(90deg, rgba(0, 75, 147, 0.2) 0%, transparent 100%);
+            border-left: 3px solid #004B93;
+        }
+        .dropdown-menu label[data-service="acquire"] {
+            color: #999;
+            background: linear-gradient(90deg, rgba(100, 100, 100, 0.1) 0%, transparent 100%);
+            border-left: 3px solid #555;
+        }
+        .dropdown-menu label:hover {
+            border: 1px solid rgba(212, 175, 55, 0.4);
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.1),
+                0 2px 8px rgba(0,0,0,0.3);
+            transform: translateX(2px);
+        }
+        .dropdown-menu label:has(input:checked) {
+            border: 1px solid rgba(212, 175, 55, 0.6);
+            box-shadow:
+                inset 0 2px 4px rgba(0,0,0,0.4),
+                inset 0 -1px 0 rgba(255,255,255,0.1),
+                0 0 10px rgba(212, 175, 55, 0.2);
+        }
+        .dropdown-menu input[type="checkbox"] {
+            width: 14px;
+            height: 14px;
+            accent-color: #d4af37;
+            cursor: pointer;
+        }
+        .clear-filters-btn {
+            background: linear-gradient(180deg, #a01010 0%, #8b0000 40%, #6a0000 100%);
+            color: #ffd700;
+            border: none;
+            padding: 10px 18px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: 'Inter', sans-serif;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            transition: all 0.2s ease;
+            box-shadow:
+                0 3px 10px rgba(139, 0, 0, 0.4),
+                inset 0 1px 0 rgba(255,255,255,0.1),
+                inset 0 -1px 0 rgba(0,0,0,0.2);
+        }
+        .clear-filters-btn:hover {
+            transform: translateY(-1px);
+            box-shadow:
+                0 5px 15px rgba(139, 0, 0, 0.5),
+                inset 0 1px 0 rgba(255,255,255,0.15);
+        }
+        tr.filtered-out {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="curtain-top"></div>
+
+    <div class="page-wrapper">
+        <div class="brand">
+            <h1>CURATARR</h1>
+            <div class="subtitle">Watchlist</div>
+            <div class="timestamp">Updated January 15, 2026 at 12:00</div>
+        </div>
+
+        <div class="header-actions">
+            <button class="export-btn" onclick="exportRadarr()">Export to Radarr (<span id="movie-count">0</span>)</button>
+            <button class="export-btn sonarr" onclick="exportSonarr()">Export to Sonarr (<span id="show-count">0</span>)</button>
+            <button class="export-btn trakt" onclick="exportTrakt()">Export for Trakt (<span id="total-count">0</span>)</button>
+        </div>
+
+        <div class="filter-bar">
+            <div class="filter-group">
+                <label>Search</label>
+                <input type="text" id="filter-search" placeholder="Title..." oninput="applyFilters()">
+            </div>
+            <div class="filter-group">
+                <label>Rating</label>
+                <input type="number" id="filter-rating-min" placeholder="Min" min="0" max="10" step="0.1" oninput="applyFilters()">
+            </div>
+            <div class="filter-group filter-group-year">
+                <label>Year</label>
+                <div class="year-inputs">
+                    <input type="number" id="filter-year-min" placeholder="From" min="1900" max="2030" oninput="applyFilters()">
+                    <span class="year-separator">–</span>
+                    <input type="number" id="filter-year-max" placeholder="To" min="1900" max="2030" oninput="applyFilters()">
+                </div>
+            </div>
+            <div class="filter-group">
+                <label>Days Listed</label>
+                <input type="number" id="filter-days-max" placeholder="Max" min="0" oninput="applyFilters()">
+            </div>
+            <div class="filter-group streaming-filter">
+                <label>Streaming</label>
+                <div class="streaming-dropdown" id="streaming-dropdown">
+                    <button type="button" class="dropdown-toggle" onclick="toggleStreamingDropdown()">
+                        All Services <span class="arrow">&#9662;</span>
+                    </button>
+                    <div class="dropdown-menu" id="streaming-menu">
+                        <label data-service="user-service"><input type="checkbox" value="user-service" onchange="applyFilters()"> My Services</label>
+                        <label data-service="netflix"><input type="checkbox" value="netflix" onchange="applyFilters()"> Netflix</label>
+                        <label data-service="hulu"><input type="checkbox" value="hulu" onchange="applyFilters()"> Hulu</label>
+                        <label data-service="disney_plus"><input type="checkbox" value="disney_plus" onchange="applyFilters()"> Disney+</label>
+                        <label data-service="amazon_prime"><input type="checkbox" value="amazon_prime" onchange="applyFilters()"> Prime</label>
+                        <label data-service="max"><input type="checkbox" value="max" onchange="applyFilters()"> Max</label>
+                        <label data-service="paramount_plus"><input type="checkbox" value="paramount_plus" onchange="applyFilters()"> Paramount+</label>
+                        <label data-service="apple_tv_plus"><input type="checkbox" value="apple_tv_plus" onchange="applyFilters()"> Apple TV+</label>
+                        <label data-service="peacock"><input type="checkbox" value="peacock" onchange="applyFilters()"> Peacock</label>
+                        <label data-service="crunchyroll"><input type="checkbox" value="crunchyroll" onchange="applyFilters()"> Crunchyroll</label>
+                        <label data-service="tubi"><input type="checkbox" value="tubi" onchange="applyFilters()"> Tubi</label>
+                        <label data-service="rent"><input type="checkbox" value="rent" onchange="applyFilters()"> Rent</label>
+                        <label data-service="acquire"><input type="checkbox" value="acquire" onchange="applyFilters()"> Acquire</label>
+                    </div>
+                </div>
+            </div>
+            <button class="clear-filters-btn" onclick="clearFilters()">Clear</button>
+        </div>
+
+        <div class="tabs-wrapper">
+            <div class="tabs">
+                <button class="tab-btn active" data-user="alice">Alice</button>
+
+            </div>
+            
+            <div class="huntarr-tabs">
+                <button class="tab-btn " data-user="sequel-huntarr">Sequel Huntarr</button>
+<button class="tab-btn " data-user="horizon-huntarr">Horizon Huntarr</button>
+
+            </div>
+        </div>
+
+        <div class="tab-panel active" data-user="alice"><h2>Movies to Watch (3)</h2>
+                <table>
+                    <thead>
+                        <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Rating</th><th class="sortable desc">Score</th><th class="sortable">Streaming</th><th class="sortable">Days</th></tr>
+                    </thead>
+                    <tbody>
+                        
+                <tr data-tmdb="10" data-imdb="tt0000010" data-type="movie" data-user="alice">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Signal Drift </td>
+                    <td>2024</td>
+                    <td>7.2</td>
+                    <td>81%</td>
+                    <td><div class="streaming-icons"><a href="https://www.justwatch.com/us/search?q=Signal+Drift" target="_blank" class="streaming-link"><span class="streaming-icon netflix user-service">Netflix</span></a></div></td>
+                    <td>14</td>
+                </tr>
+
+                <tr data-tmdb="11" data-imdb="tt0000011" data-type="movie" data-user="alice">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Glass Horizon </td>
+                    <td>2023</td>
+                    <td>6.8</td>
+                    <td>77%</td>
+                    <td><div class="streaming-icons"><a href="https://www.justwatch.com/us/search?q=Glass+Horizon" target="_blank" class="streaming-link"><span class="streaming-icon max">Max</span></a></div></td>
+                    <td>14</td>
+                </tr>
+
+                <tr data-tmdb="12" data-imdb="tt0000012" data-type="movie" data-user="alice">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Quiet Static </td>
+                    <td>2022</td>
+                    <td>6.1</td>
+                    <td>69%</td>
+                    <td><div class="streaming-icons"><span class="streaming-icon acquire">Acquire</span></div></td>
+                    <td>14</td>
+                </tr>
+                    </tbody>
+                </table><h2>TV Shows to Watch (1)</h2>
+                <table>
+                    <thead>
+                        <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Rating</th><th class="sortable desc">Score</th><th class="sortable">Streaming</th><th class="sortable">Days</th></tr>
+                    </thead>
+                    <tbody>
+                        
+                <tr data-tmdb="20" data-imdb="tt0000020" data-type="show" data-user="alice">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Nightfall Station </td>
+                    <td>2021</td>
+                    <td>8.0</td>
+                    <td>85%</td>
+                    <td><div class="streaming-icons"><a href="https://www.justwatch.com/us/search?q=Nightfall+Station" target="_blank" class="streaming-link"><span class="streaming-icon netflix user-service">Netflix</span></a></div></td>
+                    <td>14</td>
+                </tr>
+                    </tbody>
+                </table></div>
+<div class="tab-panel " data-user="sequel-huntarr"><h2>Sequel Huntarr (1)</h2><p class="subtitle">Missing movies from collections you've started.</p>
+            <table>
+                <thead>
+                    <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Year</th><th class="sortable">Collection</th><th class="sortable">Owned</th><th class="sortable">Streaming</th></tr>
+                </thead>
+                <tbody>
+                    
+                <tr data-tmdb="3" data-imdb="tt0000003" data-type="movie" data-user="sequel-huntarr">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Rogue Chronicles: Ascension </td>
+                    <td>2018</td>
+                    <td>Rogue Chronicles Collection</td>
+                    <td>1/2</td>
+                    <td><div class="streaming-icons"><a href="https://www.justwatch.com/us/search?q=Rogue+Chronicles%3A+Ascension" target="_blank" class="streaming-link"><span class="streaming-icon netflix user-service">Netflix</span></a></div></td>
+                </tr>
+                </tbody>
+            </table></div>
+<div class="tab-panel " data-user="horizon-huntarr"><h2>Horizon Huntarr (1)</h2><p class="subtitle">Upcoming unreleased movies from collections you own.</p>
+            <table>
+                <thead>
+                    <tr><th><input type="checkbox" class="select-all-table"></th><th class="sortable">Title</th><th class="sortable">Collection</th><th class="sortable">Release Date</th><th class="sortable">Status</th></tr>
+                </thead>
+                <tbody>
+                    
+                <tr data-tmdb="4" data-imdb="tt0000004" data-type="movie" data-user="horizon-huntarr">
+                    <td><input type="checkbox" class="select-item"></td>
+                    <td>Rogue Chronicles: Horizon </td>
+                    <td>Rogue Chronicles Collection</td>
+                    <td>2027-06-01</td>
+                    <td><span class="status-badge in-production">In Production</span></td>
+                </tr>
+                </tbody>
+            </table></div>
+
+
+        <div class="instructions">
+            <h3>How to Use</h3>
+            <ul>
+                <li>Click a user tab to view their personalized recommendations</li>
+                <li>Check the items you want to export</li>
+                <li><strong>Radarr:</strong> Download IMDB IDs for selected movies and import via Lists</li>
+                <li><strong>Sonarr:</strong> Download IMDB IDs for selected shows and import via Lists</li>
+                <li><strong>Trakt:</strong> Download IMDB IDs for all selected items to paste into a Trakt list</li>
+                <li>Exports include selections from all users, not just the active tab</li>
+            </ul>
+        </div>
+
+        <div class="footer">
+            Powered by <a href="https://github.com/OrchestratedChaos/curatarr" target="_blank">Curatarr</a>
+        </div>
+    </div>
+
+    <script>
+        // Tab switching
+        document.querySelectorAll('.tab-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const userId = this.getAttribute('data-user');
+
+                // Update active tab
+                document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+                this.classList.add('active');
+
+                // Show corresponding panel
+                document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+                document.querySelector(`.tab-panel[data-user="${userId}"]`).classList.add('active');
+            });
+        });
+
+        // Select-all checkbox functionality (per table)
+        document.querySelectorAll('.select-all-table').forEach(selectAll => {
+            selectAll.addEventListener('change', function() {
+                const table = this.closest('table');
+                table.querySelectorAll('.select-item').forEach(cb => {
+                    cb.checked = this.checked;
+                });
+                updateCounts();
+            });
+        });
+
+        // Update counts when individual items are checked
+        document.querySelectorAll('.select-item').forEach(cb => {
+            cb.addEventListener('change', updateCounts);
+        });
+
+        function updateCounts() {
+            // Count ALL selected items across ALL users (excluding filtered-out rows)
+            const movieCount = document.querySelectorAll('tr[data-type="movie"]:not(.filtered-out) .select-item:checked').length;
+            const showCount = document.querySelectorAll('tr[data-type="show"]:not(.filtered-out) .select-item:checked').length;
+            document.getElementById('movie-count').textContent = movieCount;
+            document.getElementById('show-count').textContent = showCount;
+            document.getElementById('total-count').textContent = movieCount + showCount;
+        }
+
+        function exportRadarr() {
+            // Export from ALL users (excluding filtered-out rows)
+            const rows = document.querySelectorAll('tr[data-type="movie"]:not(.filtered-out)');
+            const imdbIds = [];
+            rows.forEach(row => {
+                const checkbox = row.querySelector('.select-item');
+                if (checkbox && checkbox.checked) {
+                    const imdb = row.getAttribute('data-imdb');
+                    if (imdb && imdb.startsWith('tt')) {
+                        imdbIds.push(imdb);
+                    }
+                }
+            });
+            if (imdbIds.length === 0) {
+                alert('No selected movies with IMDB IDs to export. Select items first.');
+                return;
+            }
+            downloadFile('radarr_import.txt', [...new Set(imdbIds)].join('\n'));
+            alert('Exported ' + imdbIds.length + ' movies for Radarr import.');
+        }
+
+        function exportSonarr() {
+            // Export from ALL users (excluding filtered-out rows)
+            const rows = document.querySelectorAll('tr[data-type="show"]:not(.filtered-out)');
+            const imdbIds = [];
+            rows.forEach(row => {
+                const checkbox = row.querySelector('.select-item');
+                if (checkbox && checkbox.checked) {
+                    const imdb = row.getAttribute('data-imdb');
+                    if (imdb && imdb.startsWith('tt')) {
+                        imdbIds.push(imdb);
+                    }
+                }
+            });
+            if (imdbIds.length === 0) {
+                alert('No selected TV shows with IMDB IDs to export. Select items first.');
+                return;
+            }
+            downloadFile('sonarr_import.txt', [...new Set(imdbIds)].join('\n'));
+            alert('Exported ' + imdbIds.length + ' shows for Sonarr import.');
+        }
+
+        function exportTrakt() {
+            // Export ALL selected items (movies + shows) for Trakt import (excluding filtered-out rows)
+            const allRows = document.querySelectorAll('tr[data-imdb]:not(.filtered-out)');
+            const imdbIds = [];
+            allRows.forEach(row => {
+                const checkbox = row.querySelector('.select-item');
+                if (checkbox && checkbox.checked) {
+                    const imdb = row.getAttribute('data-imdb');
+                    if (imdb && imdb.startsWith('tt')) {
+                        imdbIds.push(imdb);
+                    }
+                }
+            });
+            if (imdbIds.length === 0) {
+                alert('No selected items with IMDB IDs to export. Select items first.');
+                return;
+            }
+            // Trakt accepts IMDB IDs one per line for list import
+            downloadFile('trakt_import.txt', [...new Set(imdbIds)].join('\n'));
+            alert('Exported ' + imdbIds.length + ' items for Trakt.\n\nTo import:\n1. Go to trakt.tv/users/YOUR_USERNAME/lists\n2. Create or edit a list\n3. Click "Add Items" and paste the IMDB IDs');
+        }
+
+        function downloadFile(filename, content) {
+            const blob = new Blob([content], { type: 'text/plain' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }
+
+        // Column sorting
+        function sortTable(th, colIndex) {
+            const table = th.closest('table');
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            // Determine sort direction
+            const isAsc = th.classList.contains('asc');
+            const isDesc = th.classList.contains('desc');
+
+            // Clear all sort classes in this table
+            table.querySelectorAll('th.sortable').forEach(header => {
+                header.classList.remove('asc', 'desc');
+            });
+
+            // Set new sort direction
+            let direction;
+            if (!isAsc && !isDesc) {
+                direction = 'desc'; // Default to descending (highest first)
+            } else if (isDesc) {
+                direction = 'asc';
+            } else {
+                direction = 'desc';
+            }
+            th.classList.add(direction);
+
+            // Sort rows
+            rows.sort((a, b) => {
+                const aCell = a.cells[colIndex];
+                const bCell = b.cells[colIndex];
+
+                // Handle streaming icons column (sort by service name)
+                const aIcons = aCell.querySelectorAll('.streaming-icon');
+                const bIcons = bCell.querySelectorAll('.streaming-icon');
+                if (aIcons.length > 0 || bIcons.length > 0) {
+                    // Get first service name (or "zzz" for Acquire to sort last)
+                    const aFirst = aCell.querySelector('.streaming-icon')?.textContent?.trim() || '';
+                    const bFirst = bCell.querySelector('.streaming-icon')?.textContent?.trim() || '';
+                    const aName = aFirst === 'Acquire' ? 'zzz' : aFirst;
+                    const bName = bFirst === 'Acquire' ? 'zzz' : bFirst;
+                    return direction === 'asc' ? aName.localeCompare(bName) : bName.localeCompare(aName);
+                }
+
+                // Get text, excluding badge content for title column
+                let aVal = aCell.childNodes[0]?.textContent?.trim() || aCell.textContent.trim();
+                let bVal = bCell.childNodes[0]?.textContent?.trim() || bCell.textContent.trim();
+
+                // Remove any trailing badge text (like "2/3")
+                aVal = aVal.replace(/\s+\d+\/\d+$/, '').trim();
+                bVal = bVal.replace(/\s+\d+\/\d+$/, '').trim();
+
+                // Handle percentages (Score column)
+                if (aVal.endsWith('%') && bVal.endsWith('%')) {
+                    return direction === 'asc'
+                        ? parseFloat(aVal) - parseFloat(bVal)
+                        : parseFloat(bVal) - parseFloat(aVal);
+                }
+
+                // Handle fractions like "2/4" (Owned column)
+                if (aVal.match(/^\d+\/\d+$/) && bVal.match(/^\d+\/\d+$/)) {
+                    const aNum = parseFloat(aVal.split('/')[0]);
+                    const bNum = parseFloat(bVal.split('/')[0]);
+                    return direction === 'asc' ? aNum - bNum : bNum - aNum;
+                }
+
+                // Handle plain numbers (Year, Rating, Days)
+                const aNum = parseFloat(aVal);
+                const bNum = parseFloat(bVal);
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return direction === 'asc' ? aNum - bNum : bNum - aNum;
+                }
+
+                // Text comparison (Title, Collection)
+                return direction === 'asc'
+                    ? aVal.localeCompare(bVal)
+                    : bVal.localeCompare(aVal);
+            });
+
+            // Reattach sorted rows
+            rows.forEach(row => tbody.appendChild(row));
+        }
+
+        // Initialize sortable headers
+        document.querySelectorAll('th.sortable').forEach(th => {
+            th.addEventListener('click', function() {
+                const colIndex = Array.from(this.parentNode.children).indexOf(this);
+                sortTable(this, colIndex);
+            });
+        });
+
+        // Initialize counts on load
+        updateCounts();
+
+        // Streaming dropdown toggle
+        function toggleStreamingDropdown() {
+            const menu = document.getElementById('streaming-menu');
+            menu.classList.toggle('show');
+        }
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', function(e) {
+            const dropdown = document.getElementById('streaming-dropdown');
+            if (!dropdown.contains(e.target)) {
+                document.getElementById('streaming-menu').classList.remove('show');
+            }
+        });
+
+        // Update dropdown button text based on selections
+        function updateStreamingButtonText() {
+            const checkboxes = document.querySelectorAll('#streaming-menu input[type="checkbox"]:checked');
+            const button = document.querySelector('.dropdown-toggle');
+            if (checkboxes.length === 0) {
+                button.innerHTML = 'All Services <span class="arrow">&#9662;</span>';
+            } else if (checkboxes.length === 1) {
+                const label = checkboxes[0].parentNode.textContent.trim();
+                button.innerHTML = label + ' <span class="arrow">&#9662;</span>';
+            } else {
+                button.innerHTML = checkboxes.length + ' selected <span class="arrow">&#9662;</span>';
+            }
+        }
+
+        // Main filter function
+        function applyFilters() {
+            const searchTerm = document.getElementById('filter-search').value.toLowerCase().trim();
+            const ratingMin = parseFloat(document.getElementById('filter-rating-min').value) || 0;
+            const yearMin = parseInt(document.getElementById('filter-year-min').value) || 0;
+            const yearMax = parseInt(document.getElementById('filter-year-max').value) || 9999;
+            const daysMax = parseInt(document.getElementById('filter-days-max').value) || Infinity;
+
+            // Get selected streaming services
+            const streamingCheckboxes = document.querySelectorAll('#streaming-menu input[type="checkbox"]:checked');
+            const selectedServices = Array.from(streamingCheckboxes).map(cb => cb.value);
+
+            updateStreamingButtonText();
+
+            // Filter rows in all tables
+            document.querySelectorAll('tbody tr').forEach(row => {
+                let show = true;
+
+                // Get cell values - handle different table structures
+                const cells = row.querySelectorAll('td');
+                if (cells.length < 3) return; // Skip malformed rows
+
+                // Title is in cell 1 (after checkbox)
+                const titleCell = cells[1];
+                const title = titleCell?.textContent?.toLowerCase() || '';
+
+                // Find year, rating, days cells - they contain just numbers
+                let year = 0, rating = 0, days = 0;
+                let streamingCell = null;
+
+                cells.forEach((cell, idx) => {
+                    if (idx === 0) return; // Skip checkbox
+                    const text = cell.textContent.trim();
+
+                    // Check if it's a streaming icons cell
+                    if (cell.querySelector('.streaming-icons') || cell.querySelector('.streaming-icon')) {
+                        streamingCell = cell;
+                        return;
+                    }
+
+                    // Year: 4-digit number between 1900-2030
+                    if (/^\d{4}$/.test(text) && parseInt(text) >= 1900 && parseInt(text) <= 2030) {
+                        year = parseInt(text);
+                    }
+                    // Rating: decimal between 0-10
+                    else if (/^\d+\.\d$/.test(text) && parseFloat(text) <= 10) {
+                        rating = parseFloat(text);
+                    }
+                    // Days: plain integer (last numeric column)
+                    else if (/^\d+$/.test(text) && parseInt(text) < 10000) {
+                        days = parseInt(text);
+                    }
+                });
+
+                // Search filter
+                if (searchTerm && !title.includes(searchTerm)) {
+                    show = false;
+                }
+
+                // Rating filter
+                if (rating < ratingMin) {
+                    show = false;
+                }
+
+                // Year filter
+                if (year > 0 && (year < yearMin || year > yearMax)) {
+                    show = false;
+                }
+
+                // Days filter
+                if (days > daysMax) {
+                    show = false;
+                }
+
+                // Streaming service filter
+                if (selectedServices.length > 0 && streamingCell) {
+                    const icons = streamingCell.querySelectorAll('.streaming-icon');
+                    let hasMatch = false;
+
+                    icons.forEach(icon => {
+                        const classes = Array.from(icon.classList);
+                        // Check for "user-service" class match
+                        if (selectedServices.includes('user-service') && classes.includes('user-service')) {
+                            hasMatch = true;
+                        }
+                        // Check for specific service match
+                        selectedServices.forEach(service => {
+                            if (service !== 'user-service' && classes.includes(service)) {
+                                hasMatch = true;
+                            }
+                        });
+                    });
+
+                    if (!hasMatch) {
+                        show = false;
+                    }
+                }
+
+                // Apply visibility
+                row.classList.toggle('filtered-out', !show);
+            });
+
+            updateCounts();
+        }
+
+        // Clear all filters
+        function clearFilters() {
+            document.getElementById('filter-search').value = '';
+            document.getElementById('filter-rating-min').value = '';
+            document.getElementById('filter-year-min').value = '';
+            document.getElementById('filter-year-max').value = '';
+            document.getElementById('filter-days-max').value = '';
+
+            document.querySelectorAll('#streaming-menu input[type="checkbox"]').forEach(cb => {
+                cb.checked = false;
+            });
+
+            updateStreamingButtonText();
+            applyFilters();
+        }
+    </script>
+</body>
+</html>

--- a/tests/fixtures/external_golden/golden_watchlist.md
+++ b/tests/fixtures/external_golden/golden_watchlist.md
@@ -1,0 +1,59 @@
+# Watchlist for Alice
+
+*Last updated: 2026-01-15 12:00*
+
+---
+
+## Movies to Watch
+
+### Available on Your Services
+
+#### Netflix (1 movies)
+
+| Title | Year | Rating | Score | Days on List |
+|-------|------|--------|-------|-------------|
+| Signal Drift | 2024 | 7.2 | 81.0% | 14 |
+
+---
+
+### Available on Other Services
+
+*Consider subscribing if many recommendations are on a single service*
+
+#### Max (1 movies)
+
+| Title | Year | Rating | Score | Days on List |
+|-------|------|--------|-------|-------------|
+| Glass Horizon | 2023 | 6.8 | 77.0% | 14 |
+
+---
+
+### Acquire (1 movies)
+
+*Not available on any streaming service - need physical/digital copy*
+
+| Title | Year | Rating | Score | Days on List |
+|-------|------|--------|-------|-------------|
+| Quiet Static | 2022 | 6.1 | 69.0% | 14 |
+
+## TV Shows to Watch
+
+### Available on Your Services
+
+#### Netflix (1 shows)
+
+| Title | Year | Rating | Score | Days on List |
+|-------|------|--------|-------|-------------|
+| Nightfall Station | 2021 | 8.0 | 85.0% | 14 |
+
+---
+
+---
+
+## How to Use This List
+
+- Items are automatically removed when added to your Plex library
+- To manually ignore an item, add its title to `alice_ignore.txt`
+- List updates daily with new recommendations
+- Grouped by streaming availability to help you decide what to watch or acquire
+

--- a/tests/golden_external_harness.py
+++ b/tests/golden_external_harness.py
@@ -1,0 +1,379 @@
+"""
+Golden-output equivalence harness for recommenders/external.py's watchlist
+generation pipeline (PR2, external.py architecture decomposition - see
+CHANGELOG's [2.10.4x] "external.py decomposition" entries).
+
+Exercises, against fixed synthetic inputs (no real Plex/TMDB data, no real
+network - only recommenders.external.requests.get and Plex library/section
+objects are mocked; see tests/conftest.py's `_block_non_loopback_sockets`
+suite-wide safety net for what would catch an accidental live call anyway):
+
+  - find_missing_sequels()             (Sequel Huntarr - PR2 step 1 extraction target)
+  - find_horizon_movies()              (Horizon Huntarr - PR2 step 2 extraction target)
+  - categorize_by_streaming_service()  (PR2 step 3 extraction target)
+  - generate_markdown() / generate_combined_html() (recommenders/external_render.py -
+    NOT an extraction target itself, but the final artifact the three
+    functions above feed into; byte-identical HTML/MD across a PR is the
+    actual regression signal this harness exists to catch)
+
+Deliberately NOT exercised here: find_similar_content_with_profile()'s
+iterative TMDB-Discover candidate loop, and build_user_profile()'s Plex
+watch-history scan. Neither is a PR2 extraction/relocation target in this
+sequence (build_user_profile is only being evaluated for a possible
+call-shared-code reconciliation, not moved) - see PR2's report for the
+build_user_profile finding, and tests/test_external.py's own
+TestFindSimilarContentThinProfile/build_user_profile tests for that
+narrower, already-existing regression coverage. Faithfully mocking TMDB
+Discover's paginated candidate stream here would add substantial new
+fixture surface for uncertain marginal protection value on functions this
+PR sequence isn't touching.
+
+Fixture shape (all synthetic, invented titles/ids - never real watch
+history):
+  - One movie library with 2 items: a standalone movie (tmdb_id=1, no
+    collection) and a collected movie (tmdb_id=2, owns 1 of 3 parts of the
+    "Rogue Chronicles" collection). The collection's other 2 parts are a
+    released-but-missing sequel (tmdb_id=3 - feeds Sequel Huntarr) and an
+    unreleased one (tmdb_id=4, no release year yet - feeds Horizon
+    Huntarr). tv_library_name is deliberately "" (Sequel Huntarr's
+    TV-special cross-check path is skipped - already covered by
+    tests/test_external.py's own unit tests; out of scope for this
+    harness, see PR2's report).
+  - 3 standalone "recommended" movies (tmdb_id=10/11/12) run through
+    categorize_by_streaming_service to exercise all three buckets
+    (user_services / other_services / acquire), plus 1 TV show
+    (tmdb_id=20) for the show-categorization path.
+  - Both Sequel/Horizon Huntarr results AND the categorized
+    movies/shows feed generate_markdown() (per-user .md) and
+    generate_combined_html() (combined .html) for real, so a behavior
+    change in any of the four functions above shows up as a byte-level
+    diff in the rendered artifacts - not just in an intermediate dict.
+
+No PYTHONHASHSEED pinning needed (unlike tests/harness.py): nothing in
+this call graph sums floats in an order driven by string-hash-randomized
+dict/set iteration - every dict/set with output-visible ordering here is
+keyed by int TMDB ids (CPython's int hash is its own value, never
+randomized) or built by iterating a fixed-order list.
+
+Usage (module, not script - see tests/harness.py's identical convention):
+
+    python -m tests.golden_external_harness              # print JSON diff-summary to stdout
+    python -m tests.golden_external_harness --write       # (re)write golden fixture files
+
+Two invocations must be byte-identical (see tests/test_golden_external_harness.py
+for the assertions this backs) - datetime.now() is pinned to a fixed value
+for the duration of the run (both generate_markdown/generate_combined_html
+embed a live "generated at" timestamp via datetime.now() - see
+recommenders/external_render.py - so without pinning it, no two runs on
+different days could ever match) via a datetime subclass patched in for
+recommenders.external_render.datetime.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from recommenders.external import (  # noqa: E402
+    categorize_by_streaming_service,
+    find_horizon_movies,
+    find_missing_sequels,
+)
+from recommenders.external_render import generate_combined_html, generate_markdown  # noqa: E402
+
+GOLDEN_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "external_golden")
+
+# Low-entropy placeholder (matches tests/test_external.py's own
+# tmdb_api_key="test_key" convention) - never a real key, but also
+# deliberately not a long random-looking string, which would otherwise
+# trip gitleaks' generic-high-entropy-secret rule despite the .gitleaks.toml
+# tmdb-api-key rule itself (looking for a real 32-hex-char key) not matching.
+TMDB_API_KEY = "test_key"
+
+# Pinned "now" - see module docstring. Arbitrary, fixed value; not
+# meaningful beyond "always the same across runs".
+_FIXED_NOW = datetime(2026, 1, 15, 12, 0, 0)
+
+# Fixed added_date for every synthetic "recommended" item below, so
+# generate_markdown/generate_combined_html's "days on list" column is
+# deterministic against _FIXED_NOW.
+_FIXED_ADDED_DATE = datetime(2026, 1, 1, 9, 0, 0).isoformat()
+
+
+class _FixedDateTime(datetime):
+    """Patched in for recommenders.external_render.datetime so its
+    datetime.now() calls return a pinned value - see module docstring."""
+
+    @classmethod
+    def now(cls, tz=None):
+        return _FIXED_NOW
+
+
+def _guid(tmdb_id):
+    guid = Mock()
+    guid.id = f"tmdb://{tmdb_id}"
+    return guid
+
+
+def _library_item(tmdb_id):
+    item = Mock()
+    item.guids = [_guid(tmdb_id)]
+    return item
+
+
+def _plex_with_movies(movie_items, library_name="Movies"):
+    """Fake PlexServer: plex.library.section(library_name) returns a
+    section wrapping movie_items; any other library name raises (Sequel
+    Huntarr's TV-specials check is skipped via tv_library_name="", so this
+    should never be asked for one - see module docstring)."""
+    section = Mock()
+    section.all.return_value = movie_items
+
+    def _section(name):
+        if name == library_name:
+            return section
+        raise AssertionError(f"golden harness fixture has no library configured for: {name!r}")
+
+    plex = Mock()
+    plex.library.section.side_effect = _section
+    return plex
+
+
+def _tmdb_response(data):
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = data
+    return resp
+
+
+def _strict_get_dispatcher(url_map):
+    """requests.get side_effect that routes by exact URL, raising loudly
+    on anything not in url_map instead of silently fabricating data -
+    mirrors tests/test_external.py's identical helper."""
+
+    def _fake_get(url, params=None, timeout=None):
+        if url not in url_map:
+            raise AssertionError(f"Unexpected TMDB URL requested by golden harness: {url}")
+        return url_map[url]
+
+    return _fake_get
+
+
+def _build_url_map():
+    """Fixed TMDB responses covering the whole harness run: the shared
+    "Rogue Chronicles" collection (movies 1/2/3/4) for Sequel + Horizon
+    Huntarr, and 3 movies + 1 show's watch/providers for
+    categorize_by_streaming_service."""
+    collection_parts = [
+        {"id": 2, "title": "Rogue Chronicles: Origins", "release_date": "2015-03-01", "genre_ids": [18]},
+        {"id": 3, "title": "Rogue Chronicles: Ascension", "release_date": "2018-07-04", "genre_ids": [28]},
+        # No release_date/year yet - unreleased, feeds Horizon Huntarr,
+        # excluded from Sequel Huntarr's released_movies filter.
+        {"id": 4, "title": "Rogue Chronicles: Horizon", "release_date": "", "genre_ids": [12]},
+    ]
+    return {
+        # Sequel/Horizon Huntarr library scan (movie 1: no collection; movie 2: in collection 100)
+        "https://api.themoviedb.org/3/movie/1": _tmdb_response({}),
+        "https://api.themoviedb.org/3/movie/2": _tmdb_response({"belongs_to_collection": {"id": 100}}),
+        "https://api.themoviedb.org/3/collection/100": _tmdb_response(
+            {"id": 100, "name": "Rogue Chronicles Collection", "parts": collection_parts}
+        ),
+        # Sequel Huntarr's watch-providers lookup for the missing sequel (movie 3)
+        "https://api.themoviedb.org/3/movie/3/watch/providers": _tmdb_response(
+            {"results": {"US": {"flatrate": [{"provider_id": 8}]}}}  # netflix
+        ),
+        # Horizon Huntarr's live status re-check for the unreleased movie (movie 4)
+        "https://api.themoviedb.org/3/movie/4": _tmdb_response(
+            {"status": "In Production", "release_date": "2027-06-01"}
+        ),
+        # categorize_by_streaming_service's watch-providers lookups
+        "https://api.themoviedb.org/3/movie/10/watch/providers": _tmdb_response(
+            {"results": {"US": {"flatrate": [{"provider_id": 8}]}}}  # netflix - user's service
+        ),
+        "https://api.themoviedb.org/3/movie/11/watch/providers": _tmdb_response(
+            {"results": {"US": {"flatrate": [{"provider_id": 384}]}}}  # max - other service
+        ),
+        "https://api.themoviedb.org/3/movie/12/watch/providers": _tmdb_response(
+            {"results": {"US": {}}}  # nothing - acquire bucket
+        ),
+        "https://api.themoviedb.org/3/tv/20/watch/providers": _tmdb_response(
+            {"results": {"US": {"flatrate": [{"provider_id": 8}]}}}  # netflix
+        ),
+    }
+
+
+def _recommended_movie(tmdb_id, title, year, rating, score):
+    return {
+        "tmdb_id": tmdb_id,
+        "title": title,
+        "year": year,
+        "rating": rating,
+        "score": score,
+        "vote_count": 500,
+        "original_language": "en",
+        "added_date": _FIXED_ADDED_DATE,
+    }
+
+
+def _recommended_show(tmdb_id, title, year, rating, score):
+    # Same shape as a recommended movie - categorize_by_streaming_service/
+    # generate_markdown/generate_combined_html treat movies and shows
+    # identically past this point.
+    return _recommended_movie(tmdb_id, title, year, rating, score)
+
+
+def _get_imdb_id_stub(api_key, tmdb_id, media_type):
+    """Deterministic fake IMDB id lookup - never reaches TMDB for real."""
+    return f"tt{int(tmdb_id):07d}"
+
+
+def run() -> dict:
+    """Run the full fixed pipeline and return a JSON-serializable dict of
+    every intermediate result plus the rendered .md/.html file contents."""
+    from recommenders import external as external_module
+
+    external_module._watch_provider_cache.clear()
+
+    tmp_root = tempfile.mkdtemp(prefix="curatarr_golden_external_")
+    try:
+        url_map = _build_url_map()
+        plex = _plex_with_movies([_library_item(1), _library_item(2)])
+
+        with (
+            patch("recommenders.external.get_project_root", return_value=tmp_root),
+            patch("recommenders.external.requests.get", side_effect=_strict_get_dispatcher(url_map)),
+        ):
+            missing_sequels = find_missing_sequels(TMDB_API_KEY, plex, "Movies", "", ["netflix"])
+            horizon_movies = find_horizon_movies(TMDB_API_KEY, plex, "Movies")
+
+            recommended_movies = [
+                _recommended_movie(10, "Signal Drift", "2024", 7.2, 0.81),
+                _recommended_movie(11, "Glass Horizon", "2023", 6.8, 0.77),
+                _recommended_movie(12, "Quiet Static", "2022", 6.1, 0.69),
+            ]
+            recommended_shows = [
+                _recommended_show(20, "Nightfall Station", "2021", 8.0, 0.85),
+            ]
+
+            movies_categorized = categorize_by_streaming_service(recommended_movies, TMDB_API_KEY, ["netflix"], "movie")
+            shows_categorized = categorize_by_streaming_service(recommended_shows, TMDB_API_KEY, ["netflix"], "tv")
+
+        output_dir = os.path.join(tmp_root, "output")
+
+        with patch("recommenders.external_render.datetime", _FixedDateTime):
+            md_path = generate_markdown("alice", "Alice", movies_categorized, shows_categorized, output_dir)
+
+            all_users_data = [
+                {
+                    "username": "alice",
+                    "display_name": "Alice",
+                    "user_services": ["netflix"],
+                    "movies_categorized": movies_categorized,
+                    "shows_categorized": shows_categorized,
+                }
+            ]
+            html_path = generate_combined_html(
+                all_users_data,
+                output_dir,
+                TMDB_API_KEY,
+                _get_imdb_id_stub,
+                movie_counts={},
+                show_counts={},
+                total_users=1,
+                missing_sequels=missing_sequels,
+                horizon_movies=horizon_movies,
+            )
+
+        with open(md_path, "r", encoding="utf-8") as f:
+            md_content = f.read()
+        with open(html_path, "r", encoding="utf-8") as f:
+            html_content = f.read()
+
+        return {
+            "missing_sequels": missing_sequels,
+            "horizon_movies": horizon_movies,
+            "movies_categorized": movies_categorized,
+            "shows_categorized": shows_categorized,
+            "watchlist_md": md_content,
+            "watchlist_html": html_content,
+        }
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+def _golden_path(name: str) -> str:
+    return os.path.join(GOLDEN_DIR, name)
+
+
+def write_golden(result: dict) -> None:
+    os.makedirs(GOLDEN_DIR, exist_ok=True)
+    with open(_golden_path("golden_watchlist.md"), "w", encoding="utf-8", newline="") as f:
+        f.write(result["watchlist_md"])
+    with open(_golden_path("golden_watchlist.html"), "w", encoding="utf-8", newline="") as f:
+        f.write(result["watchlist_html"])
+    with open(_golden_path("golden_huntarr.json"), "w", encoding="utf-8", newline="") as f:
+        json.dump(result["missing_sequels"], f, indent=2, sort_keys=True)
+        f.write("\n")
+    with open(_golden_path("golden_horizon.json"), "w", encoding="utf-8", newline="") as f:
+        json.dump(result["horizon_movies"], f, indent=2, sort_keys=True)
+        f.write("\n")
+    with open(_golden_path("golden_categorized.json"), "w", encoding="utf-8", newline="") as f:
+        json.dump(
+            {"movies": result["movies_categorized"], "shows": result["shows_categorized"]},
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+        f.write("\n")
+
+
+def load_golden() -> dict:
+    with open(_golden_path("golden_watchlist.md"), "r", encoding="utf-8") as f:
+        watchlist_md = f.read()
+    with open(_golden_path("golden_watchlist.html"), "r", encoding="utf-8") as f:
+        watchlist_html = f.read()
+    with open(_golden_path("golden_huntarr.json"), "r", encoding="utf-8") as f:
+        missing_sequels = json.load(f)
+    with open(_golden_path("golden_horizon.json"), "r", encoding="utf-8") as f:
+        horizon_movies = json.load(f)
+    with open(_golden_path("golden_categorized.json"), "r", encoding="utf-8") as f:
+        categorized = json.load(f)
+    return {
+        "missing_sequels": missing_sequels,
+        "horizon_movies": horizon_movies,
+        "movies_categorized": categorized["movies"],
+        "shows_categorized": categorized["shows"],
+        "watchlist_md": watchlist_md,
+        "watchlist_html": watchlist_html,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="(Re)write golden fixture files from current code")
+    args = parser.parse_args()
+
+    result = run()
+    if args.write:
+        write_golden(result)
+        print(f"Wrote golden fixtures to {GOLDEN_DIR}")
+    else:
+        summary = {
+            "num_missing_sequels": len(result["missing_sequels"]),
+            "num_horizon_movies": len(result["horizon_movies"]),
+            "num_movies_categorized_all_items": len(result["movies_categorized"]["all_items"]),
+            "num_shows_categorized_all_items": len(result["shows_categorized"]["all_items"]),
+            "watchlist_md_len": len(result["watchlist_md"]),
+            "watchlist_html_len": len(result["watchlist_html"]),
+        }
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_golden_external_harness.py
+++ b/tests/test_golden_external_harness.py
@@ -1,0 +1,68 @@
+"""
+Tests for tests/golden_external_harness.py - the golden-output
+equivalence harness backing the recommenders/external.py architecture
+decomposition (PR2 - see tests/golden_external_harness.py's own
+docstring for exactly what it exercises and what it deliberately
+doesn't).
+
+This is the actual regression gate: every PR in the external.py
+decomposition sequence must leave `test_current_run_matches_golden_files`
+passing. A failure here means the moved/refactored code produced
+different output than current main did - per that PR's own instructions,
+that's a STOP-and-report condition, not something to reconcile by
+updating the golden files (updating them is only correct when a PR's own
+described change is an intentional, separately-reviewed behavior change,
+never as a side effect of a "pure relocation" commit).
+"""
+
+from tests.golden_external_harness import load_golden, run
+
+
+class TestGoldenOutputMatchesCommittedFixtures:
+    """The core regression gate - see module docstring."""
+
+    def test_current_run_matches_golden_files(self):
+        current = run()
+        golden = load_golden()
+
+        # Compare the rendered artifacts first (the actual deliverable
+        # this harness exists to protect) with clear, specific failure
+        # messages rather than one opaque dict-equality assertion.
+        assert current["watchlist_md"] == golden["watchlist_md"], "generate_markdown() output drifted from golden"
+        assert current["watchlist_html"] == golden["watchlist_html"], (
+            "generate_combined_html() output drifted from golden"
+        )
+        assert current["missing_sequels"] == golden["missing_sequels"], (
+            "find_missing_sequels() (Sequel Huntarr) output drifted from golden"
+        )
+        assert current["horizon_movies"] == golden["horizon_movies"], (
+            "find_horizon_movies() (Horizon Huntarr) output drifted from golden"
+        )
+        assert current["movies_categorized"] == golden["movies_categorized"], (
+            "categorize_by_streaming_service() (movies) output drifted from golden"
+        )
+        assert current["shows_categorized"] == golden["shows_categorized"], (
+            "categorize_by_streaming_service() (shows) output drifted from golden"
+        )
+
+
+class TestHarnessSelfConsistency:
+    """Sanity checks on the harness itself, independent of the committed
+    golden files - catches the harness becoming flaky/nondeterministic on
+    its own, which would make the golden comparison above meaningless."""
+
+    def test_two_consecutive_runs_are_byte_identical(self):
+        first = run()
+        second = run()
+        assert first == second
+
+    def test_produces_non_trivial_output(self):
+        """A byte-identical-to-golden empty/degenerate result would
+        trivially pass the test above without proving anything."""
+        result = run()
+        assert len(result["missing_sequels"]) == 1
+        assert len(result["horizon_movies"]) == 1
+        assert len(result["movies_categorized"]["all_items"]) == 3
+        assert len(result["shows_categorized"]["all_items"]) == 1
+        assert "Alice" in result["watchlist_md"]
+        assert "Alice" in result["watchlist_html"]

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.40"
+__version__ = "2.10.41"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- Prep work for the upcoming recommenders/external.py architecture decomposition - no production code touched.
- `tests/golden_external_harness.py`: runs find_missing_sequels() (Sequel Huntarr), find_horizon_movies() (Horizon Huntarr), categorize_by_streaming_service(), and the generate_markdown()/generate_combined_html() render pipeline against fixed synthetic Plex/TMDB fixtures, comparing byte-for-byte against committed golden files under tests/fixtures/external_golden/.
- `tests/test_golden_external_harness.py` is the actual regression gate: every subsequent PR in the decomposition sequence must leave it passing.
- See the harness's own module docstring for exactly what's exercised and what's deliberately out of scope (find_similar_content_with_profile's TMDB-Discover loop, build_user_profile's Plex watch-history scan).

## Test plan
- [x] Two consecutive harness runs are byte-identical (datetime.now() pinned via a patched-in subclass)
- [x] Full suite: 2512 passed, 1 skipped
- [x] ruff check / ruff format --check clean
- [x] PyInstaller build succeeds, --version reports 2.10.41
- [x] tests/harness.py untouched