### PR TITLE
fix: web UI form 403s (#260) and multi-user private collections mislabeling (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.49] - 2026-07-27
+
+### Fixed
+
+- **Every web UI form (Save/Run/Login) was returning 403 - #260.**
+
+  `web/app.py`'s baseline security headers set `Referrer-Policy: no-referrer` on every response (added in 2.9.0, #198). Per the Fetch spec, a browser under that policy sends `Origin: null` (and no `Referer` at all) on a plain `<form method="post">` navigation - `fetch()` calls are unaffected since they use CORS mode and always send a real `Origin`. `web/security.py`'s origin guard then saw the literal string `"null"`, couldn't resolve it to this app's own host, and rejected the request with 403. Affected routes: `/run`, `/config/settings`, `/config/users`, `/config/connections`, `/config/libraries`, `/update/dismiss` - and `/login` itself, since that guard runs before token auth, so a token-protected deploy couldn't even log in.
+
+  Fixed by changing `Referrer-Policy` to `same-origin`: this still sends NO referrer on a cross-origin request (nothing new leaks to another site), but it does send one - and therefore a real `Origin` header - on a same-origin request, which is exactly what the guard needs to tell a same-origin form POST apart from a cross-site one. A cross-origin or opaque-origin (sandboxed iframe, `data:`/`blob:` document) form POST still gets `Origin: null` under `same-origin` and is still correctly rejected with 403 - this only fixes the same-origin case, the CSRF guard itself is unchanged and was not loosened.
+
+  **Why the test suite was green while this was broken in production:** the test client (`_BrowserLikeTestClient`) stamps a same-origin `Origin` header onto every request by default, and the one test that pinned `Referrer-Policy` asserted `no-referrer` in isolation - the two facts that combine to cause #260 were never asserted together. Added a regression test that pins the actual invariant (the response's `Referrer-Policy` must be a value that preserves `Origin` on a same-origin form POST, explicitly not `no-referrer`) and a second test using the raw Flask test client (bypassing the same-origin stamping) confirming cross-origin/opaque-origin POSTs are still rejected.
+
+- **Multi-user installs got a single, mis-named, shared collection with recommendations hidden from every shared user instead of their own - #261.**
+
+  `recommenders/base.py` read `collections.append_usernames` with a code default of `False`, while the shipped `config/tuning.example.yml` always documented `true` - and nothing in any install path (Dockerfile, setup.sh, the web UI) ever wrote a real `tuning.yml`, so every fresh install silently ran on the wrong default. With `append_usernames` false: every user's item label collapsed to the identical bare string `"Recommended"`; the collection title's username was then derived by stripping a `"Recommended_"` prefix that was never there, a silent no-op that left the literal word `"Recommended"` capitalized into the collection title `🎬 Recommended - Recommendation`; and - worst - `private_collections` (on by default) then pushed a `label!=Recommended` exclude filter to every non-admin user's Plex account, which matched the one shared collection's own label too, hiding it (and its items) from everyone instead of isolating each user's own recommendations.
+
+  Fixed: `append_usernames` now defaults to `true`, matching the documented example. Collection/label identity is now built from the real username the caller already has (`self.single_user`) and threaded explicitly through `recommenders/base.py`, `utils/plex.py`, and `utils/plex_policy.py`, instead of being re-derived by stripping a prefix that wasn't always there. If `append_usernames` is ever explicitly set `false` with more than one user configured - the one combination `private_collections` genuinely cannot support - curatarr now skips applying label restrictions and logs a clear warning naming the config key and file, instead of silently sending a filter that hides content.
+
+  **What changes on your next run if you were affected (multi-user install, no `tuning.yml`, default settings):** each user gets their own correctly-named collection (`🎬 <Username> - Recommendation`) and label going forward. The old shared `🎬 Recommended - Recommendation` collection is orphaned junk from the bug and is now cleaned up automatically (its bare `"Recommended"` item label is stripped and the collection deleted) the first time any user's run completes successfully after upgrading - this is idempotent and requires no manual action. The stale `label!=Recommended` Plex account filter that was hiding the shared collection from every non-admin user is also corrected automatically: applying label restrictions always recomputes and re-sends every configured user's filter in one pass, so it self-heals as soon as any single user's run succeeds post-upgrade - nobody needs to touch plex.tv account settings by hand.
+
+### Documentation
+
+- **Corrected the "private collections" claim - no functional/security change.** README.md and `config/tuning.example.yml` described per-user collections as private/hidden from other users. Verified against a live server: Plex enforces the `label!=` exclusion on the collection object (so it's absent from browse/search, and a direct `GET` on its ratingKey 404s for another user) but NOT on the items returned by that collection's own `/children` endpoint - so a user who already has, or guesses, a collection's ratingKey (Plex assigns small sequential integers) can still retrieve its full contents via the Plex API. This is Plex server-side behavior, not something curatarr can fix. Reworded README.md's feature list/FAQ, `config/tuning.example.yml`'s `private_collections` comment, and `utils/plex_policy.py`'s docstrings to describe this correctly as UI-level separation (each user's own Browse/Search only shows their own collection), not an access-control or privacy boundary. The feature itself, and its default-on behavior, are unchanged.
+
 ## [2.10.48] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Binaries self-update: the app notifies you (CLI and web UI banner) when a newer 
 
 ### For Your Library (What to Watch)
 - **Per-user recommendations** — Each user gets their own curated collection
-- **Private by default** — Users only see their own recommendations, not others'
+- **Per-user by default** — Each user's library Browse/Search only shows their own recommendation collection, not others' (UI-level separation, not access control — see FAQ)
 - **Smart scoring** — Weights keywords, genres, cast, and directors
 - **Recency bias** — Recent watches influence recommendations more
 - **Rewatch detection** — Content you love gets weighted higher
@@ -766,7 +766,7 @@ No. Only adds labels to Plex metadata.
 At least 5 for meaningful recommendations.
 
 **Q: Can users see each other's recommendations?**
-No! By default, private collections are enabled—each user only sees their own recommendations, not other users'. The admin/server owner sees all (Plex limitation). Disable with `private_collections: false` in tuning.yml if you want shared visibility.
+When browsing or searching the library, no — by default each user's recommendation collection is excluded from every other user's view (Plex label restrictions), and the admin/server owner always sees all of them (Plex limitation). This is UI-level separation, not an access-control boundary: Plex enforces the exclusion on the collection object, not on the items inside it, so a user who already has (or guesses — ratingKeys are small sequential integers) a collection's ratingKey can still retrieve its contents directly through the Plex API. Disable with `private_collections: false` in tuning.yml if you want shared visibility instead.
 
 **Q: What about new users with no history?**
 They're skipped until they have enough watch history.

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -67,8 +67,14 @@ collections:
   add_label: true  # Add 'Recommended' label to items
   label_name: Recommended
   append_usernames: true  # Include username in collection name
-  # Private collections - each user only sees their own recommendations
-  # Uses Plex label restrictions (only works on Library tab, not Home)
+  # Per-user label restrictions - each user's library Browse/Search only
+  # shows their own recommendation collection, not other users' (Plex
+  # label restrictions; Library tab only, does not apply to Home).
+  # NOT an access-control boundary: Plex enforces this exclusion on the
+  # collection object, not on the items inside it, so a user who already
+  # has (or guesses - ratingKeys are small sequential integers) a
+  # collection's ratingKey can still retrieve its contents directly via
+  # the Plex API. Treat this as UI-level separation, not privacy.
   # Note: Server admin always sees all collections (Plex limitation)
   private_collections: true
 

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -49,6 +49,7 @@ from utils import (
     build_label_name,
     categorize_labeled_items,
     check_cache_version,
+    cleanup_legacy_unnamed_collection,
     cleanup_old_collections,
     create_empty_counters,
     enhance_profile_with_trakt,
@@ -1064,8 +1065,24 @@ class BaseRecommender(ABC):
         print(f"{GREEN}Collection now has top {len(top_candidates)} recommendations by score{RESET}")
         return [plex_item for item_id, (plex_item, score) in top_candidates]
 
-    def _sync_plex_collection(self, section, label_name: str, final_items: List) -> bool:
+    def _sync_plex_collection(
+        self,
+        section,
+        label_name: str,
+        final_items: List,
+        username: Optional[str] = None,
+        private_label: Optional[str] = None,
+    ) -> bool:
         """Create/update Plex collection with final recommendations.
+
+        username/private_label are the real per-user identity and the
+        already-built PrivateCollection_* label - both computed once by
+        the caller (manage_plex_labels) and passed through explicitly,
+        rather than re-derived here by stripping a "Recommended_" prefix
+        off label_name (#261: that stripping was a silent no-op whenever
+        collections.append_usernames was false, since label_name was then
+        just the bare base label with nothing to strip - every user's
+        collection/label ended up named the literal string "Recommended").
 
         Returns:
             True if collection was created/updated, False otherwise.
@@ -1074,7 +1091,19 @@ class BaseRecommender(ABC):
             print(f"{YELLOW}No items to add to collection{RESET}")
             return False
 
-        username = label_name.replace("Recommended_", "")
+        if not username:
+            # Defensive only - every real caller (manage_plex_labels) always
+            # supplies self.single_user, which utils/cli.py's per-user loop
+            # always sets to a real username. Falls back to the old (#261)
+            # derivation so a hypothetical future caller degrades instead of
+            # crashing; still correct whenever label_name IS prefixed.
+            log_warning(
+                "_sync_plex_collection called with no username - using legacy "
+                "prefix-strip derivation, which only works if label_name is "
+                "prefixed with 'Recommended_' (see #261)"
+            )
+            username = label_name.replace("Recommended_", "")
+
         if (
             self.user_preferences
             and username in self.user_preferences
@@ -1086,9 +1115,12 @@ class BaseRecommender(ABC):
 
         emoji = "🎬" if self.media_type == "movie" else "📺"
         collection_name = f"{emoji} {display_name} - Recommendation{self._library_suffix_for_collection_name()}"
-        success = update_plex_collection(section, collection_name, final_items, logger, label_name=label_name)
+        success = update_plex_collection(
+            section, collection_name, final_items, logger, label_name=label_name, private_label=private_label
+        )
         if success:
             cleanup_old_collections(section, collection_name, username, emoji, logger)
+            cleanup_legacy_unnamed_collection(section, collection_name, emoji, logger)
         return success
 
     def manage_plex_labels(self, recommended_items: List[Dict]) -> bool:
@@ -1118,9 +1150,29 @@ class BaseRecommender(ABC):
             section = self.plex.library.section(self.library_title)
             base_label = self.config.get("collections", {}).get("label_name", "Recommended")
             base_label = f"{base_label}{self._library_suffix_for_label()}"
-            append_usernames = self.config.get("collections", {}).get("append_usernames", False)
+            # Default True (#261): matches config/tuning.example.yml's
+            # documented default. Nothing in any install path (Dockerfile,
+            # setup.sh, the web UI) ever writes a real tuning.yml, so every
+            # fresh install ran on this code default - False meant every
+            # user's item label AND collection-level filter label collapsed
+            # to the identical bare base_label ("Recommended"), which made
+            # private_collections (below) push a filter that hid every
+            # user's recommendations from every other user instead of
+            # isolating them.
+            append_usernames = self.config.get("collections", {}).get("append_usernames", True)
             users = self.users["plex_users"] or self.users["managed_users"]
             label_name = build_label_name(base_label, users, self.single_user, append_usernames)
+
+            # Separate, hardcoded-root label applied to the COLLECTION
+            # object itself (never to individual items) so the exclude
+            # filter below only ever hides a collection, never an item
+            # shared in everyone's normal library view. Built via the same
+            # build_label_name() call (same real username/append_usernames
+            # inputs) as label_name above, instead of derived later by
+            # rewriting label_name's prefix (#261 - see
+            # utils/plex_policy.apply_user_label_restrictions's docstring).
+            private_base_label = f"PrivateCollection{self._library_suffix_for_label()}"
+            private_label_name = build_label_name(private_base_label, users, self.single_user, append_usernames)
 
             # Find items in Plex
             items_found, skipped = self._find_plex_items_for_recs(section, selected_items)
@@ -1170,21 +1222,39 @@ class BaseRecommender(ABC):
             print(f"{GREEN}Successfully updated labels incrementally{RESET}")
 
             # Sync to Plex collection
-            success = self._sync_plex_collection(section, label_name, final_items)
+            success = self._sync_plex_collection(section, label_name, final_items, self.single_user, private_label_name)
 
             # Apply user label restrictions if private_collections is enabled (default: true)
             # Note: Only works for shared friends, not Plex Home managed users
             if success and self.config.get("collections", {}).get("private_collections", True):
-                # Build dict of all user labels for exclude-based restrictions
-                # Each user's label excludes them from seeing other users' recommendations
-                all_user_labels = {}
-                users = self.users["plex_users"] or self.users["managed_users"]
+                if not append_usernames and len(users) > 1:
+                    # #261: with more than one user configured, a false
+                    # append_usernames means every user's label above is
+                    # identical - private_collections has no way to tell
+                    # them apart, so applying it would push a filter that
+                    # hides the (one, shared) collection and its items from
+                    # every non-admin user instead of isolating each user's
+                    # own. Fail loud instead of sending that filter.
+                    log_warning(
+                        "collections.append_usernames is false with more than one "
+                        "user configured (see config/tuning.yml) - private_collections "
+                        "cannot correctly separate per-user labels this way, since "
+                        "every user would get the identical label. Skipping label "
+                        "restrictions this run rather than hiding recommendations "
+                        "from everyone (#261). Set collections.append_usernames: true "
+                        "in config/tuning.yml (the documented default) to enable "
+                        "per-user private collections, or private_collections: false "
+                        "if a single shared collection is what you actually want."
+                    )
+                else:
+                    # Build dict of all users' PrivateCollection_* labels for
+                    # exclude-based restrictions - each user's own label stays
+                    # visible to them, every OTHER user's label is excluded.
+                    all_user_private_labels = {}
+                    for u in users:
+                        all_user_private_labels[u] = build_label_name(private_base_label, users, u, append_usernames)
 
-                for username in users:
-                    user_label = build_label_name(base_label, users, username, append_usernames)
-                    all_user_labels[username] = user_label
-
-                apply_user_label_restrictions(self.config, all_user_labels)
+                    apply_user_label_restrictions(self.config, all_user_private_labels)
 
             return success
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1605,6 +1605,7 @@ class TestBaseRecommenderCollectionNaming:
         assert recommender._library_suffix_for_label() == "_movies-4k"
         assert recommender._cache_library_prefix() == "movies-4k_"
 
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
     @patch("recommenders.base.cleanup_old_collections")
     @patch("recommenders.base.update_plex_collection")
     @patch("recommenders.base.init_plex")
@@ -1613,7 +1614,7 @@ class TestBaseRecommenderCollectionNaming:
     @patch("recommenders.base.load_config")
     @patch("os.makedirs")
     def test_sync_plex_collection_single_library_name_unchanged(
-        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
     ):
         """Single-library install: collection name is byte-identical to
         pre-Phase-3 (no suffix)."""
@@ -1626,13 +1627,15 @@ class TestBaseRecommenderCollectionNaming:
         recommender = ConcreteRecommender("/path/to/config.yml")
         section = Mock()
 
-        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()])
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
 
         collection_name = mock_update.call_args[0][1]
         assert collection_name == "🎬 Alice - Recommendation"
         mock_cleanup.assert_called_once()
         assert mock_cleanup.call_args[0][1] == "🎬 Alice - Recommendation"
+        mock_cleanup_legacy.assert_called_once()
 
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
     @patch("recommenders.base.cleanup_old_collections")
     @patch("recommenders.base.update_plex_collection")
     @patch("recommenders.base.init_plex")
@@ -1641,7 +1644,7 @@ class TestBaseRecommenderCollectionNaming:
     @patch("recommenders.base.load_config")
     @patch("os.makedirs")
     def test_sync_plex_collection_multi_library_adds_suffix(
-        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
     ):
         """Multi-library install: collection name is suffixed with the
         library name so same-named collections across libraries are
@@ -1655,7 +1658,7 @@ class TestBaseRecommenderCollectionNaming:
         recommender = ConcreteRecommender("/path/to/config.yml", library=LIB_MOVIES_4K)
         section = Mock()
 
-        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()])
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
 
         collection_name = mock_update.call_args[0][1]
         assert collection_name == "🎬 Alice - Recommendation (Movies 4K)"
@@ -1690,8 +1693,13 @@ class TestBaseRecommenderCollectionNaming:
             pass
 
         assert mock_build_label.called
-        base_label_arg = mock_build_label.call_args[0][0]
-        assert base_label_arg == "Recommended_movies-4k"
+        # manage_plex_labels now calls build_label_name twice before the
+        # short-circuit: once for the item label (base_label), once for
+        # the collection-level private label (private_base_label, #261) -
+        # both must be library-id-qualified the same way.
+        call_base_labels = [call.args[0] for call in mock_build_label.call_args_list]
+        assert call_base_labels[0] == "Recommended_movies-4k"
+        assert "PrivateCollection_movies-4k" in call_base_labels
 
 
 # ------------------------------------------------------------------------
@@ -2066,9 +2074,17 @@ class TestManagePlexLabelsFullFlow:
         recommender.config["collections"] = {
             "add_label": True,
             "label_name": "Recommended",
-            "append_usernames": False,
+            # True matches config/tuning.example.yml's documented default
+            # and the code default (#261) - False was the exact broken
+            # production config every fresh install actually ran with
+            # (nothing in any install path ever wrote a real tuning.yml),
+            # which collapsed every user's label to the identical literal
+            # "Recommended". See TestPrivateCollectionsAppendUsernames
+            # below for explicit coverage of both the True and False paths.
+            "append_usernames": True,
             "private_collections": False,
         }
+        recommender.single_user = "alice"
         recommender.confirm_operations = False
         recommender._find_plex_items_for_recs = Mock(return_value=([Mock()], []))
         recommender._remove_outdated_labels = Mock(return_value=[])
@@ -2119,14 +2135,28 @@ class TestManagePlexLabelsFullFlow:
         assert args[1] == []
 
     @patch("recommenders.base.apply_user_label_restrictions")
-    @patch("recommenders.base.build_label_name", return_value="Recommended_alice")
-    def test_private_collections_applies_restrictions(self, mock_build_label, mock_apply):
-        recommender = self._base_recommender()
+    def test_private_collections_applies_restrictions(self, mock_apply):
+        """#261 regression: uses the REAL build_label_name (not a hardcoded
+        patch) and a multi-user fixture, and asserts on the actual per-user
+        PrivateCollection_* labels apply_user_label_restrictions receives -
+        not just that it was called. The old version of this test patched
+        build_label_name to a fixed "Recommended_alice" and used a
+        single-user fixture, so it couldn't have caught #261: every user
+        collapsing to the identical label was invisible to it."""
+        recommender = self._base_recommender(
+            users={"plex_users": ["alice", "bob"], "managed_users": [], "admin_user": "admin"}
+        )
+        recommender.single_user = "alice"
         recommender.config["collections"]["private_collections"] = True
 
         recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
 
         mock_apply.assert_called_once()
+        all_user_private_labels = mock_apply.call_args[0][1]
+        assert all_user_private_labels == {
+            "alice": "PrivateCollection_alice",
+            "bob": "PrivateCollection_bob",
+        }
 
     @patch("recommenders.base.get_max_rating_for_user", return_value="PG-13")
     @patch("recommenders.base.build_label_name", return_value="Recommended_alice")
@@ -2165,6 +2195,135 @@ class TestManagePlexLabelsFullFlow:
         recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
 
         assert recommender._update_labels_by_rank.call_args[0][3] == 7
+
+
+class TestPrivateCollectionsAppendUsernames:
+    """#261: collections.append_usernames' True/False paths, explicitly.
+
+    True is both the documented default (config/tuning.example.yml) and
+    the code default - every user gets a distinct label, so
+    private_collections' exclude filters correctly isolate each user.
+    False is only safe with exactly one user configured (build_label_name
+    just returns the bare base label either way - nothing to disambiguate
+    since there's nothing to disambiguate FROM); with more than one user
+    it must fail loud instead of applying restrictions (see
+    TestManagePlexLabelsFullFlow._base_recommender for the shared setup
+    this subclasses)."""
+
+    def _recommender(self, users, append_usernames, single_user="alice"):
+        recommender = _make_recommender(users=users)
+        recommender.plex = Mock()
+        recommender.config["collections"] = {
+            "add_label": True,
+            "label_name": "Recommended",
+            "append_usernames": append_usernames,
+            "private_collections": True,
+        }
+        recommender.single_user = single_user
+        recommender.confirm_operations = False
+        recommender._find_plex_items_for_recs = Mock(return_value=([Mock()], []))
+        recommender._remove_outdated_labels = Mock(return_value=[])
+        recommender._build_scored_candidates = Mock(return_value={1: (Mock(), 0.9)})
+        recommender._update_labels_by_rank = Mock(return_value=[Mock()])
+        recommender._sync_plex_collection = Mock(return_value=True)
+        recommender._save_watched_cache = Mock()
+        return recommender
+
+    @patch("recommenders.base.apply_user_label_restrictions")
+    def test_append_usernames_true_multi_user_applies_distinct_labels(self, mock_apply):
+        recommender = self._recommender(
+            users={"plex_users": ["alice", "bob"], "managed_users": [], "admin_user": "admin"},
+            append_usernames=True,
+        )
+
+        result = recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
+
+        assert result is True
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args[0][1] == {
+            "alice": "PrivateCollection_alice",
+            "bob": "PrivateCollection_bob",
+        }
+
+    @patch("recommenders.base.apply_user_label_restrictions")
+    def test_append_usernames_false_single_user_still_applies(self, mock_apply):
+        """A single configured user has nothing to disambiguate from, so
+        False is harmless here - apply_user_label_restrictions itself
+        also no-ops on a single-entry dict (see utils/plex_policy.py)."""
+        recommender = self._recommender(
+            users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"},
+            append_usernames=False,
+        )
+
+        result = recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
+
+        assert result is True
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args[0][1] == {"alice": "PrivateCollection"}
+
+    @patch("recommenders.base.log_warning")
+    @patch("recommenders.base.apply_user_label_restrictions")
+    def test_append_usernames_false_multi_user_skips_and_warns(self, mock_apply, mock_warn):
+        """The #261 failure mode itself: more than one user configured
+        with append_usernames false must never reach
+        apply_user_label_restrictions (every user's label would be the
+        identical bare "PrivateCollection", so the exclude filter would
+        hide the one shared collection - and its items - from everyone
+        instead of isolating each user's own). Must fail loud instead,
+        naming the config key so an operator can actually fix it."""
+        recommender = self._recommender(
+            users={"plex_users": ["alice", "bob"], "managed_users": [], "admin_user": "admin"},
+            append_usernames=False,
+        )
+
+        result = recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
+
+        assert result is True
+        mock_apply.assert_not_called()
+        mock_warn.assert_called_once()
+        warning_text = mock_warn.call_args[0][0]
+        assert "append_usernames" in warning_text
+        assert "tuning.yml" in warning_text
+
+
+class TestCollectionTitleUsesRealUsername:
+    """#261 regression: the collection title is always built from the
+    real username (self.single_user), even with append_usernames false
+    (the exact broken production default) - never from label_name string
+    surgery. Before the fix, this exact config produced the literal
+    title "🎬 Recommended - Recommendation" for every user, since
+    label_name was just the bare base label with no "Recommended_" prefix
+    to strip."""
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection", return_value=True)
+    def test_title_uses_real_username_even_with_append_usernames_false(
+        self, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        recommender = _make_recommender(users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"})
+        recommender.plex = Mock()
+        recommender.single_user = "alice"
+        recommender.config["collections"] = {
+            "add_label": True,
+            "label_name": "Recommended",
+            "append_usernames": False,
+            "private_collections": False,
+        }
+        recommender.confirm_operations = False
+        recommender._find_plex_items_for_recs = Mock(return_value=([Mock()], []))
+        recommender._remove_outdated_labels = Mock(return_value=[])
+        recommender._build_scored_candidates = Mock(return_value={1: (Mock(), 0.9)})
+        recommender._update_labels_by_rank = Mock(return_value=[Mock()])
+        recommender._save_watched_cache = Mock()
+
+        result = recommender.manage_plex_labels([{"title": "Movie", "year": 2020}])
+
+        assert result is True
+        collection_name = mock_update.call_args[0][1]
+        assert "Alice" in collection_name
+        assert collection_name == "🎬 Alice - Recommendation"
+        assert collection_name != "🎬 Recommended - Recommendation"
 
 
 class TestManagePlexLabelsExceptionHandling:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -528,6 +528,123 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         )
 
 
+class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
+    """Standing guard (#261 audit remediation): TestResolveMediaTypeOverrides
+    KeyEnumeration above only ever walked movies:/tv:, so a mismatch in any
+    OTHER top-level section of config/tuning.example.yml - like
+    collections.append_usernames (documented true, code defaulted to
+    false - #261) - was structurally outside what it could ever catch.
+    This walks every remaining top-level section and asserts each
+    documented example value matches the real code fallback that reads
+    it, so a documented default and its code default can never again
+    silently drift apart without a test failing.
+
+    Uses the real, committed config/tuning.example.yml - not a hand-rolled
+    fixture - so it also catches the example file and the code drifting
+    apart from each other, exactly like #261.
+    """
+
+    @staticmethod
+    def _load_example_tuning():
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        example_path = os.path.join(repo_root, "config", "tuning.example.yml")
+        with open(example_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def test_collections_defaults_match(self):
+        """recommenders/base.py's manage_plex_labels() reads every one of
+        these directly off self.config["collections"] with these exact
+        fallback defaults."""
+        tuning = self._load_example_tuning()
+        collections = tuning["collections"]
+        assert collections["add_label"] is True
+        assert collections["label_name"] == "Recommended"
+        assert collections["append_usernames"] is True  # #261
+        assert collections["private_collections"] is True
+
+    def test_external_recommendations_defaults_match(self):
+        from recommenders.external import MAX_DISCOVERY_ITERATIONS, OUTPUT_MIN_VOTES
+
+        tuning = self._load_example_tuning()
+        external = tuning["external_recommendations"]
+        assert external["movie_limit"] == 50
+        assert external["show_limit"] == 20
+        assert external["min_relevance_score"] == 0.65
+        assert external["auto_open_html"] is False
+        assert external["min_votes"] == OUTPUT_MIN_VOTES
+        assert external["language"] is None
+        # KNOWN MISMATCH surfaced by this guardrail, reported rather than
+        # silently "fixed" (see this PR's description) - the example
+        # documents 5, the code fallback (MAX_DISCOVERY_ITERATIONS) is 8.
+        # Pinned here on both sides so whichever way this is resolved,
+        # this test forces a deliberate update instead of drifting further.
+        assert external["max_iterations"] == 5
+        assert MAX_DISCOVERY_ITERATIONS == 8
+
+    def test_recency_decay_defaults_match(self):
+        """utils/scoring.py's calculate_recency_multiplier reads every one
+        of these with these exact fallback defaults."""
+        tuning = self._load_example_tuning()
+        recency = tuning["recency_decay"]
+        assert recency["enabled"] is True
+        assert recency["days_0_30"] == 1.0
+        assert recency["days_31_90"] == 0.75
+        assert recency["days_91_180"] == 0.50
+        assert recency["days_181_365"] == 0.25
+        assert recency["days_365_plus"] == 0.10
+
+    def test_rating_multipliers_defaults_match(self):
+        """get_rating_multipliers()'s star_X argument defaults, used
+        whenever config["rating_multipliers"] exists but is missing
+        individual star_X keys - see this test class's own docstring
+        note in the PR description about the SEPARATE
+        DEFAULT_RATING_MULTIPLIERS fallback (used only when the whole
+        rating_multipliers section is absent), which uses different
+        numbers and was NOT asserted here - reported as a distinct,
+        unresolved finding, not silently reconciled."""
+        tuning = self._load_example_tuning()
+        multipliers = tuning["rating_multipliers"]
+        assert multipliers["star_5"] == 2.5
+        assert multipliers["star_4"] == 1.7
+        assert multipliers["star_3"] == 1.0
+        assert multipliers["star_2"] == 0.4
+        assert multipliers["star_1"] == 0.2
+
+    def test_negative_signals_defaults_match(self):
+        """get_negative_signals_config()'s fallback defaults."""
+        tuning = self._load_example_tuning()
+        negative = tuning["negative_signals"]
+        assert negative["enabled"] is True
+        assert negative["bad_ratings"]["enabled"] is True
+        assert negative["bad_ratings"]["threshold"] == DEFAULT_NEGATIVE_THRESHOLD
+        assert negative["bad_ratings"]["cap_penalty"] == 0.5
+        assert negative["dropped_shows"]["enabled"] is True
+        assert negative["dropped_shows"]["min_episodes_watched"] == 2
+        assert negative["dropped_shows"]["max_completion_percent"] == 25
+        assert negative["dropped_shows"]["penalty_multiplier"] == -0.4
+
+    def test_top_level_sections_are_all_covered_by_this_class(self):
+        """Belt-and-braces, mirroring
+        TestResolveMediaTypeOverridesKeyEnumeration's own version of this:
+        fails loudly (instead of silently passing) if a future
+        tuning.example.yml edit adds a new top-level section none of the
+        tests above account for."""
+        tuning = self._load_example_tuning()
+        covered_sections = {
+            "movies",
+            "tv",
+            "collections",
+            "external_recommendations",
+            "recency_decay",
+            "rating_multipliers",
+            "negative_signals",
+            "users",
+        }
+        assert set(tuning.keys()) <= covered_sections, (
+            f"tuning.example.yml has undocumented-here top-level sections: {set(tuning.keys()) - covered_sections}"
+        )
+
+
 class TestNegativeSignalsConstants:
     """Tests for negative signals constants"""
 

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -590,6 +590,92 @@ class TestCleanupOldCollections:
         mock_logger.info.assert_called_once()
 
 
+class TestCleanupLegacyUnnamedCollection:
+    """Tests for cleanup_legacy_unnamed_collection() - #261 migration.
+
+    Installs that ran under the collections.append_usernames: false code
+    default (fixed in #261) all produced one identically-titled shared
+    collection: "{emoji} Recommended - Recommendation". cleanup_old_
+    collections() above can never find it (its patterns are all built
+    from a real username, and this title contains none), so it needs its
+    own, separate cleanup path.
+    """
+
+    def test_deletes_legacy_collection_and_strips_item_labels(self):
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        legacy_item = Mock(ratingKey=101)
+        mock_legacy_collection = Mock()
+        mock_legacy_collection.title = "🎬 Recommended - Recommendation"
+        mock_legacy_collection.items.return_value = [legacy_item]
+
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_legacy_collection]
+
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬")
+
+        mock_legacy_collection.delete.assert_called_once()
+        legacy_item.removeLabel.assert_called_once_with("Recommended")
+
+    def test_leaves_current_collection_alone(self):
+        """A real user literally named 'Recommended' would legitimately
+        produce this exact title today - never delete the collection
+        this run just created/updated."""
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        mock_section = Mock()
+
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Recommended - Recommendation", "🎬")
+
+        mock_section.collections.assert_not_called()
+
+    def test_leaves_unrelated_collections_alone(self):
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        mock_other = Mock()
+        mock_other.title = "🎬 Alice - Recommendation"
+
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_other]
+
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬")
+
+        mock_other.delete.assert_not_called()
+
+    def test_idempotent_when_already_cleaned_up(self):
+        """No legacy collection left - a no-op, not an error."""
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        mock_section = Mock()
+        mock_section.collections.return_value = []
+
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬")
+
+    def test_handles_exception(self):
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        mock_section = Mock()
+        mock_section.collections.side_effect = plexapi.exceptions.PlexApiException("API Error")
+
+        # Should not raise
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬")
+
+    def test_with_logger(self):
+        from utils.plex import cleanup_legacy_unnamed_collection
+
+        mock_logger = Mock()
+        mock_legacy_collection = Mock()
+        mock_legacy_collection.title = "🎬 Recommended - Recommendation"
+        mock_legacy_collection.items.return_value = []
+
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_legacy_collection]
+
+        cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬", logger=mock_logger)
+
+        mock_logger.info.assert_called_once()
+
+
 class TestGetPlexUserIds:
     """Tests for get_plex_user_ids() function."""
 
@@ -1903,6 +1989,47 @@ class TestUpdatePlexCollectionSort:
 
 class TestApplyUserLabelRestrictions:
     """Tests for apply_user_label_restrictions() function."""
+
+    @patch("utils.plex_policy.requests.put")
+    @patch("utils.plex_policy.requests.get")
+    @patch("utils.plex_policy.MyPlexAccount")
+    def test_exclude_filter_uses_passed_labels_verbatim(self, mock_account_class, mock_get, mock_put):
+        """#261: exclude labels are used exactly as passed in, never
+        derived by string-replacing a "Recommended_" prefix off them -
+        that derivation silently produced the wrong (unprefixed) label
+        whenever a caller's label wasn't literally "Recommended_<user>",
+        e.g. every install running with collections.append_usernames:
+        false. Passing deliberately odd label strings here (no
+        "Recommended_"/"PrivateCollection_" prefix at all) proves
+        nothing is being rewritten internally."""
+        mock_account = Mock()
+        mock_account.username = "adminuser"
+        mock_account_class.return_value = mock_account
+
+        mock_get_response = Mock()
+        mock_get_response.headers = {}
+        mock_get_response.iter_content = Mock(return_value=[])
+        mock_get_response.content = b"""<MediaContainer>
+            <User id="123" title="Jason" username="jason"/>
+            <User id="456" title="Sarah" username="sarah"/>
+        </MediaContainer>"""
+        mock_get_response.raise_for_status = Mock()
+        mock_get.return_value = mock_get_response
+
+        mock_put_response = Mock()
+        mock_put_response.headers = {}
+        mock_put_response.iter_content = Mock(return_value=[])
+        mock_put_response.raise_for_status = Mock()
+        mock_put.return_value = mock_put_response
+
+        config = {"plex": {"token": "test_token"}}
+        all_user_private_labels = {"Jason": "SomeOtherLabel_Jason", "Sarah": "SomeOtherLabel_Sarah"}
+
+        result = apply_user_label_restrictions(config, all_user_private_labels)
+
+        assert result is True
+        put_filter_values = {call.kwargs["params"]["filterMovies"] for call in mock_put.call_args_list}
+        assert put_filter_values == {"label!=SomeOtherLabel_Sarah", "label!=SomeOtherLabel_Jason"}
 
     @patch("utils.plex_policy.requests.put")
     @patch("utils.plex_policy.requests.get")

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -8,6 +8,8 @@ import sys
 import time
 from unittest.mock import Mock, patch
 
+from flask.testing import FlaskClient
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
@@ -94,8 +96,34 @@ class TestBaselineSecurityHeaders:
         assert resp.status_code == 200
         assert resp.headers.get("X-Frame-Options") == "DENY"
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
-        assert resp.headers.get("Referrer-Policy") == "no-referrer"
+        assert resp.headers.get("Referrer-Policy") == "same-origin"
         assert resp.headers.get("Content-Security-Policy") == app_module.BASELINE_CSP
+
+    def test_referrer_policy_preserves_origin_on_same_origin_form_posts(self, client):
+        """Regression test for #260: every HTML form POST returned 403.
+
+        Root cause was Referrer-Policy: no-referrer - per the Fetch spec, a
+        browser sends Origin: null (and no Referer) on a same-origin plain
+        <form method="post"> navigation under that policy, which made
+        register_origin_host_guard's Origin check (web/security.py) treat
+        every non-fetch() POST as cross-site and reject it with 403 -
+        including /login, since that guard runs before token auth.
+
+        This test pins the actual invariant, not just today's chosen
+        value: the response's Referrer-Policy must be one that still
+        sends a real Origin on a same-origin form POST. no-referrer and
+        same-origin (or stricter-when-safe) look identical from the
+        single-assertion test that pinned no-referrer before this fix -
+        that test passed while the product was broken - so this
+        explicitly allowlists only policies that preserve Origin
+        same-origin, and explicitly rejects no-referrer.
+        """
+        c, app, root = client
+        resp = c.get("/")
+        policy = resp.headers.get("Referrer-Policy")
+        allowed = {"same-origin", "strict-origin-when-cross-origin", "origin", "no-referrer-when-downgrade"}
+        assert policy in allowed, f"Referrer-Policy {policy!r} not in allowlist {allowed}"
+        assert policy != "no-referrer"
 
     def test_baseline_csp_has_no_upgrade_insecure_requests(self, client):
         """This app serves plain HTTP by design (see docs/DOCKER.md) -
@@ -409,6 +437,29 @@ class TestOriginHostGuard:
             headers={"Origin": ""},
         )
         assert resp.status_code == 403
+
+    def test_null_origin_post_rejected_403_raw_client(self, curatarr_web_root):
+        """#260 follow-up: confirms the fix does NOT loosen the guard.
+
+        Uses the raw Flask test client (not the 'client' fixture's
+        _BrowserLikeTestClient, which stamps a same-origin Origin header
+        onto every request) to model what a genuinely cross-origin or
+        opaque-origin request looks like: Origin: null with no Referer -
+        exactly what a sandboxed iframe, a data:/blob: document, or a
+        cross-site form POST produces. Both /login and /run must still
+        403 this - same-origin Referrer-Policy only fixes the same-
+        origin case (#260), it never makes the guard accept "null".
+        """
+        app = create_app(project_root=curatarr_web_root)
+        app.testing = True
+        app.test_client_class = FlaskClient
+        raw_client = app.test_client()
+
+        login_resp = raw_client.post("/login", data={"token": "whatever"}, headers={"Origin": "null"})
+        assert login_resp.status_code == 403
+
+        run_resp = raw_client.post("/run", data={"engine": "movie", "user": "alice"}, headers={"Origin": "null"})
+        assert run_resp.status_code == 403
 
     def test_referer_fallback_accepted_when_origin_absent(self, client):
         c, app, root = client

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -151,6 +151,7 @@ from .metrics import (
 
 # Plex utilities
 from .plex import (
+    cleanup_legacy_unnamed_collection,
     cleanup_old_collections,
     extract_genres,
     extract_ids_from_guids,
@@ -504,6 +505,7 @@ __all__ = [
     "fetch_watch_history_with_tmdb",
     "update_plex_collection",
     "cleanup_old_collections",
+    "cleanup_legacy_unnamed_collection",
     "get_configured_users",
     "get_current_users",
     "get_excluded_genres_for_user",

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 import yaml
 
 # Project version - single source of truth
-__version__ = "2.10.48"
+__version__ = "2.10.49"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -27,6 +27,7 @@ from plexapi.myplex import MyPlexAccount
 from .config import PLEX_LONG_REQUEST_TIMEOUT, PLEX_REQUEST_TIMEOUT
 from .display import GREEN, RED, RESET, YELLOW, log_error, log_warning
 from .helpers import normalize_title, read_response_capped
+from .labels import remove_labels_from_items
 from .metrics import record_api_call
 
 # Module-level logger
@@ -665,7 +666,12 @@ def fetch_watch_history_with_tmdb(
 
 
 def update_plex_collection(
-    section: Any, collection_name: str, items: List[Any], logger: Any = None, label_name: Optional[str] = None
+    section: Any,
+    collection_name: str,
+    items: List[Any],
+    logger: Any = None,
+    label_name: Optional[str] = None,
+    private_label: Optional[str] = None,
 ) -> bool:
     """
     Create or update a Plex collection with items in the specified order.
@@ -675,7 +681,21 @@ def update_plex_collection(
         collection_name: Name of the collection to create/update
         items: List of Plex media items in desired order (best first)
         logger: Optional logger instance
-        label_name: Optional label to add to the collection itself (for private collections)
+        label_name: Currently unused here beyond being an on/off switch for
+            adding a collection-level label at all - kept as a separate
+            parameter (rather than folded into private_label) so a caller
+            that wants item labeling without collection labeling still has
+            a way to say so.
+        private_label: The COLLECTION-level label to add (e.g.
+            "PrivateCollection_alice"), fully computed by the caller (see
+            recommenders/base.py's manage_plex_labels) via the same
+            build_label_name() call it uses for the item-level label -
+            not derived here by string-rewriting label_name. Prior to
+            #261 this was computed as
+            label_name.replace("Recommended_", "PrivateCollection_"),
+            which silently produced the wrong (unprefixed) label whenever
+            label_name wasn't literally "Recommended_<user>" - e.g. every
+            install running with collections.append_usernames: false.
 
     Returns:
         True if successful, False otherwise
@@ -723,13 +743,18 @@ def update_plex_collection(
                 if logger:
                     logger.warning(f"Could not set custom order: {e}")
 
-        # Add private label to collection itself for private collection filtering
-        # Uses a DIFFERENT prefix than item labels so exclusions only affect collections
-        # Items keep Recommended_* labels (visible to all), collections get PrivateCollection_*
-        if target_collection and label_name:
+        # Add private label to collection itself for per-user label
+        # restrictions (utils.plex_policy.apply_user_label_restrictions).
+        # Uses a DIFFERENT namespace than item labels so exclusions only ever
+        # affect collections, never the items shared in everyone's normal
+        # library view - items keep Recommended_* labels (visible to all),
+        # collections get PrivateCollection_* (see private_label's docstring
+        # above for why this is passed in fully-built, not derived here).
+        # NOT an access-control boundary - see apply_user_label_restrictions's
+        # own docstring for the enumeration caveat (Plex enforces this
+        # exclusion on the collection object, not on the items inside it).
+        if target_collection and label_name and private_label:
             try:
-                # Convert Recommended_username to PrivateCollection_username
-                private_label = label_name.replace("Recommended_", "PrivateCollection_")
                 current_labels = [label.tag for label in target_collection.labels]
                 if private_label not in current_labels:
                     target_collection.addLabel(private_label)
@@ -791,6 +816,82 @@ def cleanup_old_collections(
 
     except plexapi.exceptions.PlexApiException as e:
         error_msg = f"Error cleaning up old collections: {e}"
+        if logger:
+            logger.warning(error_msg)
+        else:
+            print(f"WARNING: {error_msg}")
+
+
+# Exact collection title every install produced while running under the
+# collections.append_usernames: false code default (fixed in #261 - the
+# shipped config/tuning.example.yml always documented true, but nothing
+# in any install path ever wrote a real tuning.yml, so every fresh
+# install got the code default instead). build_label_name() never got a
+# username to append, so every user's collection was created under this
+# one literal, identical name - and update_plex_collection's old
+# label_name.replace("Recommended_", "PrivateCollection_") was a no-op
+# on the bare "Recommended" label that produced, so the collection's own
+# filter label and every item's label were both also just "Recommended".
+_LEGACY_SHARED_COLLECTION_LABEL = "Recommended"
+
+
+def cleanup_legacy_unnamed_collection(
+    section: Any, current_collection_name: str, emoji: str, logger: Any = None
+) -> None:
+    """
+    One-time migration cleanup for the #261 append_usernames default bug.
+
+    cleanup_old_collections() above can't find this collection - it only
+    ever matches patterns built from a REAL username, and this legacy
+    collection's title contains none (see _LEGACY_SHARED_COLLECTION_LABEL's
+    comment). Left alone, it stays in Plex forever as an orphaned,
+    never-updated collection, and its items keep a stale "Recommended"
+    label that no current run ever looks at.
+
+    Idempotent and safe to call every run: does nothing once the legacy
+    collection is gone. Skips deleting *current_collection_name* itself
+    (mirroring cleanup_old_collections' own guard) so a real Plex user
+    literally named "Recommended" - who would legitimately produce this
+    exact title today - never has their live collection treated as
+    legacy junk.
+
+    Args:
+        section: PlexAPI library section
+        current_collection_name: This run's correct collection name - never deleted
+        emoji: The emoji prefix (differs between movies/TV)
+        logger: Optional logger instance
+    """
+    legacy_title = f"{emoji} Recommended - Recommendation"
+    if legacy_title == current_collection_name:
+        return
+
+    try:
+        for collection in section.collections():
+            if collection.title != legacy_title:
+                continue
+
+            try:
+                legacy_items = collection.items()
+            except plexapi.exceptions.PlexApiException:
+                legacy_items = []
+
+            if legacy_items:
+                remove_labels_from_items(
+                    legacy_items,
+                    _LEGACY_SHARED_COLLECTION_LABEL,
+                    {},
+                    "legacy collections.append_usernames=false cleanup (#261)",
+                )
+
+            collection.delete()
+            msg = f"Deleted legacy shared collection from #261 migration: {legacy_title}"
+            if logger:
+                logger.info(msg)
+            else:
+                print(msg)
+
+    except plexapi.exceptions.PlexApiException as e:
+        error_msg = f"Error cleaning up legacy shared collection: {e}"
         if logger:
             logger.warning(error_msg)
         else:

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -15,7 +15,11 @@ rules about what a user is allowed to see -
     built on top of the hierarchies above.
   - apply_user_label_restrictions: the PrivateCollection_*/Recommended_*
     labeling convention that keeps one user's recommendation collection
-    hidden from another user sharing the same server.
+    out of another user's library Browse/Search results on the same
+    server. This is UI-level separation only, not an access-control
+    boundary - see the function's own docstring for the enumeration
+    caveat (a user who already has, or guesses, a collection's ratingKey
+    can still retrieve its contents directly via the Plex API).
 
 apply_user_label_restrictions still talks to the Plex API directly (via
 utils.plex's _capped_get/_capped_put) - it's included here anyway because
@@ -103,36 +107,53 @@ def is_rating_allowed(content_rating: Optional[str], max_rating: Optional[str], 
 
 def apply_user_label_restrictions(
     config: Dict,
-    all_user_labels: Dict[str, str],
+    all_user_private_labels: Dict[str, str],
 ) -> bool:
     """
-    Apply exclude restrictions so each user can't see other users' collections.
+    Apply exclude restrictions so each user's collection is excluded from
+    every other user's library browse/search results.
 
-    Collections get PrivateCollection_* labels (hidden via exclusions).
+    NOT an access-control boundary - see the module docstring above and
+    README.md's FAQ for the enumeration caveat (Plex applies this
+    exclusion to the collection object, not to the items a client
+    requests directly from it).
+
     Items get Recommended_* labels (visible to everyone, not excluded).
+    Collections get their own PrivateCollection_* label - passed in here
+    fully built via all_user_private_labels, not derived from the item
+    labels by string surgery (#261: label.replace("Recommended_",
+    "PrivateCollection_") silently produced the wrong, unprefixed result
+    whenever the item label wasn't literally "Recommended_<user>" - e.g.
+    every install running with collections.append_usernames: false,
+    where it collapsed to the same bare label for every user).
 
     Each user gets an EXCLUDE filter for other users' PrivateCollection_* labels:
     - They can see their full library (all items, including others' recommendations)
     - They can see their own collection (their PrivateCollection label not excluded)
-    - They cannot see other users' collections (those PrivateCollection labels excluded)
+    - They cannot browse/search to other users' collections (those labels excluded)
 
     Uses direct Plex API calls (not plexapi's updateFriend which doesn't work for Home users).
     Note: Server admin cannot have restrictions applied (Plex limitation).
 
     Args:
         config: Configuration dict with plex token
-        all_user_labels: Dict mapping username to their Recommended_* label name
-                         e.g., {'Jason': 'Recommended_Jason', 'Sarah': 'Recommended_Sarah'}
-                         (converted to PrivateCollection_* internally for exclusions)
+        all_user_private_labels: Dict mapping username to their already-built
+                         PrivateCollection_* label name (see
+                         recommenders/base.py's manage_plex_labels, which
+                         builds this the same way it builds the item-level
+                         label - via build_label_name(), just rooted at
+                         "PrivateCollection" instead of the configured
+                         label_name)
+                         e.g., {'Jason': 'PrivateCollection_Jason', 'Sarah': 'PrivateCollection_Sarah'}
 
     Returns:
         True if all restrictions applied successfully, False if any failed
     """
-    if not all_user_labels:
+    if not all_user_private_labels:
         return True
 
     # Only one user - nothing to hide from anyone
-    if len(all_user_labels) <= 1:
+    if len(all_user_private_labels) <= 1:
         return True
 
     plex_token = config["plex"]["token"]
@@ -170,7 +191,7 @@ def apply_user_label_restrictions(
         logger.debug(f"Plex users available for restrictions: {list(plex_users.keys())}")
 
         all_success = True
-        for username, _user_label in all_user_labels.items():
+        for username, _user_private_label in all_user_private_labels.items():
             # Admin can't have restrictions
             if username.lower() == admin_username:
                 logger.debug(f"Skipping restrictions for admin user: {username}")
@@ -194,13 +215,13 @@ def apply_user_label_restrictions(
                 all_success = False
                 continue
 
-            # Get labels to EXCLUDE (all other users' PrivateCollection labels)
-            # We exclude PrivateCollection_* (on collections) NOT Recommended_* (on items)
-            # This hides other users' collections but keeps items visible to everyone
+            # Labels to EXCLUDE: every OTHER user's already-built
+            # PrivateCollection_* label (on collections), never
+            # Recommended_* (on items) - this hides other users'
+            # collections but keeps items visible to everyone. Used as
+            # given, not derived here (#261 - see this function's docstring).
             exclude_labels = [
-                label.replace("Recommended_", "PrivateCollection_")
-                for u, label in all_user_labels.items()
-                if u.lower() != username.lower()
+                private_label for u, private_label in all_user_private_labels.items() if u.lower() != username.lower()
             ]
 
             if not exclude_labels:

--- a/web/app.py
+++ b/web/app.py
@@ -134,7 +134,20 @@ BASELINE_CSP = (
 _BASELINE_SECURITY_HEADERS = {
     "X-Frame-Options": "DENY",
     "X-Content-Type-Options": "nosniff",
-    "Referrer-Policy": "no-referrer",
+    # same-origin (not no-referrer - see #260): still sends NO referrer on
+    # a cross-origin request, so a link out of this app never leaks
+    # anything to another site, but it DOES send one on a same-origin
+    # request/navigation - which is what makes the browser attach a real
+    # Origin header (not "null") to a plain <form method="post"> submit.
+    # register_origin_host_guard (web/security.py) reads that Origin to
+    # tell a same-origin form POST apart from a cross-site one; under
+    # no-referrer every non-fetch() POST looked cross-site (Origin: null)
+    # and got 403'd, including /login itself. A cross-origin form POST
+    # still gets Origin: null under same-origin (browsers never send
+    # Origin OR Referer cross-origin under this policy) and is still
+    # correctly rejected - this only fixes the same-origin case, it does
+    # not loosen the guard.
+    "Referrer-Policy": "same-origin",
     "Content-Security-Policy": BASELINE_CSP,
 }
 

--- a/web/security.py
+++ b/web/security.py
@@ -141,6 +141,20 @@ def register_origin_host_guard(app) -> None:
         if not is_allowed_host(request.host):
             abort(400)
         if request.method in STATE_CHANGING_METHODS:
+            # The Referer fallback only ever fires for a browser that
+            # sent Origin but not Referer, or neither - which is exactly
+            # what happens on a same-origin form POST when the response
+            # Referrer-Policy (web/app.py's _BASELINE_SECURITY_HEADERS)
+            # is stricter than "same-origin"/"origin"/"strict-origin-
+            # when-cross-origin"/"no-referrer-when-downgrade" - a plain
+            # <form method="post"> (unlike fetch()) never sets Origin
+            # itself, so it relies entirely on the browser doing so, and
+            # a "no-referrer" policy makes browsers send Origin: null on
+            # that request instead (see #260). If the policy is ever
+            # tightened back to no-referrer, every non-fetch() POST in
+            # this app breaks again, including /login - see
+            # tests/test_web_routes.py's TestBaselineSecurityHeaders for
+            # the regression test pinning this coupling.
             source = request.headers.get("Origin") or request.headers.get("Referer")
             if not source:
                 abort(403)


### PR DESCRIPTION
## Summary

Two independent, confirmed production bugs shipped together (both diagnosed with live reproduction before this PR).

### #260 - every HTML form POST returned 403

Root cause: `web/app.py`'s baseline security headers set `Referrer-Policy: no-referrer`. Per the Fetch spec, a browser under that policy sends `Origin: null` (and no `Referer`) on a same-origin plain `<form method="post">` navigation - the origin guard in `web/security.py` then can't resolve `"null"` to this app's own host and rejects with 403. `fetch()`-based routes (`/config/test/<service>`, `/update/apply`) were unaffected since fetch always sends a real Origin. Broken routes: `/run`, `/config/settings`, `/config/users`, `/config/connections`, `/config/libraries`, `/update/dismiss`, and `/login` itself (the guard runs before token auth, so a token-protected deploy couldn't log in at all).

Fix: `Referrer-Policy` -> `same-origin`. Still sends no referrer cross-origin (nothing new leaks), but now sends a real Origin on same-origin requests, which is what the guard needs. Cross-origin/opaque-origin (`null`) POSTs are still correctly rejected - the CSRF guard itself is unchanged.

**Why tests were green while this was broken:** the test client stamps a same-origin Origin header on every request, and the one test pinning `Referrer-Policy` asserted `no-referrer` in isolation - the two facts that combine to cause #260 were never asserted together. Added a regression test pinning the real invariant (Origin-preserving policy, explicitly not `no-referrer`) plus a raw-client test proving cross-origin/opaque posts are still rejected.

### #261 - multi-user installs got one shared, mis-named collection with recommendations hidden from everyone

Root cause: `recommenders/base.py` read `collections.append_usernames` with a code default of `False`, while `config/tuning.example.yml` always documented `true` - and no install path (Dockerfile, setup.sh, web UI) ever writes a real `tuning.yml`, so every fresh install silently ran on the wrong default. With that default: every user's item label collapsed to the identical bare `"Recommended"`; the collection title's username was derived by stripping a `"Recommended_"` prefix that was never there (a silent no-op), producing the literal title `🎬 Recommended - Recommendation` for everyone; and `private_collections` (on by default) then pushed `label!=Recommended` to every non-admin user's Plex account - which matched the shared collection's own label too, hiding it (and its items) from everyone instead of isolating each user's own recommendations.

Fix:
- `append_usernames` now defaults `true`, matching the documented example.
- Collection/label identity is now built from the real username the caller already has (`self.single_user`) and threaded explicitly through `recommenders/base.py` -> `utils/plex.py` -> `utils/plex_policy.py`, instead of re-derived by string-stripping a prefix that wasn't always there.
- If `append_usernames` is explicitly `false` with more than one user configured (the one combination `private_collections` genuinely can't support), curatarr now skips label restrictions and logs a clear warning naming the config key/file instead of sending a filter that hides content.
- **Transition handling:** the orphaned legacy `🎬 Recommended - Recommendation` collection (which `cleanup_old_collections` can never find, since its patterns are all built from a real username) is now cleaned up automatically - its bare `"Recommended"` item label is stripped and the collection deleted - the first time any user's run completes successfully after upgrading. The stale `label!=Recommended` Plex account filter self-heals the same way: applying label restrictions always recomputes and re-sends every configured user's filter in one pass, so it corrects itself as soon as any single user's run succeeds post-upgrade. No manual action needed on either front.

### Documentation correction (no functional change)

README.md / `config/tuning.example.yml` / `utils/plex_policy.py` described per-user collections as private/hidden. Verified against a live server: Plex enforces the `label!=` exclusion on the collection object (absent from browse/search, direct `GET` on its ratingKey 404s for another user) but NOT on the items returned by that collection's own `/children` endpoint - a user who has or guesses a ratingKey (small sequential integers) can still retrieve its full contents via the Plex API. This is Plex server-side behavior, not something curatarr can fix. Reworded the docs to describe this as UI-level separation, not an access-control/privacy boundary. Feature behavior and defaults are unchanged.

### Guardrail (audit remediation)

Extended the tuning.example.yml/code-default parity testing beyond movies:/tv: to every top-level section (collections, external_recommendations, recency_decay, rating_multipliers, negative_signals). Surfaced one additional, NOT fixed here, mismatch for a product decision: `external_recommendations.max_iterations` is documented as `5` but the code fallback (`MAX_DISCOVERY_ITERATIONS`) is `8` - pinned on both sides in the new test so it can't silently drift further.

## Test plan
- [x] Full suite: 2543 passed, 1 skipped (was 2526 passed, 1 skipped before this PR)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .`: no issues found in 126 source files
- [x] Live server verification (spare port, real curl, not just tests): `Referrer-Policy: same-origin` confirmed; POST /run and POST /login with `Origin: null` -> 403; with no Origin/Referer -> 403; with correct matching Origin -> 303 (not 403) for both routes