### PR TITLE
fix: rename collection on movie/tv_name_template change (#267 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.53] - 2026-07-27
+
+### Fixed
+
+- **Changing `collections.movie_name_template`/`tv_name_template` (#267) now renames the existing collection instead of orphaning it.** 2.10.52 documented this as a known limitation: switching templates left the previously-named collection behind in Plex, untouched and unmanaged, while a new one was created under the new name. Now, when a run's freshly-rendered collection name differs from what's currently in Plex, the existing collection is renamed in place - preserving its poster, sort title, added-at date, and any manual curation, none of which a delete-and-recreate would keep. Ownership is confirmed via the same `PrivateCollection_<user>` label curatarr already applies to every collection it manages (present regardless of whether `collections.private_collections` is on), never by guessing from the title - a collection curatarr didn't label is never touched. If both an old-named and a new-named collection already exist, nothing is renamed (that would create a duplicate title); both are logged and left alone for manual cleanup. New config key `collections.rename_on_template_change` (default `true`) controls this; set it `false` to keep the old orphan-in-place behavior.
+
 ## [2.10.52] - 2026-07-27
 
 ### Added

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -83,6 +83,18 @@ collections:
   movie_name_template: "🎬 {user} - Recommendation"
   tv_name_template: "📺 {user} - Recommendation"
 
+  # When a movie_name_template/tv_name_template edit changes a user's
+  # rendered collection name, RENAME the existing Plex collection to the
+  # new name instead of leaving it behind as an orphan (the previous
+  # collection's poster, sort title, added-at date and any manual
+  # curation are preserved - a delete-and-recreate would lose all of
+  # that). Identifies "the existing collection" via the same
+  # PrivateCollection_<user> label Curatarr already applies to every
+  # collection it manages, never by title guessing, so it will never
+  # touch a collection it didn't create. Set to false to leave old-named
+  # collections orphaned (the pre-existing behavior).
+  rename_on_template_change: true
+
   # Per-user label restrictions - each user's library Browse/Search only
   # shows their own recommendation collection, not other users' (Plex
   # label restrictions; Library tab only, does not apply to Home).

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1139,8 +1139,21 @@ class BaseRecommender(ABC):
         )
         rendered_name = render_collection_name(name_template, display_name, self.media_type)
         collection_name = f"{rendered_name}{self._library_suffix_for_collection_name()}"
+        # Default True: an old-named collection left behind by a template
+        # change is renamed (via the PrivateCollection_* label, never
+        # title-guessing) rather than orphaned - see
+        # config/tuning.example.yml's own comment and
+        # utils.plex.update_plex_collection's docstring for the exact
+        # ownership/collision rules.
+        rename_on_template_change = self.config.get("collections", {}).get("rename_on_template_change", True)
         success = update_plex_collection(
-            section, collection_name, final_items, logger, label_name=label_name, private_label=private_label
+            section,
+            collection_name,
+            final_items,
+            logger,
+            label_name=label_name,
+            private_label=private_label,
+            rename_on_template_change=rename_on_template_change,
         )
         if success:
             cleanup_old_collections(section, collection_name, username, emoji, logger)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1893,6 +1893,90 @@ class TestCollectionNameTemplate:
         assert collection_name == "TV custom - Alice"
 
 
+class TestSyncPlexCollectionRenameOnTemplateChangeWiring:
+    """_sync_plex_collection reads collections.rename_on_template_change
+    from config and passes it through to update_plex_collection - the
+    actual rename decision/logic is utils.plex.update_plex_collection's
+    own responsibility (see TestUpdatePlexCollectionRenameOnTemplateChange
+    in tests/test_plex.py)."""
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_defaults_true_when_unset(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        assert mock_update.call_args.kwargs["rename_on_template_change"] is True
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_honors_explicit_false(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        config = copy.deepcopy(SINGLE_MOVIE_LIBRARY_CONFIG)
+        config["collections"] = {"rename_on_template_change": False}
+        mock_load.return_value = config
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(section, "Recommended_alice", [Mock()], username="alice")
+
+        assert mock_update.call_args.kwargs["rename_on_template_change"] is False
+
+    @patch("recommenders.base.cleanup_legacy_unnamed_collection")
+    @patch("recommenders.base.cleanup_old_collections")
+    @patch("recommenders.base.update_plex_collection")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_private_label_still_passed_through(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_update, mock_cleanup, mock_cleanup_legacy
+    ):
+        mock_load.return_value = SINGLE_MOVIE_LIBRARY_CONFIG
+        mock_users.return_value = {"plex_users": [], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_plex.return_value = Mock()
+        mock_update.return_value = True
+
+        recommender = ConcreteRecommender("/path/to/config.yml")
+        section = Mock()
+
+        recommender._sync_plex_collection(
+            section, "Recommended_alice", [Mock()], username="alice", private_label="PrivateCollection_alice"
+        )
+
+        assert mock_update.call_args.kwargs["private_label"] == "PrivateCollection_alice"
+
+
 # ------------------------------------------------------------------------
 # Core recommendation-engine coverage: label management, candidate scoring,
 # and the TMDB/IMDb id-resolution chain shared by movie.py and tv.py.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -567,6 +567,9 @@ class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
         # defaults render_collection_name() falls back to.
         assert collections["movie_name_template"] == DEFAULT_MOVIE_NAME_TEMPLATE
         assert collections["tv_name_template"] == DEFAULT_TV_NAME_TEMPLATE
+        # rename-on-template-change: BaseRecommender._sync_plex_collection's
+        # own fallback default.
+        assert collections["rename_on_template_change"] is True
 
     def test_external_recommendations_defaults_match(self):
         from recommenders.external import MAX_DISCOVERY_ITERATIONS, OUTPUT_MIN_VOTES

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1842,6 +1842,240 @@ class TestUpdatePlexCollectionAdvanced:
         mock_logger.error.assert_called_once()
 
 
+class TestUpdatePlexCollectionRenameOnTemplateChange:
+    """Tests for update_plex_collection()'s rename-on-template-change
+    behavior (#267 follow-up): a movie_name_template/tv_name_template edit
+    that changes the rendered collection name renames the collection
+    previously identified by its PrivateCollection_<user> label, instead
+    of leaving it orphaned while a second one gets created."""
+
+    @staticmethod
+    def _make_collection(title, labels=()):
+        collection = Mock()
+        collection.title = title
+        collection.items.return_value = [Mock()]
+        collection.labels = [Mock(tag=t) for t in labels]
+        return collection
+
+    def test_renames_old_named_collection_found_by_label(self):
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale]
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        stale.editTitle.assert_called_once_with("Recommended movies - Alice")
+        stale.addItems.assert_called_once()
+        mock_section.createCollection.assert_not_called()
+
+    def test_rename_compares_full_title_including_multi_library_suffix(self):
+        """The multi-library disambiguation suffix is part of collection_name
+        by the time it reaches this function - the rename must compare/act
+        on the full, final title, not a pre-suffix version."""
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection(
+            "🎬 Alice - Recommendation (Movies 4K)", labels=["PrivateCollection_alice_movies-4k"]
+        )
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale]
+
+        update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice (Movies 4K)",
+            [Mock()],
+            label_name="Recommended_alice_movies-4k",
+            private_label="PrivateCollection_alice_movies-4k",
+        )
+
+        stale.editTitle.assert_called_once_with("Recommended movies - Alice (Movies 4K)")
+
+    def test_no_op_when_old_named_collection_absent(self):
+        """No collection carries our private_label - nothing to rename,
+        just create as normal. No error."""
+        from utils.plex import update_plex_collection
+
+        mock_section = Mock()
+        mock_section.collections.return_value = []
+        mock_section.createCollection.return_value = Mock(labels=[])
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        mock_section.createCollection.assert_called_once()
+
+    def test_no_op_when_template_renders_unchanged(self):
+        """Existing collection's title already equals the freshly-rendered
+        name - no rename call, no duplicate creation."""
+        from utils.plex import update_plex_collection
+
+        current = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [current]
+
+        result = update_plex_collection(
+            mock_section,
+            "🎬 Alice - Recommendation",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        current.editTitle.assert_not_called()
+        current.addItems.assert_called_once()
+        mock_section.createCollection.assert_not_called()
+
+    def test_does_not_rename_when_both_old_and_new_named_collections_exist(self):
+        """Both an old-named (stale-labeled) and a new-named (exact title
+        match) collection already exist - renaming would produce a
+        duplicate title. Leave both alone; sync continues against the
+        new-named one."""
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        current = self._make_collection("Recommended movies - Alice", labels=["PrivateCollection_alice"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale, current]
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        stale.editTitle.assert_not_called()
+        current.editTitle.assert_not_called()
+        current.addItems.assert_called_once()
+        mock_section.createCollection.assert_not_called()
+
+    def test_does_not_rename_when_ambiguous_multiple_stale_matches(self):
+        """More than one collection carries our private_label with a
+        mismatched title - never guess which to rename; leave all alone
+        and create a new one like pre-#267-rename behavior."""
+        from utils.plex import update_plex_collection
+
+        stale_1 = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        stale_2 = self._make_collection("Old duplicate - Alice", labels=["PrivateCollection_alice"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale_1, stale_2]
+        mock_section.createCollection.return_value = Mock(labels=[])
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        stale_1.editTitle.assert_not_called()
+        stale_2.editTitle.assert_not_called()
+        mock_section.createCollection.assert_called_once()
+
+    def test_rename_disabled_via_flag_creates_duplicate_instead(self):
+        """collections.rename_on_template_change: false - old orphaning
+        behavior is preserved verbatim."""
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale]
+        mock_section.createCollection.return_value = Mock(labels=[])
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+            rename_on_template_change=False,
+        )
+
+        assert result is True
+        stale.editTitle.assert_not_called()
+        mock_section.createCollection.assert_called_once()
+
+    def test_no_rename_search_without_private_label(self):
+        """No private_label given at all (e.g. a caller that never sets
+        one) - behaves exactly like before this feature existed."""
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection("🎬 Alice - Recommendation")
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale]
+
+        result = update_plex_collection(mock_section, "Recommended movies - Alice", [Mock()])
+
+        assert result is True
+        stale.editTitle.assert_not_called()
+        mock_section.createCollection.assert_called_once()
+
+    def test_rename_failure_falls_back_to_creating_new_collection(self):
+        """editTitle raising must not lose this run's sync - fall back to
+        creating a new collection rather than failing outright."""
+        from utils.plex import update_plex_collection
+
+        stale = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        stale.editTitle.side_effect = plexapi.exceptions.PlexApiException("locked field")
+        mock_section = Mock()
+        mock_section.collections.return_value = [stale]
+        mock_section.createCollection.return_value = Mock(labels=[])
+
+        result = update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        assert result is True
+        mock_section.createCollection.assert_called_once()
+
+    def test_one_users_rename_never_touches_another_users_collection(self):
+        """Two users' collections coexist in the same library, each
+        carrying their own private_label - renaming alice's must never
+        touch bob's, even though both are stale relative to their own
+        new names."""
+        from utils.plex import update_plex_collection
+
+        alice_stale = self._make_collection("🎬 Alice - Recommendation", labels=["PrivateCollection_alice"])
+        bob_stale = self._make_collection("🎬 Bob - Recommendation", labels=["PrivateCollection_bob"])
+        mock_section = Mock()
+        mock_section.collections.return_value = [alice_stale, bob_stale]
+
+        update_plex_collection(
+            mock_section,
+            "Recommended movies - Alice",
+            [Mock()],
+            label_name="Recommended_alice",
+            private_label="PrivateCollection_alice",
+        )
+
+        alice_stale.editTitle.assert_called_once_with("Recommended movies - Alice")
+        bob_stale.editTitle.assert_not_called()
+
+
 class TestCleanupOldCollectionsAdvanced:
     """Additional tests for cleanup_old_collections()."""
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.52"
+__version__ = "2.10.53"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -665,6 +665,30 @@ def fetch_watch_history_with_tmdb(
     return watched_items
 
 
+def _find_stale_owned_collections(all_collections: List[Any], collection_name: str, private_label: str) -> List[Any]:
+    """Every OTHER collection in this library carrying private_label whose
+    title isn't already collection_name - i.e. every rename_on_template_
+    change candidate this run's freshly-rendered collection_name could
+    apply to (see update_plex_collection's own docstring).
+
+    Trusts ONLY the PrivateCollection_<user> label already applied to the
+    collection object by this same function on every prior run (never
+    title pattern-matching) - that label is applied unconditionally
+    whenever private_label is passed in, independent of
+    collections.private_collections (that config key only gates the
+    cross-user Plex exclude-filter push in
+    utils.plex_policy.apply_user_label_restrictions, never whether the
+    label itself is set on the collection).
+
+    Steady state is exactly zero (nothing stale) or exactly one (last
+    run's rendered name, about to be renamed). More than one means
+    ownership is ambiguous - see the caller for how that's handled.
+    """
+    return [
+        c for c in all_collections if c.title != collection_name and private_label in [label.tag for label in c.labels]
+    ]
+
+
 def update_plex_collection(
     section: Any,
     collection_name: str,
@@ -672,6 +696,7 @@ def update_plex_collection(
     logger: Any = None,
     label_name: Optional[str] = None,
     private_label: Optional[str] = None,
+    rename_on_template_change: bool = True,
 ) -> bool:
     """
     Create or update a Plex collection with items in the specified order.
@@ -696,6 +721,20 @@ def update_plex_collection(
             which silently produced the wrong (unprefixed) label whenever
             label_name wasn't literally "Recommended_<user>" - e.g. every
             install running with collections.append_usernames: false.
+        rename_on_template_change: When True (default -
+            collections.rename_on_template_change in config/tuning.yml)
+            and private_label is given, a collections.movie_name_template/
+            tv_name_template (#267) edit that changes this run's rendered
+            collection_name RENAMES the previous run's collection (found
+            via private_label) instead of leaving it orphaned while a
+            second, identically-managed collection gets created under the
+            new name - renaming preserves the collection's poster, sort
+            title, added-at date and any manual curation, all of which a
+            delete-and-recreate would lose. Only ever fires when EXACTLY
+            one other collection carries private_label; see
+            _find_stale_owned_collections and the "both old- and
+            new-named collections already exist" branch below for the
+            conservative, no-guessing edge-case handling.
 
     Returns:
         True if successful, False otherwise
@@ -707,18 +746,80 @@ def update_plex_collection(
 
     try:
         existing_collection = None
-        for collection in section.collections():
+        all_collections = list(section.collections())
+        for collection in all_collections:
             if collection.title == collection_name:
                 existing_collection = collection
                 break
 
+        stale_owned_collections: List[Any] = []
+        if rename_on_template_change and private_label:
+            stale_owned_collections = _find_stale_owned_collections(all_collections, collection_name, private_label)
+
         target_collection = None
-        if existing_collection:
-            current_items = existing_collection.items()
+
+        if existing_collection and stale_owned_collections:
+            # Both the (already correct) new-named collection and at least
+            # one stale, still-labeled old-named one exist - renaming would
+            # create a second collection with the identical title. Leave
+            # both alone; this run just updates existing_collection as
+            # normal below. (Can happen if a prior run created the
+            # new-named collection before this feature existed, or a rename
+            # attempt failed previously.)
+            stale_titles = [c.title for c in stale_owned_collections]
+            msg = (
+                f"Collection {collection_name!r} already exists alongside "
+                f"{len(stale_owned_collections)} other collection(s) carrying "
+                f"label {private_label!r} ({stale_titles}) - not renaming (would "
+                f"produce a duplicate title); leaving all as-is"
+            )
+            if logger:
+                logger.warning(msg)
+            else:
+                print(f"WARNING: {msg}")
+        elif not existing_collection and len(stale_owned_collections) == 1:
+            stale_collection = stale_owned_collections[0]
+            old_title = stale_collection.title
+            try:
+                stale_collection.editTitle(collection_name)
+                target_collection = stale_collection
+                msg = f"Renamed collection {old_title!r} -> {collection_name!r} (template change)"
+                if logger:
+                    logger.info(msg)
+                else:
+                    print(msg)
+            except plexapi.exceptions.PlexApiException as e:
+                # Rename failed - fall through to the normal create path
+                # below rather than losing this run's sync entirely.
+                if logger:
+                    logger.warning(f"Could not rename collection {old_title!r} to {collection_name!r}: {e}")
+                else:
+                    print(f"WARNING: Could not rename collection {old_title!r} to {collection_name!r}: {e}")
+                target_collection = None
+        elif not existing_collection and len(stale_owned_collections) > 1:
+            # Ambiguous ownership (e.g. a leftover duplicate) - never guess
+            # which one to rename. Leave every candidate alone; a new
+            # collection gets created below like before this feature existed.
+            stale_titles = [c.title for c in stale_owned_collections]
+            msg = (
+                f"Found {len(stale_owned_collections)} collections carrying label "
+                f"{private_label!r} with a title other than {collection_name!r} "
+                f"({stale_titles}) - ownership is ambiguous, skipping rename"
+            )
+            if logger:
+                logger.warning(msg)
+            else:
+                print(f"WARNING: {msg}")
+
+        # A successful rename (if any) takes precedence; otherwise fall
+        # back to the exact-title match found above.
+        target_collection = target_collection or existing_collection
+
+        if target_collection:
+            current_items = target_collection.items()
             if current_items:
-                existing_collection.removeItems(current_items)
-            existing_collection.addItems(items)
-            target_collection = existing_collection
+                target_collection.removeItems(current_items)
+            target_collection.addItems(items)
             if logger:
                 logger.info(f"Updated collection: {collection_name} ({len(items)} items)")
             else:


### PR DESCRIPTION
## Summary
- 2.10.52 shipped custom collection-name templates but left a known limitation: changing a template orphaned the previously-named collection in Plex.
- Now renames the existing collection in place instead of leaving an orphan, preserving poster, sort title, added-at date, and manual curation that a delete-and-recreate would lose.
- Ownership is confirmed only via the PrivateCollection_<user> label curatarr already applies to every collection it manages (present regardless of collections.private_collections) - never by title guessing. If both an old-named and new-named collection already exist, or ownership is ambiguous, nothing is renamed; both/all are logged and left alone.
- New collections.rename_on_template_change config key, default true, documented in config/tuning.example.yml with a matching code default (guardrail-tested).

## Test plan
- [x] Full test suite (2624 passed, 1 skipped)
- [x] ruff check . clean
- [x] ruff format --check . clean
- [x] mypy . clean (0 errors)
- [x] New unit tests cover: rename found by label, multi-library suffix included in comparison, old-named absent (no-op), template unchanged (no-op), both old+new exist (no rename, logged), ambiguous multiple stale matches (no rename, logged), flag disabled (old orphaning behavior), no private_label given (backward compat), rename API failure falls back to create, and multi-user isolation (one user's rename never touches another's)