### PR TITLE
fix: tv: quality_filters was a production no-op (2.10.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.48] - 2026-07-27
+
+### Fixed
+
+- **`tv:` `quality_filters` (`min_rating`/`min_vote_count`) has never actually filtered anything - YOUR TV RECOMMENDATIONS WILL LOOK DIFFERENT after upgrading if you have a nonzero threshold set.**
+
+  `recommenders/tv.py`'s `ShowCache` never populated `rating`/`vote_count` on cached show entries - only `MovieCache` did. `BaseRecommender.get_recommendations()`'s quality-filter check (the same code shared by both movies and TV) reads those two fields from each cached item and defaults to `0`/`0` when they're absent, so every TV show was invisible to the filter no matter what threshold you configured under `tv: quality_filters:` in `tuning.yml` - identical in spirit to the 2.10.23 `movies:`/`tv:` config-wiring bug, but this one was in the cache-population path, not config resolution. Movies were never affected.
+
+  Fixed by having `ShowCache._process_item()` fetch and store `rating`/`vote_count` from TMDB the same way `MovieCache._process_item()` always has (`recommenders/base.py`'s shared `_get_tmdb_data()` now fetches them for TV too, alongside the `production_company_ids` it already fetched). Concretely, this means:
+  - If you have `tv: quality_filters: min_rating`/`min_vote_count` set above `0` in `tuning.yml`, low-rated/low-vote-count shows that were slipping through before will now actually be filtered out of your TV recommendations.
+  - If you've left it at the documented default (`0.0`/`0`), nothing changes - this was already a no-op for you and stays one.
+
+  **Existing show caches:** `CACHE_VERSION` is bumped (4 -> 5) so every existing `all_shows_cache.json` (and, since this constant isn't tracked per-media-type, `all_movies_cache.json` too) is deleted and fully rebuilt from TMDB on the next run after upgrading - a one-time slower run, no partial/half-migrated state. This is deliberate: without the bump, existing show cache entries would be missing `rating`/`vote_count` entirely, and the quality-filter code's `0`/`0` default would make every one of those shows look like it scored zero and get wrongly dropped the instant you set a real threshold, with no warning. The rebuild guarantees nobody hits that window. A show TMDB genuinely can't match still has no rating data after the rebuild and is filtered the same way an unmatched movie always has been (unchanged, symmetric behavior) - it isn't a new failure mode, just parity.
+
 ## [2.10.47] - 2026-07-27
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -359,7 +359,9 @@ class BaseCache(ABC):
             # Get keywords
             result["keywords"] = get_tmdb_keywords(tmdb_api_key, result["tmdb_id"], self.media_type)
 
-            # Get rating/vote_count/collection (movies only)
+            # Get rating/vote_count for both media types (used by
+            # quality_filters); collection info is movie-only (sequel
+            # bonus), production companies are TV-only (franchise bonus).
             if self.media_type == "movie":
                 detail_data = fetch_tmdb_with_retry(
                     f"https://api.themoviedb.org/3/movie/{result['tmdb_id']}", {"api_key": tmdb_api_key}
@@ -373,12 +375,13 @@ class BaseCache(ABC):
                         result["collection_id"] = collection.get("id")
                         result["collection_name"] = collection.get("name")
 
-            # Get production companies for TV (for franchise/spinoff bonus)
             elif self.media_type == "tv":
                 detail_data = fetch_tmdb_with_retry(
                     f"https://api.themoviedb.org/3/tv/{result['tmdb_id']}", {"api_key": tmdb_api_key}
                 )
                 if detail_data:
+                    result["rating"] = detail_data.get("vote_average")
+                    result["vote_count"] = detail_data.get("vote_count")
                     production_companies = detail_data.get("production_companies", [])
                     result["production_company_ids"] = [pc["id"] for pc in production_companies]
 

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -74,7 +74,7 @@ class ShowCache(BaseCache):
         tmdb_data = (
             self._get_tmdb_data(show, tmdb_api_key)
             if tmdb_api_key
-            else {"tmdb_id": None, "imdb_id": None, "keywords": []}
+            else {"tmdb_id": None, "imdb_id": None, "keywords": [], "rating": None, "vote_count": None}
         )
 
         return {
@@ -88,6 +88,12 @@ class ShowCache(BaseCache):
             "tmdb_keywords": tmdb_data["keywords"],
             "tmdb_id": tmdb_data["tmdb_id"],
             "imdb_id": tmdb_data["imdb_id"],
+            # rating/vote_count feed tv: quality_filters (min_rating/
+            # min_vote_count) in BaseRecommender.get_recommendations() -
+            # previously omitted here, so those thresholds were a no-op
+            # for TV (see CHANGELOG). Mirrors MovieCache._process_item.
+            "rating": tmdb_data.get("rating"),
+            "vote_count": tmdb_data.get("vote_count"),
             "production_company_ids": tmdb_data.get("production_company_ids", []),
         }
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -415,6 +415,74 @@ class TestBaseCacheGetTmdbData:
 
         assert mock_recommender.plex_tmdb_cache["456"] == 123
 
+    @patch("recommenders.base.fetch_tmdb_with_retry")
+    @patch("recommenders.base.get_tmdb_keywords")
+    @patch("recommenders.base.extract_ids_from_guids")
+    @patch("recommenders.base.load_media_cache")
+    def test_get_tmdb_data_fetches_tv_rating(self, mock_load, mock_extract, mock_keywords, mock_fetch):
+        """Test that TV show rating/vote_count is fetched from TMDB too,
+        mirroring test_get_tmdb_data_fetches_movie_rating above. Regression
+        test for the tv: quality_filters no-op bug - ShowCache never
+        carried these fields before (see CHANGELOG); this proves the
+        underlying _get_tmdb_data fetch itself populates them for
+        media_type="tv", alongside the pre-existing production_company_ids
+        fetch (which must keep working unchanged)."""
+        mock_load.return_value = {"shows": {}, "library_count": 0}
+        mock_extract.return_value = {"imdb_id": None, "tmdb_id": 123}
+        mock_keywords.return_value = []
+        mock_fetch.return_value = {
+            "vote_average": 8.4,
+            "vote_count": 2000,
+            "production_companies": [{"id": 42, "name": "Test Studio"}],
+        }
+
+        class TVCache(BaseCache):
+            media_type = "tv"
+            media_key = "shows"
+            cache_filename = "test_shows.json"
+
+            def _process_item(self, item, tmdb_api_key):
+                return {}
+
+        cache = TVCache("/tmp/cache")
+        mock_item = Mock()
+
+        result = cache._get_tmdb_data(mock_item, "api_key")
+
+        assert result["rating"] == 8.4
+        assert result["vote_count"] == 2000
+        assert result["production_company_ids"] == [42]
+
+    @patch("recommenders.base.fetch_tmdb_with_retry")
+    @patch("recommenders.base.get_tmdb_keywords")
+    @patch("recommenders.base.extract_ids_from_guids")
+    @patch("recommenders.base.load_media_cache")
+    def test_get_tmdb_data_movie_rating_unaffected_by_tv_change(
+        self, mock_load, mock_extract, mock_keywords, mock_fetch
+    ):
+        """Movie path regression check: a movie's _get_tmdb_data result
+        must still carry rating/vote_count/collection info and never
+        production_company_ids, unchanged by the TV branch fix above."""
+        mock_load.return_value = {"movies": {}, "library_count": 0}
+        mock_extract.return_value = {"imdb_id": None, "tmdb_id": 123}
+        mock_keywords.return_value = []
+        mock_fetch.return_value = {
+            "vote_average": 7.1,
+            "vote_count": 300,
+            "belongs_to_collection": {"id": 9, "name": "Test Collection"},
+        }
+
+        cache = ConcreteCache("/tmp/cache")
+        mock_item = Mock()
+
+        result = cache._get_tmdb_data(mock_item, "api_key")
+
+        assert result["rating"] == 7.1
+        assert result["vote_count"] == 300
+        assert result["collection_id"] == 9
+        assert result["collection_name"] == "Test Collection"
+        assert result["production_company_ids"] == []
+
 
 class ConcreteRecommender(BaseRecommender):
     """Concrete implementation of BaseRecommender for testing."""
@@ -2292,6 +2360,81 @@ class TestGetRecommendationsBranches:
 
         titles = [i["title"] for i in result["plex_recommendations"]]
         assert "Bad" not in titles
+
+    @patch("recommenders.base.get_excluded_genres_for_user", return_value=[])
+    def test_quality_filter_excludes_low_rated_tv_shows(self, mock_excl):
+        """TV parity for test_quality_filter_excludes_low_rated above.
+        Regression test for the tv: quality_filters no-op bug: once
+        ShowCache._process_item actually populates rating/vote_count (see
+        CHANGELOG), this shared filter must apply to "shows"-keyed cache
+        entries exactly the way it already does for "movies"-keyed ones -
+        proving the fix isn't just that the fields exist, but that they
+        actually drive real filtering for TV end to end."""
+        recommender = _make_recommender(
+            config={
+                "plex": {"url": "http://localhost", "token": "abc", "tv_library": "TV Shows"},
+                "general": {},
+                "weights": {"genre": 0.5, "actor": 0.5},
+            },
+            recommender_cls=ConcreteTVRecommender,
+        )
+        media_cache = Mock()
+        media_cache.cache = {
+            "shows": {
+                "1": {"title": "Good Show", "rating": 8.0, "vote_count": 500, "genres": []},
+                "2": {"title": "Bad Show", "rating": 2.0, "vote_count": 5, "genres": []},
+            }
+        }
+        media_cache._save_cache = Mock()
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = set()
+        recommender.profile_hash = "hash1"
+        recommender.exclude_genres = []
+        recommender.user_preferences = {}
+        recommender.randomize_recommendations = False
+        recommender.media_config = {"quality_filters": {"min_rating": 5.0, "min_vote_count": 100}}
+
+        result = recommender.get_recommendations()
+
+        titles = [i["title"] for i in result["plex_recommendations"]]
+        assert "Bad Show" not in titles
+        assert "Good Show" in titles
+
+    @patch("recommenders.base.get_excluded_genres_for_user", return_value=[])
+    def test_quality_filter_tv_show_missing_rating_treated_as_zero_not_crashed(self, mock_excl):
+        """A show cache entry with no rating/vote_count data at all (the
+        exact shape every existing on-disk show cache has today, before
+        this fix's CACHE_VERSION bump forces a rebuild) must not crash the
+        filter, and is treated the same way a movie with no rating data
+        already is: as below any positive threshold, not specially
+        exempted. In production this is a non-issue for pre-fix caches
+        specifically because bumping CACHE_VERSION deletes and fully
+        rebuilds them on the next run (see utils/config.py CACHE_VERSION
+        comment / CHANGELOG) - this test documents the fallback behavior
+        for the narrower, ongoing case of a genuine per-item TMDB lookup
+        miss, which is symmetric with movies and unchanged by this fix."""
+        recommender = _make_recommender(
+            config={
+                "plex": {"url": "http://localhost", "token": "abc", "tv_library": "TV Shows"},
+                "general": {},
+                "weights": {"genre": 0.5, "actor": 0.5},
+            },
+            recommender_cls=ConcreteTVRecommender,
+        )
+        media_cache = Mock()
+        media_cache.cache = {"shows": {"1": {"title": "No TMDB Match", "genres": []}}}
+        media_cache._save_cache = Mock()
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender.watched_ids = set()
+        recommender.profile_hash = "hash1"
+        recommender.exclude_genres = []
+        recommender.user_preferences = {}
+        recommender.randomize_recommendations = False
+        recommender.media_config = {"quality_filters": {"min_rating": 5.0, "min_vote_count": 100}}
+
+        result = recommender.get_recommendations()  # must not raise
+
+        assert result["plex_recommendations"] == []
 
     @patch("recommenders.base.get_excluded_genres_for_user", return_value=[])
     def test_uses_cached_score_when_profile_hash_matches(self, mock_excl):

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -74,14 +74,16 @@ docstring):
     _update_labels_by_rank, update_plex_collection, content-rating
     filtering via get_max_rating_for_user/is_rating_allowed). Mocked
     wholesale per this test's mandate.
-  - TV quality_filters: confirmed while building this fixture that
-    recommenders/tv.py's ShowCache._process_item never populates
-    "rating"/"vote_count" on show cache entries (only MovieCache does, via
-    TMDB), so BaseRecommender.get_recommendations()'s quality-filter check
-    is a no-op for TV in production today, not just in this test. tv:
-    quality_filters is therefore left at 0.0/0 here (a nonzero threshold
-    would silently exclude every show) and this test asserts genre
-    exclusion for TV but does not claim TV quality-filter coverage.
+  - TV quality_filters: recommenders/tv.py's ShowCache._process_item was
+    fixed to populate "rating"/"vote_count" on show cache entries the same
+    way MovieCache always has (see CHANGELOG) - TV quality_filters is no
+    longer a production no-op. This fixture's SHOW_CATALOG still doesn't
+    carry rating/vote_count values, so tv: quality_filters stays at 0.0/0
+    here (a nonzero threshold would exclude every show in *this* catalog,
+    same as it would for any pre-fix on-disk show cache) and this test
+    asserts genre exclusion for TV but does not claim TV quality-filter
+    coverage - that's covered directly by tests/test_base.py and
+    tests/test_tv.py instead.
   - Negative-signal ratings/rewatch weighting and TV's dropped-show
     detection (negative_signals.dropped_shows) - explicitly disabled in
     this fixture's config to keep the fake watch-history HTTP layer to a
@@ -171,9 +173,9 @@ def _write_project_root(tmp_path, *, movies_randomize: bool, tv_randomize: bool)
         "tv": {
             "limit_results": 3,
             "randomize_recommendations": tv_randomize,
-            # Left at 0.0/0 deliberately - see module docstring: TV cache
-            # entries never carry rating/vote_count in production, so a
-            # nonzero threshold here would silently exclude every show.
+            # Left at 0.0/0 deliberately - see module docstring: this
+            # fixture's SHOW_CATALOG doesn't carry rating/vote_count
+            # values, so a nonzero threshold here would exclude every show.
             "quality_filters": {"min_rating": 0.0, "min_vote_count": 0},
             "weights": {"genre": 0.30, "studio": 0.10, "actor": 0.15, "keyword": 0.40, "language": 0.05},
         },

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -171,6 +171,72 @@ class TestShowCache:
         assert result["year"] is None
         assert result["genres"] == []
 
+    @patch("recommenders.base.load_media_cache")
+    def test_process_item_includes_rating_and_vote_count(self, mock_load):
+        """Regression test for the tv: quality_filters no-op bug: with a
+        tmdb_api_key, _process_item must carry rating/vote_count through
+        from _get_tmdb_data into the cached show entry (mirrors
+        MovieCache._process_item - see CHANGELOG), so
+        BaseRecommender.get_recommendations()'s quality-filter check
+        actually has data to filter on for TV."""
+        mock_load.return_value = {"shows": {}, "library_count": 0}
+
+        cache = ShowCache("/tmp/cache")
+        cache._get_tmdb_data = Mock(
+            return_value={
+                "tmdb_id": 123,
+                "imdb_id": "tt123",
+                "keywords": [],
+                "rating": 8.4,
+                "vote_count": 2000,
+                "production_company_ids": [],
+            }
+        )
+
+        mock_show = Mock()
+        mock_show.title = "Test Show"
+        mock_show.year = 2020
+        mock_show.genres = []
+        mock_show.studio = "HBO"
+        mock_show.roles = []
+        mock_show.summary = "A test show"
+        mock_show.guids = []
+
+        result = cache._process_item(mock_show, "api_key")
+
+        assert result["rating"] == 8.4
+        assert result["vote_count"] == 2000
+
+    @patch("recommenders.base.load_media_cache")
+    def test_process_item_rating_and_vote_count_none_without_tmdb_key(self, mock_load):
+        """Without a tmdb_api_key, _get_tmdb_data is never called (see the
+        `if tmdb_api_key else {...}` fallback dict) - rating/vote_count
+        must come back None rather than the key being absent entirely, so
+        downstream .get("rating") calls behave identically (None, not a
+        KeyError) whether or not TMDB was reachable for this item. A show
+        with no rating data (this case, or a genuine TMDB lookup miss on a
+        real run) is filtered the same way a movie with no rating data
+        already is - not silently exempted, not crashed on, just treated
+        as below any positive threshold like it always has been for
+        movies (parity, not a new special case)."""
+        mock_load.return_value = {"shows": {}, "library_count": 0}
+
+        cache = ShowCache("/tmp/cache")
+
+        mock_show = Mock()
+        mock_show.title = "Test Show"
+        mock_show.year = 2020
+        mock_show.genres = []
+        mock_show.studio = "HBO"
+        mock_show.roles = []
+        mock_show.summary = "A test show"
+        mock_show.guids = []
+
+        result = cache._process_item(mock_show, None)
+
+        assert result["rating"] is None
+        assert result["vote_count"] is None
+
 
 class TestPlexTVRecommenderInit:
     """Tests for PlexTVRecommender initialization."""

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,10 +11,17 @@ from typing import Dict, List, Optional
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.47"
+__version__ = "2.10.48"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
-CACHE_VERSION = 4  # v4: Added production_company_ids for TV franchise bonus
+CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so
+# tv: quality_filters (min_rating/min_vote_count) actually apply - they were
+# previously silently a no-op for TV (see CHANGELOG). Bumping this forces a
+# one-time full rebuild of BOTH the movie and show caches on next run (this
+# constant isn't tracked per-media-type) - existing cache files are deleted
+# and every item is re-fetched from TMDB from scratch, so no show is ever
+# left with a half-populated/missing rating that would be misread as 0 and
+# wrongly filtered out.
 
 # Common constants used across recommenders
 TOP_CAST_COUNT = 3  # Number of top actors to consider


### PR DESCRIPTION
## Summary
- `recommenders/tv.py`'s `ShowCache._process_item()` never populated `rating`/`vote_count` on cached show entries - only `MovieCache` did. `BaseRecommender.get_recommendations()`'s shared quality-filter check reads those fields and defaults to `0`/`0` when absent, so `tv: quality_filters` (`min_rating`/`min_vote_count`) has been a silent production no-op for TV. Movies were never affected.
- Fixed by having `ShowCache` fetch and store `rating`/`vote_count` from TMDB the same way `MovieCache` always has (`recommenders/base.py`'s shared `_get_tmdb_data()` now fetches them for TV too).
- **Production behavior change:** anyone with a nonzero `tv: quality_filters` threshold set will see different TV recommendations after upgrading (low-rated/low-vote shows now actually get filtered). Anyone left at the documented `0.0`/`0` default sees no change. Called out in the CHANGELOG in the same style as the 2.10.23 config-fix entry.
- **Cache migration:** `CACHE_VERSION` bumped 4 -> 5, so both the existing show *and* movie caches are deleted and fully rebuilt from TMDB on the next run after upgrading (one-time slower run, no partial state). This is deliberate - without it, existing show cache entries would be missing `rating`/`vote_count` entirely, and the filter's `0`/`0` default would make every one of those shows look like it scored zero and get wrongly dropped the instant a real threshold is set, with no warning.
- Added tests: TV rating/vote_count actually fetched from TMDB and flow into `ShowCache._process_item()`'s output; the shared quality filter applies real thresholds to `shows`-keyed cache entries (parity with the existing movies-keyed test); a show missing rating data entirely doesn't crash the filter and degrades the same way an unmatched movie always has; movie path (`_get_tmdb_data`'s rating/vote_count/collection fetch) proven unchanged by this refactor.

## Test plan
- [x] Full suite: 2524 passed, 1 skipped (baseline 2518 + 6 new tests)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .` clean
- [x] `tests/harness.py` / `tests/golden_external_harness.py` byte-identical (untouched)
