### PR TITLE
fix: persist refreshed Trakt tokens, surface auth failures (2.10.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.54] - 2026-07-27
+
+### Fixed
+
+- **Trakt exports have been silently failing for every user roughly 24 hours after linking their account, since access tokens now expire that fast (Trakt changed this 2025-03-20) - and every run still reported success.** `create_trakt_client()` built its Trakt API client with no way to save a refreshed token: the refresh itself worked and updated the token in memory, but as soon as that process exited the refreshed token was gone, and since Trakt's refresh tokens are single-use, the *next* run replayed the same already-consumed refresh token and failed - a one-way trapdoor with zero persisted state ever recovering on its own. Refreshed tokens (access + refresh + issued-at/expiry) are now saved back to `config/trakt.yml` immediately, atomically, and without disturbing any other key in the file.
+
+  Also fixed, all part of the same root cause:
+  - The refresh request was missing `redirect_uri`, which Trakt's documented refresh body (and PyTrakt) includes on a refresh grant.
+  - A refresh failure was completely silent - no HTTP status, no response body, nothing logged. Both are now logged (secrets redacted first, same as every other log line).
+  - `get_username()` swallowed the real authentication error into a bare `None`, which turned "your refresh was just rejected" into the identical, misleading "Cannot get lists: not authenticated" every caller already showed for "never linked at all". The real cause is now logged.
+  - **The failure was invisible in the web UI** - the run still exited 0 and the dashboard still said "succeeded". A new explicit integration-health signal (`utils/integration_status.py`) records the real outcome of every Trakt export/sync attempt and surfaces it as a banner on every page plus a `trakt_export` field in `/status.json` - deliberately not log-string matching, which is exactly how this hid for months in the first place.
+  - **Recovering no longer requires hand-editing `trakt.yml`.** `python3 utils/trakt_auth.py` refused to re-authenticate whenever *any* `access_token` was present, telling you to remove it from the file yourself first - awkward for a source install, effectively impossible for Docker/frozen-binary users who can't reasonably shell in to do that edit. It now takes a `--reauth`/`--force` flag that bypasses that check and starts a fresh device-code sign-in immediately. (A web-UI "re-link Trakt" button would need its own device-code-polling flow comparable in size to the existing web-triggered-run plumbing - not built this round; the CLI flag is the fix for now.)
+  - The client now also tracks when its access token was issued and how long it's valid for, and refreshes proactively before it expires rather than only reactively after a request gets rejected.
+
+  **`trakt.export.auto_sync`'s code default is now `false` (was `true`) - this changes behavior for anyone who never explicitly set this key.** `config/trakt.example.yml`, `setup.sh`, and both web UI config screens have always documented/shown `false`; only this one code path silently defaulted the opposite way, meaning recommendations could be pushed to a linked Trakt account with no explicit opt-in. If you were relying on the undocumented `true` default, add `trakt.export.auto_sync: true` to `trakt.yml` explicitly.
+
+  **Verified against a real refresh (once, deliberately - Trakt rotates refresh tokens single-use, so every attempt is potentially consuming): the stored refresh token is already dead.** Trakt returned `HTTP 400 {"error":"invalid_grant","error_description":"session not found"}` - `invalid_grant` (not a malformed-request `invalid_request`) means the token itself is no longer valid, not that the request body was wrong. The account needs an interactive re-link: `python3 utils/trakt_auth.py --reauth`. This fix still matters going forward - every account that re-links will actually stay linked now, instead of silently breaking again on its first automatic refresh.
+
 ## [2.10.53] - 2026-07-27
 
 ### Fixed

--- a/config/trakt.example.yml
+++ b/config/trakt.example.yml
@@ -7,10 +7,17 @@ enabled: true
 client_id: YOUR_CLIENT_ID
 client_secret: YOUR_CLIENT_SECRET
 
-# OAuth tokens - set automatically after authentication
+# OAuth tokens - set automatically after authentication, and kept up
+# to date automatically as they're refreshed (access tokens currently
+# last about 24 hours - refreshed transparently before/on expiry, no
+# action needed unless the refresh itself is rejected, in which case
+# re-run trakt_auth.py below with --reauth).
 # Run: python3 utils/trakt_auth.py
 access_token: null
 refresh_token: null
+# token_created_at / token_expires_in: also set automatically (used to
+# refresh proactively, before expiry, rather than only reactively on a
+# failed request) - never set these by hand.
 
 # =============================================================================
 # EXPORT SETTINGS

--- a/recommenders/external_sync.py
+++ b/recommenders/external_sync.py
@@ -34,15 +34,32 @@ from utils import (
     get_authenticated_trakt_client,
     get_effective_arr_config,
     get_libraries_for_media_type,
+    get_project_root,
     log_error,
     log_warning,
     print_status,
+    record_integration_status,
 )
 
 logger = logging.getLogger("curatarr")
 
 # Batch size for Trakt sync operations
 TRAKT_BATCH_SIZE = 100
+
+# Name this module records its Trakt export attempts under (see
+# utils/integration_status.py) - read back by web/app.py's dashboard
+# banner/status.json, so a Trakt auth/export failure is visible without
+# opening a log file.
+TRAKT_EXPORT_STATUS_NAME = "trakt_export"
+
+
+def _cache_dir(config: Dict) -> str:
+    """Same cache_dir resolution every other cache/status file in this
+    module's config already uses (see sync_watch_history_to_trakt's own
+    sync_cache_file below) - get_project_root() so this respects
+    CURATARR_CONFIG_DIR (Docker) same as everything else, rather than a
+    second, independent __file__-relative computation."""
+    return os.path.join(get_project_root(), config.get("cache_dir", "cache"))
 
 
 def flatten_categorized(categorized: Dict) -> List[Dict]:
@@ -201,14 +218,28 @@ def export_to_trakt(config: Dict, all_users_data: List[Dict], tmdb_api_key: str)
         return
     if not export_config.get("enabled", True):
         return
-    # Check if auto_sync is enabled (can still manually export via HTML)
-    if not export_config.get("auto_sync", True):
+    # Check if auto_sync is enabled (can still manually export via HTML).
+    # Default False (#trakt-token-refresh-persistence): config/trakt.
+    # example.yml, setup.sh, web/config_settings.py, and
+    # web/config_connections.py have always documented/displayed this as
+    # False - only this one code fallback disagreed. Silently writing
+    # recommendations to someone's external Trakt account must never be
+    # the default when the key is merely absent from trakt.yml.
+    if not export_config.get("auto_sync", False):
         return
 
     # Get authenticated Trakt client
     trakt_client = get_authenticated_trakt_client(config)
     if not trakt_client:
         log_warning("Trakt not authenticated - run setup wizard to authenticate")
+        record_integration_status(
+            _cache_dir(config),
+            TRAKT_EXPORT_STATUS_NAME,
+            False,
+            "Trakt client not authenticated - a token refresh may have failed "
+            "(see logs) or the account was never linked. Run "
+            "`python3 utils/trakt_auth.py --reauth` to re-link.",
+        )
         return
 
     list_prefix = export_config.get("list_prefix", "Curatarr")
@@ -279,11 +310,15 @@ def export_to_trakt(config: Dict, all_users_data: List[Dict], tmdb_api_key: str)
                 print_status(f"  Combined: {len(all_show_imdb_ids)} shows -> Trakt", "success")
                 print(f"    {clickable_link(show_url)}")
 
+            record_integration_status(_cache_dir(config), TRAKT_EXPORT_STATUS_NAME, True)
         except (TraktAPIError, TraktAuthError) as e:
             log_error(f"Failed to export combined list to Trakt: {e}")
+            record_integration_status(_cache_dir(config), TRAKT_EXPORT_STATUS_NAME, False, str(e))
         return
 
     # Per-user or mapping mode - separate list per user
+    had_failure = False
+    failure_detail = ""
     for user_data in users_to_export:
         display_name = user_data["display_name"]
         movies_categorized = user_data["movies_categorized"]
@@ -321,6 +356,10 @@ def export_to_trakt(config: Dict, all_users_data: List[Dict], tmdb_api_key: str)
 
         except (TraktAPIError, TraktAuthError) as e:
             log_error(f"Failed to export {display_name} to Trakt: {e}")
+            had_failure = True
+            failure_detail = f"{display_name}: {e}"
+
+    record_integration_status(_cache_dir(config), TRAKT_EXPORT_STATUS_NAME, not had_failure, failure_detail)
 
 
 def _resolve_library_groups(config: Dict, users_to_export: List[Dict], media_type: str) -> List[Any]:
@@ -1104,6 +1143,14 @@ def sync_watch_history_to_trakt(
     trakt_client = get_authenticated_trakt_client(config)
     if not trakt_client:
         log_warning("Trakt not authenticated - run setup wizard to authenticate")
+        record_integration_status(
+            _cache_dir(config),
+            TRAKT_EXPORT_STATUS_NAME,
+            False,
+            "Trakt client not authenticated - a token refresh may have failed "
+            "(see logs) or the account was never linked. Run "
+            "`python3 utils/trakt_auth.py --reauth` to re-link.",
+        )
         return
 
     user_mode = export_config.get("user_mode", "mapping")
@@ -1263,5 +1310,7 @@ def sync_watch_history_to_trakt(
         total_shows_added = _sync_items_in_batches(new_show_imdb, trakt_client, "shows", "episodes")
 
         print_status(f"  Synced to Trakt: {total_movies_added} movies, {total_shows_added} shows", "success")
+        record_integration_status(_cache_dir(config), TRAKT_EXPORT_STATUS_NAME, True)
     except (TraktAPIError, TraktAuthError) as e:
         log_error(f"Failed to sync watch history to Trakt: {e}")
+        record_integration_status(_cache_dir(config), TRAKT_EXPORT_STATUS_NAME, False, str(e))

--- a/tests/test_external_sync.py
+++ b/tests/test_external_sync.py
@@ -252,6 +252,21 @@ class TestExportToTrakt:
 
         export_to_trakt(config, all_users_data, "api_key")
 
+    @patch("recommenders.external_sync.get_authenticated_trakt_client")
+    def test_auto_sync_unset_defaults_to_disabled(self, mock_get_client):
+        """#trakt-token-refresh-persistence: auto_sync's code default is
+        now False, matching config/trakt.example.yml, setup.sh, and the
+        web UI's own displayed default (all of which have always said
+        False) - previously only this code path disagreed (True), so
+        Trakt exports silently ran for anyone who never set the key at
+        all. Never even reaches get_authenticated_trakt_client when
+        auto_sync is absent."""
+        config = {"trakt": {"enabled": True, "export": {"enabled": True}}}
+
+        export_to_trakt(config, [], "api_key")
+
+        mock_get_client.assert_not_called()
+
 
 class TestExportToRadarr:
     """Tests for export_to_radarr function"""
@@ -1135,7 +1150,7 @@ class TestExportToTraktLogic:
     @patch("recommenders.external_sync.get_authenticated_trakt_client")
     def test_no_client_warns_and_returns(self, mock_get_client):
         mock_get_client.return_value = None
-        config = {"trakt": {"enabled": True}}
+        config = {"trakt": {"enabled": True, "export": {"auto_sync": True}}}
 
         export_to_trakt(config, [], "tmdb-key")
 
@@ -1145,7 +1160,7 @@ class TestExportToTraktLogic:
     def test_mapping_mode_no_plex_users_warns_and_returns(self, mock_get_client):
         client = _mock_trakt_client()
         mock_get_client.return_value = client
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "mapping", "plex_users": []}}}
+        config = {"trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "mapping", "plex_users": []}}}
 
         export_to_trakt(config, [{"username": "jason"}], "tmdb-key")
 
@@ -1155,7 +1170,12 @@ class TestExportToTraktLogic:
     def test_mapping_mode_placeholder_plex_users_warns(self, mock_get_client):
         client = _mock_trakt_client()
         mock_get_client.return_value = client
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "mapping", "plex_users": ["YourPlexUsername"]}}}
+        config = {
+            "trakt": {
+                "enabled": True,
+                "export": {"auto_sync": True, "user_mode": "mapping", "plex_users": ["YourPlexUsername"]},
+            }
+        }
 
         export_to_trakt(config, [{"username": "jason"}], "tmdb-key")
 
@@ -1165,7 +1185,9 @@ class TestExportToTraktLogic:
     def test_mapping_mode_no_matching_users_warns(self, mock_get_client):
         client = _mock_trakt_client()
         mock_get_client.return_value = client
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "mapping", "plex_users": ["jason"]}}}
+        config = {
+            "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "mapping", "plex_users": ["jason"]}}
+        }
         all_users_data = [{"username": "other", "display_name": "Other"}]
 
         export_to_trakt(config, all_users_data, "tmdb-key")
@@ -1182,7 +1204,12 @@ class TestExportToTraktLogic:
         config = {
             "trakt": {
                 "enabled": True,
-                "export": {"user_mode": "mapping", "plex_users": ["Jason"], "list_prefix": "MyRecs"},
+                "export": {
+                    "auto_sync": True,
+                    "user_mode": "mapping",
+                    "plex_users": ["Jason"],
+                    "list_prefix": "MyRecs",
+                },
             }
         }
         all_users_data = [
@@ -1216,7 +1243,9 @@ class TestExportToTraktLogic:
         client = _mock_trakt_client()
         mock_get_client.return_value = client
         mock_get_imdb.side_effect = lambda api, tmdb, media: f"tt{tmdb}"
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "mapping", "plex_users": ["jason"]}}}
+        config = {
+            "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "mapping", "plex_users": ["jason"]}}
+        }
         all_users_data = [
             {
                 "username": "jason",
@@ -1237,7 +1266,9 @@ class TestExportToTraktLogic:
         client = _mock_trakt_client(username="jasontv")
         mock_get_client.return_value = client
         mock_get_imdb.side_effect = lambda api, tmdb, media: f"tt{tmdb}"
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "combined", "list_prefix": "Fam"}}}
+        config = {
+            "trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "combined", "list_prefix": "Fam"}}
+        }
         all_users_data = [
             {
                 "username": "a",
@@ -1275,7 +1306,7 @@ class TestExportToTraktLogic:
         mock_get_imdb.side_effect = lambda api, tmdb, media: f"tt{tmdb}"
         client.sync_list.side_effect = [TraktAPIError("boom"), {}]
 
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "per_user"}}}
+        config = {"trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "per_user"}}}
         all_users_data = [
             {
                 "username": "a",
@@ -1303,7 +1334,7 @@ class TestExportToTraktLogic:
         mock_get_imdb.side_effect = lambda api, tmdb, media: f"tt{tmdb}"
         client.sync_list.side_effect = TraktAuthError("expired")
 
-        config = {"trakt": {"enabled": True, "export": {"user_mode": "combined"}}}
+        config = {"trakt": {"enabled": True, "export": {"auto_sync": True, "user_mode": "combined"}}}
         all_users_data = [
             {
                 "username": "a",

--- a/tests/test_integration_status.py
+++ b/tests/test_integration_status.py
@@ -1,0 +1,95 @@
+"""Tests for utils/integration_status.py - explicit integration-health
+signal (see module docstring: replaces log-string matching for
+surfacing a Trakt auth/export failure to the web UI)."""
+
+import json
+import os
+
+from utils.integration_status import get_integration_status, record_integration_status
+
+
+class TestRecordAndGetIntegrationStatus:
+    def test_roundtrip_success(self, tmp_path):
+        record_integration_status(str(tmp_path), "trakt_export", True)
+
+        result = get_integration_status(str(tmp_path), "trakt_export")
+
+        assert result["success"] is True
+        assert result["detail"] == ""
+        assert "timestamp" in result
+
+    def test_roundtrip_failure_with_detail(self, tmp_path):
+        record_integration_status(str(tmp_path), "trakt_export", False, "boom")
+
+        result = get_integration_status(str(tmp_path), "trakt_export")
+
+        assert result["success"] is False
+        assert result["detail"] == "boom"
+
+    def test_overwrites_previous_status(self, tmp_path):
+        """Only the LAST attempt's outcome is kept - a run that succeeds
+        after a prior failure must clear the failed signal, not append
+        to a history."""
+        record_integration_status(str(tmp_path), "trakt_export", False, "first failure")
+        record_integration_status(str(tmp_path), "trakt_export", True)
+
+        result = get_integration_status(str(tmp_path), "trakt_export")
+
+        assert result["success"] is True
+        assert result["detail"] == ""
+
+    def test_different_names_are_independent(self, tmp_path):
+        record_integration_status(str(tmp_path), "trakt_export", False, "trakt broke")
+        record_integration_status(str(tmp_path), "simkl_export", True)
+
+        trakt_status = get_integration_status(str(tmp_path), "trakt_export")
+        simkl_status = get_integration_status(str(tmp_path), "simkl_export")
+
+        assert trakt_status["success"] is False
+        assert simkl_status["success"] is True
+
+    def test_detail_is_redacted(self, tmp_path):
+        record_integration_status(str(tmp_path), "trakt_export", False, "access_token=supersecrettoken123")
+
+        result = get_integration_status(str(tmp_path), "trakt_export")
+
+        assert "supersecrettoken123" not in result["detail"]
+
+    def test_creates_cache_dir_if_missing(self, tmp_path):
+        cache_dir = tmp_path / "does_not_exist_yet"
+
+        record_integration_status(str(cache_dir), "trakt_export", True)
+
+        assert cache_dir.is_dir()
+
+    def test_write_is_atomic_no_leftover_temp_file(self, tmp_path):
+        record_integration_status(str(tmp_path), "trakt_export", True)
+
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".tmp-")]
+        assert leftover == []
+
+    def test_get_returns_none_when_never_recorded(self, tmp_path):
+        assert get_integration_status(str(tmp_path), "trakt_export") is None
+
+    def test_get_returns_none_on_corrupt_file(self, tmp_path):
+        path = tmp_path / "integration_status_trakt_export.json"
+        path.write_text("{not valid json")
+
+        assert get_integration_status(str(tmp_path), "trakt_export") is None
+
+    def test_get_returns_none_on_unexpected_shape(self, tmp_path):
+        path = tmp_path / "integration_status_trakt_export.json"
+        path.write_text(json.dumps(["not", "a", "dict"]))
+
+        assert get_integration_status(str(tmp_path), "trakt_export") is None
+
+    def test_record_never_raises_on_unwritable_dir(self, tmp_path, monkeypatch):
+        """Recording status must never itself crash the run that's
+        already succeeding/failing."""
+
+        def _boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "makedirs", _boom)
+
+        record_integration_status(str(tmp_path / "sub"), "trakt_export", True)  # must not raise

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -1,9 +1,12 @@
 """Tests for utils/trakt.py - Trakt API client."""
 
+import os
 import time
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
+import yaml
 
 from utils.trakt import (
     TRAKT_RATE_LIMIT_DELAY,
@@ -274,7 +277,32 @@ class TestTraktClientDeviceAuth:
         assert result is True
         assert client.access_token == "access123"
         assert client.refresh_token == "refresh456"
-        callback.assert_called_once_with("access123", "refresh456")
+        callback.assert_called_once_with("access123", "refresh456", None, None)
+
+    @patch("utils.trakt.requests.post")
+    def test_poll_for_token_captures_created_at_and_expires_in(self, mock_post):
+        """The token grant's own created_at/expires_in fields (device-
+        code polling's own `expires_in` parameter is a DIFFERENT thing -
+        the polling window, not the access token's lifetime) are stored
+        on the client and forwarded to token_callback."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "access123",
+            "refresh_token": "refresh456",
+            "created_at": 1700000000,
+            "expires_in": 7776000,
+        }
+        mock_post.return_value = mock_response
+
+        callback = Mock()
+        client = TraktClient("id", "secret", token_callback=callback)
+        result = client.poll_for_token("device_code", interval=0, expires_in=10)
+
+        assert result is True
+        assert client.created_at == 1700000000
+        assert client.expires_in == 7776000
+        callback.assert_called_once_with("access123", "refresh456", 1700000000, 7776000)
 
     @patch("utils.trakt.requests.post")
     def test_poll_for_token_pending(self, mock_post):
@@ -325,19 +353,77 @@ class TestTraktClientTokenRefresh:
         assert result is True
         assert client.access_token == "new_access"
         assert client.refresh_token == "new_refresh"
-        callback.assert_called_once_with("new_access", "new_refresh")
+        callback.assert_called_once_with("new_access", "new_refresh", None, None)
 
     @patch("utils.trakt.requests.post")
-    def test_refresh_access_token_failure(self, mock_post):
-        """Test failed token refresh."""
+    def test_refresh_access_token_sends_redirect_uri(self, mock_post):
+        """Trakt's documented /oauth/token refresh body includes
+        redirect_uri (PyTrakt sends this too) - suspected-required per
+        the diagnosis that motivated this whole fix."""
+        from utils.trakt import TRAKT_OOB_REDIRECT_URI
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "new_access", "refresh_token": "new_refresh"}
+        mock_post.return_value = mock_response
+
+        client = TraktClient("id", "secret", refresh_token="old_refresh")
+        client._refresh_access_token()
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["redirect_uri"] == TRAKT_OOB_REDIRECT_URI
+        assert body["grant_type"] == "refresh_token"
+
+    @patch("utils.trakt.requests.post")
+    def test_refresh_access_token_captures_created_at_and_expires_in(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access",
+            "refresh_token": "new_refresh",
+            "created_at": 1700000000,
+            "expires_in": 7776000,
+        }
+        mock_post.return_value = mock_response
+
+        client = TraktClient("id", "secret", refresh_token="old_refresh")
+        client._refresh_access_token()
+
+        assert client.created_at == 1700000000
+        assert client.expires_in == 7776000
+
+    @patch("utils.trakt.log_error")
+    @patch("utils.trakt.requests.post")
+    def test_refresh_access_token_failure(self, mock_post, mock_log_error):
+        """Test failed token refresh - status + body are logged (#trakt-
+        token-refresh-persistence: this used to fail completely silently)."""
         mock_response = Mock()
         mock_response.status_code = 401
+        mock_response.text = '{"error": "invalid_grant"}'
         mock_post.return_value = mock_response
 
         client = TraktClient("id", "secret", refresh_token="old_refresh")
         result = client._refresh_access_token()
 
         assert result is False
+        mock_log_error.assert_called_once()
+        logged_message = mock_log_error.call_args[0][0]
+        assert "401" in logged_message
+        assert "invalid_grant" in logged_message
+
+    @patch("utils.trakt.log_error")
+    @patch("utils.trakt.requests.post")
+    def test_refresh_access_token_request_exception_is_logged(self, mock_post, mock_log_error):
+        """A network-level failure (not just a bad HTTP status) must
+        also be logged, not silently swallowed."""
+        mock_post.side_effect = requests.RequestException("connection reset")
+
+        client = TraktClient("id", "secret", refresh_token="old_refresh")
+        result = client._refresh_access_token()
+
+        assert result is False
+        mock_log_error.assert_called_once()
+        assert "connection reset" in mock_log_error.call_args[0][0]
 
     def test_refresh_access_token_no_refresh_token(self):
         """Test refresh fails when no refresh token."""
@@ -345,6 +431,140 @@ class TestTraktClientTokenRefresh:
         result = client._refresh_access_token()
 
         assert result is False
+
+
+class TestTraktClientProactiveExpiry:
+    """Tests for TraktClient._access_token_expired / proactive refresh."""
+
+    def test_no_expiry_data_never_expired(self):
+        """Unknown created_at/expires_in (e.g. a trakt.yml predating this
+        feature) must never be treated as expired - falls back to
+        exactly today's reactive-only (401-triggered) refresh."""
+        client = TraktClient("id", "secret", access_token="tok")
+        assert client._access_token_expired() is False
+
+    def test_well_within_lifetime_not_expired(self):
+        client = TraktClient("id", "secret", access_token="tok", created_at=int(time.time()), expires_in=7776000)
+        assert client._access_token_expired() is False
+
+    def test_past_expiry_is_expired(self):
+        client = TraktClient(
+            "id", "secret", access_token="tok", created_at=int(time.time()) - 7776001, expires_in=7776000
+        )
+        assert client._access_token_expired() is True
+
+    def test_within_safety_margin_is_expired(self):
+        from utils.trakt import TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS
+
+        created_at = int(time.time()) - 7776000 + (TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS - 10)
+        client = TraktClient("id", "secret", access_token="tok", created_at=created_at, expires_in=7776000)
+        assert client._access_token_expired() is True
+
+    @patch("utils.trakt.requests.post")
+    def test_make_request_refreshes_proactively_before_sending(self, mock_post):
+        """An expired-per-our-tracking token triggers a refresh BEFORE
+        the real request is sent, not just reactively after a 401."""
+        refresh_response = Mock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {"access_token": "new_access", "refresh_token": "new_refresh"}
+        mock_post.return_value = refresh_response
+
+        client = TraktClient(
+            "id",
+            "secret",
+            access_token="stale_access",
+            refresh_token="old_refresh",
+            created_at=int(time.time()) - 7776001,
+            expires_in=7776000,
+        )
+        with patch.object(client, "_send_with_retries") as mock_send:
+            api_response = Mock()
+            api_response.status_code = 200
+            api_response.json.return_value = {"ok": True}
+            mock_send.return_value = api_response
+
+            client._make_request("GET", "/some/endpoint")
+
+            # The real request went out with the REFRESHED token, not
+            # the stale one.
+            sent_headers = mock_send.call_args.kwargs["headers"]
+            assert sent_headers["Authorization"] == "Bearer new_access"
+
+
+class TestSaveTraktTokens:
+    """Tests for save_trakt_tokens() - the shared, atomic token-persistence
+    function hoisted out of utils/trakt_auth.py's own save_tokens (see
+    that module) so TraktClient's runtime token_callback and the manual
+    `python3 utils/trakt_auth.py` re-auth flow persist identically."""
+
+    def test_updates_tokens_preserves_other_keys(self, tmp_path):
+        from utils.trakt import save_trakt_tokens
+
+        trakt_path = tmp_path / "trakt.yml"
+        trakt_path.write_text(
+            "enabled: true\nclient_id: abc\nclient_secret: def\naccess_token: old_access\n"
+            "refresh_token: old_refresh\nexport:\n  auto_sync: false\n  user_mode: mapping\n"
+        )
+
+        save_trakt_tokens(str(trakt_path), "new_access", "new_refresh", 1700000000, 7776000)
+
+        result = yaml.safe_load(trakt_path.read_text())
+        assert result["access_token"] == "new_access"
+        assert result["refresh_token"] == "new_refresh"
+        assert result["token_created_at"] == 1700000000
+        assert result["token_expires_in"] == 7776000
+        # Every other key untouched.
+        assert result["enabled"] is True
+        assert result["client_id"] == "abc"
+        assert result["client_secret"] == "def"
+        assert result["export"] == {"auto_sync": False, "user_mode": "mapping"}
+
+    def test_omits_created_at_expires_in_when_not_given(self, tmp_path):
+        from utils.trakt import save_trakt_tokens
+
+        trakt_path = tmp_path / "trakt.yml"
+        trakt_path.write_text("access_token: old\nrefresh_token: old\n")
+
+        save_trakt_tokens(str(trakt_path), "new_access", "new_refresh")
+
+        result = yaml.safe_load(trakt_path.read_text())
+        assert "token_created_at" not in result
+        assert "token_expires_in" not in result
+
+    def test_write_is_atomic_no_leftover_temp_file(self, tmp_path):
+        from utils.trakt import save_trakt_tokens
+
+        trakt_path = tmp_path / "trakt.yml"
+        trakt_path.write_text("access_token: old\nrefresh_token: old\n")
+
+        save_trakt_tokens(str(trakt_path), "new_access", "new_refresh")
+
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".tmp-")]
+        assert leftover == []
+        assert trakt_path.exists()
+
+    def test_hardens_permissions(self, tmp_path):
+        from utils.trakt import save_trakt_tokens
+
+        trakt_path = tmp_path / "trakt.yml"
+        trakt_path.write_text("access_token: old\nrefresh_token: old\n")
+
+        save_trakt_tokens(str(trakt_path), "new_access", "new_refresh")
+
+        if os.name != "nt":
+            mode = trakt_path.stat().st_mode & 0o777
+            assert mode == 0o600
+
+    def test_raises_and_leaves_original_file_untouched_on_bad_target_dir(self, tmp_path):
+        """A write failure (e.g. the temp file can't be created) must
+        raise - not silently succeed - so create_trakt_client's
+        token_callback can log it instead of pretending persistence
+        worked."""
+        from utils.trakt import save_trakt_tokens
+
+        trakt_path = tmp_path / "missing_dir" / "trakt.yml"
+        with pytest.raises(OSError):
+            save_trakt_tokens(str(trakt_path), "new_access", "new_refresh")
 
 
 class TestCreateTraktClient:
@@ -385,6 +605,82 @@ class TestCreateTraktClient:
         assert isinstance(result, TraktClient)
         assert result.client_id == "test_id"
         assert result.access_token == "token"
+
+    def test_reads_created_at_and_expires_in_from_config(self):
+        config = {
+            "trakt": {
+                "enabled": True,
+                "client_id": "test_id",
+                "client_secret": "test_secret",
+                "access_token": "token",
+                "refresh_token": "refresh",
+                "token_created_at": 1700000000,
+                "token_expires_in": 7776000,
+            }
+        }
+        result = create_trakt_client(config)
+
+        assert result.created_at == 1700000000
+        assert result.expires_in == 7776000
+
+    @patch("utils.trakt.save_trakt_tokens")
+    @patch("utils.trakt.get_project_root")
+    def test_token_callback_persists_via_save_trakt_tokens(self, mock_project_root, mock_save):
+        """#trakt-token-refresh-persistence: create_trakt_client's
+        token_callback is now wired to actually persist a refreshed
+        token (previously no callback was passed at all, so a refresh
+        during a normal run was never saved anywhere - and since Trakt
+        rotates refresh tokens single-use, the NEXT run then replayed an
+        already-consumed one)."""
+        mock_project_root.return_value = os.path.join("fake", "project", "root")
+        config = {
+            "trakt": {
+                "enabled": True,
+                "client_id": "test_id",
+                "client_secret": "test_secret",
+                "access_token": "token",
+                "refresh_token": "refresh",
+            }
+        }
+        client = create_trakt_client(config)
+        assert client.token_callback is not None
+
+        client.token_callback("new_access", "new_refresh", 1700000000, 7776000)
+
+        mock_save.assert_called_once_with(
+            os.path.join("fake", "project", "root", "config", "trakt.yml"),
+            "new_access",
+            "new_refresh",
+            1700000000,
+            7776000,
+        )
+
+    @patch("utils.trakt.log_error")
+    @patch("utils.trakt.save_trakt_tokens")
+    @patch("utils.trakt.get_project_root")
+    def test_token_callback_persistence_failure_is_logged_not_raised(
+        self, mock_project_root, mock_save, mock_log_error
+    ):
+        """A disk-level failure while persisting a refreshed token must
+        never crash the run that triggered the refresh - the refreshed
+        token still works in memory for the rest of this process."""
+        mock_project_root.return_value = os.path.join("fake", "project", "root")
+        mock_save.side_effect = OSError("disk full")
+        config = {
+            "trakt": {
+                "enabled": True,
+                "client_id": "test_id",
+                "client_secret": "test_secret",
+                "access_token": "token",
+                "refresh_token": "refresh",
+            }
+        }
+        client = create_trakt_client(config)
+
+        client.token_callback("new_access", "new_refresh", None, None)  # must not raise
+
+        mock_log_error.assert_called_once()
+        assert "disk full" in mock_log_error.call_args[0][0]
 
 
 class TestRevokeToken:
@@ -473,6 +769,33 @@ class TestTraktClientUserInfo:
         result = client.get_username()
 
         assert result is None
+
+    @patch("utils.trakt.log_warning")
+    def test_get_username_logs_real_auth_failure_cause(self, mock_log_warning):
+        """#trakt-token-refresh-persistence: a TraktAuthError (e.g. "Failed
+        to refresh Trakt token" from a rejected refresh) must be logged,
+        not silently discarded - previously this collapsed straight to
+        None with zero indication a refresh was even attempted, turning
+        into the misleading "Cannot get lists: not authenticated" at
+        every calling site with no way to tell a real refresh failure
+        apart from simply never having authenticated at all."""
+        client = TraktClient("id", "secret", access_token="token")
+        with patch.object(client, "get_user_settings", side_effect=TraktAuthError("Failed to refresh Trakt token")):
+            result = client.get_username()
+
+        assert result is None
+        mock_log_warning.assert_called_once()
+        assert "Failed to refresh Trakt token" in mock_log_warning.call_args[0][0]
+
+    @patch("utils.trakt.log_warning")
+    def test_get_username_logs_real_api_error_cause(self, mock_log_warning):
+        client = TraktClient("id", "secret", access_token="token")
+        with patch.object(client, "get_user_settings", side_effect=TraktAPIError("Trakt API error 500: boom")):
+            result = client.get_username()
+
+        assert result is None
+        mock_log_warning.assert_called_once()
+        assert "500" in mock_log_warning.call_args[0][0]
 
 
 class TestTraktClientListManagement:

--- a/tests/test_trakt_auth.py
+++ b/tests/test_trakt_auth.py
@@ -132,7 +132,7 @@ class TestTraktAuthMain:
         mock_load.side_effect = FileNotFoundError()
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1
 
     @patch("utils.trakt_auth.load_config")
@@ -143,7 +143,7 @@ class TestTraktAuthMain:
         mock_load.return_value = {"trakt": {"enabled": False}}
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1
 
     @patch("utils.trakt_auth.load_config")
@@ -154,7 +154,7 @@ class TestTraktAuthMain:
         mock_load.return_value = {"trakt": {"enabled": True, "client_id": None, "client_secret": "secret"}}
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1
 
     @patch("utils.trakt_auth.load_config")
@@ -167,8 +167,62 @@ class TestTraktAuthMain:
         }
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 0
+
+    @patch("utils.trakt_auth.TraktClient")
+    @patch("utils.trakt_auth.load_config")
+    def test_reauth_flag_bypasses_already_authenticated_check(self, mock_load, mock_client_class):
+        """--reauth (recovery flag - FIX 5) lets a user with an already-
+        present (possibly refresh-rejected/dead) access_token restart
+        device auth without hand-editing trakt.yml first - important for
+        Docker/frozen-binary users who can't reasonably shell in to do
+        that edit."""
+        from utils.trakt_auth import main
+
+        mock_load.return_value = {
+            "trakt": {"enabled": True, "client_id": "id", "client_secret": "secret", "access_token": "existing_token"}
+        }
+
+        mock_client = Mock()
+        mock_client.get_device_code.return_value = {
+            "device_code": "abc123",
+            "user_code": "XYZ789",
+            "verification_url": "https://trakt.tv/activate",
+            "interval": 5,
+            "expires_in": 600,
+        }
+        mock_client.poll_for_token.return_value = True
+        mock_client.get_username.return_value = "testuser"
+        mock_client_class.return_value = mock_client
+
+        # Should proceed to the device-auth flow instead of exiting 0.
+        main(["--reauth"])
+
+        mock_client.get_device_code.assert_called_once()
+
+    @patch("utils.trakt_auth.TraktClient")
+    @patch("utils.trakt_auth.load_config")
+    def test_force_is_an_alias_for_reauth(self, mock_load, mock_client_class):
+        from utils.trakt_auth import main
+
+        mock_load.return_value = {
+            "trakt": {"enabled": True, "client_id": "id", "client_secret": "secret", "access_token": "existing_token"}
+        }
+
+        mock_client = Mock()
+        mock_client.get_device_code.return_value = {
+            "device_code": "abc123",
+            "user_code": "XYZ789",
+            "verification_url": "https://trakt.tv/activate",
+        }
+        mock_client.poll_for_token.return_value = True
+        mock_client.get_username.return_value = "testuser"
+        mock_client_class.return_value = mock_client
+
+        main(["--force"])
+
+        mock_client.get_device_code.assert_called_once()
 
     @patch("utils.trakt_auth.TraktClient")
     @patch("utils.trakt_auth.load_config")
@@ -193,7 +247,7 @@ class TestTraktAuthMain:
         mock_client_class.return_value = mock_client
 
         # Should complete without exit
-        main()
+        main([])
 
         mock_client.get_device_code.assert_called_once()
         mock_client.poll_for_token.assert_called_once()
@@ -218,7 +272,7 @@ class TestTraktAuthMain:
         mock_client_class.return_value = mock_client
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1
 
     @patch("utils.trakt_auth.TraktClient")
@@ -236,7 +290,7 @@ class TestTraktAuthMain:
         mock_client_class.return_value = mock_client
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1
 
     @patch("utils.trakt_auth.TraktClient")
@@ -254,5 +308,5 @@ class TestTraktAuthMain:
         mock_client_class.return_value = mock_client
 
         with pytest.raises(SystemExit) as exc_info:
-            main()
+            main([])
         assert exc_info.value.code == 1

--- a/tests/test_web_trakt_health_banner.py
+++ b/tests/test_web_trakt_health_banner.py
@@ -1,0 +1,116 @@
+"""Tests for the Trakt export/sync health banner (web/app.py's
+_trakt_health_context context processor) and /status.json's
+trakt_export key - the explicit integration-health signal that
+replaces log-string matching for surfacing a Trakt auth/export failure
+in the web UI (see utils/integration_status.py and CHANGELOG's Trakt
+token-refresh-persistence entry for why log-grepping was fragile enough
+to hide a months-long silent failure)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from utils.integration_status import record_integration_status
+from web.app import create_app
+from web.config_io import module_path
+
+
+@pytest.fixture
+def client(curatarr_web_root):
+    app = create_app(project_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app, curatarr_web_root
+
+
+def _write_config(root, trakt_enabled=True):
+    config_path = module_path(root, "config")
+    trakt_section = f"trakt:\n  enabled: {str(trakt_enabled).lower()}\n"
+    with open(config_path, "w", encoding="utf-8") as f:
+        f.write(f'plex:\n  url: "http://localhost:32400"\nusers:\n  list: "alice"\n{trakt_section}')
+
+
+class TestTraktHealthBanner:
+    def test_no_banner_when_trakt_disabled(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=False)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", False, "should never show")
+
+        resp = c.get("/")
+
+        assert b"trakt-banner" not in resp.data
+
+    def test_no_banner_when_nothing_recorded_yet(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+
+        resp = c.get("/")
+
+        assert b"trakt-banner" not in resp.data
+
+    def test_no_banner_when_last_attempt_succeeded(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", True)
+
+        resp = c.get("/")
+
+        assert b"trakt-banner" not in resp.data
+
+    def test_banner_shown_when_last_attempt_failed(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", False, "Trakt client not authenticated")
+
+        resp = c.get("/")
+
+        assert b"trakt-banner" in resp.data
+        assert b"Trakt client not authenticated" in resp.data
+
+    def test_banner_shown_on_every_page_not_just_dashboard(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", False, "boom")
+
+        resp = c.get("/run")
+
+        assert b"trakt-banner" in resp.data
+
+
+class TestStatusJsonTraktExport:
+    def test_trakt_export_none_when_disabled(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=False)
+
+        resp = c.get("/status.json")
+
+        assert resp.json["trakt_export"] is None
+
+    def test_trakt_export_none_when_nothing_recorded(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+
+        resp = c.get("/status.json")
+
+        assert resp.json["trakt_export"] is None
+
+    def test_trakt_export_reflects_last_recorded_failure(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", False, "refresh rejected")
+
+        resp = c.get("/status.json")
+
+        assert resp.json["trakt_export"]["success"] is False
+        assert resp.json["trakt_export"]["detail"] == "refresh rejected"
+
+    def test_trakt_export_reflects_last_recorded_success(self, client):
+        c, app, root = client
+        _write_config(root, trakt_enabled=True)
+        record_integration_status(os.path.join(root, "cache"), "trakt_export", True)
+
+        resp = c.get("/status.json")
+
+        assert resp.json["trakt_export"]["success"] is True

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -122,6 +122,13 @@ from .helpers import (
     normalize_title,
 )
 
+# Integration-health signal (explicit, structured last-attempt status -
+# see module docstring for why this exists instead of log-string matching)
+from .integration_status import (
+    get_integration_status,
+    record_integration_status,
+)
+
 # Label utilities
 from .labels import (
     DEFAULT_MOVIE_NAME_TEMPLATE,
@@ -493,6 +500,9 @@ __all__ = [
     "map_path",
     "cleanup_old_logs",
     "compute_profile_hash",
+    # Integration-health signal
+    "record_integration_status",
+    "get_integration_status",
     # CLI
     "get_users_from_config",
     "resolve_admin_username",

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.53"
+__version__ = "2.10.54"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/integration_status.py
+++ b/utils/integration_status.py
@@ -1,0 +1,89 @@
+"""Small, dependency-free integration-health signal.
+
+Lets the web UI show "this Trakt export attempt failed" without
+grepping any log file for an English error string - fragile, and
+exactly how a months-long silent Trakt token-refresh failure hid (every
+run exited 0 and the dashboard reported "succeeded" the whole time; see
+CHANGELOG's Trakt token-refresh-persistence entry). This module is the
+explicit, structured alternative: the code that actually attempts an
+integration call records its own real outcome here, and any reader
+(the web dashboard, /status.json, a future CLI check) reads that
+outcome back directly - no string matching involved.
+
+Deliberately narrow: one JSON file per named integration under
+cache/, holding only the LAST attempt's outcome - not a history, not a
+queue. A run that succeeds after a prior failure overwrites the file,
+so the signal always reflects the CURRENT state, never a stale one.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .redact import redact
+
+logger = logging.getLogger("curatarr")
+
+
+def _status_path(cache_dir: str, name: str) -> str:
+    return os.path.join(cache_dir, f"integration_status_{name}.json")
+
+
+def record_integration_status(cache_dir: str, name: str, success: bool, detail: str = "") -> None:
+    """Persist the outcome of the most recent *name* integration attempt
+    (e.g. "trakt_export").
+
+    *detail* is redacted (see utils/redact.py) before being written -
+    it's frequently str(exception), which could in principle echo a
+    token (an API error body reflecting a bad request, for instance) -
+    the same defense-in-depth already applied to log_warning/log_error.
+
+    Atomic (temp file + rename) so a concurrent reader (the web
+    dashboard rendering a page while a run is mid-write) never sees a
+    half-written file, and a crash mid-write never corrupts the
+    previous, still-valid status.
+
+    Never raises - recording status must never itself fail (or further
+    complicate) the run that's already succeeding/failing; any error
+    here is logged at debug level and swallowed.
+    """
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+        payload: Dict[str, Any] = {
+            "success": success,
+            "detail": redact(detail),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=cache_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.replace(tmp_path, _status_path(cache_dir, name))
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+    except Exception as e:
+        logger.debug(f"Could not record integration status for {name}: {e}")
+
+
+def get_integration_status(cache_dir: str, name: str) -> Optional[Dict[str, Any]]:
+    """Return the last recorded {"success", "detail", "timestamp"} dict
+    for *name*, or None if nothing's been recorded yet, or the file
+    can't be read/parsed.
+
+    Callers must treat None as "unknown" (never attempted, or this
+    install predates this feature) - never as "failed".
+    """
+    path = _status_path(cache_dir, name)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "success" not in data:
+            return None
+        return data
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -7,12 +7,16 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import time
 from typing import Any, Callable, Dict, List, Optional
 
 import requests
+import yaml
 
 from .api_client import BaseAPIClient
+from .display import log_error, log_warning
+from .helpers import get_project_root, harden_file_permissions
 from .metrics import record_api_call
 
 logger = logging.getLogger("curatarr")
@@ -20,6 +24,22 @@ logger = logging.getLogger("curatarr")
 # Trakt API endpoints
 TRAKT_API_URL = "https://api.trakt.tv"
 TRAKT_AUTH_URL = "https://trakt.tv"
+
+# Out-of-band redirect_uri for non-web (device-code/PIN) OAuth flows -
+# the OAuth 2.0 standard placeholder value, and what PyTrakt (the
+# reference third-party Trakt client) sends on both the authorization
+# and refresh grant - see its trakt/core.py REDIRECT_URI constant.
+# Trakt's own documented /oauth/token body includes redirect_uri on a
+# refresh_token grant; curatarr's device-code flow never establishes
+# one of its own (device auth doesn't use it), so this is the value to
+# send instead of omitting the field entirely.
+TRAKT_OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+
+# How long before Trakt's own reported token expiry to proactively
+# refresh (see TraktClient._access_token_expired) rather than waiting
+# for a reactive 401 - covers clock skew and a request already in
+# flight when the token crosses its exact expiry instant.
+TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS = 300
 
 # Rate limiting: 0.2s delay (5 req/sec, well under 1000/5min limit)
 TRAKT_RATE_LIMIT_DELAY = 0.2
@@ -75,7 +95,9 @@ class TraktClient(BaseAPIClient):
         client_secret: str,
         access_token: Optional[str] = None,
         refresh_token: Optional[str] = None,
-        token_callback: Optional[Callable[[str, str], None]] = None,
+        created_at: Optional[int] = None,
+        expires_in: Optional[int] = None,
+        token_callback: Optional[Callable[[str, str, Optional[int], Optional[int]], None]] = None,
     ):
         """
         Initialize Trakt client.
@@ -85,19 +107,50 @@ class TraktClient(BaseAPIClient):
             client_secret: Trakt API application client secret
             access_token: Existing access token (optional)
             refresh_token: Existing refresh token (optional)
-            token_callback: Function to call when tokens are updated (for saving)
+            created_at: Unix timestamp the current access_token was issued
+                at (Trakt's token-grant response field of the same name -
+                previously discarded; see _access_token_expired below for
+                why this is tracked now)
+            expires_in: Seconds the current access_token is valid for from
+                created_at (also a token-grant response field, previously
+                discarded)
+            token_callback: Called with (access_token, refresh_token,
+                created_at, expires_in) whenever a token grant/refresh
+                succeeds, so the caller can persist the rotated tokens
+                (see create_trakt_client's token_callback - without this,
+                a refreshed token lives only in this process's memory,
+                and since Trakt rotates refresh tokens single-use, the
+                NEXT run replays an already-consumed one and fails)
         """
         super().__init__()
         self.client_id = client_id
         self.client_secret = client_secret
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self.created_at = created_at
+        self.expires_in = expires_in
         self.token_callback = token_callback
 
     @property
     def is_authenticated(self) -> bool:
         """Check if client has valid tokens."""
         return self.access_token is not None
+
+    def _access_token_expired(self) -> bool:
+        """True if created_at/expires_in are both known and the access
+        token is at or within TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS of
+        Trakt's reported expiry - used to refresh proactively (see
+        _make_request) instead of only reactively on an actual 401.
+
+        False whenever either value is unknown (e.g. a trakt.yml
+        written before this was tracked, or a client constructed without
+        them) - never invents an expiry, and every existing install
+        falls back to exactly today's reactive-only behavior until its
+        next real token grant/refresh populates both.
+        """
+        if not self.created_at or not self.expires_in:
+            return False
+        return time.time() >= (self.created_at + self.expires_in - TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS)
 
     def _get_headers(self, authenticated: bool = True) -> Dict[str, str]:
         """Get headers for API requests."""
@@ -133,6 +186,18 @@ class TraktClient(BaseAPIClient):
             TraktAPIError: If still rate limited (429) after
                 TRAKT_MAX_429_RETRIES retries, or on any other API error.
         """
+        # Proactive refresh (#trakt-token-refresh-persistence): if we
+        # know this token is at/past its reported expiry, refresh BEFORE
+        # sending the request rather than waiting for Trakt to reject it
+        # with a 401 first. Best-effort only - if it fails, fall through
+        # and let the existing reactive 401-retry below handle it exactly
+        # as before (this is purely an optimization to avoid a guaranteed
+        # wasted round-trip, never a behavior curatarr depends on for
+        # correctness).
+        if authenticated and retry_auth and self.access_token and self.refresh_token and self._access_token_expired():
+            logger.info("Trakt token nearing/at expiry, refreshing proactively...")
+            self._refresh_access_token()
+
         url = f"{TRAKT_API_URL}{endpoint}"
         headers = self._get_headers(authenticated)
 
@@ -233,10 +298,16 @@ class TraktClient(BaseAPIClient):
                 data = response.json()
                 self.access_token = data["access_token"]
                 self.refresh_token = data["refresh_token"]
+                # Distinct names from this method's own `expires_in`
+                # parameter (the device-code polling window) - this is
+                # the ACCESS TOKEN's lifetime, a same-named but unrelated
+                # field on the token-grant response.
+                self.created_at = data.get("created_at")
+                self.expires_in = data.get("expires_in")
 
                 # Notify callback to save tokens
                 if self.token_callback:
-                    self.token_callback(self.access_token, self.refresh_token)
+                    self.token_callback(self.access_token, self.refresh_token, self.created_at, self.expires_in)
 
                 return True
 
@@ -284,6 +355,14 @@ class TraktClient(BaseAPIClient):
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
                     "grant_type": "refresh_token",
+                    # Trakt's documented /oauth/token body includes
+                    # redirect_uri on a refresh_token grant (PyTrakt sends
+                    # this too - see TRAKT_OOB_REDIRECT_URI's own comment).
+                    # Previously omitted entirely; suspected (not yet
+                    # confirmed against a real refresh at the time this
+                    # was written) to be why every refresh attempt in the
+                    # retained log window failed.
+                    "redirect_uri": TRAKT_OOB_REDIRECT_URI,
                 },
                 headers={"Content-Type": "application/json"},
                 timeout=TRAKT_REQUEST_TIMEOUT,
@@ -294,17 +373,28 @@ class TraktClient(BaseAPIClient):
                 data = response.json()
                 self.access_token = data["access_token"]
                 self.refresh_token = data["refresh_token"]
+                self.created_at = data.get("created_at")
+                self.expires_in = data.get("expires_in")
 
                 # Notify callback to save tokens
                 if self.token_callback:
-                    self.token_callback(self.access_token, self.refresh_token)
+                    self.token_callback(self.access_token, self.refresh_token, self.created_at, self.expires_in)
 
                 logger.info("Trakt token refreshed successfully")
                 return True
 
+            # Log status + body (redacted by log_error - see
+            # utils/display.py) so a refresh failure is actually
+            # diagnosable instead of silently collapsing to a bare
+            # False that every caller already treats identically to
+            # "no refresh token configured" - see _make_request's
+            # "Failed to refresh Trakt token" TraktAuthError, which
+            # previously carried no detail about WHY.
+            log_error(f"Trakt token refresh failed: HTTP {response.status_code}: {response.text}")
             return False
 
-        except requests.RequestException:
+        except requests.RequestException as e:
+            log_error(f"Trakt token refresh request failed: {e}")
             return False
 
     def revoke_token(self) -> bool:
@@ -345,11 +435,25 @@ class TraktClient(BaseAPIClient):
         return self._make_request("GET", "/users/settings")
 
     def get_username(self) -> Optional[str]:
-        """Get authenticated user's username."""
+        """Get authenticated user's username.
+
+        Returns None on any failure (every caller below already treats
+        None as "not authenticated" and reports its own generic message)
+        - but the REAL cause is logged first rather than silently
+        discarded, since a TraktAuthError here is very often "the token
+        refresh this request triggered just failed" (see _make_request),
+        which used to come out as the misleading "Cannot get lists: not
+        authenticated" with zero indication that a refresh was even
+        attempted, let alone why it failed.
+        """
         try:
             settings = self.get_user_settings()
             return settings.get("user", {}).get("username")
-        except (TraktAPIError, TraktAuthError):
+        except TraktAuthError as e:
+            log_warning(f"Trakt get_username failed (authentication): {e}")
+            return None
+        except TraktAPIError as e:
+            log_warning(f"Trakt get_username failed (API error): {e}")
             return None
 
     # =========================================================================
@@ -847,6 +951,89 @@ class TraktClient(BaseAPIClient):
         return self._make_request("GET", endpoint + params, authenticated=False)
 
 
+def save_trakt_tokens(
+    trakt_path: str,
+    access_token: str,
+    refresh_token: str,
+    created_at: Optional[int] = None,
+    expires_in: Optional[int] = None,
+) -> None:
+    """
+    Persist rotated Trakt tokens to trakt.yml.
+
+    The single, shared implementation TraktClient's own runtime
+    token_callback (see create_trakt_client below) AND utils/trakt_auth.py's
+    manual `python3 utils/trakt_auth.py` device-auth flow both call -
+    previously duplicated (trakt_auth.py had its own copy; create_trakt_client
+    passed no callback at all, so a refreshed token during a normal
+    recommender run was never saved anywhere - Trakt rotates refresh
+    tokens single-use, so the NEXT run then replayed an already-consumed
+    one and failed).
+
+    Atomic (temp file in the same directory + os.replace) so a crash
+    mid-write, or two recommenders (movie.py/tv.py, or a web-UI-triggered
+    run racing a cron run) refreshing at close to the same moment, can
+    never truncate/corrupt the file a third reader might load at the
+    same time. Permissions are re-hardened after every write
+    (harden_file_permissions) since this file holds live OAuth
+    credentials.
+
+    Every OTHER key/section in trakt.yml (export/import/discovery
+    settings, comments) survives untouched, since the file is read into
+    a dict first and only these specific keys are set on it - EXCEPT
+    comments specifically: this uses plain pyyaml, not ruamel.yaml's
+    round-trip mode (config_io.load_module/save_module's approach for
+    the web UI's own config-save routes), because ruamel.yaml is a
+    requirements-ui.txt-only dependency and this path runs on every
+    plain CLI/cron install (requirements.txt only, no UI stack) - adding
+    it here would mean every install pulls in the heavier UI dependency
+    just to keep a token refresh's rewrite comment-preserving. Comments
+    in trakt.yml are therefore NOT preserved across an automatic token
+    refresh (they already weren't across a manual `trakt_auth.py`
+    re-auth, before this change hoisted that script's own save_tokens
+    into this one shared function).
+
+    Args:
+        trakt_path: Full path to config/trakt.yml
+        access_token: New access token to save
+        refresh_token: New (rotated) refresh token to save
+        created_at: Unix timestamp the new access_token was issued at,
+            if known (see TraktClient.created_at) - stored as
+            token_created_at
+        expires_in: Seconds the new access_token is valid for, if known
+            (see TraktClient.expires_in) - stored as token_expires_in
+
+    Raises:
+        OSError: if trakt_path can't be read or the atomic write fails -
+            callers (create_trakt_client's token_callback below) catch
+            this so a persistence failure never crashes the run that
+            triggered the refresh; the refreshed tokens still work for
+            the REST of this process's lifetime either way, exactly as
+            before this function existed.
+    """
+    directory = os.path.dirname(trakt_path) or "."
+    with open(trakt_path, "r", encoding="utf-8") as f:
+        trakt_config = yaml.safe_load(f) or {}
+
+    trakt_config["access_token"] = access_token
+    trakt_config["refresh_token"] = refresh_token
+    if created_at is not None:
+        trakt_config["token_created_at"] = created_at
+    if expires_in is not None:
+        trakt_config["token_expires_in"] = expires_in
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".yml", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(trakt_config, f, default_flow_style=False, sort_keys=False)
+        os.replace(tmp_path, trakt_path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+    harden_file_permissions(trakt_path)
+
+
 def create_trakt_client(config: Dict) -> Optional[TraktClient]:
     """
     Create a TraktClient from config, if enabled.
@@ -871,9 +1058,36 @@ def create_trakt_client(config: Dict) -> Optional[TraktClient]:
 
     access_token = trakt_config.get("access_token")
     refresh_token = trakt_config.get("refresh_token")
+    created_at = trakt_config.get("token_created_at")
+    expires_in = trakt_config.get("token_expires_in")
+
+    trakt_path = os.path.join(get_project_root(), "config", "trakt.yml")
+
+    def _persist_refreshed_tokens(
+        new_access_token: str,
+        new_refresh_token: str,
+        new_created_at: Optional[int] = None,
+        new_expires_in: Optional[int] = None,
+    ) -> None:
+        try:
+            save_trakt_tokens(trakt_path, new_access_token, new_refresh_token, new_created_at, new_expires_in)
+        except OSError as e:
+            # Persistence failing must never crash the run that
+            # triggered the refresh - the refreshed token still works
+            # in memory for the rest of THIS process either way. Logged
+            # loud (error, not warning) since this is exactly the
+            # failure mode that made refreshed tokens a one-way trapdoor
+            # before this function existed - it must never go silent again.
+            log_error(f"Could not persist refreshed Trakt tokens to {trakt_path}: {e}")
 
     return TraktClient(
-        client_id=client_id, client_secret=client_secret, access_token=access_token, refresh_token=refresh_token
+        client_id=client_id,
+        client_secret=client_secret,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        created_at=created_at,
+        expires_in=expires_in,
+        token_callback=_persist_refreshed_tokens,
     )
 
 

--- a/utils/trakt_auth.py
+++ b/utils/trakt_auth.py
@@ -6,17 +6,16 @@ Run this script to authenticate with Trakt using device code flow.
 Tokens are saved to trakt.yml for future use.
 """
 
+import argparse
 import os
 import sys
-
-import yaml
+from typing import Optional
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.config import load_config as _load_canonical_config
-from utils.helpers import harden_file_permissions
-from utils.trakt import TraktAuthError, TraktClient
+from utils.trakt import TraktAuthError, TraktClient, save_trakt_tokens
 
 
 def get_config_dir():
@@ -39,24 +38,50 @@ def load_config():
     return _load_canonical_config(config_path)
 
 
-def save_tokens(access_token: str, refresh_token: str):
-    """Save tokens to trakt.yml"""
+def save_tokens(
+    access_token: str,
+    refresh_token: str,
+    created_at: Optional[int] = None,
+    expires_in: Optional[int] = None,
+):
+    """Save tokens to trakt.yml.
+
+    Thin wrapper around utils.trakt.save_trakt_tokens - the SAME
+    persistence TraktClient's own runtime token_callback uses when a
+    token is refreshed mid-run (see utils/trakt.py's
+    create_trakt_client) - so a manual `python3 utils/trakt_auth.py`
+    re-auth and an automatic in-run refresh persist identically instead
+    of two divergent implementations (this used to have its own
+    separate yaml.safe_load/dump + harden_file_permissions copy).
+    """
     trakt_path = os.path.join(get_config_dir(), "trakt.yml")
-
-    with open(trakt_path, "r") as f:
-        trakt_config = yaml.safe_load(f)
-
-    trakt_config["access_token"] = access_token
-    trakt_config["refresh_token"] = refresh_token
-
-    with open(trakt_path, "w") as f:
-        yaml.dump(trakt_config, f, default_flow_style=False, sort_keys=False)
-    harden_file_permissions(trakt_path)
-
+    save_trakt_tokens(trakt_path, access_token, refresh_token, created_at, expires_in)
     print("\033[92mTokens saved to config/trakt.yml\033[0m")
 
 
-def main():
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Trakt device-code authentication for Curatarr")
+    parser.add_argument(
+        "--reauth",
+        "--force",
+        dest="reauth",
+        action="store_true",
+        help=(
+            "Re-authenticate even if config/trakt.yml already has an access_token "
+            "(e.g. after a refresh failure/rejected token) instead of requiring a "
+            "manual hand-edit of the file first."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """argv defaults to sys.argv[1:] (argparse's own default) - an
+    explicit list (e.g. []) lets tests/callers invoke this without
+    picking up whatever's actually in sys.argv (e.g. pytest's own CLI
+    args when this is called directly from a test)."""
+    args = parse_args(argv)
+
     print("\033[96m=== Trakt Authentication ===\033[0m")
     print()
 
@@ -82,10 +107,13 @@ def main():
         print("Add them to config/trakt.yml")
         sys.exit(1)
 
-    # Check if already authenticated
-    if trakt_config.get("access_token") and trakt_config.get("access_token") != "null":
+    # Check if already authenticated - skipped entirely with --reauth/--force
+    # (e.g. after a refresh failure/rejected token: Docker/frozen-binary
+    # users can't reasonably hand-edit trakt.yml and shell in to remove
+    # access_token first, and even a source install shouldn't have to).
+    if not args.reauth and trakt_config.get("access_token") and trakt_config.get("access_token") != "null":
         print("Already authenticated!")
-        print("To re-authenticate, remove access_token from config/trakt.yml first.")
+        print("To re-authenticate, run: python3 utils/trakt_auth.py --reauth")
         sys.exit(0)
 
     # Create client

--- a/web/app.py
+++ b/web/app.py
@@ -54,6 +54,7 @@ from werkzeug.datastructures import Headers
 
 from utils import (
     __version__,
+    get_integration_status,
     get_project_root,
     get_update_mode,
     get_users_from_config,
@@ -388,6 +389,42 @@ def create_app(
             return {"update_banner": None}
 
     @app.context_processor
+    def _trakt_health_context():
+        """Injected into every rendered template (see base.html's banner
+        block) - surfaces a Trakt export/sync failure explicitly,
+        without requiring anyone to open a log file. Reads the
+        structured status utils.integration_status.record_integration_status
+        writes from recommenders/external_sync.py's export_to_trakt /
+        sync_watch_history_to_trakt - deliberately NOT log-string
+        matching (see CHANGELOG's Trakt token-refresh-persistence entry
+        for how fragile/silent that approach turned out to be: every run
+        exited 0 and the dashboard reported "succeeded" for months while
+        every single Trakt export actually failed).
+
+        Fails open (no banner) on any error, same spirit as
+        _update_banner_context above - a broken health check must never
+        break normal page rendering. Also hidden whenever Trakt isn't
+        even enabled, so an install that's never configured Trakt at
+        all never sees this.
+        """
+        try:
+            config = _load_config()
+            if not config or not (config.get("trakt") or {}).get("enabled", False):
+                return {"trakt_banner": None}
+            cache_dir = os.path.join(project_root, config.get("cache_dir", "cache"))
+            status = get_integration_status(cache_dir, "trakt_export")
+            if not status or status.get("success", True):
+                return {"trakt_banner": None}
+            return {
+                "trakt_banner": {
+                    "detail": status.get("detail") or "Trakt export/sync failed - see logs for detail.",
+                    "timestamp": status.get("timestamp"),
+                }
+            }
+        except Exception:
+            return {"trakt_banner": None}
+
+    @app.context_processor
     def _version_context():
         """#265: the running version, injected into every rendered
         template (see base.html's topbar) so it's visible on every page,
@@ -496,6 +533,19 @@ def create_app(
                 continue
             if last_run is None or status["timestamp"] > last_run["timestamp"]:
                 last_run = status
+
+        # Trakt export/sync health (see utils.integration_status and
+        # recommenders/external_sync.py) - an explicit, structured signal
+        # rather than log-string matching, so a Trakt auth/refresh
+        # failure is visible here even though it isn't a `last_run`
+        # failure (movie.py/tv.py's own run can - and did, for months -
+        # exit 0 while Trakt export silently failed underneath it).
+        # None whenever Trakt isn't enabled or nothing's been recorded yet.
+        trakt_export = None
+        if config and (config.get("trakt") or {}).get("enabled", False):
+            cache_dir = os.path.join(project_root, config.get("cache_dir", "cache"))
+            trakt_export = get_integration_status(cache_dir, "trakt_export")
+
         return jsonify(
             {
                 "version": __version__,
@@ -510,6 +560,7 @@ def create_app(
                 }
                 if last_run
                 else None,
+                "trakt_export": trakt_export,
             }
         )
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -132,6 +132,14 @@
         })();
       </script>
       {% endif %}
+      {% if trakt_banner %}
+      <div class="banner error" id="trakt-banner">
+        Trakt export/sync failed: {{ trakt_banner.detail }}
+        {% if trakt_banner.timestamp %}(last attempt: {{ trakt_banner.timestamp }}){% endif %}
+        - see <a href="{{ url_for('config_connections') }}">Connections</a> to check credentials, or run
+        <code>python3 utils/trakt_auth.py --reauth</code> to re-link your account.
+      </div>
+      {% endif %}
       {% block content %}{% endblock %}
     </main>
   </div>


### PR DESCRIPTION
## Summary
- Trakt exports have been silently failing for every user roughly 24h after linking (Trakt access tokens now last ~24h, not 90 days) - create_trakt_client() built its client with no token_callback, so a successfully refreshed token was never saved anywhere. Every run still exited 0 and the dashboard still reported success.
- Refreshed tokens (access/refresh/issued-at/expiry) are now persisted to trakt.yml atomically via a single save_trakt_tokens(), shared between the runtime callback and the manual trakt_auth.py re-auth flow (no duplication).
- Added the redirect_uri Trakt's documented refresh grant needs; logged HTTP status/body on refresh failure; stopped get_username() swallowing the real auth error into a bare None.
- New utils/integration_status.py: explicit, structured last-attempt signal for Trakt export/sync, surfaced as a web UI banner + /status.json field - not log-string matching (which is exactly how this hid for months).
- utils/trakt_auth.py --reauth/--force flag: recovery no longer requires hand-editing trakt.yml. (A web-UI re-link button would need its own device-code-polling flow comparable to the existing job-runner SSE plumbing - not built this round; reporting the scope instead of guessing at it.)
- Tracks created_at/expires_in and refreshes proactively before expiry, not just reactively on a 401.
- trakt.export.auto_sync code default changed to false, matching the documented example/setup-wizard/web-UI default that only this one code path disagreed with.

## Live verification (step 7 - the one deliberate live call)
Ran exactly once against the real config, since Trakt rotates refresh tokens single-use and every attempt is potentially consuming:

```
HTTP 400 {"error":"invalid_grant","error_description":"session not found"}
```

`invalid_grant` (not `invalid_request`) means this specific stored refresh token is already dead, not that the request body was malformed. The account needs an interactive re-link: `python3 utils/trakt_auth.py --reauth`. The fix still matters going forward - every account that re-links will actually stay linked now instead of silently breaking again on its first automatic refresh.

## Test plan
- [x] Full test suite (2666 passed, 1 skipped)
- [x] ruff check . / ruff format --check . clean
- [x] mypy . clean (0 errors)
- [x] New/updated unit tests: token persistence (atomic, preserves other keys, hardens permissions), redirect_uri sent on refresh, failure logging (status+body, redacted), proactive-expiry refresh, get_username real-cause logging, create_trakt_client token_callback wiring, --reauth/--force flag, auto_sync default flip (with existing tests updated to explicitly opt in where they relied on the old default), new utils/integration_status.py module, web UI banner + /status.json trakt_export field