### PR TITLE
test: end-to-end recommendation-pipeline test (2.10.45) (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.45] - 2026-07-26
+
+### Added
+
+- **End-to-end recommendation-pipeline test (`tests/test_e2e_pipeline.py`, `tests/e2e_plex_fixture.py`) - the first test in this suite to drive config -> Plex fetch -> watched-history build -> profile -> scoring -> selection -> output/labels top to bottom, for both movies and TV.**
+
+  - Drives the real production entrypoints - `utils.cli.run_recommender_main` (flagship movie/TV tests, with `recommenders/movie.py`'s/`tv.py`'s own `process_recommendations` as the real `process_func`) and `PlexMovieRecommender.get_recommendations()` directly (narrower isolation/determinism tests) - against a synthetic-but-realistic 30-movie/20-show Plex library and real, on-disk `config.yml`/`tuning.yml` files (via a real `CURATARR_CONFIG_DIR` override, the same mechanism Docker installs use).
+  - The only seams mocked: `recommenders.base.init_plex` (a duck-typed `FakePlexServer`), `utils.plex._capped_get`/`utils.plex.MyPlexAccount` (the raw-HTTP/plexapi-account layer behind the watch-history functions - real XML parsing/business logic runs against synthetic XML instead of a live server), and `PlexMovieRecommender`/`PlexTVRecommender.manage_plex_labels` (the collection/label-writing stage, replaced with a plain function that captures what it would have written without ever reaching `FakeSection`/`FakePlexServer` - both raise if the real label-writing code path is reached by mistake). The movie/show metadata cache is pre-seeded so `BaseCache.update_cache()` takes its real "cache is up to date" branch, mirroring `tests/harness.py`'s own established fixture convention rather than re-deriving metadata from a fake TMDB.
+  - Asserts on real observable outcomes: exact per-user watched-item sets and watched-genre profiles (proving per-user isolation at its source, not just call counts), already-watched exclusion, global and per-user genre exclusion, quality-filter thresholds applied against real per-item cache data, and reproducibility of both the deterministic (`randomize_recommendations: false`) and seeded-random tiered-selection paths.
+  - Confirmed while building this fixture: `recommenders/tv.py`'s `ShowCache._process_item()` never populates `rating`/`vote_count` on show cache entries (only `MovieCache` does, via TMDB), so `tv:` `quality_filters` is a no-op in production today, not just in this fixture - documented in the test's own module docstring rather than silently worked around.
+
 ## [2.10.44] - 2026-07-26
 
 ### Changed

--- a/tests/e2e_plex_fixture.py
+++ b/tests/e2e_plex_fixture.py
@@ -1,0 +1,605 @@
+"""
+Fully-synthetic Plex fixture for tests/test_e2e_pipeline.py.
+
+Builds a small-but-realistic movie/TV catalog, a synthetic per-user watch
+history, and a duck-typed plexapi object tree (FakePlexServer et al.) so the
+end-to-end pipeline test can drive the REAL recommendation pipeline
+(recommenders/movie.py, recommenders/tv.py, recommenders/base.py,
+utils/scoring.py, utils/plex.py's watch-history/account-id business logic)
+without ever opening a real socket to a Plex server.
+
+Design choices (see tests/test_e2e_pipeline.py's module docstring for the
+full rationale):
+
+  - The movie/show metadata cache (cache/all_movies_cache.json /
+    all_shows_cache.json) is pre-seeded with this module's catalog, with
+    `library_count` and item keys matching the FakePlexServer's catalog
+    exactly. That makes recommenders/base.py's BaseCache.update_cache()
+    take its real "cache is up to date" branch (current_count ==
+    cache['library_count'], current_ids == existing_ids) - a genuine
+    production code path - so no TMDB HTTP calls are needed to populate
+    genres/cast/directors/keywords/ratings. This mirrors tests/harness.py's
+    own established convention of feeding the scorer a cache-shaped
+    fixture rather than re-deriving it from Plex+TMDB on every test run.
+
+  - The only Plex surface actually exercised for real is the watch-history/
+    account-id HTTP layer in utils/plex.py (get_plex_account_ids,
+    get_watched_movie_count/get_watched_show_count,
+    fetch_plex_watch_history_movies/shows) - these are real, unmocked
+    business logic (XML parsing, per-account matching, recency timestamps)
+    running against synthetic-but-real-shaped XML served by
+    make_fake_capped_get() below, plus library.section(...).all() serving
+    this module's catalog as duck-typed Plex items.
+"""
+
+from typing import Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
+
+from utils.config import CACHE_VERSION
+
+# ---------------------------------------------------------------------------
+# Account identities - shared between the fake /accounts XML and the fake
+# MyPlexAccount.users() list, so utils/plex.py's two independent account-id
+# resolution paths (get_plex_account_ids's raw-XML lookup and
+# _resolve_myplex_account_ids's MyPlexAccount-object lookup) agree.
+# ---------------------------------------------------------------------------
+ACCOUNT_IDS = {"alice": "101", "bob": "102"}
+
+
+# ---------------------------------------------------------------------------
+# Movie catalog
+# ---------------------------------------------------------------------------
+def _m(rating_key, title, year, genres, director, cast, keywords, rating, vote_count) -> Dict:
+    return {
+        "rating_key": str(rating_key),
+        "title": title,
+        "year": year,
+        "genres": genres,
+        "directors": [director],
+        "cast": cast,
+        "summary": f"Synthetic fixture summary for {title}.",
+        "language": "English",
+        "tmdb_keywords": keywords,
+        "tmdb_id": rating_key,
+        "imdb_id": f"tt{rating_key}",
+        "rating": rating,
+        "vote_count": vote_count,
+        "collection_id": None,
+        "collection_name": None,
+        "ratings": {"audience_rating": rating} if rating else {},
+    }
+
+
+# Watched by alice (action/sci-fi leaning profile).
+MOVIE_CATALOG: List[Dict] = [
+    _m(
+        101,
+        "Skyfire Protocol",
+        2019,
+        ["action", "sci-fi"],
+        "Ridley Stone",
+        ["Jordan Vance", "Casey Rhodes", "Alex Monroe"],
+        ["heist", "space-station"],
+        8.2,
+        900,
+    ),
+    _m(
+        102,
+        "Iron Horizon",
+        2018,
+        ["action"],
+        "Ridley Stone",
+        ["Jordan Vance", "Sam Kestrel"],
+        ["revenge", "survival"],
+        7.9,
+        700,
+    ),
+    _m(
+        103,
+        "Quantum Drift",
+        2020,
+        ["sci-fi"],
+        "Marcus Webb",
+        ["Alex Monroe", "Robin Alvarez"],
+        ["time-travel", "space-station"],
+        8.5,
+        1200,
+    ),
+    _m(
+        104,
+        "Night Convoy",
+        2017,
+        ["action"],
+        "Nora Lin",
+        ["Casey Rhodes", "Taylor Nguyen"],
+        ["road-trip", "undercover"],
+        7.4,
+        500,
+    ),
+    _m(
+        105,
+        "Starless Engine",
+        2021,
+        ["sci-fi"],
+        "Marcus Webb",
+        ["Jordan Vance", "Robin Alvarez"],
+        ["survival", "space-station"],
+        8.0,
+        650,
+    ),
+    _m(
+        106,
+        "Redline Pursuit",
+        2016,
+        ["action"],
+        "Priya Anand",
+        ["Sam Kestrel", "Alex Monroe"],
+        ["heist", "undercover"],
+        7.6,
+        400,
+    ),
+    # Watched by bob (comedy/romance leaning profile).
+    _m(
+        107,
+        "The Wedding Detour",
+        2019,
+        ["comedy", "romance"],
+        "Nora Lin",
+        ["Robin Alvarez", "Taylor Nguyen"],
+        ["wedding", "road-trip"],
+        7.0,
+        300,
+    ),
+    _m(
+        108,
+        "Laugh Track",
+        2015,
+        ["comedy"],
+        "Priya Anand",
+        ["Casey Rhodes", "Sam Kestrel"],
+        ["coming-of-age"],
+        6.8,
+        250,
+    ),
+    _m(109, "Second Chances", 2018, ["romance"], "Nora Lin", ["Alex Monroe", "Taylor Nguyen"], ["wedding"], 7.2, 350),
+    _m(
+        110,
+        "Office Antics",
+        2020,
+        ["comedy"],
+        "Marcus Webb",
+        ["Jordan Vance", "Sam Kestrel"],
+        ["coming-of-age"],
+        6.5,
+        200,
+    ),
+    # Horror - excluded for everyone via general.exclude_genre.
+    _m(111, "Bloodmoon Manor", 2014, ["horror"], "Priya Anand", ["Robin Alvarez"], ["survival"], 6.9, 300),
+    _m(112, "The Hollow Woods", 2013, ["horror"], "Ridley Stone", ["Sam Kestrel"], ["survival"], 7.1, 400),
+    _m(113, "Static Screams", 2019, ["horror"], "Marcus Webb", ["Casey Rhodes"], ["undercover"], 6.4, 280),
+    _m(114, "Widow's Peak Asylum", 2012, ["horror"], "Nora Lin", ["Alex Monroe"], ["survival"], 7.3, 320),
+    # Below the movies.quality_filters threshold (min_rating 5.0 / min_vote_count 50).
+    _m(115, "Forgettable Flick One", 2011, ["drama"], "Priya Anand", ["Taylor Nguyen"], ["coming-of-age"], 3.5, 20),
+    _m(116, "Forgettable Flick Two", 2010, ["action"], "Ridley Stone", ["Jordan Vance"], ["heist"], 4.0, 15),
+    _m(117, "Obscure Indie Three", 2022, ["comedy"], "Marcus Webb", ["Sam Kestrel"], ["road-trip"], 8.0, 10),
+    _m(118, "Straight to Video Four", 2009, ["sci-fi"], "Nora Lin", ["Robin Alvarez"], ["space-station"], 2.9, 500),
+    # Romance - excluded only for bob (per-user users.preferences.bob.exclude_genres).
+    _m(119, "Autumn Letters", 2017, ["romance"], "Nora Lin", ["Taylor Nguyen", "Alex Monroe"], ["wedding"], 7.8, 600),
+    _m(
+        120,
+        "Two If By Sea",
+        2016,
+        ["romance"],
+        "Priya Anand",
+        ["Robin Alvarez", "Casey Rhodes"],
+        ["road-trip"],
+        7.5,
+        550,
+    ),
+    # Unwatched by both, above quality threshold - the real candidate pool.
+    _m(
+        121,
+        "Vertical Descent",
+        2021,
+        ["action", "sci-fi"],
+        "Ridley Stone",
+        ["Jordan Vance", "Alex Monroe"],
+        ["heist", "space-station"],
+        8.1,
+        800,
+    ),
+    _m(
+        122,
+        "The Last Convoy",
+        2020,
+        ["action"],
+        "Marcus Webb",
+        ["Casey Rhodes", "Sam Kestrel"],
+        ["road-trip", "revenge"],
+        7.7,
+        650,
+    ),
+    _m(
+        123,
+        "Orbital Decay",
+        2022,
+        ["sci-fi"],
+        "Nora Lin",
+        ["Robin Alvarez", "Jordan Vance"],
+        ["time-travel", "survival"],
+        8.3,
+        900,
+    ),
+    _m(
+        124,
+        "Comic Timing",
+        2019,
+        ["comedy"],
+        "Priya Anand",
+        ["Taylor Nguyen", "Sam Kestrel"],
+        ["coming-of-age"],
+        7.0,
+        400,
+    ),
+    _m(
+        125,
+        "The Understudy",
+        2018,
+        ["drama"],
+        "Marcus Webb",
+        ["Alex Monroe", "Casey Rhodes"],
+        ["coming-of-age"],
+        7.4,
+        380,
+    ),
+    _m(
+        126,
+        "Deep Cover Protocol",
+        2021,
+        ["action"],
+        "Ridley Stone",
+        ["Sam Kestrel", "Robin Alvarez"],
+        ["undercover", "heist"],
+        7.9,
+        700,
+    ),
+    _m(
+        127,
+        "Signal Loss",
+        2020,
+        ["sci-fi"],
+        "Nora Lin",
+        ["Jordan Vance", "Taylor Nguyen"],
+        ["space-station", "survival"],
+        8.0,
+        750,
+    ),
+    _m(128, "The Punchline", 2017, ["comedy"], "Priya Anand", ["Casey Rhodes", "Alex Monroe"], ["road-trip"], 6.9, 310),
+    _m(
+        129, "Backroad Requiem", 2016, ["drama"], "Marcus Webb", ["Robin Alvarez", "Sam Kestrel"], ["revenge"], 7.6, 420
+    ),
+    _m(
+        130,
+        "Chrome Getaway",
+        2023,
+        ["action"],
+        "Ridley Stone",
+        ["Taylor Nguyen", "Jordan Vance"],
+        ["heist", "road-trip"],
+        8.4,
+        950,
+    ),
+]
+
+MOVIE_WATCHED_BY = {
+    "alice": ["101", "102", "103", "104", "105", "106"],
+    "bob": ["107", "108", "109", "110"],
+}
+
+MOVIE_HORROR_IDS = {"111", "112", "113", "114"}
+MOVIE_QUALITY_EXCLUDED_IDS = {"115", "116", "117", "118"}
+MOVIE_ROMANCE_IDS = {"119", "120"}
+
+
+# ---------------------------------------------------------------------------
+# TV catalog
+# ---------------------------------------------------------------------------
+def _s(rating_key, title, year, genres, studio, cast, keywords) -> Dict:
+    return {
+        "rating_key": str(rating_key),
+        "title": title,
+        "year": year,
+        "genres": genres,
+        "studio": studio,
+        "cast": cast,
+        "summary": f"Synthetic fixture summary for {title}.",
+        "language": "English",
+        "tmdb_keywords": keywords,
+        "tmdb_id": rating_key,
+        "imdb_id": f"tt{rating_key}",
+        "production_company_ids": [],
+    }
+
+
+SHOW_CATALOG: List[Dict] = [
+    # Watched by alice (sci-fi/crime leaning profile).
+    _s(
+        201,
+        "Frontier Signal",
+        2019,
+        ["sci-fi"],
+        "Northgate Studios",
+        ["Mira Solano", "Derek Cho"],
+        ["first-contact", "exploration"],
+    ),
+    _s(
+        202,
+        "Cold Case Vienna",
+        2018,
+        ["crime"],
+        "Bluecrest Media",
+        ["Elena Frost", "Theo Baptiste"],
+        ["investigation", "noir"],
+    ),
+    _s(
+        203,
+        "Deep Range",
+        2020,
+        ["sci-fi"],
+        "Ferrous Pictures",
+        ["Nadia Okafor", "Lucas Wren"],
+        ["exploration", "survival"],
+    ),
+    _s(
+        204,
+        "The Ledger",
+        2017,
+        ["crime"],
+        "Northgate Studios",
+        ["Derek Cho", "Mira Solano"],
+        ["heist", "investigation"],
+    ),
+    # Watched by bob (comedy leaning profile).
+    _s(
+        205,
+        "Sitcom Heights",
+        2016,
+        ["comedy"],
+        "Lumen Works",
+        ["Theo Baptiste", "Elena Frost"],
+        ["roommates", "workplace"],
+    ),
+    _s(206, "Roommate Chaos", 2015, ["comedy"], "Bluecrest Media", ["Lucas Wren", "Nadia Okafor"], ["roommates"]),
+    _s(207, "The Office Pool", 2020, ["comedy"], "Lumen Works", ["Mira Solano", "Theo Baptiste"], ["workplace"]),
+    # Horror - excluded for everyone via general.exclude_genre.
+    _s(208, "Night Terrors Manor", 2014, ["horror"], "Ferrous Pictures", ["Derek Cho"], ["haunting"]),
+    _s(209, "The Beckoning", 2013, ["horror"], "Northgate Studios", ["Elena Frost"], ["haunting"]),
+    _s(210, "Static Hour", 2019, ["horror"], "Bluecrest Media", ["Nadia Okafor"], ["haunting"]),
+    # Unwatched by both - the real candidate pool.
+    _s(
+        211,
+        "Nova Drift",
+        2021,
+        ["sci-fi"],
+        "Ferrous Pictures",
+        ["Lucas Wren", "Mira Solano"],
+        ["exploration", "first-contact"],
+    ),
+    _s(212, "Precinct 44", 2020, ["crime"], "Northgate Studios", ["Theo Baptiste", "Derek Cho"], ["investigation"]),
+    _s(213, "Laugh Riot", 2022, ["comedy"], "Lumen Works", ["Elena Frost", "Nadia Okafor"], ["workplace"]),
+    _s(214, "Family Ties Reimagined", 2019, ["drama"], "Bluecrest Media", ["Mira Solano", "Lucas Wren"], ["family"]),
+    _s(215, "Enchanted Vale", 2021, ["fantasy"], "Ferrous Pictures", ["Derek Cho", "Elena Frost"], ["magic", "quest"]),
+    _s(
+        216,
+        "The Long Con",
+        2018,
+        ["crime"],
+        "Northgate Studios",
+        ["Nadia Okafor", "Theo Baptiste"],
+        ["heist", "investigation"],
+    ),
+    _s(
+        217,
+        "Orbit Station Zero",
+        2020,
+        ["sci-fi"],
+        "Lumen Works",
+        ["Mira Solano", "Derek Cho"],
+        ["exploration", "survival"],
+    ),
+    _s(218, "Sketch Night Live", 2017, ["comedy"], "Bluecrest Media", ["Lucas Wren", "Elena Frost"], ["workplace"]),
+    _s(219, "The Quiet Ward", 2016, ["drama"], "Ferrous Pictures", ["Theo Baptiste", "Nadia Okafor"], ["family"]),
+    _s(
+        220, "Dragon's Hollow", 2022, ["fantasy"], "Northgate Studios", ["Derek Cho", "Mira Solano"], ["magic", "quest"]
+    ),
+]
+
+SHOW_WATCHED_BY = {
+    "alice": ["201", "202", "203", "204"],
+    "bob": ["205", "206", "207"],
+}
+
+SHOW_HORROR_IDS = {"208", "209", "210"}
+
+
+# ---------------------------------------------------------------------------
+# Pre-seeded media caches - see module docstring for why this replaces the
+# TMDB-enrichment stage with a fixture, mirroring tests/harness.py.
+# ---------------------------------------------------------------------------
+def build_movies_cache_payload() -> Dict:
+    movies = {m["rating_key"]: {k: v for k, v in m.items() if k != "rating_key"} for m in MOVIE_CATALOG}
+    return {
+        "movies": movies,
+        "last_updated": "2026-01-01T00:00:00",
+        "library_count": len(MOVIE_CATALOG),
+        "cache_version": CACHE_VERSION,
+    }
+
+
+def build_shows_cache_payload() -> Dict:
+    shows = {s["rating_key"]: {k: v for k, v in s.items() if k != "rating_key"} for s in SHOW_CATALOG}
+    return {
+        "shows": shows,
+        "last_updated": "2026-01-01T00:00:00",
+        "library_count": len(SHOW_CATALOG),
+        "cache_version": CACHE_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed plexapi object tree
+# ---------------------------------------------------------------------------
+class FakeGuid:
+    def __init__(self, guid_id: str):
+        self.id = guid_id
+
+
+class FakeMediaItem:
+    """Minimal duck-typed stand-in for a plexapi Movie/Show object.
+
+    Only carries the attributes the real (unmocked) code paths this test
+    exercises actually touch: BaseCache.update_cache()'s item-identity
+    bookkeeping (ratingKey only, since the cache is pre-seeded and
+    up-to-date - see module docstring), _get_library_movies_set()/
+    _get_library_shows_set()/_get_library_imdb_ids() (ratingKey/title/year/
+    guids), and the optional viewCount/userRating watched-item bookkeeping
+    in recommenders/movie.py's/tv.py's own watched-data builders. Deliberately
+    has no .genres/.directors/.roles/.media - those only matter to
+    BaseCache._process_item(), which never runs here (see module docstring).
+    """
+
+    def __init__(self, rating_key: str, title: str, year: Optional[int], view_count: int = 0):
+        self.ratingKey = int(rating_key)
+        self.title = title
+        self.year = year
+        self.guids = [FakeGuid(f"imdb://tt{rating_key}")]
+        self.viewCount = view_count
+        self.userRating = None
+
+    def reload(self):
+        """No-op - real code only calls this on items about to be
+        label/collection-written, a stage this test never reaches for
+        real (see FakeSection.search/FakePlexServer.fetchItem below)."""
+
+
+class FakeSection:
+    def __init__(self, key: str, items: List[FakeMediaItem]):
+        self.key = key
+        self._items = items
+
+    def all(self) -> List[FakeMediaItem]:
+        return list(self._items)
+
+    def search(self, **kwargs):
+        raise AssertionError(
+            "FakeSection.search() was called - the label/collection-writing stage "
+            "must stay mocked in this test (patch PlexMovieRecommender/"
+            "PlexTVRecommender.manage_plex_labels instead of letting it reach here)."
+        )
+
+
+class FakeLibrary:
+    def __init__(self, sections: Dict[str, FakeSection]):
+        self._sections = sections
+
+    def section(self, name: str) -> FakeSection:
+        return self._sections[name]
+
+
+class FakePlexServer:
+    def __init__(self, sections: Dict[str, FakeSection]):
+        self.library = FakeLibrary(sections)
+
+    def fetchItem(self, rating_key):
+        raise AssertionError(
+            "FakePlexServer.fetchItem() was called - the label/collection-writing stage must stay mocked in this test."
+        )
+
+
+def build_fake_plex_server() -> FakePlexServer:
+    movies = [FakeMediaItem(m["rating_key"], m["title"], m["year"]) for m in MOVIE_CATALOG]
+    shows = [FakeMediaItem(s["rating_key"], s["title"], s["year"]) for s in SHOW_CATALOG]
+    sections = {
+        "Movies": FakeSection("1", movies),
+        "TV Shows": FakeSection("2", shows),
+    }
+    return FakePlexServer(sections)
+
+
+class FakeUser:
+    def __init__(self, title: str, user_id: int):
+        self.title = title
+        self.id = user_id
+
+
+class FakeMyPlexAccount:
+    """Stand-in for plexapi.myplex.MyPlexAccount - only the surface
+    utils/plex.py's get_configured_users()/_resolve_myplex_account_ids()/
+    fetch_plex_watch_history_movies() actually call (.username, .id,
+    .users())."""
+
+    def __init__(self, token: Optional[str] = None):
+        self.token = token
+        self.username = "owner"
+        self.id = 1
+
+    def users(self):
+        return [FakeUser(name, int(account_id)) for name, account_id in ACCOUNT_IDS.items()]
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP layer for utils.plex._capped_get - the raw XML watch-history/
+# account-id endpoints bypass plexapi objects entirely in production (see
+# utils/plex.py's get_plex_account_ids/get_watched_movie_count/
+# fetch_plex_watch_history_movies), so this is the single, narrow seam
+# patched to keep that real business logic (XML parsing, per-account
+# matching, timestamp tracking) running for real without a socket.
+# ---------------------------------------------------------------------------
+class FakeXMLResponse:
+    def __init__(self, xml_bytes: bytes):
+        self.content = xml_bytes
+        self.headers: Dict = {}
+
+    def raise_for_status(self):
+        return None
+
+
+def _accounts_xml() -> bytes:
+    accounts = "".join(f'<Account id="{account_id}" name="{name}"/>' for name, account_id in ACCOUNT_IDS.items())
+    return f"<MediaContainer>{accounts}</MediaContainer>".encode("utf-8")
+
+
+def _history_xml_for_account(account_id: str) -> bytes:
+    username = next((name for name, aid in ACCOUNT_IDS.items() if aid == str(account_id)), None)
+    videos = []
+    if username:
+        for i, rating_key in enumerate(MOVIE_WATCHED_BY.get(username, [])):
+            viewed_at = 1700000000 + i * 3600
+            videos.append(f'<Video type="movie" ratingKey="{rating_key}" viewedAt="{viewed_at}"/>')
+        for i, rating_key in enumerate(SHOW_WATCHED_BY.get(username, [])):
+            viewed_at = 1700000000 + i * 3600
+            videos.append(
+                f'<Video type="episode" grandparentKey="/library/metadata/{rating_key}" '
+                f'grandparentRatingKey="{rating_key}" viewedAt="{viewed_at}"/>'
+            )
+    return f"<MediaContainer>{''.join(videos)}</MediaContainer>".encode("utf-8")
+
+
+def make_fake_capped_get():
+    """Returns a drop-in replacement for utils.plex._capped_get that serves
+    synthetic-but-real-shaped Plex XML instead of making a network call."""
+
+    def _fake_capped_get(url, **kwargs):
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        params = kwargs.get("params") or {}
+        account_id = params.get("accountID") or query.get("accountID", [None])[0]
+
+        if parsed.path.endswith("/accounts"):
+            return FakeXMLResponse(_accounts_xml())
+        if parsed.path.endswith("/status/sessions/history/all"):
+            return FakeXMLResponse(_history_xml_for_account(str(account_id)))
+
+        raise AssertionError(f"Unexpected fake Plex HTTP call: {url} params={params or dict(query)}")
+
+    return _fake_capped_get

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1,0 +1,404 @@
+"""
+End-to-end recommendation-pipeline test: config -> Plex fetch -> watched-
+history build -> profile -> scoring -> selection -> output/labels.
+
+Unlike every other test in this suite (which mocks the Plex layer per-
+function or exercises a single slice), this drives the REAL production
+entrypoints - utils.cli.run_recommender_main (movie/TV flagship tests) and
+PlexMovieRecommender/PlexTVRecommender.get_recommendations() directly (the
+narrower isolation/stability tests) - against a synthetic-but-realistic
+Plex library (see tests/e2e_plex_fixture.py), with real config.yml/
+tuning.yml files on disk, real YAML loading/merging, real watched-history
+XML parsing, real profile-building, real utils.scoring similarity scoring,
+and real tiered/random selection.
+
+What's real (unmocked) in every test here:
+  - config.yml/tuning.yml loading and merging (utils/config.py's
+    load_config/resolve_media_type_overrides/get_libraries_for_media_type)
+    from real files on disk, via a real CURATARR_CONFIG_DIR override.
+  - The watch-history/account-id HTTP business logic in utils/plex.py
+    (get_plex_account_ids, get_watched_movie_count/get_watched_show_count,
+    fetch_plex_watch_history_movies/shows) - real XML parsing, real
+    per-account matching, real recency timestamps - running against
+    synthetic XML (see make_fake_capped_get()) instead of a live server.
+  - Profile building (recommenders/movie.py's/tv.py's
+    _get_plex_watched_data()/_get_plex_watched_shows_data(),
+    utils/counters.py's process_counters_from_cache).
+  - Similarity scoring (utils/scoring.py's calculate_similarity_score) and
+    tiered/random selection (utils/scoring.py's
+    select_tiered_recommendations), with genre exclusion (global +
+    per-user) and quality-filter thresholds applied by
+    BaseRecommender.get_recommendations() exactly as in production.
+  - The per-user loop, single-vs-multi-library resolution, and per-library
+    item-fetch sharing in utils.cli.run_recommender_main (for the two
+    "_end_to_end" flagship tests below).
+
+What's mocked, and why:
+  - recommenders.base.init_plex - replaced with a duck-typed FakePlexServer
+    (tests/e2e_plex_fixture.py) instead of a real plexapi.server.PlexServer
+    handshake. Its library.section(...).all() serves this test's synthetic
+    catalog for real to every real (unmocked) consumer.
+  - utils.plex._capped_get / utils.plex.MyPlexAccount - the raw-HTTP/
+    plexapi-account seam behind the watch-history functions above; replaced
+    with a fake responder serving synthetic-but-real-shaped Plex XML (see
+    module docstring in tests/e2e_plex_fixture.py for why this is the
+    narrowest defensible seam, not the pipeline logic itself).
+  - The movie/show metadata cache (cache/all_movies_cache.json /
+    all_shows_cache.json) is pre-seeded so BaseCache.update_cache() takes
+    its real "cache is up to date" branch - see tests/e2e_plex_fixture.py's
+    module docstring for why this deliberately does NOT exercise TMDB
+    enrichment (_process_item's new-item branch), mirroring tests/
+    harness.py's own established fixture convention.
+  - PlexMovieRecommender.manage_plex_labels / PlexTVRecommender.
+    manage_plex_labels - per this test's mandate, the collection/label-
+    writing stage must never reach real Plex. Replaced with a plain
+    function (not a MagicMock) so `self` is still bound normally, letting
+    each test assert on exactly what recommended_items/state WOULD have
+    been written, without executing a single line of the real label/
+    collection code (FakeSection.search()/FakePlexServer.fetchItem() would
+    raise if that code path were ever reached by mistake - see
+    tests/e2e_plex_fixture.py).
+  - utils.cli.migrate_renamed_plex_users - a distinct feature (Plex-
+    account-rename detection), not part of the recommendation pipeline
+    under test; tests/test_cli.py's own run_recommender_main tests already
+    patch this out for the same reason.
+
+What this test deliberately does NOT cover (see also each test's own
+docstring):
+  - TMDB metadata enrichment (BaseCache._process_item's new-item /
+    _get_tmdb_data path) - the cache is always pre-seeded "up to date" (see
+    above). A real Plex/TMDB integration test is a different, larger
+    undertaking than this pipeline-wiring test.
+  - The actual Plex collection/label write (manage_plex_labels' internals -
+    _find_plex_items_for_recs, _build_scored_candidates,
+    _update_labels_by_rank, update_plex_collection, content-rating
+    filtering via get_max_rating_for_user/is_rating_allowed). Mocked
+    wholesale per this test's mandate.
+  - TV quality_filters: confirmed while building this fixture that
+    recommenders/tv.py's ShowCache._process_item never populates
+    "rating"/"vote_count" on show cache entries (only MovieCache does, via
+    TMDB), so BaseRecommender.get_recommendations()'s quality-filter check
+    is a no-op for TV in production today, not just in this test. tv:
+    quality_filters is therefore left at 0.0/0 here (a nonzero threshold
+    would silently exclude every show) and this test asserts genre
+    exclusion for TV but does not claim TV quality-filter coverage.
+  - Negative-signal ratings/rewatch weighting and TV's dropped-show
+    detection (negative_signals.dropped_shows) - explicitly disabled in
+    this fixture's config to keep the fake watch-history HTTP layer to a
+    single endpoint shape; covered elsewhere by tests/test_movie.py,
+    tests/test_tv.py, tests/test_plex.py's own targeted unit tests.
+  - Trakt/Tautulli merge paths, huntarr, external recommendations - all
+    left at their disabled defaults; out of scope for this pipeline test.
+  - True cross-process determinism (PYTHONHASHSEED pinning via a fresh
+    interpreter, the way tests/harness.py's subprocess invocation does).
+    The seeded-RNG tests below reseed Python's global `random` module
+    in-process instead: the only two set()s on this pipeline's hot path
+    (watched_ids, excluded_genres) are used solely for O(1) membership
+    tests, never iterated in an order-sensitive way, so hash-seed-
+    dependent set ordering has no observable effect on this pipeline's
+    output - an in-process reseed is a faithful determinism proof here.
+"""
+
+import json
+import os
+import random
+import sys
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from recommenders.movie import PlexMovieRecommender, process_recommendations as movie_process_recommendations
+from recommenders.tv import PlexTVRecommender, process_recommendations as tv_process_recommendations
+from tests.e2e_plex_fixture import (
+    MOVIE_HORROR_IDS,
+    MOVIE_QUALITY_EXCLUDED_IDS,
+    MOVIE_ROMANCE_IDS,
+    MOVIE_WATCHED_BY,
+    SHOW_HORROR_IDS,
+    SHOW_WATCHED_BY,
+    FakeMyPlexAccount,
+    build_fake_plex_server,
+    build_movies_cache_payload,
+    build_shows_cache_payload,
+    make_fake_capped_get,
+)
+from utils.cli import run_recommender_main
+
+# Fixed, arbitrary seed - only meaningful as "always the same value" so
+# repeated runs in the seeded-RNG tests below are comparable (mirrors
+# tests/harness.py's own DEFAULT_SEED convention).
+E2E_SEED = 20260726
+
+
+def _write_project_root(tmp_path, *, movies_randomize: bool, tv_randomize: bool) -> str:
+    """Writes a real, on-disk config.yml + tuning.yml + pre-seeded caches
+    for a throwaway project root, and returns the config.yml path."""
+    root = tmp_path / "project"
+    (root / "config").mkdir(parents=True)
+    (root / "cache").mkdir()
+    (root / "logs").mkdir()
+
+    config_yaml = {
+        "plex": {"url": "http://127.0.0.1:32400", "token": "test-e2e-token"},
+        "tmdb": {"api_key": None},
+        "users": {
+            "list": "alice, bob",
+            "preferences": {"bob": {"exclude_genres": ["romance"]}},
+        },
+        "general": {
+            "update_mode": "off",
+            "exclude_genre": "horror",
+            "log_retention_days": 0,
+            "cache_prune": {"enabled": False},
+        },
+        # Explicit libraries: (rather than the legacy plex.movie_library/
+        # tv_library) so loading this config never trips utils/
+        # migrate_config.py's needs_migration() auto-migration rewrite.
+        "libraries": [
+            {"id": "movies", "name": "Movies", "section": "Movies", "media_type": "movie"},
+            {"id": "tv-shows", "name": "TV Shows", "section": "TV Shows", "media_type": "tv"},
+        ],
+    }
+    tuning_yaml = {
+        "movies": {
+            "limit_results": 5,
+            "randomize_recommendations": movies_randomize,
+            "show_summary": False,
+            "quality_filters": {"min_rating": 5.0, "min_vote_count": 50},
+            "weights": {"genre": 0.35, "director": 0.05, "actor": 0.15, "keyword": 0.45},
+        },
+        "tv": {
+            "limit_results": 3,
+            "randomize_recommendations": tv_randomize,
+            # Left at 0.0/0 deliberately - see module docstring: TV cache
+            # entries never carry rating/vote_count in production, so a
+            # nonzero threshold here would silently exclude every show.
+            "quality_filters": {"min_rating": 0.0, "min_vote_count": 0},
+            "weights": {"genre": 0.30, "studio": 0.10, "actor": 0.15, "keyword": 0.40, "language": 0.05},
+        },
+        "collections": {"add_label": True},
+        "negative_signals": {"enabled": True, "dropped_shows": {"enabled": False}},
+    }
+
+    (root / "config" / "config.yml").write_text(yaml.safe_dump(config_yaml, sort_keys=False), encoding="utf-8")
+    (root / "config" / "tuning.yml").write_text(yaml.safe_dump(tuning_yaml, sort_keys=False), encoding="utf-8")
+    (root / "cache" / "all_movies_cache.json").write_text(json.dumps(build_movies_cache_payload()), encoding="utf-8")
+    (root / "cache" / "all_shows_cache.json").write_text(json.dumps(build_shows_cache_payload()), encoding="utf-8")
+    return str(root / "config" / "config.yml")
+
+
+@pytest.fixture
+def e2e_project(tmp_path, monkeypatch):
+    """Factory fixture: wires every monkeypatch this E2E test needs (see
+    module docstring's "What's mocked" section) and returns a builder
+    function so each test can pick its own randomize_recommendations
+    setting. Returns the config.yml path."""
+
+    def _build(*, movies_randomize: bool = True, tv_randomize: bool = True) -> str:
+        config_path = _write_project_root(tmp_path, movies_randomize=movies_randomize, tv_randomize=tv_randomize)
+        project_root = os.path.dirname(os.path.dirname(config_path))
+        # The real utils.helpers.get_project_root() (used unpatched by
+        # utils.cli.run_recommender_main, and honored by the conftest.py
+        # autouse fixtures that patch recommenders.base/external's own
+        # bindings) takes this override at top priority - the same
+        # mechanism Docker installs use, not a test-only shortcut.
+        monkeypatch.setenv("CURATARR_CONFIG_DIR", project_root)
+
+        fake_plex = build_fake_plex_server()
+        monkeypatch.setattr("recommenders.base.init_plex", lambda config: fake_plex)
+        monkeypatch.setattr("utils.plex.MyPlexAccount", FakeMyPlexAccount)
+        monkeypatch.setattr("utils.plex._capped_get", make_fake_capped_get())
+        monkeypatch.setattr("utils.cli.migrate_renamed_plex_users", lambda *a, **kw: {})
+        return config_path
+
+    return _build
+
+
+class TestMoviePipelineEndToEnd:
+    """Flagship movie test: drives utils.cli.run_recommender_main exactly
+    as production's run.sh does (real argv, real per-user loop, real
+    library resolution) with recommenders.movie.process_recommendations as
+    the real process_func."""
+
+    def test_full_pipeline_via_run_recommender_main(self, e2e_project, monkeypatch):
+        config_path = e2e_project(movies_randomize=True, tv_randomize=True)
+        random.seed(E2E_SEED)
+
+        captured = {}
+
+        def _fake_manage_plex_labels(self, recommended_items):
+            # Plain function (not a MagicMock) so `self` binds normally -
+            # see module docstring's "What's mocked" section. Captures
+            # exactly what the real label/collection stage would have
+            # received, without letting it touch FakeSection/FakePlexServer.
+            captured[self.single_user] = {
+                "items": list(recommended_items),
+                "limit_plex_results": self.limit_plex_results,
+                "watched_ids": set(self.watched_ids),
+                "watched_genres": set(self.watched_data.get("genres", {})),
+            }
+            return True
+
+        monkeypatch.setattr(sys, "argv", ["movie.py"])
+        with patch.object(PlexMovieRecommender, "manage_plex_labels", new=_fake_manage_plex_labels):
+            run_recommender_main(
+                media_type="Movie",
+                description="Movie Recommendations for Plex (E2E test)",
+                process_func=movie_process_recommendations,
+                media_type_key="movie",
+            )
+
+        assert os.path.exists(config_path)
+        assert set(captured) == {"alice", "bob"}
+        alice, bob = captured["alice"], captured["bob"]
+
+        # Per-user isolation, verified at its source: each recommender's
+        # own watched_ids/profile reflect ONLY that user's Plex history -
+        # never the other user's.
+        assert alice["watched_ids"] == {int(x) for x in MOVIE_WATCHED_BY["alice"]}
+        assert bob["watched_ids"] == {int(x) for x in MOVIE_WATCHED_BY["bob"]}
+        assert "comedy" not in alice["watched_genres"] and "romance" not in alice["watched_genres"]
+        assert "action" not in bob["watched_genres"] and "sci-fi" not in bob["watched_genres"]
+
+        alice_ids = {str(i["plex_rating_key"]) for i in alice["items"]}
+        bob_ids = {str(i["plex_rating_key"]) for i in bob["items"]}
+
+        # Already-watched items excluded (and never leak from one user's
+        # history into the other user's recommendations).
+        assert alice_ids.isdisjoint(set(MOVIE_WATCHED_BY["alice"]))
+        assert bob_ids.isdisjoint(set(MOVIE_WATCHED_BY["bob"]))
+
+        # Global genre exclusion (general.exclude_genre: horror) honored
+        # for both users.
+        assert alice_ids.isdisjoint(MOVIE_HORROR_IDS)
+        assert bob_ids.isdisjoint(MOVIE_HORROR_IDS)
+
+        # Per-user genre exclusion (users.preferences.bob.exclude_genres)
+        # honored for bob only - alice has no such restriction.
+        assert bob_ids.isdisjoint(MOVIE_ROMANCE_IDS)
+
+        # Quality filter (movies.quality_filters) applied for real, on
+        # real per-item cache data - not just inferred from exclusion.
+        for item in list(alice["items"]) + list(bob["items"]):
+            assert item["rating"] >= 5.0
+            assert item["vote_count"] >= 50
+            assert "similarity_score" in item  # scoring stage actually ran
+            assert "horror" not in item.get("genres", [])
+
+        # Tiered/random selection path actually ran: candidate pool (16
+        # eligible movies per user - see tests/e2e_plex_fixture.py) exceeds
+        # limit_plex_results for both users.
+        assert 0 < len(alice["items"]) <= alice["limit_plex_results"]
+        assert 0 < len(bob["items"]) <= bob["limit_plex_results"]
+        assert alice["limit_plex_results"] < 16
+        assert bob["limit_plex_results"] < 16
+
+
+class TestTVPipelineEndToEnd:
+    """TV mirror of TestMoviePipelineEndToEnd - same real entrypoint, same
+    fixture project, the TV media type only."""
+
+    def test_full_pipeline_via_run_recommender_main(self, e2e_project, monkeypatch):
+        config_path = e2e_project(movies_randomize=True, tv_randomize=True)
+        random.seed(E2E_SEED)
+
+        captured = {}
+
+        def _fake_manage_plex_labels(self, recommended_items):
+            captured[self.single_user] = {
+                "items": list(recommended_items),
+                "limit_plex_results": self.limit_plex_results,
+                "watched_ids": set(self.watched_ids),
+                "watched_genres": set(self.watched_data.get("genres", {})),
+            }
+            return True
+
+        monkeypatch.setattr(sys, "argv", ["tv.py"])
+        with patch.object(PlexTVRecommender, "manage_plex_labels", new=_fake_manage_plex_labels):
+            run_recommender_main(
+                media_type="TV Show",
+                description="TV Show Recommendations for Plex (E2E test)",
+                process_func=tv_process_recommendations,
+                media_type_key="tv",
+            )
+
+        assert os.path.exists(config_path)
+        assert set(captured) == {"alice", "bob"}
+        alice, bob = captured["alice"], captured["bob"]
+
+        assert alice["watched_ids"] == {int(x) for x in SHOW_WATCHED_BY["alice"]}
+        assert bob["watched_ids"] == {int(x) for x in SHOW_WATCHED_BY["bob"]}
+        assert "comedy" not in alice["watched_genres"]
+        assert "sci-fi" not in bob["watched_genres"] and "crime" not in bob["watched_genres"]
+
+        alice_ids = {str(i["plex_rating_key"]) for i in alice["items"]}
+        bob_ids = {str(i["plex_rating_key"]) for i in bob["items"]}
+
+        assert alice_ids.isdisjoint(set(SHOW_WATCHED_BY["alice"]))
+        assert bob_ids.isdisjoint(set(SHOW_WATCHED_BY["bob"]))
+        assert alice_ids.isdisjoint(SHOW_HORROR_IDS)
+        assert bob_ids.isdisjoint(SHOW_HORROR_IDS)
+
+        for item in list(alice["items"]) + list(bob["items"]):
+            assert "similarity_score" in item
+            assert "horror" not in item.get("genres", [])
+
+        assert 0 < len(alice["items"]) <= alice["limit_plex_results"]
+        assert 0 < len(bob["items"]) <= bob["limit_plex_results"]
+
+
+class TestMoviePipelineDeterminism:
+    """Narrower tests built directly on PlexMovieRecommender.get_recommendations()
+    (the pipeline's core, without the CLI/label-writing layers) - isolation
+    at the profile level, and reproducibility of both the deterministic
+    (randomize_recommendations: false) and seeded-random (tiered) paths."""
+
+    def test_per_user_watched_profile_isolation(self, e2e_project):
+        config_path = e2e_project(movies_randomize=False, tv_randomize=False)
+
+        alice = PlexMovieRecommender(config_path, single_user="alice")
+        bob = PlexMovieRecommender(config_path, single_user="bob")
+
+        assert alice.watched_ids == {int(x) for x in MOVIE_WATCHED_BY["alice"]}
+        assert bob.watched_ids == {int(x) for x in MOVIE_WATCHED_BY["bob"]}
+
+        # alice only ever watched action/sci-fi movies - bob's comedy/
+        # romance genres must never appear in her profile, and vice versa.
+        alice_genres = set(alice.watched_data.get("genres", {}))
+        bob_genres = set(bob.watched_data.get("genres", {}))
+        assert alice_genres == {"action", "sci-fi"}
+        assert bob_genres == {"comedy", "romance"}
+
+    def test_randomize_false_produces_stable_output(self, e2e_project):
+        config_path = e2e_project(movies_randomize=False, tv_randomize=False)
+        recommender = PlexMovieRecommender(config_path, single_user="alice")
+
+        first = recommender.get_recommendations()["plex_recommendations"]
+        second = recommender.get_recommendations()["plex_recommendations"]
+
+        assert len(first) > 0
+        assert [i["plex_rating_key"] for i in first] == [i["plex_rating_key"] for i in second]
+        assert [i["similarity_score"] for i in first] == [i["similarity_score"] for i in second]
+
+    def test_tiered_random_selection_is_seed_reproducible(self, e2e_project):
+        config_path = e2e_project(movies_randomize=True, tv_randomize=True)
+        recommender = PlexMovieRecommender(config_path, single_user="bob")
+
+        random.seed(E2E_SEED)
+        first = recommender.get_recommendations()["plex_recommendations"]
+        random.seed(E2E_SEED)
+        second = recommender.get_recommendations()["plex_recommendations"]
+
+        assert len(first) > 0
+        assert [i["plex_rating_key"] for i in first] == [i["plex_rating_key"] for i in second]
+
+    def test_quality_filter_excludes_low_rated_and_low_vote_items(self, e2e_project):
+        config_path = e2e_project(movies_randomize=False, tv_randomize=False)
+        recommender = PlexMovieRecommender(config_path, single_user="alice")
+
+        recs = recommender.get_recommendations()["plex_recommendations"]
+        rec_ids = {str(i["plex_rating_key"]) for i in recs}
+
+        assert rec_ids.isdisjoint(MOVIE_QUALITY_EXCLUDED_IDS)
+        assert all(i["rating"] >= 5.0 and i["vote_count"] >= 50 for i in recs)

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.44"
+__version__ = "2.10.45"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- First test in the suite to drive the full recommendation pipeline (config -> Plex fetch -> watched-history build -> profile -> scoring -> selection -> output/labels) top to bottom, for both movies and TV.
- Drives the real entrypoints: utils.cli.run_recommender_main (flagship movie/TV tests) and PlexMovieRecommender/PlexTVRecommender.get_recommendations() (isolation/determinism tests) against a synthetic 30-movie/20-show Plex library.
- Only mocked: init_plex (FakePlexServer), utils.plex._capped_get/MyPlexAccount (watch-history HTTP layer - real XML parsing runs against synthetic XML), and manage_plex_labels (label/collection-writing stage, per the requirement it never reach real Plex).
- See tests/test_e2e_pipeline.py's module docstring for the full real-vs-mocked breakdown and explicit list of what this deliberately does not cover (TMDB enrichment, the label-write internals, Trakt/Tautulli/dropped-show paths, cross-process PYTHONHASHSEED pinning).

## Test plan
- [x] Full suite: 2518 passed, 1 skipped (baseline 2512/1 + 6 new tests)
- [x] tests/harness.py and tests/golden_external_harness.py untouched (git diff confirms no changes)
- [x] ruff check . - clean
- [x] ruff format --check . - clean
- [x] Coverage 96% (--cov-fail-under=85 gate unaffected)
- [x] No production code changed (test files + CHANGELOG + version bump only) - PyInstaller build unaffected