### PR TITLE
fix: Sonarr add_series kwarg and MDBList get_user_info crashes (2.10.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.47] - 2026-07-27
+
+### Fixed
+
+- **Two runtime crashes found during the 2.10.46 mypy pass (both were left as documented `# type: ignore[...]` there on purpose, since fixing them was a behavior change outside that typing-only PR's scope) are now actually fixed.**
+
+  - `export_to_sonarr()` called `SonarrClient.add_series()` with `search_for_missing_episodes=` - the real parameter is `search_for_missing`. Every send-to-Sonarr export raised `TypeError` the moment it ran (both the combined-mode and per-user/mapping-mode call sites). Fixed by renaming the kwarg to match the actual signature; behavior is otherwise unchanged (it's now what the per-library `search` setting always should have done - actually starting a search for missing episodes on add, instead of crashing before the add ever happened).
+  - `export_to_mdblist()` called `MDBListClient.get_user_info()`, which doesn't exist on that class at all (MDBList's client only ever implemented list management, never a user-info endpoint) - every MDBList export raised `AttributeError` (not caught by the surrounding `except MDBListAPIError`, so it propagated as an unhandled exception) the moment it ran. Fixed by calling `test_connection()` instead - the same "verify the API key works, then print the section header" pattern already used by `export_to_sonarr()`/`export_to_radarr()`/`export_to_simkl()`. The "Connected as: {name}" line is removed since no real user-info data was ever available to back it.
+  - **Root cause of why neither was caught by tests:** both call sites were exercised only against a bare `unittest.mock.MagicMock()`, which accepts any attribute name and any keyword argument silently - so a call-site kwarg typo or a call to a method that doesn't exist on the real class both passed clean. Every `SonarrClient`/`RadarrClient`/`MDBListClient` test double in `tests/test_external_sync.py` is now built via `unittest.mock.create_autospec(...)` instead, which enforces the real class's method set and call signatures - reverting either fix locally and re-running the suite now fails loudly (`TypeError`/`AttributeError`) instead of passing. Radarr's `add_movie()` call sites and every other Sonarr/Radarr/MDBList client call in `external_sync.py` were audited for the same class of kwarg mismatch; none found.
+
 ## [2.10.46] - 2026-07-27
 
 ### Changed

--- a/recommenders/external_sync.py
+++ b/recommenders/external_sync.py
@@ -538,7 +538,7 @@ def export_to_sonarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str
                         season_folder=season_folder,
                         series_type=series_type,
                         tag_ids=[tag_id],
-                        search_for_missing_episodes=search_for_series,  # type: ignore[call-arg]  # KNOWN PRE-EXISTING BUG (found during mypy remediation, not introduced/fixed here): SonarrClient.add_series's real param is `search_for_missing`, not `search_for_missing_episodes` - this call raises TypeError at runtime whenever it executes. Renaming it is a behavior change outside this typing-only PR's scope; tracked for a follow-up fix.
+                        search_for_missing=search_for_series,
                     )
                     added += 1
                     print(f"  {GREEN}Added: {series_data['title']}{RESET}")
@@ -599,7 +599,7 @@ def export_to_sonarr(config: Dict, all_users_data: List[Dict], tmdb_api_key: str
                         season_folder=season_folder,
                         series_type=series_type,
                         tag_ids=[tag_id],
-                        search_for_missing_episodes=search_for_series,  # type: ignore[call-arg]  # KNOWN PRE-EXISTING BUG (found during mypy remediation, not introduced/fixed here): SonarrClient.add_series's real param is `search_for_missing`, not `search_for_missing_episodes` - this call raises TypeError at runtime whenever it executes. Renaming it is a behavior change outside this typing-only PR's scope; tracked for a follow-up fix.
+                        search_for_missing=search_for_series,
                     )
                     added += 1
                     print(f"    {GREEN}Added: {series_data['title']}{RESET}")
@@ -871,9 +871,8 @@ def export_to_mdblist(config: Dict, all_users_data: List[Dict], tmdb_api_key: st
 
     # Test connection
     try:
-        user_info = mdblist_client.get_user_info()  # type: ignore[attr-defined]  # KNOWN PRE-EXISTING BUG (found during mypy remediation, not introduced/fixed here): MDBListClient has no get_user_info method at all - this raises AttributeError (not caught by the except MDBListAPIError below) whenever this code path executes. Fixing it is a behavior change outside this typing-only PR's scope; tracked for a follow-up fix.
+        mdblist_client.test_connection()
         print(f"\n{CYAN}=== Exporting to MDBList ==={RESET}")
-        print(f"  Connected as: {user_info.get('name', 'Unknown')}")
     except MDBListAPIError as e:
         log_error(f"Could not connect to MDBList: {e}")
         return

--- a/tests/test_external_sync.py
+++ b/tests/test_external_sync.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 import tempfile
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import requests
 
@@ -30,6 +30,7 @@ from recommenders.external_sync import (
     get_imdb_id,
     sync_watch_history_to_trakt,
 )
+from utils import MDBListClient, RadarrClient, SonarrClient  # noqa: E402
 
 
 class TestFlattenCategorized:
@@ -281,9 +282,11 @@ class TestExportToRadarr:
 
 
 def _mock_radarr_client():
-    """MagicMock RadarrClient that echoes routing args back so tests can
-    assert exactly what each per-library group resolved."""
-    client = MagicMock()
+    """autospec'd RadarrClient that echoes routing args back so tests can
+    assert exactly what each per-library group resolved. autospec (not a bare
+    MagicMock) enforces the real add_movie signature, so a call-site kwarg
+    typo raises TypeError here instead of silently passing."""
+    client = create_autospec(RadarrClient, instance=True)
     client.test_connection.return_value = None
     client.get_movies.return_value = []
     client.get_quality_profile_id.side_effect = lambda name: f"qp-{name}"
@@ -550,9 +553,11 @@ class TestExportToSonarr:
 
 
 def _mock_sonarr_client():
-    """MagicMock SonarrClient that echoes routing args back so tests can
-    assert exactly what each per-library group resolved."""
-    client = MagicMock()
+    """autospec'd SonarrClient that echoes routing args back so tests can
+    assert exactly what each per-library group resolved. autospec (not a bare
+    MagicMock) enforces the real add_series signature, so a call-site kwarg
+    typo raises TypeError here instead of silently passing."""
+    client = create_autospec(SonarrClient, instance=True)
     client.test_connection.return_value = None
     client.get_series.return_value = []
     client.get_quality_profile_id.side_effect = lambda name: f"qp-{name}"
@@ -615,7 +620,7 @@ class TestExportToSonarrPerLibraryRouting:
         assert kwargs["quality_profile_id"] == "qp-HD-1080p"
         assert kwargs["tag_ids"] == ["tag-Curatarr"]
         assert kwargs["monitored"] is True
-        assert kwargs["search_for_missing_episodes"] is True
+        assert kwargs["search_for_missing"] is True
         assert kwargs["season_folder"] is True
         assert kwargs["series_type"] == "standard"
 
@@ -1752,9 +1757,12 @@ class TestExportToSonarrNonCombinedMode:
 
 
 def _mock_mdblist_client():
-    """MagicMock MDBListClient for export_to_mdblist tests."""
-    client = MagicMock()
-    client.get_user_info.return_value = {"name": "jason"}
+    """autospec'd MDBListClient for export_to_mdblist tests. autospec
+    (not a bare MagicMock) enforces the real client's method set/signatures,
+    so a call to a nonexistent method like get_user_info raises AttributeError
+    here instead of silently passing."""
+    client = create_autospec(MDBListClient, instance=True)
+    client.test_connection.return_value = True
     client.get_or_create_list.side_effect = lambda name: {"id": abs(hash(name)) % 1000, "name": name}
     client.clear_list.return_value = True
     client.add_items.return_value = {"added": 2}
@@ -1768,7 +1776,7 @@ class TestExportToMdblistLogic:
     @patch("recommenders.external_sync.create_mdblist_client")
     def test_connection_error_logs_and_returns(self, mock_create):
         client = _mock_mdblist_client()
-        client.get_user_info.side_effect = MDBListAPIError("bad token")
+        client.test_connection.side_effect = MDBListAPIError("bad token")
         mock_create.return_value = client
         config = {"mdblist": {"enabled": True, "auto_sync": True}}
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.46"
+__version__ = "2.10.47"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus


### PR DESCRIPTION
## Summary
- `export_to_sonarr()` called `SonarrClient.add_series()` with a stale kwarg (`search_for_missing_episodes` -> real param `search_for_missing`), crashing every send-to-Sonarr export with `TypeError`.
- `export_to_mdblist()` called `MDBListClient.get_user_info()`, which doesn't exist, crashing every MDBList export with `AttributeError`.
- Neither was caught because the test doubles for these clients were bare `MagicMock()`s (any attribute/kwarg passes silently). Switched to `create_autospec(...)` so a real signature/attribute mismatch fails the suite.
- Audited every other Sonarr/Radarr/MDBList client call in `external_sync.py` for the same class of kwarg mismatch - none found.

## Test plan
- [x] `pytest tests/test_external_sync.py -q` - 117 passed
- [x] Full suite: 2518 passed, 1 skipped (matches baseline)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .` clean
- [x] Reverting the source fix locally with the new autospec mocks in place makes the affected tests fail loudly (TypeError/AttributeError) - confirmed test gap is closed
