### PR TITLE
feat: version display, fetch from Plex, custom collection templates (#265, #266, #267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.52] - 2026-07-27
+
+### Added
+
+- **Running version is now shown in the web UI, not just /healthz and /status.json (#265).** Every page's top bar now shows `v2.10.52` (or whatever's actually running) next to the Curatarr logo - useful given how often new versions ship.
+
+- **"Fetch from Plex" on the Users and Libraries settings screens (#266).** Both screens now have a button that connects to your already-configured Plex server/account and lists real users (server owner, Home/managed users, shared friends) or real library sections that aren't configured yet, with a checklist to add exactly the ones you want in one save - no more typing usernames/section names by hand and risking a typo that silently doesn't match anything in Plex. Re-run it any time your Plex users or libraries change. Read-only until you actually check boxes and save; a broken/unreachable Plex connection shows a message instead of breaking the page.
+
+- **Custom collection-name templates (#267).** `collections.movie_name_template` / `collections.tv_name_template` in `tuning.yml` let you control what curatarr's generated collections are called, with `{user}` (the resolved display name) and `{media_type}` ("Movie"/"TV") placeholders - e.g. `"Recommended movies - {user}"`. Leaving these unset (the default) produces byte-for-byte the same name curatarr has always used (`🎬 {user} - Recommendation` / `📺 {user} - Recommendation`), so nobody's collections get renamed unless they opt in. An invalid template (unknown placeholder, malformed `{}`) falls back to the default and logs a warning rather than breaking a run. The multi-library disambiguation suffix (e.g. `(Movies 4K)`) is still always appended after the template renders, regardless of what it says, so a custom template can't reintroduce a same-media-type naming collision across libraries.
+
+  **Known limitation, not solved by this change:** changing the template later doesn't rename or clean up the collection under its previous name - the old one is left behind in Plex, same as if you changed `collections.label_name` or a user's `display_name` today. If you want the old name gone, remove it in Plex yourself after switching templates.
+
 ## [2.10.51] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Binaries self-update: the app notifies you (CLI and web UI banner) when a newer 
 - **Recency bias** — Recent watches influence recommendations more
 - **Rewatch detection** — Content you love gets weighted higher
 - **Genre exclusions** — Skip horror for the kids, documentaries for movie night
-- **Auto-updating collections** — `🎬 John - Recommendations` appears in Plex
+- **Auto-updating collections** — `🎬 John - Recommendations` appears in Plex (customizable naming template — `collections.movie_name_template`/`tv_name_template` in tuning.yml)
 
 ### For Acquisition (What to Get)
 - **External watchlists** — Content NOT in your library that users would love
@@ -154,13 +154,16 @@ hand-editing YAML:
   this screen.)
 - **Users** (`/config/users`) - add/remove Plex users and per-user preferences
   (display name, excluded genres, max content rating, streaming services).
+  A "Fetch from Plex" button pulls the real account/Home/friend user list
+  instead of typing names by hand, and can be re-run any time Plex users change.
 - **Settings** (`/config/settings`) - scoring weights, quality filters, recency
   decay, rating multipliers, negative signals, external recommendation limits,
   and the Sonarr/Radarr/Trakt auto-sync safety toggles (surfaced with a warning -
   turning auto-sync on starts writing to your download clients on every run).
 - **Libraries** (`/config/libraries`) - manage multiple Plex libraries, each
   with its own Sonarr/Radarr root folder, quality profile, tags, monitor/search
-  behavior, and optionally its own *arr instance.
+  behavior, and optionally its own *arr instance. Same "Fetch from Plex" button
+  as Users, for library sections.
 
 Secrets (tokens/API keys) are never shown once saved - fields show a
 "configured" / "not set" status, and you only need to enter a new value to

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -67,6 +67,22 @@ collections:
   add_label: true  # Add 'Recommended' label to items
   label_name: Recommended
   append_usernames: true  # Include username in collection name
+
+  # Custom collection-name templates (#267) - optional. Placeholders:
+  #   {user}       - the collection's resolved display name (a user's
+  #                  users.preferences.<user>.display_name if set, else
+  #                  their username capitalized)
+  #   {media_type} - "Movie" or "TV"
+  # Leave unset (or delete these two lines) to keep the default format
+  # shown here - every install that doesn't set these sees no change.
+  # An invalid template (unknown placeholder, bad {}) falls back to the
+  # default and logs a warning rather than breaking a run.
+  # Note: the multi-library disambiguation suffix (e.g. " (Movies 4K)")
+  # is always appended after this template renders, regardless of what
+  # it says - a custom template can't break that guarantee.
+  movie_name_template: "🎬 {user} - Recommendation"
+  tv_name_template: "📺 {user} - Recommendation"
+
   # Per-user label restrictions - each user's library Browse/Search only
   # shows their own recommendation collection, not other users' (Plex
   # label restrictions; Library tab only, does not apply to Home).

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -26,7 +26,9 @@ from utils import (
     CACHE_VERSION,
     CANDIDATE_BUFFER_MULTIPLIER,
     CYAN,
+    DEFAULT_MOVIE_NAME_TEMPLATE,
     DEFAULT_NEGATIVE_THRESHOLD,
+    DEFAULT_TV_NAME_TEMPLATE,
     GREEN,
     RATING_MULTIPLIER_2_STAR,
     RATING_MULTIPLIER_3_STAR,
@@ -76,6 +78,7 @@ from utils import (
     print_similarity_breakdown,
     process_counters_from_cache,
     remove_labels_from_items,
+    render_collection_name,
     resolve_media_type_overrides,
     save_media_cache,
     save_watched_cache,
@@ -1113,8 +1116,29 @@ class BaseRecommender(ABC):
         else:
             display_name = username.capitalize()
 
+        # emoji is still needed below, independent of the #267 naming
+        # template - cleanup_old_collections/cleanup_legacy_unnamed_
+        # collection match OLD, hardcoded "{emoji} ..." patterns to find
+        # orphaned collections left behind by a prior run/config, and
+        # that legacy-pattern matching is unaffected by whatever NEW
+        # template collections.movie_name_template/tv_name_template may
+        # now be set to.
         emoji = "🎬" if self.media_type == "movie" else "📺"
-        collection_name = f"{emoji} {display_name} - Recommendation{self._library_suffix_for_collection_name()}"
+
+        # #267: collections.movie_name_template/tv_name_template (see
+        # config/tuning.example.yml) - defaults are byte-for-byte the
+        # pre-#267 hardcoded "{emoji} {display_name} - Recommendation"
+        # format, so an install that never sets these sees zero change.
+        # The multi-library disambiguation suffix is appended
+        # unconditionally AFTER the template renders (see
+        # render_collection_name's own docstring for why) - a custom
+        # template can't accidentally break that correctness guarantee.
+        name_template = self.config.get("collections", {}).get(
+            f"{self.media_type}_name_template",
+            DEFAULT_MOVIE_NAME_TEMPLATE if self.media_type == "movie" else DEFAULT_TV_NAME_TEMPLATE,
+        )
+        rendered_name = render_collection_name(name_template, display_name, self.media_type)
+        collection_name = f"{rendered_name}{self._library_suffix_for_collection_name()}"
         success = update_plex_collection(
             section, collection_name, final_items, logger, label_name=label_name, private_label=private_label
         )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1702,6 +1702,197 @@ class TestBaseRecommenderCollectionNaming:
         assert "PrivateCollection_movies-4k" in call_base_labels
 
 
+class TestCollectionNameTemplate:
+    """#267: collections.movie_name_template/tv_name_template - custom
+    collection-name templates, with {user}/{media_type} placeholders,
+    a safe fallback on an invalid template, and the multi-library
+    suffix still applied unconditionally afterward."""
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_default_template_unchanged_from_pre_267_format(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        """No collections.movie_name_template set - byte-for-byte the
+        same name a pre-#267 install would have produced."""
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "🎬 Alice - Recommendation"
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_custom_movie_template_with_user_placeholder(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        config = copy.deepcopy(SINGLE_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {"movie_name_template": "Recommended movies - {user}"}
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "Recommended movies - Alice"
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_media_type_placeholder_renders_title_case(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        config = copy.deepcopy(SINGLE_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {"movie_name_template": "{media_type} picks for {user}"}
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "Movie picks for Alice"
+
+    @patch("utils.labels.log_warning")
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_invalid_template_falls_back_to_default_and_warns(
+        self,
+        mock_makedirs,
+        mock_load,
+        mock_tmdb,
+        mock_users,
+        mock_plex,
+        mock_update,
+        mock_cleanup,
+        mock_cleanup_legacy,
+        mock_warn,
+    ):
+        """A bad placeholder (typo'd {usr} instead of {user}) must never
+        crash a run - falls back to the default template instead.
+        Patches utils.labels.log_warning (not recommenders.base's own
+        reference) since that's where render_collection_name's warning
+        actually gets emitted from."""
+        config = copy.deepcopy(SINGLE_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {"movie_name_template": "Oops {usr}"}
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "🎬 Alice - Recommendation"
+        mock_warn.assert_called_once()
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_custom_template_still_gets_multi_library_suffix(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        """A custom template can't accidentally break the multi-library
+        disambiguation guarantee (#157) - the suffix is always appended
+        after the template renders, regardless of what the template is."""
+        config = copy.deepcopy(MULTI_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {"movie_name_template": "Recommended movies - {user}"}
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml", library=LIB_MOVIES_4K)
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "Recommended movies - Alice (Movies 4K)"
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_movie_and_tv_templates_are_independent(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        config = copy.deepcopy(SINGLE_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {
+            "movie_name_template": "Movie custom - {user}",
+            "tv_name_template": "TV custom - {user}",
+        }
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteTVRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        collection_name = mock_update.call_args[0][1]
+        assert collection_name == "TV custom - Alice"
+
+
 # ------------------------------------------------------------------------
 # Core recommendation-engine coverage: label management, candidate scoring,
 # and the TMDB/IMDb id-resolution chain shared by movie.py and tv.py.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -555,12 +555,18 @@ class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
         """recommenders/base.py's manage_plex_labels() reads every one of
         these directly off self.config["collections"] with these exact
         fallback defaults."""
+        from utils.labels import DEFAULT_MOVIE_NAME_TEMPLATE, DEFAULT_TV_NAME_TEMPLATE
+
         tuning = self._load_example_tuning()
         collections = tuning["collections"]
         assert collections["add_label"] is True
         assert collections["label_name"] == "Recommended"
         assert collections["append_usernames"] is True  # #261
         assert collections["private_collections"] is True
+        # #267: documented example templates must match the code
+        # defaults render_collection_name() falls back to.
+        assert collections["movie_name_template"] == DEFAULT_MOVIE_NAME_TEMPLATE
+        assert collections["tv_name_template"] == DEFAULT_TV_NAME_TEMPLATE
 
     def test_external_recommendations_defaults_match(self):
         from recommenders.external import MAX_DISCOVERY_ITERATIONS, OUTPUT_MIN_VOTES

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -5,7 +5,67 @@ Tests for utils/labels.py - Label management functions.
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
-from utils.labels import add_labels_to_items, build_label_name, categorize_labeled_items, remove_labels_from_items
+from utils.labels import (
+    DEFAULT_MOVIE_NAME_TEMPLATE,
+    DEFAULT_TV_NAME_TEMPLATE,
+    add_labels_to_items,
+    build_label_name,
+    categorize_labeled_items,
+    remove_labels_from_items,
+    render_collection_name,
+)
+
+
+class TestRenderCollectionName:
+    """Tests for render_collection_name() - #267 custom collection-name
+    templates."""
+
+    def test_default_movie_template_matches_pre_267_format(self):
+        result = render_collection_name(DEFAULT_MOVIE_NAME_TEMPLATE, "Alice", "movie")
+        assert result == "🎬 Alice - Recommendation"
+
+    def test_default_tv_template_matches_pre_267_format(self):
+        result = render_collection_name(DEFAULT_TV_NAME_TEMPLATE, "Alice", "tv")
+        assert result == "📺 Alice - Recommendation"
+
+    def test_custom_template_with_user_placeholder(self):
+        result = render_collection_name("Recommended movies - {user}", "Alice", "movie")
+        assert result == "Recommended movies - Alice"
+
+    def test_media_type_placeholder_movie_renders_title_case(self):
+        result = render_collection_name("{media_type} picks - {user}", "Alice", "movie")
+        assert result == "Movie picks - Alice"
+
+    def test_media_type_placeholder_tv_renders_title_case(self):
+        result = render_collection_name("{media_type} picks - {user}", "Alice", "tv")
+        assert result == "TV picks - Alice"
+
+    def test_template_with_no_placeholders_at_all(self):
+        """A template that drops {user} entirely is still valid - not
+        every install wants the username in the collection title."""
+        result = render_collection_name("My Curated Picks", "Alice", "movie")
+        assert result == "My Curated Picks"
+
+    @patch("utils.labels.log_warning")
+    def test_unknown_placeholder_falls_back_to_movie_default_and_warns(self, mock_warn):
+        result = render_collection_name("Oops {typo}", "Alice", "movie")
+        assert result == "🎬 Alice - Recommendation"
+        mock_warn.assert_called_once()
+
+    @patch("utils.labels.log_warning")
+    def test_unknown_placeholder_falls_back_to_tv_default_and_warns(self, mock_warn):
+        result = render_collection_name("Oops {typo}", "Alice", "tv")
+        assert result == "📺 Alice - Recommendation"
+        mock_warn.assert_called_once()
+
+    @patch("utils.labels.log_warning")
+    def test_bad_positional_placeholder_falls_back_and_warns(self, mock_warn):
+        """A bare {} (positional, no args passed to .format) raises
+        IndexError - must fall back exactly like an unknown named
+        placeholder (KeyError) does."""
+        result = render_collection_name("Oops {}", "Alice", "movie")
+        assert result == "🎬 Alice - Recommendation"
+        mock_warn.assert_called_once()
 
 
 class TestBuildLabelName:

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1676,6 +1676,120 @@ class TestGetConfiguredUsers:
         assert len(result["managed_users"]) == 1
 
 
+class TestFetchPlexUsers:
+    """Tests for fetch_plex_users() - #266 (web UI 'Fetch from Plex')."""
+
+    @patch("utils.plex.MyPlexAccount")
+    def test_admin_listed_first(self, mock_account_class):
+        from utils.plex import fetch_plex_users
+
+        mock_account = Mock()
+        mock_account.username = "AdminUser"
+        mock_account.users.return_value = []
+        mock_account_class.return_value = mock_account
+
+        result = fetch_plex_users({"plex": {"token": "test"}})
+
+        assert result == [{"username": "AdminUser", "title": "AdminUser", "is_admin": True}]
+
+    @patch("utils.plex.MyPlexAccount")
+    def test_includes_every_account_user(self, mock_account_class):
+        from utils.plex import fetch_plex_users
+
+        alice = Mock(username="alice", title="Alice")
+        bob = Mock(username="bob", title="Bob")
+
+        mock_account = Mock()
+        mock_account.username = "AdminUser"
+        mock_account.users.return_value = [alice, bob]
+        mock_account_class.return_value = mock_account
+
+        result = fetch_plex_users({"plex": {"token": "test"}})
+
+        assert result == [
+            {"username": "AdminUser", "title": "AdminUser", "is_admin": True},
+            {"username": "alice", "title": "Alice", "is_admin": False},
+            {"username": "bob", "title": "Bob", "is_admin": False},
+        ]
+
+    @patch("utils.plex.MyPlexAccount")
+    def test_blank_username_falls_back_to_title(self, mock_account_class):
+        """A Home user with no linked Plex account/email has a blank
+        plexapi username - fall back to title (what get_configured_users
+        already matches managed_users against)."""
+        from utils.plex import fetch_plex_users
+
+        home_user = Mock(username="", title="Kid")
+
+        mock_account = Mock()
+        mock_account.username = "AdminUser"
+        mock_account.users.return_value = [home_user]
+        mock_account_class.return_value = mock_account
+
+        result = fetch_plex_users({"plex": {"token": "test"}})
+
+        assert result[1] == {"username": "Kid", "title": "Kid", "is_admin": False}
+
+    @patch("utils.plex.MyPlexAccount")
+    def test_propagates_connection_failure(self, mock_account_class):
+        """Fails loud (raises) - the web route (web/config_users.py) is
+        responsible for catching this and showing a friendly message,
+        same convention as init_plex/get_configured_users."""
+        from utils.plex import fetch_plex_users
+
+        mock_account_class.side_effect = plexapi.exceptions.Unauthorized("bad token")
+
+        with pytest.raises(plexapi.exceptions.Unauthorized):
+            fetch_plex_users({"plex": {"token": "bad"}})
+
+
+class TestFetchPlexLibraries:
+    """Tests for fetch_plex_libraries() - #266 (web UI 'Fetch from Plex')."""
+
+    @patch("utils.plex.init_plex")
+    def test_maps_movie_and_show_sections(self, mock_init_plex):
+        from utils.plex import fetch_plex_libraries
+
+        movies_section = Mock(title="Movies", type="movie")
+        shows_section = Mock(title="TV Shows", type="show")
+
+        mock_server = Mock()
+        mock_server.library.sections.return_value = [movies_section, shows_section]
+        mock_init_plex.return_value = mock_server
+
+        result = fetch_plex_libraries({"plex": {"url": "http://x", "token": "y"}})
+
+        assert result == [
+            {"section": "Movies", "media_type": "movie"},
+            {"section": "TV Shows", "media_type": "tv"},
+        ]
+
+    @patch("utils.plex.init_plex")
+    def test_skips_unmanaged_section_types(self, mock_init_plex):
+        """music/photo/etc. sections aren't something curatarr manages -
+        must be silently skipped, not surfaced as some third media_type."""
+        from utils.plex import fetch_plex_libraries
+
+        music_section = Mock(title="Music", type="artist")
+
+        mock_server = Mock()
+        mock_server.library.sections.return_value = [music_section]
+        mock_init_plex.return_value = mock_server
+
+        result = fetch_plex_libraries({"plex": {"url": "http://x", "token": "y"}})
+
+        assert result == []
+
+    @patch("utils.plex.init_plex")
+    def test_propagates_connection_failure(self, mock_init_plex):
+        from utils.plex import fetch_plex_libraries
+
+        mock_init_plex.side_effect = plexapi.exceptions.PlexApiException("connection refused")
+
+        with pytest.raises(plexapi.exceptions.PlexApiException):
+            fetch_plex_libraries({"plex": {"url": "http://x", "token": "y"}})
+
+
 class TestUpdatePlexCollectionAdvanced:
     """Additional tests for update_plex_collection()."""
 

--- a/tests/test_web_config_libraries.py
+++ b/tests/test_web_config_libraries.py
@@ -6,6 +6,7 @@ round-trip of unrelated config.yml keys (plex/users)."""
 
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -253,3 +254,124 @@ class TestValidation:
         c.post("/config/libraries", data=_base_form(**{"media_type_0": "not-a-type"}))
         after = _read_config(root)
         assert after == before
+
+
+class TestFetchFromPlex:
+    """#266: 'Fetch from Plex' checklist - POST /config/libraries/fetch-plex
+    (preview, never writes) and POST /config/libraries/add-plex (saves
+    the checked selection). Fixture already has 'Movies' (movie) and
+    'TV Shows' (tv) configured - see _CONFIG_YML in tests/conftest.py."""
+
+    def test_fetch_shows_only_sections_not_already_configured(self, client):
+        c, app, root = client
+        fetched = [
+            {"section": "Movies", "media_type": "movie"},
+            {"section": "Kids Movies", "media_type": "movie"},
+        ]
+        with patch("web.config_libraries.fetch_plex_libraries", return_value=fetched):
+            resp = c.post("/config/libraries/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"Kids Movies" in resp.data
+        assert b'value="Kids Movies::movie"' in resp.data
+        assert b'value="Movies::movie"' not in resp.data
+
+    def test_fetch_all_already_configured_shows_nothing_to_add(self, client):
+        c, app, root = client
+        fetched = [
+            {"section": "Movies", "media_type": "movie"},
+            {"section": "TV Shows", "media_type": "tv"},
+        ]
+        with patch("web.config_libraries.fetch_plex_libraries", return_value=fetched):
+            resp = c.post("/config/libraries/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"already configured" in resp.data
+
+    def test_fetch_missing_credentials_shows_message(self, client):
+        c, app, root = client
+        config_path = module_path(root, "config")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write('plex:\n  url: ""\n  token: ""\nusers:\n  list: "alice"\n')
+
+        resp = c.post("/config/libraries/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"not configured yet" in resp.data
+
+    def test_fetch_connection_failure_shows_redacted_message(self, client):
+        c, app, root = client
+        with patch(
+            "web.config_libraries.fetch_plex_libraries",
+            side_effect=Exception("boom X-Plex-Token=abcdef123456"),
+        ):
+            resp = c.post("/config/libraries/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"Could not fetch libraries from Plex" in resp.data
+        assert b"abcdef123456" not in resp.data
+
+    def test_add_plex_appends_selected_libraries(self, client):
+        c, app, root = client
+        resp = c.post(
+            "/config/libraries/add-plex",
+            data={"selected_library": ["Kids Movies::movie", "Anime::tv"]},
+        )
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        sections = {lib["section"] for lib in core["libraries"]}
+        assert "Movies" in sections
+        assert "TV Shows" in sections
+        assert "Kids Movies" in sections
+        assert "Anime" in sections
+
+        kids = next(lib for lib in core["libraries"] if lib["section"] == "Kids Movies")
+        assert kids["media_type"] == "movie"
+        assert kids["name"] == "Kids Movies"
+        assert kids["id"]
+
+    def test_add_plex_skips_already_configured_section(self, client):
+        c, app, root = client
+        resp = c.post("/config/libraries/add-plex", data={"selected_library": ["Movies::movie", "Anime::tv"]})
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        sections = [lib["section"] for lib in core["libraries"]]
+        assert sections.count("Movies") == 1
+        assert "Anime" in sections
+
+    def test_add_plex_preserves_existing_arr_routing(self, client):
+        c, app, root = client
+        c.post("/config/libraries/add-plex", data={"selected_library": ["Anime::tv"]})
+
+        core = _read_config(root)
+        movies = next(lib for lib in core["libraries"] if lib["section"] == "Movies")
+        assert movies["arr"]["root_folder"] == "/data/movies"
+
+    def test_add_plex_no_selection_is_a_noop(self, client):
+        c, app, root = client
+        resp = c.post("/config/libraries/add-plex", data={})
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        assert len(core["libraries"]) == 2
+
+    def test_add_plex_derives_unique_id_on_slug_collision(self, client):
+        """'Movies!!!' is a different section name than the existing
+        'Movies' (so it isn't filtered out as already-configured), but
+        _derive_library_id() strips non-alphanumerics - both slugify to
+        the same 'movies' id. Must not silently produce two libraries
+        sharing one id (see this module's docstring for why id
+        collisions matter - cache keys, --library-id, etc.)."""
+        c, app, root = client
+        resp = c.post(
+            "/config/libraries/add-plex",
+            data={"selected_library": ["Movies!!!::movie"]},
+        )
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        ids = [lib["id"] for lib in core["libraries"]]
+        assert len(ids) == len(set(ids))
+        assert "movies-2" in ids

--- a/tests/test_web_config_users.py
+++ b/tests/test_web_config_users.py
@@ -4,6 +4,7 @@ streaming_services), and validation/round-trip behavior."""
 
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -219,3 +220,98 @@ class TestNullSection:
 
         core = _read_config(root)
         assert core["users"]["preferences"]["alice"]["display_name"] == "Alice A"
+
+
+class TestFetchFromPlex:
+    """#266: 'Fetch from Plex' checklist - POST /config/users/fetch-plex
+    (preview, never writes) and POST /config/users/add-plex (saves the
+    checked selection)."""
+
+    def test_fetch_shows_only_users_not_already_configured(self, client):
+        c, app, root = client
+        fetched = [
+            {"username": "alice", "title": "Alice", "is_admin": True},
+            {"username": "charlie", "title": "Charlie", "is_admin": False},
+        ]
+        with patch("web.config_users.fetch_plex_users", return_value=fetched):
+            resp = c.post("/config/users/fetch-plex")
+
+        assert resp.status_code == 200
+        # alice is already configured (see _CONFIG_YML fixture) - must
+        # not be offered again on the Fetch-from-Plex checklist
+        # specifically (the regular users table above still has its
+        # own, unrelated value="alice" hidden field for the existing
+        # row - only the checklist's checkbox is what must exclude it).
+        assert b"Charlie" in resp.data
+        assert b'name="selected_username" value="charlie"' in resp.data
+        assert b'name="selected_username" value="alice"' not in resp.data
+
+    def test_fetch_all_already_configured_shows_nothing_to_add(self, client):
+        c, app, root = client
+        fetched = [
+            {"username": "alice", "title": "Alice", "is_admin": True},
+            {"username": "bob", "title": "Bob", "is_admin": False},
+        ]
+        with patch("web.config_users.fetch_plex_users", return_value=fetched):
+            resp = c.post("/config/users/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"already configured" in resp.data
+
+    def test_fetch_missing_token_shows_message(self, client):
+        c, app, root = client
+        config_path = module_path(root, "config")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write('plex:\n  url: "http://localhost:32400"\nusers:\n  list: "alice"\n')
+
+        resp = c.post("/config/users/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"Plex token is not configured" in resp.data
+
+    def test_fetch_connection_failure_shows_redacted_message(self, client):
+        c, app, root = client
+        with patch("web.config_users.fetch_plex_users", side_effect=Exception("boom X-Plex-Token=abcdef123456")):
+            resp = c.post("/config/users/fetch-plex")
+
+        assert resp.status_code == 200
+        assert b"Could not fetch users from Plex" in resp.data
+        assert b"abcdef123456" not in resp.data
+
+    def test_add_plex_appends_selected_users(self, client):
+        c, app, root = client
+        resp = c.post("/config/users/add-plex", data={"selected_username": ["charlie", "dave"]})
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        usernames = [u.strip() for u in core["users"]["list"].split(",")]
+        assert "alice" in usernames
+        assert "bob" in usernames
+        assert "charlie" in usernames
+        assert "dave" in usernames
+
+    def test_add_plex_skips_already_configured_duplicate(self, client):
+        c, app, root = client
+        resp = c.post("/config/users/add-plex", data={"selected_username": ["alice", "eve"]})
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        usernames = [u.strip() for u in core["users"]["list"].split(",")]
+        assert usernames.count("alice") == 1
+        assert "eve" in usernames
+
+    def test_add_plex_preserves_existing_preferences(self, client):
+        c, app, root = client
+        c.post("/config/users/add-plex", data={"selected_username": ["charlie"]})
+
+        core = _read_config(root)
+        assert core["users"]["preferences"]["alice"]["display_name"] == "Alice A"
+
+    def test_add_plex_no_selection_is_a_noop(self, client):
+        c, app, root = client
+        resp = c.post("/config/users/add-plex", data={})
+
+        assert resp.status_code == 303
+        core = _read_config(root)
+        usernames = [u.strip() for u in core["users"]["list"].split(",")]
+        assert usernames == ["alice", "bob"]

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -97,6 +97,23 @@ class TestConfigLoadCaching:
         assert b"carol" in second.data
 
 
+class TestVersionDisplay:
+    """#265: the running version is shown in the UI, not just exposed
+    via /healthz and /status.json - on every page (the topbar), not
+    just Settings (the issue's literal ask), since a page reload is all
+    it takes to check it either way."""
+
+    def test_version_shown_on_dashboard(self, client):
+        c, app, root = client
+        resp = c.get("/")
+        assert f"v{app_module.__version__}".encode() in resp.data
+
+    def test_version_shown_on_settings_page(self, client):
+        c, app, root = client
+        resp = c.get("/config/settings")
+        assert f"v{app_module.__version__}".encode() in resp.data
+
+
 class TestDashboard:
     """Tests for GET /"""
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -124,10 +124,13 @@ from .helpers import (
 
 # Label utilities
 from .labels import (
+    DEFAULT_MOVIE_NAME_TEMPLATE,
+    DEFAULT_TV_NAME_TEMPLATE,
     add_labels_to_items,
     build_label_name,
     categorize_labeled_items,
     remove_labels_from_items,
+    render_collection_name,
 )
 
 # MDBList utilities
@@ -157,6 +160,8 @@ from .plex import (
     extract_genres,
     extract_ids_from_guids,
     extract_rating,
+    fetch_plex_libraries,
+    fetch_plex_users,
     fetch_plex_watch_history_movies,
     fetch_plex_watch_history_shows,
     fetch_show_completion_data,
@@ -508,6 +513,11 @@ __all__ = [
     "update_plex_collection",
     "cleanup_old_collections",
     "cleanup_legacy_unnamed_collection",
+    "render_collection_name",
+    "DEFAULT_MOVIE_NAME_TEMPLATE",
+    "DEFAULT_TV_NAME_TEMPLATE",
+    "fetch_plex_users",
+    "fetch_plex_libraries",
     "get_configured_users",
     "get_current_users",
     "get_excluded_genres_for_user",

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.51"
+__version__ = "2.10.52"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/labels.py
+++ b/utils/labels.py
@@ -8,9 +8,69 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
-from .display import GREEN, RESET, log_info
+from .display import GREEN, RESET, log_info, log_warning
 
 logger = logging.getLogger("curatarr")
+
+# #267: default collection-name templates - byte-for-byte what the
+# hardcoded f"{emoji} {display_name} - Recommendation" format produced
+# before this was configurable, so every install that never sets
+# collections.movie_name_template/tv_name_template sees zero change.
+# {user}/{media_type} are the only placeholders render_collection_name
+# below supports - see that function's docstring.
+DEFAULT_MOVIE_NAME_TEMPLATE = "🎬 {user} - Recommendation"
+DEFAULT_TV_NAME_TEMPLATE = "📺 {user} - Recommendation"
+
+_DEFAULT_NAME_TEMPLATES = {
+    "movie": DEFAULT_MOVIE_NAME_TEMPLATE,
+    "tv": DEFAULT_TV_NAME_TEMPLATE,
+}
+
+
+def render_collection_name(template: str, user: str, media_type: str) -> str:
+    """
+    Render a #267 custom collection-name template.
+
+    Args:
+        template: e.g. "Recommended movies - {user}" (config/tuning.yml's
+            collections.movie_name_template/tv_name_template - see
+            config/tuning.example.yml)
+        user: the collection's resolved display name (user_preferences.
+            <user>.display_name if configured, else the username
+            capitalized) - the exact value the pre-#267 hardcoded format
+            already used for this position
+        media_type: "movie" or "tv" - rendered into {media_type} as
+            "Movie"/"TV" (title case, singular) so one template can be
+            shared across both collections.movie_name_template and
+            collections.tv_name_template if desired, even though
+            separate keys for each are the documented/recommended way
+            to do it
+
+    Returns:
+        The rendered name, WITHOUT the multi-library disambiguation
+        suffix (see recommenders/base.py's
+        _library_suffix_for_collection_name) - that's applied
+        unconditionally after this, regardless of any custom template,
+        so a bad/creative template can never break that correctness
+        guarantee (same-media-type libraries would otherwise collide on
+        an identical collection name).
+
+        Falls back to the matching DEFAULT_*_NAME_TEMPLATE constant
+        above on any formatting error (an unknown placeholder like
+        {typo}, or a bad positional {} - str.format raises KeyError/
+        IndexError for those respectively) - a bad template in
+        tuning.yml must never crash a run.
+    """
+    media_type_label = "Movie" if media_type == "movie" else "TV"
+    try:
+        return template.format(user=user, media_type=media_type_label)
+    except (KeyError, IndexError, ValueError) as e:
+        log_warning(
+            f"Invalid collections.{media_type}_name_template {template!r} ({e}) - "
+            f"falling back to the default template this run"
+        )
+        fallback = _DEFAULT_NAME_TEMPLATES.get(media_type, DEFAULT_MOVIE_NAME_TEMPLATE)
+        return fallback.format(user=user, media_type=media_type_label)
 
 
 def build_label_name(

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -955,6 +955,71 @@ def get_configured_users(config: dict) -> dict:
     return {"managed_users": managed_users, "plex_users": plex_users, "admin_user": admin_user}
 
 
+def fetch_plex_users(config: Dict) -> List[Dict[str, Any]]:
+    """
+    #266: fetch real Plex account users (server owner + every Home/
+    managed user and shared friend) for the web UI's "Fetch from Plex"
+    convenience on the Users screen (web/config_users.py) - lets an
+    admin pick real usernames instead of typing them by hand and
+    risking a mismatch (curatarr silently not matching a misspelled
+    name is exactly what get_configured_users above already has to
+    guard against for managed_users).
+
+    NOT used by the recommender run path itself, which still resolves
+    users from config (users.list/managed_users) exactly as before -
+    this only helps discover what to put there.
+
+    Returns a list of {"username", "title", "is_admin"} dicts, admin
+    first, then every other Plex account user by title. "username" is
+    what get_configured_users/managed_users matching above actually
+    compares against - falls back to title for a Home user with no
+    linked Plex account/email, where plexapi's own username is blank.
+
+    Raises requests.RequestException/plexapi.exceptions.PlexApiException
+    on any connection/auth failure - callers (the web route) are
+    responsible for catching and turning that into a UI-friendly
+    message, same convention as init_plex/get_configured_users above.
+    """
+    account = MyPlexAccount(token=config["plex"]["token"])
+    admin_username = account.username
+    users = [{"username": admin_username, "title": admin_username, "is_admin": True}]
+    for u in account.users():
+        username = u.username or u.title
+        users.append({"username": username, "title": u.title, "is_admin": False})
+    return users
+
+
+def fetch_plex_libraries(config: Dict) -> List[Dict[str, str]]:
+    """
+    #266: fetch real Plex library sections for the web UI's "Fetch from
+    Plex" convenience on the Libraries screen (web/config_libraries.py) -
+    same rationale as fetch_plex_users above, and likewise never used by
+    the recommender run path itself.
+
+    Returns a list of {"section", "media_type"} dicts - section is the
+    Plex library's own display title (what utils.config.get_libraries's
+    'section:' field and Plex's own library.section() lookup both match
+    against), media_type is curatarr's "movie"/"tv" vocabulary (Plex's
+    own section.type of "movie"/"show" respectively). Library types
+    curatarr doesn't manage (music, photo, etc.) are silently skipped -
+    there's nothing meaningful to configure for them here.
+
+    Raises requests.RequestException/plexapi.exceptions.PlexApiException
+    on any connection failure - same convention as init_plex above.
+    """
+    server = init_plex(config)
+    libraries = []
+    for section in server.library.sections():
+        if section.type == "movie":
+            media_type = "movie"
+        elif section.type == "show":
+            media_type = "tv"
+        else:
+            continue
+        libraries.append({"section": section.title, "media_type": media_type})
+    return libraries
+
+
 def get_current_users(users: dict) -> str:
     """
     Get formatted string of current users being processed.

--- a/web/app.py
+++ b/web/app.py
@@ -387,6 +387,17 @@ def create_app(
         except Exception:
             return {"update_banner": None}
 
+    @app.context_processor
+    def _version_context():
+        """#265: the running version, injected into every rendered
+        template (see base.html's topbar) so it's visible on every page,
+        not just Settings (the issue's original ask) - with "so many
+        versions shipped every day" (the issue's own words), a single
+        page felt like the wrong place to bury it. Same __version__
+        already exposed via /healthz and /status.json - just never
+        rendered anywhere a human looks at it directly before this."""
+        return {"curatarr_version": __version__}
+
     @app.post("/update/dismiss")
     def update_dismiss():
         """Snooze the update banner for this version for 7 days (see

--- a/web/config_libraries.py
+++ b/web/config_libraries.py
@@ -47,13 +47,16 @@ called once from web.config_app.register_config_routes().
 """
 
 import re
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from flask import redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
+from utils.plex import fetch_plex_libraries
+
 from .config_io import commit_modules, existing_library_secret, load_module, merge_secret, module_path, secret_status
 from .config_validate import validate_media_type, validate_required, validate_url
+from .security import redact
 
 MEDIA_TYPE_CHOICES = ("movie", "tv")
 
@@ -92,6 +95,45 @@ def register_libraries_routes(app) -> None:
             ), 400
 
         modules = _apply_libraries(project_root, core, parsed)
+        commit_error = commit_modules(project_root, modules)
+        if commit_error:
+            return render_template(
+                "config_libraries.html",
+                saved=False,
+                errors={"_global": f"Could not save: {commit_error}"},
+                **_libraries_view(load_module(module_path(project_root, "config"))),
+            ), 500
+        return redirect(url_for("config_libraries", saved="1"), code=303)
+
+    @app.post("/config/libraries/fetch-plex")
+    def config_libraries_fetch_plex():
+        """#266: preview step - connect to the already-configured Plex
+        server and list its library sections that aren't configured yet,
+        for the checklist below. Never writes anything - see
+        config_libraries_add_plex for the follow-up that actually saves
+        a selection."""
+        core = load_module(module_path(project_root, "config"))
+        return render_template(
+            "config_libraries.html",
+            saved=False,
+            errors={},
+            plex_fetch=_fetch_plex_libraries_view(core),
+            **_libraries_view(core),
+        )
+
+    @app.post("/config/libraries/add-plex")
+    def config_libraries_add_plex():
+        """#266: add every checked library from the Fetch-from-Plex
+        checklist in one save - each gets no arr/instance routing yet,
+        same as a single manually-added library (editable on a
+        follow-up visit)."""
+        core = load_module(module_path(project_root, "config"))
+        selected = []
+        for raw in request.form.getlist("selected_library"):
+            section, sep, media_type = raw.partition("::")
+            if sep:
+                selected.append({"section": section, "media_type": media_type})
+        modules = _apply_libraries_from_plex(core, selected)
         commit_error = commit_modules(project_root, modules)
         if commit_error:
             return render_template(
@@ -298,6 +340,73 @@ def _parse_libraries_form(form, errors: Dict[str, str]) -> Dict:
         errors["_global"] = "At least one library is required."
 
     return {"libraries": rows, "new_name": "", "new_section": "", "new_media_type": "movie"}
+
+
+def _fetch_plex_libraries_view(core: CommentedMap) -> Dict:
+    """#266: fetch real Plex library sections and filter out ones
+    already configured (matched by Plex section name) - the context
+    config_libraries.html renders as the "Fetch from Plex" checklist.
+    Fails open (never raises) exactly like web/config_test_connection.py's
+    test_plex - a broken/unreachable Plex must never break this screen,
+    just show why the fetch didn't work."""
+    plex_config = core.get("plex") or {}
+    url = plex_config.get("url", "")
+    token = plex_config.get("token", "")
+    if not url or not token:
+        return {
+            "ok": False,
+            "message": "Plex URL/token are not configured yet - set them on the Connections screen first.",
+            "available": [],
+        }
+    try:
+        fetched = fetch_plex_libraries({"plex": {"url": url, "token": token}})
+    except Exception as exc:
+        return {"ok": False, "message": redact(f"Could not fetch libraries from Plex: {exc}"), "available": []}
+
+    existing_sections = {(entry.get("section") or "").strip().lower() for entry in (core.get("libraries") or [])}
+    available = [lib for lib in fetched if lib["section"].strip().lower() not in existing_sections]
+    return {"ok": True, "message": "", "available": available}
+
+
+def _apply_libraries_from_plex(core: CommentedMap, selected: List[Dict[str, str]]) -> Dict[str, CommentedMap]:
+    """#266: append *selected* ({"section", "media_type"} dicts checked
+    on the Fetch-from-Plex checklist) as new library entries, skipping
+    any whose section already matches an existing one - WITHOUT writing
+    to disk (see config_connections._apply_connections' docstring for
+    why). Each new entry gets name=section and no arr/instance routing
+    yet, same as a single manually-added library via
+    _parse_libraries_form's 'new_name' path (editable on a follow-up
+    visit)."""
+    libraries_seq = core.get("libraries")
+    if libraries_seq is None:
+        libraries_seq = CommentedSeq()
+        core["libraries"] = libraries_seq
+
+    existing_sections = {(entry.get("section") or "").strip().lower() for entry in libraries_seq}
+    existing_ids = {entry.get("id") for entry in libraries_seq}
+
+    for lib in selected:
+        section = lib["section"].strip()
+        if not section or section.lower() in existing_sections:
+            continue
+
+        base_id = _derive_library_id(section)
+        library_id = base_id
+        suffix = 2
+        while library_id in existing_ids:
+            library_id = f"{base_id}-{suffix}"
+            suffix += 1
+
+        entry = CommentedMap()
+        entry["id"] = library_id
+        entry["name"] = section
+        entry["section"] = section
+        entry["media_type"] = lib["media_type"]
+        libraries_seq.append(entry)
+        existing_sections.add(section.lower())
+        existing_ids.add(library_id)
+
+    return {"config": core}
 
 
 def _apply_libraries(project_root: str, core: CommentedMap, parsed: Dict) -> Dict[str, CommentedMap]:

--- a/web/config_users.py
+++ b/web/config_users.py
@@ -14,14 +14,16 @@ _parse_users_form/_apply_users below are the only places that shape is
 read or written, so that's a contained change when #157 lands.
 """
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from flask import redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
 
+from utils.plex import fetch_plex_users
 from utils.plex_policy import MOVIE_RATING_HIERARCHY, TV_RATING_HIERARCHY
 
 from .config_io import commit_modules, ensure_section, format_csv_list, load_module, module_path, parse_csv_list
+from .security import redact
 
 RATING_CHOICES = MOVIE_RATING_HIERARCHY + TV_RATING_HIERARCHY
 
@@ -60,6 +62,41 @@ def register_users_routes(app) -> None:
             ), 400
 
         modules = _apply_users(project_root, core, parsed)
+        commit_error = commit_modules(project_root, modules)
+        if commit_error:
+            return render_template(
+                "config_users.html",
+                saved=False,
+                errors={"_global": f"Could not save: {commit_error}"},
+                **_users_view(load_module(module_path(project_root, "config"))),
+            ), 500
+        return redirect(url_for("config_users", saved="1"), code=303)
+
+    @app.post("/config/users/fetch-plex")
+    def config_users_fetch_plex():
+        """#266: preview step - connect to the already-configured Plex
+        server/account and list its users that aren't in users.list yet,
+        for the checklist below. Never writes anything - see
+        config_users_add_plex for the follow-up that actually saves a
+        selection."""
+        core = load_module(module_path(project_root, "config"))
+        return render_template(
+            "config_users.html",
+            saved=False,
+            errors={},
+            plex_fetch=_fetch_plex_users_view(core),
+            **_users_view(core),
+        )
+
+    @app.post("/config/users/add-plex")
+    def config_users_add_plex():
+        """#266: add every checked username from the Fetch-from-Plex
+        checklist to users.list in one save - each gets no preferences
+        yet, same as a single manually-added user (editable on a
+        follow-up visit)."""
+        core = load_module(module_path(project_root, "config"))
+        selected = request.form.getlist("selected_username")
+        modules = _apply_users_from_plex(core, selected)
         commit_error = commit_modules(project_root, modules)
         if commit_error:
             return render_template(
@@ -147,6 +184,61 @@ def _parse_users_form(form, errors: Dict[str, str]) -> Dict:
         )
 
     return {"users": rows, "new_username": ""}
+
+
+def _fetch_plex_users_view(core: CommentedMap) -> Dict:
+    """#266: fetch real Plex account users and filter out ones already
+    in users.list - the context config_users.html renders as the
+    "Fetch from Plex" checklist. Fails open (never raises) exactly like
+    web/config_test_connection.py's test_plex - a broken/unreachable
+    Plex must never break this screen, just show why the fetch didn't
+    work."""
+    plex_config = core.get("plex") or {}
+    token = plex_config.get("token", "")
+    if not token:
+        return {
+            "ok": False,
+            "message": "Plex token is not configured yet - set it on the Connections screen first.",
+            "available": [],
+        }
+    try:
+        fetched = fetch_plex_users({"plex": {"token": token}})
+    except Exception as exc:
+        return {"ok": False, "message": redact(f"Could not fetch users from Plex: {exc}"), "available": []}
+
+    users_section = core.get("users") or {}
+    raw_list = users_section.get("list", "")
+    if isinstance(raw_list, str):
+        existing = {u.strip().lower() for u in raw_list.split(",") if u.strip()}
+    else:
+        existing = {str(u).strip().lower() for u in (raw_list or [])}
+
+    available = [u for u in fetched if u["username"].lower() not in existing]
+    return {"ok": True, "message": "", "available": available}
+
+
+def _apply_users_from_plex(core: CommentedMap, selected_usernames: List[str]) -> Dict[str, CommentedMap]:
+    """#266: append *selected_usernames* (checked on the Fetch-from-Plex
+    checklist) to users.list, skipping any already present - WITHOUT
+    writing to disk (see config_connections._apply_connections'
+    docstring for why). New entries get no preferences yet, same as a
+    single manually-added user via 'new_username' in _apply_users."""
+    users_section = ensure_section(core, "users")
+    raw_list = users_section.get("list", "")
+    if isinstance(raw_list, str):
+        existing_usernames = [u.strip() for u in raw_list.split(",") if u.strip()]
+    else:
+        existing_usernames = list(raw_list or [])
+
+    existing_lower = {u.lower() for u in existing_usernames}
+    for username in selected_usernames:
+        username = username.strip()
+        if username and username.lower() not in existing_lower:
+            existing_usernames.append(username)
+            existing_lower.add(username.lower())
+
+    users_section["list"] = ", ".join(existing_usernames)
+    return {"config": core}
 
 
 def _apply_users(project_root: str, core: CommentedMap, parsed: Dict) -> Dict[str, CommentedMap]:

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -140,6 +140,14 @@ body {
   filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.3));
 }
 
+.topbar .version-tag {
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
 .topbar nav {
   display: flex;
   flex-wrap: wrap;
@@ -391,6 +399,42 @@ button:disabled {
   letter-spacing: 1.5px;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+/* #266 "Fetch from Plex" checklists (Users/Libraries screens) - not
+   nested inside .config-form (it's its own, separate form/action from
+   the main Save form above it), so it needs its own copy of the same
+   panel look rather than inheriting .config-form's descendant rules. */
+fieldset.plex-fetch {
+  background: var(--panel-gradient);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 22px 22px;
+  margin-bottom: 20px;
+  box-shadow:
+    0 8px 25px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+fieldset.plex-fetch legend {
+  padding: 0 10px;
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.plex-fetch-list {
+  list-style: none;
+  margin: 12px 0;
+  padding: 0;
+}
+
+.plex-fetch-list li {
+  padding: 4px 0;
+  color: var(--muted);
+  font-size: 0.85rem;
 }
 
 .config-form h3 {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -13,6 +13,7 @@
   <div class="page-wrapper">
     <header class="topbar">
       <a class="brand" href="{{ url_for('dashboard') }}">Curatarr</a>
+      <span class="version-tag" title="Running version">v{{ curatarr_version }}</span>
       <nav>
         <a href="{{ url_for('dashboard') }}" class="{{ 'active' if request.path == url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('run_form') }}" class="{{ 'active' if request.path == url_for('run_form') }}">Run</a>

--- a/web/templates/config_libraries.html
+++ b/web/templates/config_libraries.html
@@ -109,4 +109,37 @@
 
   <button type="submit">Save</button>
 </form>
+
+<fieldset class="plex-fetch">
+  <legend>Fetch from Plex</legend>
+  <p class="muted">
+    Pull the current movie/TV library list from Plex instead of typing section names by hand - avoids mismatched
+    names, and can be re-run any time libraries change on the server.
+  </p>
+  <form method="post" action="{{ url_for('config_libraries_fetch_plex') }}">
+    <button type="submit">Fetch from Plex</button>
+  </form>
+
+  {% if plex_fetch %}
+    {% if not plex_fetch.ok %}
+    <p class="banner error">{{ plex_fetch.message }}</p>
+    {% elif not plex_fetch.available %}
+    <p class="muted">Every Plex library is already configured.</p>
+    {% else %}
+    <form method="post" action="{{ url_for('config_libraries_add_plex') }}">
+      <ul class="plex-fetch-list">
+        {% for lib in plex_fetch.available %}
+        <li>
+          <label>
+            <input type="checkbox" name="selected_library" value="{{ lib.section }}::{{ lib.media_type }}" checked>
+            {{ lib.section }} ({{ lib.media_type }})
+          </label>
+        </li>
+        {% endfor %}
+      </ul>
+      <button type="submit">Add selected</button>
+    </form>
+    {% endif %}
+  {% endif %}
+</fieldset>
 {% endblock %}

--- a/web/templates/config_users.html
+++ b/web/templates/config_users.html
@@ -72,4 +72,37 @@
 
   <button type="submit">Save</button>
 </form>
+
+<fieldset class="plex-fetch">
+  <legend>Fetch from Plex</legend>
+  <p class="muted">
+    Pull the current user list from Plex (server owner, Home/managed users, and shared friends) instead of typing
+    names by hand - avoids mismatched usernames, and can be re-run any time Plex users change.
+  </p>
+  <form method="post" action="{{ url_for('config_users_fetch_plex') }}">
+    <button type="submit">Fetch from Plex</button>
+  </form>
+
+  {% if plex_fetch %}
+    {% if not plex_fetch.ok %}
+    <p class="banner error">{{ plex_fetch.message }}</p>
+    {% elif not plex_fetch.available %}
+    <p class="muted">Every Plex account user is already configured.</p>
+    {% else %}
+    <form method="post" action="{{ url_for('config_users_add_plex') }}">
+      <ul class="plex-fetch-list">
+        {% for u in plex_fetch.available %}
+        <li>
+          <label>
+            <input type="checkbox" name="selected_username" value="{{ u.username }}" checked>
+            {{ u.title }}{% if u.is_admin %} (server owner){% endif %}
+          </label>
+        </li>
+        {% endfor %}
+      </ul>
+      <button type="submit">Add selected</button>
+    </form>
+    {% endif %}
+  {% endif %}
+</fieldset>
 {% endblock %}


### PR DESCRIPTION
## Summary

Three feature requests bundled into one PR per the queued plan.

### #265 - Add version number to webUI

The running version was only ever exposed via `/healthz`/`/status.json`, never rendered anywhere a human looks. Added a small context processor (`web/app.py`) injecting it into every template; shown in `base.html`'s topbar next to the logo, so it's visible on every page (not just Settings, the issue's literal ask - with "so many versions shipped every day" per the issue, a single page felt like the wrong place to bury it).

### #266 - Fetch user and library list from Plex

Added `utils.plex.fetch_plex_users()`/`fetch_plex_libraries()` and wired a "Fetch from Plex" button into both the Users and Libraries settings screens:
- Connects to the **already-configured** Plex server/account (never accepts an arbitrary url/token from the request - no exfiltration surface) and lists users/library sections not yet configured.
- Read-only preview step (`POST /config/{users,libraries}/fetch-plex`) - nothing is written until a follow-up "Add selected" submit (`POST /config/{users,libraries}/add-plex`) saves the checked selection in one go.
- Fails open with a friendly, redacted message on a broken/unreachable Plex connection or missing credentials - never a 500.
- New library entries get a collision-safe derived id (see `_derive_library_id`'s existing convention); new users get no preferences yet - both match how a single manually-added row already behaves today, editable on a follow-up visit.
- **Verified against a real (unreachable/unauthorized) Plex endpoint in a real Docker container** - both fetch endpoints correctly show a friendly error (200, not 500) with the real plex.tv 401 / DNS-resolution-failure text redacted.

### #267 - Custom collection naming templates

`collections.movie_name_template`/`collections.tv_name_template` (see `config/tuning.example.yml`) with `{user}` (resolved display name) and `{media_type}` ("Movie"/"TV") placeholders - e.g. `"Recommended movies - {user}"`.
- Defaults are byte-for-byte the pre-#267 hardcoded format (`🎬 {user} - Recommendation` / `📺 {user} - Recommendation`) - zero change for anyone who doesn't set these.
- An invalid template (unknown placeholder, malformed `{}`) falls back to the default and logs a warning rather than crashing a run.
- The multi-library disambiguation suffix (e.g. `(Movies 4K)`) is always appended AFTER the template renders, regardless of what it says - a custom template can never reintroduce a same-media-type collision across libraries.
- **Scoping decision, flagging explicitly rather than guessing further:** not exposed on the web UI Settings screen. The whole `collections:` config section (`add_label`, `label_name`, `append_usernames`, `private_collections`) has zero web UI presence today - it's tuning.yml-only. Adding web UI fields for just these 2 of 6 keys would be inconsistent; full `collections:` web UI support looks like its own, separate scope if wanted.
- **Known limitation, documented not solved:** changing the template later doesn't rename/clean up the collection under its previous name - same pre-existing behavior as changing `collections.label_name` or a user's `display_name` today (the old collection is orphaned in Plex until removed by hand). Flagging this since the issue's own "alternatives considered" mentions manual Plex renames being overwritten - this doesn't fully solve that class of problem, it just adds a supported way to set the name going forward.

## Test plan
- [x] Full suite: 2611 passed, 1 skipped (was 2570 passed, 1 skipped after PR3 merged)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy .`: no issues found in 126 source files
- [x] New tests: version rendered on dashboard + settings page; fetch-plex/add-plex round-trips for both Users and Libraries (including duplicate-skip, id-collision, preference/routing preservation, missing-credentials, connection-failure-redacted); `fetch_plex_users`/`fetch_plex_libraries` unit tests; `render_collection_name` unit tests (default/custom/media_type/no-placeholder/invalid-template-fallback); collection-name-template integration tests through `_sync_plex_collection` (default unchanged, custom, multi-library suffix still applied, movie/tv templates independent)
- [x] Verified in a real Docker container: version tag renders on every page checked, both Fetch-from-Plex endpoints against a real unreachable/unauthorized Plex connection fail open with a friendly message