### PR TITLE
fix: web UI Run in Docker (issue #260 pt 2) + tuning.yml doc mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.51] - 2026-07-27
+
+### Fixed
+
+- **The web UI's Run button now actually starts a run in Docker - the second half of issue #260.** PR1 (2.10.49) fixed the 403 that blocked the request from reaching the server at all; the run itself was still silently broken behind it. `JobManager` resolved `recommenders/<engine>.py` and `run.sh`/`run.ps1` against `CURATARR_CONFIG_DIR` (the *config/data* directory - `/data` in the Docker image) instead of the directory the code actually lives in (`/app`) - every movie/tv/external/full run launched from the web UI in Docker failed immediately with `can't open file '/data/recommenders/movie.py'`, while the HTTP request itself still returned a normal 200/redirect, so nothing in the UI indicated the run never happened.
+
+  Fixed with a new `utils.helpers.get_code_root()` - deliberately separate from `get_project_root()` (which answers "where's config/cache/logs", not "where's the code" - the two happen to coincide for a plain source checkout, which is exactly why this went unnoticed until Docker deliberately splits them). `JobManager` now resolves scripts against this instead.
+
+  Verified end-to-end in all four ways curatarr actually ships, not just that the HTTP request returns 200: a real Docker container (movie/tv/external all launch and produce real log output, including a real recommenders/movie.py traceback instead of a file-not-found error - full/run.sh also now launches, though it separately hits a pip-install step that isn't expected to succeed inside this image and needs its own look), a real PyInstaller frozen binary build (all three engines launch via `--run-recommender`), a native (non-Docker) web-mode run, and the existing source-checkout test suite. Issue #260 stays open until this ships and the reporter confirms.
+
+- **Two `config/tuning.example.yml` documentation mismatches, surfaced by the guardrail test added in 2.10.49, now resolved:**
+  - `external_recommendations.max_iterations`: the example documented `5`; the code's actual fallback has been `8` for months and every install has been running on `8` the whole time (nothing ever wrote a real `tuning.yml` - see 2.10.49's #261 notes for why that's been true of every fresh install). The example was corrected to `8` to match reality, not the other way around - changing the code to `5` would have silently altered discovery behavior for every existing install to match a doc that was simply wrong. The web UI Settings screen's own "if not set" default (`web/config_settings.py`) was corrected to match.
+  - **`external_recommendations.enabled` is now actually honored - this changes output for anyone who had set it to `false`.** The example has always documented this key, but nothing in `recommenders/external.py` ever read it - every install got external recommendations regardless of what this was set to. It's now wired up (defaulting `true`, so nobody's current setup changes unless they'd already set it `false`). **If you have `external_recommendations.enabled: false` in your `tuning.yml`, external recommendations/watchlist generation will now actually stop** - Huntarr (`huntarr.sequel_huntarr`/`huntarr.horizon_huntarr`) is unaffected, since it's a separate feature under its own config keys. This is the behavior you configured; it just wasn't being honored before.
+  - The guardrail test now passes clean across every top-level section of `tuning.example.yml` with no known mismatches remaining.
+
 ## [2.10.50] - 2026-07-27
 
 ### Fixed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -90,7 +90,7 @@ external_recommendations:
   auto_open_html: false  # Open watchlist in browser after generation
   # Discovery iteration settings
   min_votes: 50  # Minimum TMDB votes for reliability (filters garbage entries)
-  max_iterations: 5  # Max discovery passes before giving up (more = slower but more thorough)
+  max_iterations: 8  # Max discovery passes before giving up (more = slower but more thorough)
   # Language filter - only recommend content in this language (ISO 639-1 code)
   # Examples: "en" (English), "es" (Spanish), "ja" (Japanese), "ko" (Korean)
   # Set to null or omit to disable language filtering

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -2343,12 +2343,23 @@ def _main_impl():
     huntarr_config = config.get("huntarr", {})
     run_sequel_huntarr = huntarr_config.get("sequel_huntarr", True)
     run_horizon_huntarr = huntarr_config.get("horizon_huntarr", True)
-    run_recommendations = not args.huntarr_only
+    # external_recommendations.enabled: default True, matching the
+    # documented example and every install's effective behavior before
+    # this was wired up - this key was previously read nowhere at all
+    # (config/tuning.example.yml documented it, but no code path ever
+    # checked it), so anyone who set it false was silently still getting
+    # external recommendations anyway. Gates ONLY the recommendations/
+    # watchlist-building pass below, never Huntarr (a separate feature
+    # under its own huntarr.* keys, already independently gated above).
+    external_recommendations_enabled = config.get("external_recommendations", {}).get("enabled", True)
+    run_recommendations = not args.huntarr_only and external_recommendations_enabled
 
     if args.huntarr_only:
         print(f"\n{GREEN}=== Huntarr: Collection Movie Finder ==={RESET}")
     else:
         print(f"\n{GREEN}=== External Recommendations Generator ==={RESET}")
+        if not external_recommendations_enabled:
+            print(f"{YELLOW}Skipping recommendations (external_recommendations.enabled is false in config){RESET}")
         if run_sequel_huntarr:
             print(f"{CYAN}Sequel Huntarr enabled{RESET}")
         if run_horizon_huntarr:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -567,19 +567,26 @@ class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
 
         tuning = self._load_example_tuning()
         external = tuning["external_recommendations"]
+        # #260/#261-guardrail follow-up: this WAS a mismatch (example
+        # said 5, MAX_DISCOVERY_ITERATIONS was 8) - every install has
+        # been running 8 for months, so the example was corrected to
+        # match longstanding real behavior rather than the code changed
+        # to match a doc that was simply wrong. web/config_settings.py's
+        # own "if unset" display default was fixed to match too.
+        assert external["max_iterations"] == 8
+        assert MAX_DISCOVERY_ITERATIONS == 8
+        # enabled: previously documented here but read by NOTHING in
+        # recommenders/external.py - now wired up (main()/_main_impl()),
+        # defaulting True to match the example and every install's
+        # prior (accidental, since the key was never honored) effective
+        # behavior.
+        assert external["enabled"] is True
         assert external["movie_limit"] == 50
         assert external["show_limit"] == 20
         assert external["min_relevance_score"] == 0.65
         assert external["auto_open_html"] is False
         assert external["min_votes"] == OUTPUT_MIN_VOTES
         assert external["language"] is None
-        # KNOWN MISMATCH surfaced by this guardrail, reported rather than
-        # silently "fixed" (see this PR's description) - the example
-        # documents 5, the code fallback (MAX_DISCOVERY_ITERATIONS) is 8.
-        # Pinned here on both sides so whichever way this is resolved,
-        # this test forces a deliberate update instead of drifting further.
-        assert external["max_iterations"] == 5
-        assert MAX_DISCOVERY_ITERATIONS == 8
 
     def test_recency_decay_defaults_match(self):
         """utils/scoring.py's calculate_recency_multiplier reads every one

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -3113,6 +3113,115 @@ class TestMainOutputGenerationBranches:
     @patch("recommenders.external.load_config")
     @patch("recommenders.external.get_project_root")
     @patch("sys.argv", ["external.py"])
+    def test_external_recommendations_enabled_false_skips_recommendations_not_huntarr(
+        self,
+        mock_root,
+        mock_load_config,
+        mock_get_tmdb,
+        mock_plex_server,
+        mock_process_user,
+        mock_sequels,
+        mock_horizon,
+        mock_html,
+        mock_trakt,
+        mock_sonarr,
+        mock_radarr,
+        mock_mdblist,
+        mock_simkl,
+    ):
+        """external_recommendations.enabled: false (newly wired up, was
+        previously read nowhere) must skip the recommendations/watchlist
+        pass - but NOT Huntarr, which is a separate feature under its
+        own huntarr.* keys and stays independently gated."""
+        mock_root.return_value = "/fake/root"
+        mock_load_config.return_value = self._base_config(
+            external_recommendations={"enabled": False},
+            huntarr={"sequel_huntarr": True, "horizon_huntarr": True},
+        )
+        mock_get_tmdb.return_value = {"api_key": "key", "use_keywords": True}
+        mock_plex_server.return_value = Mock()
+        mock_html.return_value = None
+        mock_sequels.return_value = []
+        mock_horizon.return_value = []
+
+        from recommenders.external import main
+
+        main()
+
+        mock_process_user.assert_not_called()
+        mock_trakt.assert_not_called()
+        mock_sonarr.assert_not_called()
+        mock_radarr.assert_not_called()
+        mock_mdblist.assert_not_called()
+        mock_simkl.assert_not_called()
+        mock_sequels.assert_called_once()
+        mock_horizon.assert_called_once()
+
+    @patch("recommenders.external.export_to_simkl")
+    @patch("recommenders.external.export_to_mdblist")
+    @patch("recommenders.external.export_to_radarr")
+    @patch("recommenders.external.export_to_sonarr")
+    @patch("recommenders.external.export_to_trakt")
+    @patch("recommenders.external.generate_combined_html")
+    @patch("recommenders.external.process_user")
+    @patch("recommenders.external.PlexServer")
+    @patch("recommenders.external.get_tmdb_config")
+    @patch("recommenders.external.load_config")
+    @patch("recommenders.external.get_project_root")
+    @patch("sys.argv", ["external.py"])
+    def test_external_recommendations_enabled_defaults_true_when_unset(
+        self,
+        mock_root,
+        mock_load_config,
+        mock_get_tmdb,
+        mock_plex_server,
+        mock_process_user,
+        mock_html,
+        mock_trakt,
+        mock_sonarr,
+        mock_radarr,
+        mock_mdblist,
+        mock_simkl,
+    ):
+        """No external_recommendations.enabled key at all (the state of
+        every install before this was wired up) must behave exactly like
+        enabled: true - nobody's working setup changes by accident."""
+        mock_root.return_value = "/fake/root"
+        mock_load_config.return_value = self._base_config()
+        mock_get_tmdb.return_value = {"api_key": "key", "use_keywords": True}
+        mock_plex_server.return_value = Mock()
+        mock_html.return_value = None
+        mock_process_user.return_value = {
+            "username": "alice",
+            "display_name": "alice",
+            "movies_categorized": {"user_services": {}, "other_services": {}, "acquire": []},
+            "shows_categorized": {"user_services": {}, "other_services": {}, "acquire": []},
+            "movie_profile": {},
+            "show_profile": {},
+            "user_services": [],
+            "library_id": None,
+        }
+
+        from recommenders.external import main
+
+        main()
+
+        mock_process_user.assert_called()
+
+    @patch("recommenders.external.export_to_simkl")
+    @patch("recommenders.external.export_to_mdblist")
+    @patch("recommenders.external.export_to_radarr")
+    @patch("recommenders.external.export_to_sonarr")
+    @patch("recommenders.external.export_to_trakt")
+    @patch("recommenders.external.generate_combined_html")
+    @patch("recommenders.external.find_horizon_movies")
+    @patch("recommenders.external.find_missing_sequels")
+    @patch("recommenders.external.process_user")
+    @patch("recommenders.external.PlexServer")
+    @patch("recommenders.external.get_tmdb_config")
+    @patch("recommenders.external.load_config")
+    @patch("recommenders.external.get_project_root")
+    @patch("sys.argv", ["external.py"])
     def test_process_user_exception_is_isolated_per_user(
         self,
         mock_root,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,6 +13,7 @@ from utils.helpers import (
     TITLE_SUFFIXES_TO_STRIP,
     cleanup_old_logs,
     compute_profile_hash,
+    get_code_root,
     get_project_root,
     map_path,
     migrate_legacy_cache_dir,
@@ -386,6 +387,53 @@ class TestComputeProfileHash:
         result = compute_profile_hash(profile)
         assert len(result) == 16
         assert isinstance(result, str)
+
+
+class TestGetCodeRoot:
+    """Tests for get_code_root() - #260's second half.
+
+    Unlike get_project_root(), this is NOT @lru_cache'd (nothing here
+    is expensive enough to need caching) and deliberately ignores
+    CURATARR_CONFIG_DIR entirely - that's the whole point of it
+    existing as a separate function (see its own docstring).
+    """
+
+    def test_returns_repo_root(self):
+        root = get_code_root()
+        assert os.path.isdir(os.path.join(root, "utils"))
+        assert os.path.isdir(os.path.join(root, "web"))
+        assert os.path.isdir(os.path.join(root, "recommenders"))
+
+    def test_ignores_config_dir_env_override(self, tmp_path, monkeypatch):
+        """The exact divergence #260's second half was about: in Docker,
+        CURATARR_CONFIG_DIR points get_project_root() at a separate,
+        mounted data volume while the code stays at the image's fixed
+        WORKDIR - get_code_root() must never follow that override."""
+        monkeypatch.setenv("CURATARR_CONFIG_DIR", str(tmp_path))
+
+        code_root = get_code_root()
+
+        assert code_root != str(tmp_path)
+        assert os.path.isdir(os.path.join(code_root, "recommenders"))
+
+    def test_differs_from_project_root_when_config_dir_overridden(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CURATARR_CONFIG_DIR", str(tmp_path))
+        get_project_root.cache_clear()
+        try:
+            assert get_code_root() != get_project_root()
+        finally:
+            get_project_root.cache_clear()
+
+    def test_same_as_project_root_when_config_dir_unset(self, monkeypatch):
+        """Plain source checkout / Docker with no override: the two
+        genuinely coincide - this is exactly why the bug was invisible
+        until CURATARR_CONFIG_DIR diverged them."""
+        monkeypatch.delenv("CURATARR_CONFIG_DIR", raising=False)
+        get_project_root.cache_clear()
+        try:
+            assert get_code_root() == get_project_root()
+        finally:
+            get_project_root.cache_clear()
 
 
 class TestGetProjectRoot:

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -29,7 +29,12 @@ def _wait_until_done(job, timeout=10):
 
 
 def _manager(root):
-    return JobManager(root, os.path.join(root, "logs"))
+    # code_root=root: this fixture directory also contains fake
+    # recommenders/*.py + run.sh/run.ps1 (see curatarr_web_root/
+    # _make_root below) precisely so JobManager finds THOSE instead of
+    # the real repo's - see web/app.py's create_app docstring for why
+    # code_root is independent of project_root (#260).
+    return JobManager(root, os.path.join(root, "logs"), code_root=root)
 
 
 def _make_root(tmp_path, movie_py):
@@ -51,6 +56,92 @@ def _make_root(tmp_path, movie_py):
     (root / "run.sh").write_text("#!/bin/bash\necho full done\n", encoding="utf-8")
     (root / "run.ps1").write_text('Write-Host "full done"\n', encoding="utf-8")
     return str(root)
+
+
+class TestBuildCommandCodeRootDivergence:
+    """#260 (second half) regression: JobManager must resolve
+    recommenders/<x>.py and run.sh/run.ps1 against the CODE directory,
+    never against project_root (the *data* dir - config/cache/logs).
+    In Docker, CURATARR_CONFIG_DIR points project_root at a separately
+    mounted /data while the code stays at the image's fixed /app - the
+    exact divergence that made every UI-triggered movie/tv/external/full
+    run fail with "can't open file '/data/recommenders/movie.py'" while
+    the /run POST itself still returned a normal redirect (a 200/303
+    with a dead subprocess behind it - the failure #260 was actually
+    about, on top of the 403 PR1 fixed in front of it).
+
+    Uses two DELIBERATELY DIFFERENT directories for project_root and
+    code_root (neither needs to exist on disk - _build_command only
+    constructs the path string, it doesn't open the file) so a
+    regression that resolves against the wrong one is caught
+    immediately, not masked by a fixture where both happen to coincide.
+    """
+
+    def _manager(self, project_root, code_root):
+        return JobManager(project_root, os.path.join(project_root, "logs"), code_root=code_root)
+
+    def test_movie_script_path_uses_code_root_not_project_root(self):
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("movie", "alice")
+        script = cmd[1]
+        assert script.startswith("/app")
+        assert not script.startswith("/data")
+        assert script == os.path.join("/app", "recommenders", "movie.py")
+
+    def test_tv_script_path_uses_code_root_not_project_root(self):
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("tv", "alice")
+        script = cmd[1]
+        assert script == os.path.join("/app", "recommenders", "tv.py")
+
+    def test_external_script_path_uses_code_root_not_project_root(self):
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("external", "all")
+        script = cmd[1]
+        assert script == os.path.join("/app", "recommenders", "external.py")
+
+    def test_full_engine_run_sh_uses_code_root_not_project_root(self):
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[1]
+        assert script == os.path.join("/app", "run.sh")
+
+    def test_full_engine_run_ps1_uses_code_root_not_project_root(self, monkeypatch):
+        monkeypatch.setattr(job_runner_mod.os, "name", "nt")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[4]
+        assert script == os.path.join("/app", "run.ps1")
+
+    def test_code_root_defaults_to_get_code_root_when_not_given(self):
+        """No code_root passed at all - must resolve to the real
+        installed code location (utils.helpers.get_code_root()),
+        never silently fall back to project_root."""
+        from utils.helpers import get_code_root
+
+        manager = JobManager("/some/data/dir", "/some/data/dir/logs")
+        cmd, _env, _log_name = manager._build_command("movie", "alice")
+        script = cmd[1]
+        assert script == os.path.join(get_code_root(), "recommenders", "movie.py")
+        assert not script.startswith("/some/data/dir")
+
+    def test_frozen_branch_unaffected_by_code_root_divergence(self, monkeypatch):
+        """The 4th deployment shape (PyInstaller --onefile binary) never
+        had this bug: it doesn't reference a code_root-resolved script
+        path at all, re-invoking sys.executable itself with
+        --run-recommender instead (see this module's own docstring for
+        why - recommenders/<x>.py isn't shipped as loose files once
+        packaged). Confirms this PR's fix left that branch untouched
+        even with project_root/code_root pointing at completely
+        different, nonexistent directories."""
+        monkeypatch.setattr(job_runner_mod.sys, "frozen", True, raising=False)
+        manager = self._manager("/data", "/app")
+
+        for engine, user in (("movie", "alice"), ("tv", "alice"), ("external", "all"), ("full", "all")):
+            cmd, _env, _log_name = manager._build_command(engine, user)
+            assert cmd[0] == job_runner_mod.sys.executable
+            assert "--run-recommender" in cmd
+            assert not any("/data" in part or "/app" in part for part in cmd)
 
 
 class TestJobManagerStart:

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -20,7 +20,12 @@ from web.app import BIND_RETRY_ATTEMPTS, _run_with_bind_retry, _wait_for_listeni
 
 @pytest.fixture
 def client(curatarr_web_root):
-    app = create_app(project_root=curatarr_web_root)
+    # code_root=curatarr_web_root too: that fixture also contains fake
+    # recommenders/*.py + run.sh/run.ps1 precisely so a POST /run in
+    # these tests launches THOSE instead of the real repo's (#260 -
+    # see web/app.py's create_app docstring for why project_root and
+    # code_root are independent).
+    app = create_app(project_root=curatarr_web_root, code_root=curatarr_web_root)
     app.testing = True
     return app.test_client(), app, curatarr_web_root
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -115,6 +115,7 @@ from .helpers import (
     TITLE_SUFFIXES_TO_STRIP,
     cleanup_old_logs,
     compute_profile_hash,
+    get_code_root,
     get_project_root,
     map_path,
     migrate_legacy_cache_dir,
@@ -480,6 +481,7 @@ __all__ = [
     "process_counters_from_cache",
     # Helpers
     "TITLE_SUFFIXES_TO_STRIP",
+    "get_code_root",
     "get_project_root",
     "migrate_legacy_cache_dir",
     "normalize_title",

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.50"
+__version__ = "2.10.51"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -16,10 +16,49 @@ from .config import MAX_LOG_FILE_BYTES
 from .display import log_info, log_warning
 
 
+def get_code_root() -> str:
+    """
+    Get the directory the curatarr *code* (recommenders/, utils/, web/,
+    run.sh/run.ps1) actually lives in on disk - deliberately NOT the
+    same thing get_project_root() below returns.
+
+    get_project_root() answers "where does config/cache/logs/
+    recommendations live" - for a source checkout or a Docker image
+    those two questions happen to have the same answer (the repo root),
+    which is exactly why this distinction was missing for so long and
+    why #260's second half (JobManager launching movie/tv/external
+    subprocesses) went unnoticed until Docker: CURATARR_CONFIG_DIR
+    deliberately makes get_project_root() point at a separate, mounted
+    *data* volume (/data) while the code stays at the image's fixed
+    WORKDIR (/app) - anything that needs to find recommenders/<x>.py or
+    run.sh/run.ps1 on disk (see web/job_runner.py's JobManager, the only
+    current caller) must resolve against THIS, never against
+    get_project_root().
+
+    Not meaningful for a frozen (PyInstaller --onefile) binary - there
+    is no on-disk recommenders/<x>.py to point at once packaged (they're
+    bundled into the executable, not shipped as loose .py files - see
+    curatarr_app.py's dispatcher) - callers must branch on
+    `sys.frozen` themselves and never call this in that branch (see
+    JobManager._build_command's `if frozen: ... else:` split, which
+    already does exactly this for an unrelated reason: re-invoking the
+    packaged exe with --run-recommender instead of a script path).
+
+    Returns:
+        Absolute path to the directory containing utils/ (this file's
+        own parent's parent) - always the on-disk code location,
+        regardless of CURATARR_CONFIG_DIR or sys.frozen.
+    """
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
 @lru_cache(maxsize=1)
 def get_project_root() -> str:
     """
-    Get the project root directory path.
+    Get the project root directory path - i.e. where config/cache/logs/
+    recommendations live, NOT necessarily where the code itself lives
+    (see get_code_root() above for that, and for why the two can
+    genuinely differ).
 
     For a normal source checkout / Docker image this is the parent of
     utils/ (repo root), same as always.
@@ -62,7 +101,7 @@ def get_project_root() -> str:
             root = os.path.join(os.path.expanduser("~"), ".curatarr")
         os.makedirs(root, exist_ok=True)
         return root
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return get_code_root()
 
 
 def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:

--- a/web/app.py
+++ b/web/app.py
@@ -181,7 +181,9 @@ class _BrowserLikeTestClient(FlaskClient):
         return super().open(*args, **kwargs)
 
 
-def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = None) -> Flask:
+def create_app(
+    project_root: Optional[str] = None, bind_host: Optional[str] = None, code_root: Optional[str] = None
+) -> Flask:
     """Application factory. project_root is overridable so tests can
     point the app at a throwaway fixture repo instead of the real one.
 
@@ -194,6 +196,19 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
     only caller that ever sets that env var) else '127.0.0.1', so every
     existing call site - including every test - that doesn't pass this
     explicitly keeps today's loopback-only, no-token-required behavior.
+
+    code_root is passed straight through to JobManager (see that
+    module's docstring, and utils.helpers.get_code_root's) - it's
+    deliberately independent of project_root: the latter defaults to
+    get_project_root() (the *data* dir - config/cache/logs, which
+    CURATARR_CONFIG_DIR points at a separate volume in Docker), while
+    JobManager needs to know where recommenders/<x>.py and run.sh/
+    run.ps1 actually live on disk to launch a UI-triggered run (#260) -
+    get_code_root() by default when this is left unset, exactly like
+    every real caller (native web/app.py's main(), web/docker_server.py)
+    wants. Only tests that also stand up a fake recommenders/ tree (see
+    tests/conftest.py's curatarr_web_root fixture) need to pass this
+    explicitly, pointed at that same fixture root.
     """
     project_root = project_root or get_project_root()
     bind_host = bind_host or os.environ.get("CURATARR_UI_HOST", "127.0.0.1")
@@ -206,7 +221,7 @@ def create_app(project_root: Optional[str] = None, bind_host: Optional[str] = No
     app.config["EXTERNAL_DIR"] = external_dir
     # Flask's stub doesn't declare these - real, deliberate attribute
     # attachment (every route reads them back the same way), not a typo.
-    app.job_manager = JobManager(project_root, logs_dir)  # type: ignore[attr-defined]
+    app.job_manager = JobManager(project_root, logs_dir, code_root=code_root)  # type: ignore[attr-defined]
     app.update_manager = UpdateManager(project_root, logs_dir)  # type: ignore[attr-defined]
     app.test_client_class = _BrowserLikeTestClient
 

--- a/web/config_settings.py
+++ b/web/config_settings.py
@@ -171,7 +171,7 @@ def _settings_view(
             "show_limit": external.get("show_limit", 20),
             "min_relevance_score": external.get("min_relevance_score", 0.65),
             "min_votes": external.get("min_votes", 50),
-            "max_iterations": external.get("max_iterations", 5),
+            "max_iterations": external.get("max_iterations", 8),
             "language": external.get("language") or "",
             "auto_open_html": bool(external.get("auto_open_html", False)),
         },

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -36,7 +36,7 @@ import threading
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from utils.helpers import no_window_kwargs
+from utils.helpers import get_code_root, no_window_kwargs
 from utils.run_lock import PosixRunLock, run_lock_path
 
 from .security import redact
@@ -202,9 +202,17 @@ class Job:
 class JobManager:
     """Owns the single-run lock and launches recommender subprocesses."""
 
-    def __init__(self, project_root: str, logs_dir: str):
+    def __init__(self, project_root: str, logs_dir: str, code_root: Optional[str] = None):
         self.project_root = project_root
         self.logs_dir = logs_dir
+        # #260 (second half): defaults to get_code_root() - the real
+        # on-disk code location - independently of project_root (the
+        # *data* dir: config/cache/logs, see get_project_root()'s
+        # docstring for why these two genuinely differ in Docker).
+        # Overridable (see web/app.py's create_app) so tests can point
+        # both at the same throwaway fixture root, same as before this
+        # split existed.
+        self.code_root = code_root if code_root is not None else get_code_root()
         self._lock = threading.Lock()
         self._current: Optional[Job] = None
 
@@ -351,18 +359,33 @@ class JobManager:
         on disk, so this re-invokes the packaged exe itself with
         `--run-recommender <engine> [user]` - see curatarr_app.py's
         dispatcher and this module's docstring.
+
+        #260 (second half): the non-frozen script/run.sh/run.ps1 paths
+        below are resolved against get_code_root() - where the code
+        actually lives - NEVER against self.project_root, which is
+        get_project_root()'s *data* dir (config/cache/logs). Those are
+        the same directory for a plain source checkout, which is
+        exactly why this was never caught until Docker, where
+        CURATARR_CONFIG_DIR points self.project_root at the separately
+        mounted /data while the code stays at the image's fixed /app -
+        every engine here failed with "can't open file
+        '/data/recommenders/movie.py'" (or run.sh) before this fix, with
+        the web UI still reporting a 200 because the HTTP request
+        itself succeeded even though the subprocess it launched never
+        started. See utils/helpers.get_code_root's own docstring.
         """
         env = dict(os.environ)
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         frozen = getattr(sys, "frozen", False)
+        code_root = self.code_root
 
         if engine == "full":
             if frozen:
                 cmd = [sys.executable, "--run-recommender", "full"]
             elif os.name == "nt":
-                cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", os.path.join(self.project_root, "run.ps1")]
+                cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", os.path.join(code_root, "run.ps1")]
             else:
-                cmd = ["bash", os.path.join(self.project_root, "run.sh")]
+                cmd = ["bash", os.path.join(code_root, "run.sh")]
             # Skip the interactive setup wizard / auto-update git-checkout
             # dance for UI-triggered runs - config is assumed already
             # set up, same bypass run.sh already supports for Docker.
@@ -372,7 +395,7 @@ class JobManager:
             if frozen:
                 cmd = [sys.executable, "--run-recommender", engine]
             else:
-                script = os.path.join(self.project_root, "recommenders", f"{engine}.py")
+                script = os.path.join(code_root, "recommenders", f"{engine}.py")
                 cmd = [sys.executable, script]
             if user != "all":
                 cmd.append(user)
@@ -381,7 +404,7 @@ class JobManager:
             if frozen:
                 cmd = [sys.executable, "--run-recommender", "external"]
             else:
-                script = os.path.join(self.project_root, "recommenders", "external.py")
+                script = os.path.join(code_root, "recommenders", "external.py")
                 cmd = [sys.executable, script]
             target = "all"
         else:  # pragma: no cover - guarded by start()'s validation above


### PR DESCRIPTION
## Summary

**This PR is the second half of issue #260 ("Run through WebUI fails").** PR1 (2.10.49, #269) fixed the front-door 403 (Referrer-Policy caused Origin: null on same-origin form POSTs). This PR fixes what was still broken behind that fix: the run itself never actually started in Docker. Issue #260 should stay OPEN until this ships and is confirmed working - do not close it from this PR.

### PR3a - JobManager script path in Docker

`JobManager` (`web/job_runner.py`) resolved `recommenders/<engine>.py` and `run.sh`/`run.ps1` against `self.project_root`, which is `utils.helpers.get_project_root()` - the *config/data* directory. In Docker, `CURATARR_CONFIG_DIR=/data` deliberately points that at a separate, mounted volume while the code stays at the image's fixed `/app` - every movie/tv/external/full run launched from the web UI failed immediately with `can't open file '/data/recommenders/movie.py'` (or `run.sh`), while the `/run` POST itself still returned a normal 200/redirect - a 200 with a dead subprocess behind it.

Fixed with a new `utils.helpers.get_code_root()`, deliberately kept separate from `get_project_root()` (see that function's own updated docstring for why they differ) rather than introducing a fourth, different notion of "where am I" - it reuses the exact `__file__`-relative computation `get_project_root()`'s own source-checkout fallback already used. `JobManager` now takes an optional `code_root` (defaulting to `get_code_root()`) and resolves every script path against that instead.

**Verified in all four ways curatarr ships - not just that the HTTP request returns 200:**
- **Docker** (built the actual image from this branch): POSTed `/run` for movie, tv, and external - all three launch and produce real log output, including a genuine `plexapi.exceptions.Unauthorized` traceback through `/app/recommenders/movie.py` (fake creds, expected) instead of a file-not-found error. `full` (run.sh) also now launches correctly, though it separately reaches a `pip install` step that isn't expected to succeed inside this image's environment - flagging that as a possibly-separate, pre-existing consideration for the `full`-via-web-UI-in-Docker combination specifically, not a regression from this fix.
- **PyInstaller frozen binary**: built a real (unsigned, local) binary from this branch and triggered movie/tv/external via the running web UI - all three launch via `--run-recommender`, executing the bundled code (this code path was never affected by the bug in the first place, since frozen mode re-invokes the packaged exe instead of resolving a script path at all - confirmed by the diff and pinned with a new test).
- **Native (non-Docker) web mode**: launched `web/app.py`'s own `main()` against a throwaway copy of the tree (never touched the real dev config/Plex server) with no `CURATARR_CONFIG_DIR` override - `project_root`/`code_root` correctly coincide, run launches correctly.
- **Source-checkout test suite**: existing + new regression tests, see below.

Added a regression test asserting the resolved script path points at `code_root`, not `project_root`, using two deliberately different (nonexistent) directories - the exact divergence the bug was about - plus a test confirming the frozen branch is unaffected.

### PR3b - two tuning.example.yml doc-contract mismatches (from the 2.10.49 guardrail)

- `external_recommendations.max_iterations`: example documented `5`; the code's real fallback (`MAX_DISCOVERY_ITERATIONS`) has been `8` for months, and every install has been running `8` the whole time (nothing writes a real `tuning.yml` - see 2.10.49's #261 notes). **Corrected the example to `8`**, not the code to `5` - changing the code would have silently altered discovery behavior for every existing install to match a doc that was simply wrong. Also fixed `web/config_settings.py`'s own "if unset" Settings-screen display default, which had the same stale `5`.
- `external_recommendations.enabled`: documented in the example, read by nothing in `recommenders/external.py`. **Wired up and honored**, defaulting `true` (matching the example and every install's prior, accidental, effective behavior). **Behavior change for anyone who had set this `false`**: external recommendations/watchlist generation will now actually stop, as configured - Huntarr is unaffected (separate feature, own config keys). Called out prominently in the CHANGELOG, not buried.
- Re-ran the extended tuning.example.yml guardrail (added in 2.10.49) after both fixes - it now passes clean across every top-level section, no further mismatches surfaced.

## Test plan
- [x] Full suite: 2570 passed, 1 skipped (was 2557 passed, 1 skipped after PR2 merged)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .`: no issues found in 126 source files
- [x] New tests: `get_code_root()` (ignores `CURATARR_CONFIG_DIR`, matches `get_project_root()` when unset), `JobManager`/`_build_command` code_root-vs-project_root divergence for every engine (movie/tv/external/full, posix+Windows), frozen-branch non-regression, `external_recommendations.enabled` true/false/default gating (skips recommendations, not Huntarr), guardrail assertions for both corrected values
- [x] Verified end-to-end in a real Docker container, a real frozen binary, and native web mode (see above) - this is the part that actually matters for #260, not just green tests