### PR TITLE
refactor: extract streaming-service categorization into recommenders/streaming.py (2.10.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.44] - 2026-07-26
+
+### Changed
+
+- **Extracted streaming-service categorization (`categorize_by_streaming_service`) out of `recommenders/external.py` into `recommenders/streaming.py` (PR2 step 3, external.py architecture decomposition).**
+
+  - Pure relocation: `categorize_by_streaming_service` moved byte-for-byte;
+    only the import path changed. `recommenders/streaming.py` imports
+    `get_watch_providers` from `recommenders/huntarr.py` (the TMDB
+    watch-provider lookup helper Sequel Huntarr originally introduced).
+    `recommenders/external.py` still calls `categorize_by_streaming_service`
+    directly from several of its own functions (`process_user`,
+    `process_user_movie_library`, `process_user_tv_library`), so it
+    stays a normal top-level import there - not an `__all__`-only
+    re-export. `get_watch_providers` moved from "used internally" to
+    "re-export only" status in `external.py` now that its last internal
+    caller moved out too.
+  - Verified via the golden-output equivalence harness: watchlist
+    HTML/MD, Sequel/Horizon Huntarr results, and categorized-by-
+    streaming-service output are all byte-identical to pre-move golden
+    fixtures.
+  - `tests/test_external.py`'s `TestCategorizeByStreamingService` and
+    `TestCategorizeByStreamingServiceAllItems` patches updated from
+    `recommenders.external.get_watch_providers` to
+    `recommenders.streaming.get_watch_providers` - same reasoning as the
+    Sequel/Horizon Huntarr moves (a mocked function is looked up in
+    whichever module's own namespace calls it at runtime).
+
 ## [2.10.43] - 2026-07-26
 
 ### Changed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -54,6 +54,7 @@ from recommenders.huntarr import (
     load_huntarr_cache,
     save_huntarr_cache,
 )
+from recommenders.streaming import categorize_by_streaming_service
 from utils import (
     CYAN,
     DEFAULT_RATING_MULTIPLIERS,
@@ -109,15 +110,20 @@ logger = logging.getLogger("curatarr")
 #     by tests/test_external.py.
 #   - TMDB_ANIMATION_GENRE_ID, TMDB_PROVIDERS, TV_MOVIE_GENRE_ID,
 #     HUNTARR_CACHE_VERSION, save_huntarr_cache, _watch_provider_cache,
-#     get_collection_details, load_huntarr_cache: find_missing_sequels/
-#     get_watch_providers moved to recommenders/huntarr.py (PR2 external.py
-#     decomposition - see CHANGELOG). get_collection_details/
-#     load_huntarr_cache were still called from find_horizon_movies (this
-#     module) until PR2 step 2 moved that too - now nothing in this module
-#     calls them, but tests/test_external.py still imports them from here.
+#     get_collection_details, load_huntarr_cache: find_missing_sequels
+#     moved to recommenders/huntarr.py (PR2 external.py decomposition -
+#     see CHANGELOG). get_collection_details/load_huntarr_cache were
+#     still called from find_horizon_movies (this module) until PR2 step
+#     2 moved that too - now nothing in this module calls them, but
+#     tests/test_external.py still imports them from here.
 #   - HORIZON_HUNTARR_CACHE_VERSION, load_horizon_cache, save_horizon_cache,
 #     get_movie_status: same story, find_horizon_movies moved to
 #     recommenders/horizon.py (PR2 step 2), tests still import these from here.
+#   - get_watch_providers: moved to recommenders/huntarr.py along with
+#     find_missing_sequels (PR2 step 1); still called from this module's
+#     categorize_by_streaming_service until PR2 step 3 moved that to
+#     recommenders/streaming.py too - now nothing in this module calls it,
+#     but tests/test_external.py still imports it from here.
 __all__ = [
     "sync_watch_history_to_trakt",
     "SERVICE_DISPLAY_NAMES",
@@ -130,6 +136,7 @@ __all__ = [
     "_watch_provider_cache",
     "get_collection_details",
     "load_huntarr_cache",
+    "get_watch_providers",
     "HORIZON_HUNTARR_CACHE_VERSION",
     "load_horizon_cache",
     "save_horizon_cache",
@@ -799,68 +806,6 @@ def fetch_similar_from_tmdb(
         logger.debug(f"Error fetching similar for TMDB {tmdb_id}: {e}")
 
     return candidates
-
-
-def categorize_by_streaming_service(
-    recommendations: List[Dict], tmdb_api_key: str, user_services: List[str], media_type: str = "movie"
-) -> Dict:
-    """
-    Categorize recommendations by streaming availability.
-    Each item gets streaming_services, rent_services, buy_services, and on_user_services added.
-
-    Returns dict: {
-        'user_services': {service_name: [items]},
-        'other_services': {service_name: [items]},
-        'acquire': [items],
-        'all_items': [all items sorted by score with streaming info]
-    }
-    """
-    result: Dict[str, Any] = {"user_services": {}, "other_services": {}, "acquire": [], "all_items": []}
-
-    for item in recommendations:
-        tmdb_id = item["tmdb_id"]
-        providers = get_watch_providers(tmdb_api_key, tmdb_id, media_type)
-
-        # Attach streaming info to item
-        streaming = providers.get("streaming", [])
-        item["streaming_services"] = streaming
-        item["rent_services"] = providers.get("rent", [])
-        item["buy_services"] = providers.get("buy", [])
-        item["on_user_services"] = [s for s in streaming if s in user_services]
-
-        # Add to all_items for flat display
-        result["all_items"].append(item)
-
-        if not streaming:
-            # Not available on any subscription streaming service
-            result["acquire"].append(item)
-        else:
-            # Check which services have it - add to FIRST matching service only
-            # Priority: user's services first, then other services
-            placed = False
-
-            # First try user's services
-            for service in streaming:
-                if service in user_services:
-                    if service not in result["user_services"]:
-                        result["user_services"][service] = []
-                    result["user_services"][service].append(item)
-                    placed = True
-                    break  # Only add to ONE service
-
-            # If not on user's services, add to first other service
-            if not placed:
-                for service in streaming:
-                    if service not in user_services:
-                        if service not in result["other_services"]:
-                            result["other_services"][service] = []
-                        result["other_services"][service].append(item)
-                        break  # Only add to ONE service
-
-    # Sort all_items by score (highest first)
-    result["all_items"].sort(key=lambda x: x.get("score", 0), reverse=True)
-
-    return result
 
 
 def get_genre_distribution(plex: Any, config: Dict, username: str, media_type: str = "movie") -> Tuple[Dict, int]:

--- a/recommenders/streaming.py
+++ b/recommenders/streaming.py
@@ -1,0 +1,87 @@
+"""
+Streaming-service categorization for external recommendations - buckets a
+list of scored recommendations into "available on your services",
+"available on other services", or "acquire" (not streaming anywhere),
+using TMDB watch-provider data.
+
+Extracted out of recommenders/external.py (PR2 architecture decomposition,
+step 3 - see CHANGELOG). Depends on recommenders/huntarr.py's
+get_watch_providers() - the TMDB watch-provider lookup helper Sequel
+Huntarr originally introduced (see that module's docstring for why it
+lives there rather than a separate shared "TMDB lookups" module).
+
+This is a pure relocation: categorize_by_streaming_service() below is
+byte-for-byte identical to its former recommenders/external.py definition
+(see that module's git history for the pre-move version) - only the
+import path changed. recommenders/external.py re-exports it (it's still
+called from several of that module's own functions, so it stays a normal
+top-level import there, not an __all__-only re-export) so existing
+callers/tests (many of which `@patch("recommenders.external.
+categorize_by_streaming_service")`) keep working unchanged.
+"""
+
+from typing import Any, Dict, List
+
+from recommenders.huntarr import get_watch_providers
+
+
+def categorize_by_streaming_service(
+    recommendations: List[Dict], tmdb_api_key: str, user_services: List[str], media_type: str = "movie"
+) -> Dict:
+    """
+    Categorize recommendations by streaming availability.
+    Each item gets streaming_services, rent_services, buy_services, and on_user_services added.
+
+    Returns dict: {
+        'user_services': {service_name: [items]},
+        'other_services': {service_name: [items]},
+        'acquire': [items],
+        'all_items': [all items sorted by score with streaming info]
+    }
+    """
+    result: Dict[str, Any] = {"user_services": {}, "other_services": {}, "acquire": [], "all_items": []}
+
+    for item in recommendations:
+        tmdb_id = item["tmdb_id"]
+        providers = get_watch_providers(tmdb_api_key, tmdb_id, media_type)
+
+        # Attach streaming info to item
+        streaming = providers.get("streaming", [])
+        item["streaming_services"] = streaming
+        item["rent_services"] = providers.get("rent", [])
+        item["buy_services"] = providers.get("buy", [])
+        item["on_user_services"] = [s for s in streaming if s in user_services]
+
+        # Add to all_items for flat display
+        result["all_items"].append(item)
+
+        if not streaming:
+            # Not available on any subscription streaming service
+            result["acquire"].append(item)
+        else:
+            # Check which services have it - add to FIRST matching service only
+            # Priority: user's services first, then other services
+            placed = False
+
+            # First try user's services
+            for service in streaming:
+                if service in user_services:
+                    if service not in result["user_services"]:
+                        result["user_services"][service] = []
+                    result["user_services"][service].append(item)
+                    placed = True
+                    break  # Only add to ONE service
+
+            # If not on user's services, add to first other service
+            if not placed:
+                for service in streaming:
+                    if service not in user_services:
+                        if service not in result["other_services"]:
+                            result["other_services"][service] = []
+                        result["other_services"][service].append(item)
+                        break  # Only add to ONE service
+
+    # Sort all_items by score (highest first)
+    result["all_items"].sort(key=lambda x: x.get("score", 0), reverse=True)
+
+    return result

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -181,7 +181,7 @@ class TestGetWatchProviders:
 class TestCategorizeByStreamingService:
     """Tests for categorize_by_streaming_service function"""
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_categorizes_by_user_services(self, mock_providers):
         mock_providers.return_value = {"streaming": ["netflix"], "rent": [], "buy": []}
 
@@ -202,7 +202,7 @@ class TestCategorizeByStreamingService:
         assert "netflix" in result["user_services"]
         assert len(result["user_services"]["netflix"]) == 1
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_categorizes_to_acquire(self, mock_providers):
         mock_providers.return_value = {"streaming": [], "rent": [], "buy": []}
 
@@ -221,7 +221,7 @@ class TestCategorizeByStreamingService:
 
         assert len(result["acquire"]) == 1
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_categorizes_other_services(self, mock_providers):
         mock_providers.return_value = {"streaming": ["disney_plus"], "rent": [], "buy": []}
 
@@ -2393,7 +2393,7 @@ class TestFindHorizonMovies:
 class TestCategorizeByStreamingServiceAllItems:
     """Tests for categorize_by_streaming_service with all_items structure"""
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_returns_all_items_list(self, mock_providers):
         """Test that categorized data includes all_items."""
         mock_providers.side_effect = [
@@ -2411,7 +2411,7 @@ class TestCategorizeByStreamingServiceAllItems:
         assert "all_items" in result
         assert len(result["all_items"]) == 2
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_all_items_sorted_by_score(self, mock_providers):
         """Test all_items are sorted by score descending."""
         mock_providers.return_value = {"streaming": [], "rent": [], "buy": []}
@@ -2426,7 +2426,7 @@ class TestCategorizeByStreamingServiceAllItems:
         scores = [item["score"] for item in result["all_items"]]
         assert scores == sorted(scores, reverse=True)
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_items_include_streaming_services_list(self, mock_providers):
         """Test each item has streaming_services list from API."""
         mock_providers.return_value = {"streaming": ["netflix", "hulu"], "rent": [], "buy": []}
@@ -2441,7 +2441,7 @@ class TestCategorizeByStreamingServiceAllItems:
         assert "netflix" in item["streaming_services"]
         assert "hulu" in item["streaming_services"]
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_items_include_on_user_services(self, mock_providers):
         """Test each item has on_user_services list."""
         mock_providers.return_value = {"streaming": ["netflix", "hulu"], "rent": [], "buy": []}
@@ -2457,7 +2457,7 @@ class TestCategorizeByStreamingServiceAllItems:
         assert "netflix" in item["on_user_services"]
         assert "hulu" not in item["on_user_services"]
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_acquire_items_have_no_streaming(self, mock_providers):
         """Test items with no providers go to acquire list."""
         mock_providers.return_value = {"streaming": [], "rent": [], "buy": []}
@@ -2470,7 +2470,7 @@ class TestCategorizeByStreamingServiceAllItems:
         assert len(result["acquire"]) == 1
         assert result["acquire"][0]["title"] == "Rare Movie"
 
-    @patch("recommenders.external.get_watch_providers")
+    @patch("recommenders.streaming.get_watch_providers")
     def test_user_service_items_categorized(self, mock_providers):
         """Test items on user's services go to user_services dict."""
         mock_providers.return_value = {"streaming": ["netflix"], "rent": [], "buy": []}

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.43"
+__version__ = "2.10.44"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- PR2 step 3 of the recommenders/external.py architecture decomposition.
- Pure relocation: categorize_by_streaming_service moved byte-for-byte to recommenders/streaming.py.
- streaming.py imports get_watch_providers from recommenders/huntarr.py.
- external.py still calls categorize_by_streaming_service directly from process_user/process_user_movie_library/process_user_tv_library, so it stays a normal top-level import there. get_watch_providers moved from 'used internally' to 're-export only' status in external.py now that its last internal caller moved out too.
- tests/test_external.py's TestCategorizeByStreamingService/TestCategorizeByStreamingServiceAllItems patches updated from recommenders.external.get_watch_providers to recommenders.streaming.get_watch_providers.

## Test plan
- [x] Golden-output harness: watchlist HTML/MD, Sequel/Horizon Huntarr results, and categorized-by-streaming-service output all byte-identical to pre-move golden fixtures
- [x] Full suite: 2512 passed, 1 skipped (same count as pre-move baseline)
- [x] ruff check / ruff format --check clean
- [x] PyInstaller build succeeds, --version reports 2.10.44
- [x] tests/harness.py untouched