### PR TITLE
fix: silence config-load noise (#262) and stop losing log files on kill (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.50] - 2026-07-27
+
+### Fixed
+
+- **The Docker container was never actually restarting - it just looked like it - #262.**
+
+  `utils/config.py`'s `load_config()` (and the helper it calls to merge in `tuning.yml`/`trakt.yml`/`radarr.yml`/`sonarr.yml`) printed a handful of "Loaded X.yml"/"Successfully loaded configuration" lines with `print()` on every single call, with no level control. `web/app.py` calls this 1-2x per page render (the update-banner banner shown on every page, plus whichever route is actually serving the request each load config independently) - so every dashboard view, config save, or status check produced a fresh burst of these lines in `docker logs`, which read exactly like the container repeatedly restarting.
+
+  Fixed: those `print()` calls are now the project logger (`log_info`/`log_warning`/`log_error`), and `web/app.py` now caches the parsed config (keyed on the mtimes of every file `load_config()` reads) and the update-check result (a short TTL, deliberately excluding the dismiss check, which still takes effect immediately), so a page view costs at most one real disk read/parse instead of two-plus. A config edit - through the web UI's own save routes, or a hand edit to `tuning.yml` on disk - is still picked up on the very next request, no restart needed. The CLI is unaffected: it always configures logging with these messages visible at their existing default level, so a normal `curatarr` run looks exactly the same as before. Verified in a real container: 11 requests across the dashboard/run/status.json routes produced zero additional log lines beyond one one-time config-format-migration notice, versus roughly 15-20 lines under the old behavior.
+
+- **An interrupted run - `docker stop`, a container recreate, or a crash - could leave a zeroed-out, unexplained log file - #263.**
+
+  Three compounding bugs, all in the log-writing/shutdown path:
+  - `utils/display.py`'s `TeeLogger` (used by every CLI/native recommender run) never flushed the log file per write - only a clean shutdown did. A hard kill lost the whole unflushed buffer, leaving a 0-byte log file. Fixed: every write is now flushed immediately (write volume here is a few hundred/thousand status lines over a multi-minute run, not a hot per-item loop, so this is negligible overhead).
+  - `web/docker_server.py` (the Docker image's own entrypoint) registered no signal handling at all - it caught SIGINT but never SIGTERM. Every `docker stop`/`compose restart`/recreate therefore ate the entire 10-second stop grace period before being hard SIGKILLed (exit 137), which also guaranteed any in-flight run lost its unflushed log buffer. Fixed: it now registers the same SIGINT/SIGTERM -> stop-the-running-job handling the native app has always had. Verified in a real container: `docker stop` dropped from 10.1s/exit 137 to 0.14s/exit 0.
+  - `utils/helpers.py`'s `cleanup_old_logs()` (which runs at the start of every run) truncated any `.log` file over 20MB to exactly 0 bytes in place - a legitimate, still-wanted log from an earlier run could get silently zeroed the moment the very next run's cleanup pass saw it cross that size. Fixed: it now keeps the file's last 20MB (a tail) instead of erasing it outright.
+
+  Also: `web/status.py`'s `unknown` status (shown when a log file has no readable content) now explains itself - "log file is empty (0 bytes) - the run was likely interrupted before writing any output" versus "log file unreadable (...)" for a permissions/OS-level failure - surfaced both on the dashboard (as a tooltip on the badge) and on the log-view page itself (instead of just a blank pane), in the `/status.json` API, and available programmatically as `get_last_run_status()`'s new `reason` field.
+
 ## [2.10.49] - 2026-07-27
 
 ### Fixed

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -218,6 +218,38 @@ class TestTeeLogger:
         # Buffer write called twice (initial + fallback)
         assert mock_buffer.write.call_count == 2
 
+    def test_write_flushes_logfile_immediately(self):
+        """#263: every write() flushes the logfile right away, so a hard
+        kill (SIGKILL, or the pre-fix docker_server.py path this same PR
+        also fixes) can't lose buffered output - confirmed in a real
+        container as a 0-byte log file after an interrupted run."""
+        mock_logfile = Mock()
+        tee = TeeLogger(mock_logfile)
+        tee.stdout_buffer = Mock()
+
+        tee.write("some output\n")
+
+        mock_logfile.write.assert_called_once()
+        mock_logfile.flush.assert_called_once()
+
+    def test_write_survives_kill_real_file(self, tmp_path):
+        """Same guarantee as test_write_flushes_logfile_immediately, but
+        against a real file with no Python-level close/flush afterward -
+        proves content is actually on disk, not just sitting in Python's
+        io buffer waiting for a graceful shutdown that a kill would skip."""
+        log_path = tmp_path / "run.log"
+        with open(log_path, "w", encoding="utf-8") as logfile:
+            tee = TeeLogger(logfile)
+            tee.stdout_buffer = Mock()
+            tee.write("line one\n")
+            tee.write("line two\n")
+            # No explicit flush()/close() here - if TeeLogger.write()
+            # didn't flush per-call, this content would still be sitting
+            # in the OS-level file buffer at this point.
+            with open(log_path, "r", encoding="utf-8") as readback:
+                content = readback.read()
+        assert content == "line one\nline two\n"
+
     def test_flush_without_buffer(self):
         """Test flush() when stdout has no buffer."""
         mock_logfile = Mock()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -291,21 +291,40 @@ class TestCleanupOldLogs:
             assert not os.path.exists(old_log)
             assert os.path.exists(new_log)
 
-    def test_truncates_oversized_append_only_log(self):
-        """An append-only log's mtime is refreshed on every write, so it
-        can never age past retention_days - proves the size-based cap
-        catches what the mtime check structurally cannot."""
+    def test_caps_oversized_append_only_log_keeping_tail(self):
+        """#263: an append-only log's mtime is refreshed on every write,
+        so it can never age past retention_days - proves the size-based
+        cap catches what the mtime check structurally cannot. Must keep
+        a tail, not truncate to 0 - the old zero-byte behavior was
+        confirmed data loss (see cleanup_old_logs' own docstring)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             huge_log = os.path.join(tmpdir, "daily-run.log")
             with open(huge_log, "wb") as f:
-                f.write(b"x" * (MAX_LOG_FILE_BYTES + 1))
+                f.write(b"a" * 1000)
+                f.write(b"z" * MAX_LOG_FILE_BYTES)
 
             # Freshly written - mtime is "now", nowhere near the
             # retention_days cutoff.
             cleanup_old_logs(tmpdir, retention_days=7)
 
             assert os.path.exists(huge_log)
-            assert os.path.getsize(huge_log) == 0
+            with open(huge_log, "rb") as f:
+                content = f.read()
+            assert len(content) == MAX_LOG_FILE_BYTES
+            # Kept the TAIL (the most recent writes), dropped the head.
+            assert content == b"z" * MAX_LOG_FILE_BYTES
+
+    def test_oversized_log_not_zeroed(self):
+        """Belt-and-braces regression pin for #263 - the exact bug
+        report: a file over the cap must never come out at 0 bytes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            huge_log = os.path.join(tmpdir, "recommendations_alice.log")
+            with open(huge_log, "wb") as f:
+                f.write(b"x" * (MAX_LOG_FILE_BYTES + 1))
+
+            cleanup_old_logs(tmpdir, retention_days=7)
+
+            assert os.path.getsize(huge_log) > 0
 
     def test_keeps_log_under_size_cap(self):
         """A log under the cap is left alone by the size check (mtime

--- a/tests/test_web_docker_server.py
+++ b/tests/test_web_docker_server.py
@@ -10,6 +10,7 @@ of web/app.py's own guarantee.
 """
 
 import os
+import signal
 import sys
 from unittest.mock import Mock, patch
 
@@ -23,6 +24,24 @@ import web.docker_server as docker_server
 # _require_auth_token_or_exit to NOT fail closed - see
 # web/security.py's MIN_AUTH_TOKEN_LENGTH.
 _STRONG_TOKEN = "a" * 32
+
+
+@pytest.fixture(autouse=True)
+def _restore_process_signal_handlers():
+    """#263: main() now really does call signal.signal(SIGINT/SIGTERM, ...)
+    with a real handler (previously it registered none at all - that was
+    the bug) - every TestMain test below calls main() with waitress.serve
+    mocked out so it returns immediately, which means this process's own
+    SIGINT/SIGTERM handlers get overwritten as a side effect of just
+    running these tests. Save/restore around every test in this module
+    so that side effect can never leak into a later test or into
+    pytest's own Ctrl-C handling for the rest of the session.
+    """
+    original_sigint = signal.getsignal(signal.SIGINT)
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+    yield
+    signal.signal(signal.SIGINT, original_sigint)
+    signal.signal(signal.SIGTERM, original_sigterm)
 
 
 class TestMain:
@@ -190,3 +209,54 @@ class TestIndependenceFromNativeAppGuardrail:
         source = inspect.getsource(docker_server)
         assert "waitress.serve(" in source
         assert ".run(" not in source
+
+
+class TestShutdownHandling:
+    """#263: docker_server.py's main() caught SIGINT but never SIGTERM
+    (confirmed via /proc/1/status's SigCgt bitmask in a real container),
+    so every `docker stop`/`compose restart`/recreate ate the full stop
+    grace period before being SIGKILLed - and any in-flight recommender
+    run's log lost whatever hadn't been flushed. main() must register
+    the same atexit + SIGINT/SIGTERM -> terminate_running() handling
+    web/app.py's own main() (native mode) has always had.
+    """
+
+    def _run_main_with_mocks(self, monkeypatch):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", _STRONG_TOKEN)
+        fake_app = Mock()
+        with (
+            patch.object(docker_server, "create_app", return_value=fake_app),
+            patch.object(docker_server.waitress, "serve"),
+            patch.object(docker_server.atexit, "register") as mock_atexit_register,
+        ):
+            docker_server.main()
+        return fake_app, mock_atexit_register
+
+    def test_registers_atexit_terminate_running(self, monkeypatch):
+        fake_app, mock_atexit_register = self._run_main_with_mocks(monkeypatch)
+        mock_atexit_register.assert_called_once_with(fake_app.job_manager.terminate_running)
+
+    def test_sigterm_handler_terminates_running_job_and_exits(self, monkeypatch):
+        fake_app, _mock_atexit_register = self._run_main_with_mocks(monkeypatch)
+
+        sigterm_handler = signal.getsignal(signal.SIGTERM)
+        assert sigterm_handler is not None
+        assert sigterm_handler not in (signal.SIG_DFL, signal.SIG_IGN)
+
+        with pytest.raises(SystemExit) as exc_info:
+            sigterm_handler(signal.SIGTERM, None)
+
+        fake_app.job_manager.terminate_running.assert_called_once()
+        assert exc_info.value.code == 0
+
+    def test_sigint_handler_also_terminates_running_job(self, monkeypatch):
+        fake_app, _mock_atexit_register = self._run_main_with_mocks(monkeypatch)
+
+        sigint_handler = signal.getsignal(signal.SIGINT)
+        assert sigint_handler is not None
+        assert sigint_handler not in (signal.SIG_DFL, signal.SIG_IGN)
+
+        with pytest.raises(SystemExit):
+            sigint_handler(signal.SIGINT, None)
+
+        fake_app.job_manager.terminate_running.assert_called_once()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -34,6 +34,64 @@ def _wait_until_idle(app, timeout=10):
     raise AssertionError("job did not finish in time")
 
 
+class TestConfigLoadCaching:
+    """#262: load_config() re-read+re-parsed config.yml (plus every
+    module file it merges in) from disk on EVERY call, and web/app.py
+    called it 1-2x per page render - which read as a container that was
+    repeatedly restarting. Pins both halves of the fix: a render costs
+    at most one real load_config() call, AND a config change made
+    through the web UI is still picked up on the very next request (no
+    stale cache surviving a save).
+    """
+
+    def test_dashboard_render_triggers_at_most_one_config_load(self, client):
+        c, app, root = client
+        with patch("web.app.load_config", wraps=app_module.load_config) as mock_load_config:
+            resp = c.get("/")
+        assert resp.status_code == 200
+        assert mock_load_config.call_count == 1
+
+    def test_repeated_renders_reuse_the_cached_config(self, client):
+        c, app, root = client
+        with patch("web.app.load_config", wraps=app_module.load_config) as mock_load_config:
+            c.get("/")
+            c.get("/")
+            c.get("/")
+        # Three renders, config.yml/tuning.yml untouched in between -
+        # still exactly one real disk load, not three.
+        assert mock_load_config.call_count == 1
+
+    def test_web_ui_save_invalidates_the_cache_immediately(self, client):
+        """The critical round-trip: a save through /config/users must be
+        visible on the very next dashboard render, not served stale from
+        the cache populated by an earlier render."""
+        c, app, root = client
+        first = c.get("/")
+        assert b"alice" in first.data
+        assert b"carol" not in first.data
+
+        c.post(
+            "/config/users",
+            data={
+                "user_count": "2",
+                "username_0": "alice",
+                "display_name_0": "",
+                "exclude_genres_0": "",
+                "max_rating_0": "",
+                "streaming_services_0": "",
+                "username_1": "bob",
+                "display_name_1": "",
+                "exclude_genres_1": "",
+                "max_rating_1": "",
+                "streaming_services_1": "",
+                "new_username": "carol",
+            },
+        )
+
+        second = c.get("/")
+        assert b"carol" in second.data
+
+
 class TestDashboard:
     """Tests for GET /"""
 
@@ -324,6 +382,15 @@ class TestResults:
         c, app, root = client
         resp = c.get("/results/log/..%2Fconfig%2Fconfig.yml")
         assert resp.status_code == 404
+
+    def test_empty_log_shows_reason_instead_of_blank_pane(self, client):
+        """#263: a 0-byte log used to render as a silent blank pane with
+        no indication of why - now shows why."""
+        c, app, root = client
+        open(os.path.join(root, "logs", "empty.log"), "w").close()
+        resp = c.get("/results/log/empty.log")
+        assert resp.status_code == 200
+        assert b"empty" in resp.data.lower()
 
 
 class TestWaitForListening:

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -31,7 +31,7 @@ class TestGetLastRunStatus:
 
     def test_never_run_when_no_logs(self, tmp_path):
         result = get_last_run_status(str(tmp_path), "alice")
-        assert result == {"status": "never_run", "timestamp": None, "log_file": None}
+        assert result == {"status": "never_run", "timestamp": None, "log_file": None, "reason": None}
 
     def test_success_when_no_failure_markers(self, tmp_path):
         _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "Processing alice\nDone\n")
@@ -58,6 +58,30 @@ class TestGetLastRunStatus:
         _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "")
         result = get_last_run_status(str(tmp_path), "alice")
         assert result["status"] == "unknown"
+
+    def test_unknown_reason_distinguishes_empty_from_unreadable(self, tmp_path):
+        """#263: 'unknown' used to collapse two very different causes -
+        a 0-byte log (run interrupted before writing anything) and a
+        log that exists but can't be read at all (permissions, or a
+        race with log-retention cleanup) - into the identical bare
+        'unknown' with no explanation. Both must now say why."""
+        log_path = _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "")
+        empty_result = get_last_run_status(str(tmp_path), "alice")
+        assert empty_result["status"] == "unknown"
+        assert empty_result["reason"] is not None
+        assert "empty" in empty_result["reason"].lower()
+
+        try:
+            os.chmod(log_path, 0o000)
+            if os.access(log_path, os.R_OK):
+                pytest.skip("running as a user that bypasses file permissions (e.g. root)")
+            unreadable_result = get_last_run_status(str(tmp_path), "alice")
+            assert unreadable_result["status"] == "unknown"
+            assert unreadable_result["reason"] is not None
+            assert "unreadable" in unreadable_result["reason"].lower()
+            assert unreadable_result["reason"] != empty_result["reason"]
+        finally:
+            os.chmod(log_path, 0o644)
 
     def test_picks_newest_log_by_mtime(self, tmp_path):
         older = _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "ok\n")
@@ -91,7 +115,7 @@ class TestGetLastRunStatus:
         # last-run status onto this one's dashboard row.
         _write_log(tmp_path, "recommendations_bob_20260101_030000.log", "ok\n")
         result = get_last_run_status(str(tmp_path), "*")
-        assert result == {"status": "never_run", "timestamp": None, "log_file": None}
+        assert result == {"status": "never_run", "timestamp": None, "log_file": None, "reason": None}
 
     def test_username_with_bracket_glob_chars_does_not_match(self, tmp_path):
         _write_log(tmp_path, "recommendations_bob_20260101_030000.log", "ok\n")
@@ -172,7 +196,9 @@ class TestReadLogTail:
 
     def test_reads_content(self, tmp_path):
         _write_log(tmp_path, "a.log", "line1\nline2\n")
-        assert read_log_tail(str(tmp_path), "a.log") == "line1\nline2"
+        content, reason = read_log_tail(str(tmp_path), "a.log")
+        assert content == "line1\nline2"
+        assert reason is None
 
     def test_raises_for_missing_file(self, tmp_path):
         with pytest.raises(FileNotFoundError):
@@ -184,13 +210,13 @@ class TestReadLogTail:
 
     def test_redacts_secrets(self, tmp_path):
         _write_log(tmp_path, "a.log", "token=abcdef123456\n")
-        result = read_log_tail(str(tmp_path), "a.log")
-        assert "abcdef123456" not in result
+        content, _reason = read_log_tail(str(tmp_path), "a.log")
+        assert "abcdef123456" not in content
 
     def test_truncates_to_max_lines(self, tmp_path):
         content = "\n".join(f"line{i}" for i in range(10))
         _write_log(tmp_path, "a.log", content)
-        result = read_log_tail(str(tmp_path), "a.log", max_lines=3)
+        result, _reason = read_log_tail(str(tmp_path), "a.log", max_lines=3)
         assert result.splitlines() == ["line7", "line8", "line9"]
 
     def test_rejects_non_log_extension(self, tmp_path):
@@ -210,6 +236,15 @@ class TestReadLogTail:
             pytest.skip("symlinks not supported in this environment")
         with pytest.raises(FileNotFoundError):
             read_log_tail(str(logs_dir), "escape.log")
+
+    def test_empty_log_returns_reason(self, tmp_path):
+        """#263: a 0-byte log (interrupted run) gets an explanatory
+        reason instead of just an empty string with no context."""
+        _write_log(tmp_path, "a.log", "")
+        content, reason = read_log_tail(str(tmp_path), "a.log")
+        assert content == ""
+        assert reason is not None
+        assert "empty" in reason.lower()
 
 
 class TestDisplayNameSafeSlug:

--- a/tests/test_web_update_banner.py
+++ b/tests/test_web_update_banner.py
@@ -382,3 +382,40 @@ class TestDismissSnooze:
             resp = fresh_client.get("/")
 
         assert b"update-banner" not in resp.data
+
+
+class TestUpdateAvailableCaching:
+    """#262: update_available() (itself already interval-gated against
+    hitting the network, see utils/update_check.py) still re-reads its
+    own small on-disk cache file on every call - the context processor
+    fired it on EVERY page render. Deduped per app instance for a short
+    TTL, same spirit as _load_config's own cache (see
+    TestConfigLoadCaching in tests/test_web_routes.py)."""
+
+    def test_repeated_renders_reuse_the_cached_update_check(self, client):
+        c, app, root = client
+        _write_config(root, update_mode="notify")
+
+        with patch("web.app.update_available", return_value=("2.9.0", "2.8.28", True)) as mock_update_available:
+            c.get("/")
+            c.get("/")
+            c.get("/")
+
+        assert mock_update_available.call_count == 1
+
+    def test_dismiss_still_takes_effect_on_the_very_next_render(self, client):
+        """The one thing that must NOT be cached: is_dismissed() itself
+        is checked fresh every render, so dismissing still hides the
+        banner immediately - caching update_available()'s own result
+        must never delay that."""
+        c, app, root = client
+        _write_config(root, update_mode="notify")
+
+        with patch("web.app.update_available", return_value=("2.9.0", "2.8.28", True)):
+            shown = c.get("/")
+            assert b"update-banner" in shown.data
+
+            c.post("/update/dismiss", data={"version": "2.9.0", "next": "/"})
+
+            hidden = c.get("/")
+            assert b"update-banner" not in hidden.data

--- a/utils/config.py
+++ b/utils/config.py
@@ -10,8 +10,10 @@ from typing import Dict, List, Optional
 
 import yaml
 
+from .display import log_error, log_info, log_warning
+
 # Project version - single source of truth
-__version__ = "2.10.49"
+__version__ = "2.10.50"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so
@@ -254,9 +256,9 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
                 tuning = yaml.safe_load(f)
                 if tuning:
                     config = _deep_merge_dicts(config, tuning)
-                    print("  Loaded tuning.yml")
+                    log_info("Loaded tuning.yml")
         except Exception as e:
-            print(f"\033[93mWarning: Could not load tuning.yml: {e}\033[0m")
+            log_warning(f"Could not load tuning.yml: {e}")
 
     # Feature modules go under their key, but still deep-merge in case
     # config.yml already carries a same-named section (e.g. pre-migration
@@ -273,9 +275,9 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
                             config[module] = _deep_merge_dicts(existing, module_config)
                         else:
                             config[module] = module_config
-                        print(f"  Loaded {module}.yml")
+                        log_info(f"Loaded {module}.yml")
             except Exception as e:
-                print(f"\033[93mWarning: Could not load {module}.yml: {e}\033[0m")
+                log_warning(f"Could not load {module}.yml: {e}")
 
     return config
 
@@ -325,7 +327,23 @@ def load_config(config_path: str) -> dict:
     try:
         with open(config_path, "r", encoding="utf-8") as file:
             config = yaml.safe_load(file)
-            print(f"Successfully loaded configuration from {config_path}")
+            # #262: this (and every print() in _load_module_configs
+            # above) fired on EVERY load_config() call with no level
+            # control - web/app.py calls load_config() 1-2x per page
+            # render (dashboard/config context-processor/route handler),
+            # so a container's logs filled with "Loaded tuning.yml"-style
+            # lines on every request, which read as if the container
+            # were repeatedly restarting. Converted to the project
+            # logger: the CLI (utils/cli.py) always calls setup_logging()
+            # first, which attaches a handler at INFO by default, so
+            # normal CLI runs see exactly the same lines as before at
+            # the same default visibility. web/app.py and
+            # web/docker_server.py never call setup_logging() at all,
+            # so with no handler configured these fall through to
+            # Python's WARNING-only last-resort handler and are silent
+            # by default there - see web/app.py's own config-load cache
+            # (added in this same PR) for the other half of this fix.
+            log_info(f"Successfully loaded configuration from {config_path}")
 
         config_dir = os.path.dirname(config_path) or "."
 
@@ -348,11 +366,11 @@ def load_config(config_path: str) -> dict:
                 if section not in config:
                     config[section] = {}
                 config[section][key] = value
-                print(f"  Using {env_var} from environment")
+                log_info(f"Using {env_var} from environment")
 
         return config
     except Exception as e:
-        print(f"\033[91mError loading config from {config_path}: {e}\033[0m")
+        log_error(f"Error loading config from {config_path}: {e}")
         raise
 
 

--- a/utils/display.py
+++ b/utils/display.py
@@ -121,6 +121,26 @@ class TeeLogger:
     """
     A simple 'tee' class that writes to both console and a file,
     stripping ANSI color codes for the file and handling Unicode characters.
+
+    #263: the log file is flushed after every write() call. setup_log_file()
+    (utils/cli.py) opens it with Python's default block buffering, and
+    nothing else in the write path flushed per-line - only
+    teardown_log_file()'s explicit close on a clean exit did. A hard kill
+    (SIGKILL, or the SIGTERM-less docker_server.py path this PR also
+    fixes) lost the whole in-process buffer, leaving a 0-byte log file
+    that web/status.py then reports as an unexplained "unknown" status.
+    Confirmed in a real container: python-exit=137, ~60 bytes printed to
+    stdout, 0 bytes on disk.
+
+    Chose per-write flush() over opening the file line-buffered
+    (buffering=1): write volume here is a few hundred to low thousands of
+    status lines over a multi-minute run (not a per-item hot loop - this
+    is CLI progress output, not an access log), and every write() call
+    already does a redact() pass plus an ANSI-stripping regex substitution,
+    both costlier than the flush() syscall this adds. Per-write flush is
+    also a strictly stronger guarantee than line buffering: it can never
+    lose a write regardless of whether that write happened to end in a
+    newline (line buffering only flushes when it sees one).
     """
 
     def __init__(self, logfile):
@@ -145,9 +165,11 @@ class TeeLogger:
             else:
                 sys.__stdout__.write(text)
 
-            # Write to file (strip ANSI codes)
+            # Write to file (strip ANSI codes), then flush immediately
+            # (#263 - see class docstring) so a kill can never zero it.
             stripped = ANSI_PATTERN.sub("", text)
             self.logfile.write(stripped)
+            self.logfile.flush()
         except UnicodeEncodeError:
             # Fallback for problematic characters
             safe_text = text.encode("ascii", "replace").decode("ascii")
@@ -157,6 +179,7 @@ class TeeLogger:
                 sys.__stdout__.write(safe_text)
             stripped = ANSI_PATTERN.sub("", safe_text)
             self.logfile.write(stripped)
+            self.logfile.flush()
 
     def flush(self):
         if hasattr(sys.stdout, "buffer"):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -339,16 +339,29 @@ def cleanup_old_logs(log_dir: str, retention_days: int) -> None:
     """
     Remove log files older than specified retention period.
 
-    Also force-truncates any single .log file that has grown past
-    MAX_LOG_FILE_BYTES, regardless of its mtime. This exists for
-    append-only logs (e.g. a cron job's `>> logs/daily-run.log`
-    redirect) - every write refreshes the mtime, so the age-based
-    removal below can never trigger for them and they would otherwise
-    grow forever. Truncating in place (rather than removing/renaming)
-    is deliberate: a process that already has the file open in append
-    mode keeps writing from the new end-of-file without needing to
-    reopen it - the same "copytruncate" strategy logrotate uses for
-    this exact situation.
+    Also caps any single .log file that has grown past MAX_LOG_FILE_BYTES,
+    regardless of its mtime, to its last MAX_LOG_FILE_BYTES - keeping a
+    tail instead of truncating to zero (#263 - see below for why this
+    changed). This exists for append-only logs (e.g. a cron job's
+    `>> logs/daily-run.log` redirect) - every write refreshes the mtime,
+    so the age-based removal below can never trigger for them and they
+    would otherwise grow forever. Rewriting in place (rather than
+    removing/renaming) is deliberate: a process that already has the
+    file open in append mode keeps writing from the new end-of-file
+    without needing to reopen it - the same "copytruncate" strategy
+    logrotate uses for this exact situation.
+
+    #263: this used to truncate to exactly 0 bytes (`open(path, "w")`),
+    which is silent, permanent data loss the moment ANY .log file in
+    log_dir - not just genuinely append-only ones - happens to exceed
+    the cap: this function runs at the START of every setup_log_file()
+    call (see utils/cli.py), so a user's own completed, still-wanted
+    run log got zeroed out by the very NEXT user's run in the same
+    batch, the moment it crossed 20MB - producing a permanent "unknown"
+    status (web/status.py) with no way to recover the content. Keeping
+    a tail preserves the same size-bounding property (and the same
+    copytruncate-safety for an actively-appending writer) without
+    destroying everything that was there.
 
     Args:
         log_dir: Directory containing log files
@@ -369,12 +382,18 @@ def cleanup_old_logs(log_dir: str, retention_days: int) -> None:
             try:
                 file_size = os.path.getsize(filepath)
                 if file_size > MAX_LOG_FILE_BYTES:
-                    with open(filepath, "w"):
-                        pass
-                    log_info(f"Truncated oversized log: {filename} ({file_size} bytes > {MAX_LOG_FILE_BYTES} cap)")
+                    with open(filepath, "rb") as f:
+                        f.seek(file_size - MAX_LOG_FILE_BYTES)
+                        tail = f.read()
+                    with open(filepath, "wb") as f:
+                        f.write(tail)
+                    log_info(
+                        f"Capped oversized log to its last {MAX_LOG_FILE_BYTES} bytes: "
+                        f"{filename} (was {file_size} bytes)"
+                    )
                     continue
             except Exception as e:
-                log_warning(f"Failed to check/truncate oversized log {filename}: {e}")
+                log_warning(f"Failed to check/cap oversized log {filename}: {e}")
                 continue
 
             try:

--- a/web/app.py
+++ b/web/app.py
@@ -35,7 +35,7 @@ import threading
 import time
 import webbrowser
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from flask import (
     Flask,
@@ -226,16 +226,90 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
                 response.headers[name] = value
         return response
 
+    # #262: load_config() re-reads and re-parses config.yml (plus up to
+    # 4 module files - tuning/trakt/radarr/sonarr.yml) from disk on
+    # EVERY call, and this closure gets called 1-2x per page render (the
+    # update-banner context processor below plus whichever route handler
+    # is serving the request each call _load_config() independently) -
+    # most of what made a Docker container's logs look like it was
+    # repeatedly restarting (utils/config.py's own log_info calls for
+    # this are now level-controlled, but the disk I/O + YAML parsing
+    # itself was still happening every time regardless). Cached below,
+    # keyed on the mtimes of every file load_config() reads, so a page
+    # view costs at most one disk read - and a config change (through
+    # the web UI's own save routes, or a hand edit to tuning.yml on
+    # disk) invalidates the cache and is picked up on the very next
+    # request, no restart needed. Nanosecond mtimes (not the coarser
+    # whole-second os.path.getmtime) so two saves landing within the
+    # same second still invalidate correctly.
+    _config_cache_lock = threading.Lock()
+    _config_cache: Dict[str, Any] = {"populated": False, "mtimes": None, "config": None}
+    _CONFIG_MODULE_NAMES = ("tuning", "trakt", "radarr", "sonarr")
+
+    def _config_file_mtimes(config_dir: str) -> Tuple[Optional[int], ...]:
+        paths = [os.path.join(config_dir, "config.yml")] + [
+            os.path.join(config_dir, f"{name}.yml") for name in _CONFIG_MODULE_NAMES
+        ]
+        mtimes: List[Optional[int]] = []
+        for path in paths:
+            try:
+                mtimes.append(os.stat(path).st_mtime_ns)
+            except OSError:
+                mtimes.append(None)
+        return tuple(mtimes)
+
     def _load_config():
-        config_path = os.path.join(project_root, "config", "config.yml")
+        config_dir = os.path.join(project_root, "config")
+        config_path = os.path.join(config_dir, "config.yml")
+        mtimes = _config_file_mtimes(config_dir)
+        with _config_cache_lock:
+            if _config_cache["populated"] and _config_cache["mtimes"] == mtimes:
+                return _config_cache["config"]
         try:
-            return load_config(config_path)
+            config = load_config(config_path)
         except Exception:
-            return None
+            config = None
+        with _config_cache_lock:
+            _config_cache["populated"] = True
+            _config_cache["mtimes"] = mtimes
+            _config_cache["config"] = config
+        return config
 
     def _load_users():
         config = _load_config()
         return get_users_from_config(config) if config else []
+
+    # #262: update_available() (itself already interval-gated against
+    # hitting the network more than once every UPDATE_CHECK_INTERVAL_HOURS
+    # - see utils/update_check.py) still re-reads its own small on-disk
+    # cache file on every call, and the context processor below calls it
+    # on every single page render. Cached here too, same spirit as
+    # _load_config above, but deliberately NOT wrapping is_dismissed()
+    # below - a dismiss must take effect on the very next render, and
+    # only update_mode is part of this cache's key (so a config change
+    # invalidates it immediately, same as _load_config), so a short TTL
+    # is enough to dedupe the common case of several renders in a row
+    # with nothing having changed.
+    _update_check_cache_lock = threading.Lock()
+    _update_check_cache: Dict[str, Any] = {"update_mode": None, "computed_at": 0.0, "result": None}
+    _UPDATE_CHECK_CACHE_TTL_SECONDS = 60
+
+    def _cached_update_available(update_mode: str):
+        now = time.time()
+        with _update_check_cache_lock:
+            cached = _update_check_cache
+            if (
+                cached["result"] is not None
+                and cached["update_mode"] == update_mode
+                and now - cached["computed_at"] < _UPDATE_CHECK_CACHE_TTL_SECONDS
+            ):
+                return cached["result"]
+        result = update_available(update_mode=update_mode)
+        with _update_check_cache_lock:
+            _update_check_cache["update_mode"] = update_mode
+            _update_check_cache["computed_at"] = now
+            _update_check_cache["result"] = result
+        return result
 
     @app.context_processor
     def _update_banner_context():
@@ -272,7 +346,7 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
             if not config:
                 return {"update_banner": None}
             update_mode = get_update_mode(config)
-            latest, current, is_newer = update_available(update_mode=update_mode)
+            latest, current, is_newer = _cached_update_available(update_mode)
             if not is_newer:
                 return {"update_banner": None}
             # 7-day dismiss snooze, keyed to the exact version offered -
@@ -404,6 +478,9 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
                 "last_run": {
                     "timestamp": last_run["timestamp"].isoformat(),
                     "status": last_run["status"],
+                    # Only non-None when status is "unknown" (#263) - see
+                    # web/status.py's get_last_run_status docstring.
+                    "reason": last_run.get("reason"),
                 }
                 if last_run
                 else None,
@@ -564,10 +641,10 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
     @app.get("/results/log/<path:filename>")
     def results_log(filename):
         try:
-            tail = read_log_tail(logs_dir, filename)
+            tail, empty_reason = read_log_tail(logs_dir, filename)
         except FileNotFoundError:
             abort(404)
-        return render_template("log_view.html", filename=filename, content=tail)
+        return render_template("log_view.html", filename=filename, content=tail, empty_reason=empty_reason)
 
     return app
 

--- a/web/docker_server.py
+++ b/web/docker_server.py
@@ -38,7 +38,9 @@ see requirements-docker.txt/.lock and the Dockerfile - never installed
 for a native source/binary install, which has no use for it.
 """
 
+import atexit
 import os
+import signal
 import sys
 
 import waitress
@@ -131,6 +133,38 @@ def main() -> None:
     host = os.environ.get("CURATARR_UI_HOST", "0.0.0.0")
     _require_auth_token_or_exit(host)
     app = create_app(bind_host=host)
+
+    # #263: this process is PID 1 in the container (no init system in
+    # front of it), and until this fix it caught SIGINT but never
+    # SIGTERM - confirmed via /proc/1/status's SigCgt bitmask in a real
+    # container. `docker stop`/`compose restart`/a `compose up -d`
+    # recreate all send SIGTERM first and only SIGKILL after the full
+    # stop grace period (10s by default) if the process hasn't exited -
+    # so every one of those operations was silently eating that entire
+    # grace period before being hard-killed (exit 137), which also
+    # meant any in-flight recommender run's log file lost whatever
+    # hadn't been flushed yet (see utils/display.py's TeeLogger, fixed
+    # in this same PR to flush per-write - this handler is what actually
+    # gets a chance to run BEFORE that kill now). Mirrors web/app.py's
+    # main() (native mode), which has always registered this.
+    # Flask's stub doesn't declare this dynamically-attached attribute
+    # (see web/app.py's create_app(), the only place it's set) - real,
+    # deliberate attribute access, not a typo.
+    atexit.register(app.job_manager.terminate_running)  # type: ignore[attr-defined]
+
+    def _handle_shutdown_signal(signum, frame):
+        app.job_manager.terminate_running()  # type: ignore[attr-defined]
+        sys.exit(0)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handle_shutdown_signal)
+        except (ValueError, OSError):
+            # signal.signal() only works on the main thread, and not
+            # every signal is available on every platform - atexit above
+            # still covers a normal interpreter shutdown either way.
+            pass
+
     waitress.serve(app, host=host, port=port, threads=THREADS)
 
 

--- a/web/status.py
+++ b/web/status.py
@@ -8,7 +8,7 @@ import glob
 import os
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .security import redact, safe_join
 
@@ -38,16 +38,47 @@ def _parse_timestamp(filename: str) -> Optional[datetime]:
 
 
 def _read_tail(path: str, max_bytes: int = TAIL_BYTES) -> str:
-    """Best-effort read of up to the last max_bytes of a file as text."""
+    """Best-effort read of up to the last max_bytes of a file as text.
+
+    Thin wrapper around _read_tail_with_reason() for callers that don't
+    need to distinguish WHY an empty result came back - see that
+    function's docstring (#263).
+    """
+    content, _reason = _read_tail_with_reason(path, max_bytes)
+    return content
+
+
+def _read_tail_with_reason(path: str, max_bytes: int = TAIL_BYTES) -> Tuple[str, Optional[str]]:
+    """Same read as _read_tail, but also returns WHY the content is empty
+    when it is - _read_tail alone collapsed "0-byte log, run was
+    interrupted before writing anything" and "file exists but can't be
+    read (permissions, race with log-retention cleanup, etc.)" into the
+    same bare "" (#263), which is exactly what made get_last_run_status's
+    "unknown" status unexplainable - a real interrupted-run report showed
+    an "unknown" badge with a live "view log" link, and the log pane was
+    just blank with no indication of why.
+
+    Returns:
+        (content, reason) - reason is None whenever content is genuinely
+        non-empty; otherwise a short human-readable explanation.
+    """
     try:
         size = os.path.getsize(path)
+    except OSError as e:
+        return "", f"log file unreadable ({e.strerror or e})"
+
+    try:
         with open(path, "rb") as f:
             if size > max_bytes:
                 f.seek(size - max_bytes)
             data = f.read()
-        return data.decode("utf-8", errors="replace")
-    except OSError:
-        return ""
+    except OSError as e:
+        return "", f"log file unreadable ({e.strerror or e})"
+
+    content = data.decode("utf-8", errors="replace")
+    if size == 0:
+        return content, "log file is empty (0 bytes) - the run was likely interrupted before writing any output"
+    return content, None
 
 
 def latest_user_log(logs_dir: str, username: str) -> Optional[str]:
@@ -76,10 +107,14 @@ def get_last_run_status(logs_dir: str, username: str) -> Dict:
       status: 'never_run' | 'success' | 'failed' | 'unknown'
       timestamp: datetime or None
       log_file: basename of the log, or None
+      reason: human-readable explanation, only set (non-None) when
+        status is 'unknown' (#263) - distinguishes a genuinely empty
+        (0-byte, interrupted-run) log from one that exists but couldn't
+        be read at all.
     """
     log_path = latest_user_log(logs_dir, username)
     if not log_path:
-        return {"status": "never_run", "timestamp": None, "log_file": None}
+        return {"status": "never_run", "timestamp": None, "log_file": None, "reason": None}
 
     basename = os.path.basename(log_path)
     timestamp = _parse_timestamp(basename)
@@ -92,15 +127,17 @@ def get_last_run_status(logs_dir: str, username: str) -> Dict:
             # timestamp rather than 500ing the dashboard.
             timestamp = None
 
-    content = _read_tail(log_path)
+    content, empty_reason = _read_tail_with_reason(log_path)
+    reason: Optional[str] = None
     if not content.strip():
         status = "unknown"
+        reason = empty_reason or "log file has no readable content"
     elif any(marker in content.lower() for marker in _FAILURE_MARKERS):
         status = "failed"
     else:
         status = "success"
 
-    return {"status": status, "timestamp": timestamp, "log_file": basename}
+    return {"status": status, "timestamp": timestamp, "log_file": basename, "reason": reason}
 
 
 def list_log_files(logs_dir: str) -> List[Dict]:
@@ -156,17 +193,22 @@ def find_user_watchlist(external_dir: str, config: Dict, username: str) -> Optio
     return None
 
 
-def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> str:
+def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> Tuple[str, Optional[str]]:
     """Read the last max_lines of logs_dir/filename, secrets redacted.
 
     Raises FileNotFoundError if filename escapes logs_dir, isn't a
     *.log file, or doesn't resolve to a real file.
+
+    Returns (content, empty_reason) - empty_reason is None whenever
+    content is non-empty, otherwise the same human-readable explanation
+    get_last_run_status's "reason" surfaces (#263), so the log-view page
+    can show why a log is blank instead of just rendering nothing.
     """
     if not filename.endswith(".log"):
         raise FileNotFoundError(filename)
     path = safe_join(logs_dir, filename)
     if not os.path.isfile(path):
         raise FileNotFoundError(filename)
-    content = _read_tail(path)
+    content, reason = _read_tail_with_reason(path)
     lines = content.splitlines()[-max_lines:]
-    return redact("\n".join(lines))
+    return redact("\n".join(lines)), (reason if not content.strip() else None)

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -20,7 +20,7 @@
     <tr>
       <td>{{ row.username }}</td>
       <td>{{ row.timestamp.strftime('%Y-%m-%d %H:%M:%S') if row.timestamp else '—' }}</td>
-      <td><span class="badge {{ row.status }}">{{ row.status }}</span></td>
+      <td><span class="badge {{ row.status }}"{% if row.reason %} title="{{ row.reason }}"{% endif %}>{{ row.status }}</span></td>
       <td>
         {% if row.log_file %}
         <a href="{{ url_for('results_log', filename=row.log_file) }}">view log</a>

--- a/web/templates/log_view.html
+++ b/web/templates/log_view.html
@@ -3,5 +3,8 @@
 {% block content %}
 <h1>{{ filename }}</h1>
 <p><a href="{{ url_for('results') }}">&larr; back to results</a></p>
+{% if empty_reason %}
+<p class="banner"><strong>Log is empty:</strong> {{ empty_reason }}</p>
+{% endif %}
 <pre class="log-output">{{ content }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary

Two independent, confirmed production bugs, both reproduced end-to-end in the real container image.

### #262 - container looked like it was repeatedly restarting

Not a restart: an idle container (0 requests) produces zero log lines and `RestartCount=0`. What the reporter saw was per-request config loading printed at `print()` level with no level control - `utils/config.py`'s `load_config()` (and the tuning/trakt/radarr/sonarr.yml merge helper) print "Loaded X.yml"/"Successfully loaded configuration" on every single call, and `web/app.py` calls it 1-2x per page render (the update-banner context processor plus whichever route handler is serving the request each independently reload it) - so a dashboard view cost 2 full loads, each bursting a handful of lines into `docker logs`.

Fix:
- Converted those `print()` calls to the project logger (`log_info`/`log_warning`/`log_error`). The CLI is unaffected - `utils/cli.py` always calls `setup_logging()` first, which attaches a handler at INFO by default, so a normal run shows exactly the same lines at the same visibility. `web/app.py`/`web/docker_server.py` never call `setup_logging()`, so with no handler configured these now fall through to Python's WARNING-only last-resort handler and are silent there by default - genuine load failures (logged at ERROR) still surface.
- Cached the parsed config in `web/app.py`, keyed on the mtimes of `config.yml` plus the four module files it merges in, so a page view costs at most one real disk read/parse. A save through the web UI's own routes (or a hand edit to `tuning.yml` on disk) still invalidates the cache and is picked up on the very next request - verified with a round-trip test (save a user via `/config/users`, confirm the very next dashboard render shows it).
- Same treatment for `update_available()` in the context processor (itself already interval-gated against hitting the network, but still re-read its own small cache file every render) - cached per app instance with a short TTL, deliberately NOT wrapping the dismiss check, so dismissing an update still hides the banner on the very next render (verified).

**Real container measurements:** idle for 65s -> 0 log lines, `RestartCount=0`, healthy. 11 requests across `/`, `/run`, `/status.json` -> exactly 0 additional log lines beyond one one-time config-format-migration notice (an unrelated, genuinely one-time action, left as a visible `print()`).

### #263 - an interrupted run could leave a zeroed-out, unexplained log file

Three compounding bugs in the log-write/shutdown path, all confirmed:
- `utils/display.py`'s `TeeLogger` (used by every CLI/native run, including the recommender subprocess a web-UI-triggered run launches) never flushed the log file per write - only `teardown_log_file()`'s clean-exit close did. A hard kill lost the whole unflushed buffer. **Chose per-write `flush()` over opening the file line-buffered**: write volume here is a few hundred/thousand status lines over a multi-minute run (not a per-item hot loop - every `write()` call already does a `redact()` pass plus an ANSI-strip regex, both costlier than the added flush syscall), and per-write flush is a strictly stronger guarantee (works even for a write that doesn't end in a newline).
- `web/docker_server.py` (the Docker image's own entrypoint, PID 1 in the container) registered no signal handling at all - confirmed via `/proc/1/status`'s SigCgt bitmask, it caught SIGINT but never SIGTERM. Every `docker stop`/`compose restart`/recreate therefore ate the full 10s stop grace period before being hard SIGKILLed. Fixed: registers the same SIGINT/SIGTERM -> `terminate_running()` + `atexit` handling `web/app.py`'s native-mode `main()` has always had.
- `utils/helpers.py`'s `cleanup_old_logs()` (runs at the start of every `setup_log_file()` call) truncated any `.log` file over the 20MB cap to **exactly 0 bytes in place** - a legitimate, still-wanted log from an earlier run in the same batch could get silently zeroed by the very next run's cleanup pass. Fixed to keep the file's last 20MB (a tail) instead of erasing it.

Also: `web/status.py`'s `unknown` status (a log file with no readable content) now explains itself instead of just being an unexplained badge - "log file is empty (0 bytes) - the run was likely interrupted before writing any output" vs. "log file unreadable (...)" for a permissions/OS-level failure - surfaced on the dashboard (tooltip on the badge), the log-view page (instead of a silent blank pane), and `/status.json`.

**Real container measurements:**
- `docker stop` on a container with this fix: **0.14s, exit 0**.
- `docker stop` on a container built from `main` (pre-fix, same commit PR1 merged): **10.1s, exit 137**.
- A process using `TeeLogger` inside the real container, SIGKILLed mid-run (before a scheduled third `print()` call): the log file on disk contains everything printed before the kill, nothing lost.

## Test plan
- [x] Full suite: 2557 passed, 1 skipped (was 2543 passed, 1 skipped after PR1 merged)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .`: no issues found in 126 source files
- [x] New regression tests: config-load-per-render count, update-check caching + dismiss-still-immediate, TeeLogger surviving a kill (mock + real-file), `unknown` status reason (empty vs. unreadable), `cleanup_old_logs` tail retention, docker_server SIGTERM/SIGINT handler wiring
- [x] Verified in a real container (see measurements above), not just unit tests