### PR TITLE
In-app scheduler for recommendation runs (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.55] - 2026-07-27
+
+### Added
+
+- **In-app scheduler (#264).** Settings -> Scheduling: enable a daily time (24-hour, optionally restricted to specific weekdays) to run the full pipeline (movie + tv + external) from inside the web UI process itself - no host cron or separate container needed. Off by default.
+  - Timezone is always the container's own `TZ` environment variable (falls back to UTC if unset) - there's no separate timezone setting, so there's exactly one clock to reason about. The Settings screen shows the resolved timezone and the computed next-run time.
+  - Shares the exact same cross-container run lock the existing `docker-compose.yml` `schedule` profile / host-cron approach already uses - a scheduled run can never overlap a run triggered any other way. If the scheduled time arrives while a run is already in progress, that occurrence is skipped and logged (never queued) - the dashboard shows the last scheduled attempt and its result.
+  - Never fires a missed occurrence on restart or redeploy - only the next real occurrence ever fires. Correctly handles both DST transitions: a time inside a spring-forward gap runs shortly after the gap closes rather than being skipped for the day; a fall-back-repeated hour fires once, not twice.
+  - **This does not replace host cron / the compose `schedule` profile - they coexist.** `docs/DOCKER.md` now documents both as explicit alternatives and states plainly to use only one: the shared run lock prevents the two from overlapping, but nothing prevents both from firing at different times of day if you enable the in-app scheduler while also running host cron/the compose profile. There's no reliable way to detect that combination from inside the container (no Docker socket access, no host crontab visibility), so this is a documentation warning, not an automatic check.
+
 ## [2.10.54] - 2026-07-27
 
 ### Fixed

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -70,6 +70,37 @@ general:
   #   enabled: true
   #   dry_run: true
 
+# Optional: in-app scheduler (#264) - runs the full recommendation
+# pipeline (movie + tv + external, same as `full` on the Run screen) at
+# a fixed daily time from inside this same process, no host cron or
+# separate container needed. Off by default.
+#
+# Coexists with, does NOT replace, the host-cron / docker-compose.yml
+# `schedule` profile approach documented in docs/DOCKER.md - pick ONE.
+# The two share the same cross-container run lock, so they can never
+# OVERLAP, but nothing stops both firing at different times of day if
+# you enable this while host cron/the compose profile is also active.
+#
+# Timezone is always this container's own TZ environment variable
+# (falls back to UTC if TZ is unset) - there is no separate timezone
+# key here, so there's exactly one clock to reason about, not two that
+# could disagree. The web UI's Settings screen shows the resolved
+# timezone and the computed next-run time so it's never ambiguous.
+#
+# If a scheduled run's target time arrives while another run (web-UI-
+# triggered, or the compose `schedule` profile's sibling container) is
+# already in progress, that occurrence is skipped (logged) - never
+# queued. Missed occurrences (e.g. the container was down at 3am) are
+# never caught up on the next start - only the next real occurrence
+# ever fires.
+schedule:
+  enabled: false
+  time: "03:00"  # 24-hour HH:MM, local to the TZ above
+  # weekdays:               # optional; omit (or leave empty) for every day
+  #   - monday
+  #   - wednesday
+  #   - friday
+
 # Huntarr: Find missing/upcoming movies from collections
 huntarr:
   sequel_huntarr: true    # Missing movies from collections you've started

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -178,9 +178,49 @@ access; neither is a substitute for the other.
 
 ## Scheduling recommendation runs
 
+There are TWO ways to schedule recurring runs. **Pick exactly one.**
+Both ultimately call the same recommender code and share the same
+cross-container run lock (`utils/run_lock.py`), so they can never
+*overlap* each other or a manual web-UI-triggered run - but that lock
+only prevents overlap, not duplication: if you enable the in-app
+scheduler below *and* also have host cron or the `schedule` profile
+active, you will get two separate runs at two different times of day,
+each thinking it's the only one scheduled. Nothing in curatarr can
+reliably detect that from inside the container (no Docker socket
+access, no visibility into a sibling container's compose profile or
+the host's crontab), so this is on you to avoid - use one mechanism,
+not both.
+
+### Option A: the in-app scheduler (recommended if you don't want to touch compose/cron)
+
+Settings -> Scheduling: enable it, set a daily time (24-hour, in the
+container's own `TZ` - see below), optionally restrict to specific
+weekdays. Runs the `full` pipeline (movie, tv, external) from inside
+this same container - no host cron, no second container, no compose
+file editing.
+
+- **Timezone** is always the container's `TZ` environment variable
+  (`-e TZ=Australia/Melbourne`, etc.), falling back to UTC if unset -
+  there's no separate timezone setting to configure or get out of sync.
+  The Settings screen shows the resolved timezone and the computed
+  next-run time so it's never ambiguous which clock is in play.
+- If the scheduled time arrives while another run is already in
+  progress (a web-UI-triggered run, or - see Option B below - the
+  `schedule` profile's sibling container), that occurrence is **skipped
+  and logged**, never queued. The dashboard shows the last scheduled
+  attempt and its result (started / skipped / error).
+- A missed occurrence (e.g. the container was down at the scheduled
+  time) is **never** made up on the next start - only the next real
+  occurrence ever fires. This matters for `docker compose up -d`,
+  which happens on every redeploy: without this, a redeploy loop could
+  trigger a surprise run (or several) every time, hammering Plex/TMDB.
+- Off by default.
+
+### Option B: host cron / the `schedule` compose profile
+
 The web UI can trigger runs itself, but for a fully unattended/cron
-style setup, run the recommender as a one-shot container instead of
-the long-running web service:
+style setup independent of the web container's own uptime, run the
+recommender as a one-shot container instead:
 
 ```bash
 docker run --rm \
@@ -195,8 +235,8 @@ or `movie` / `tv` / `external` individually; any extra arguments (e.g.
 `--debug`, a specific username) are passed straight through to the
 underlying recommender script.
 
-**Host cron** (the clean MVP for scheduling - this image doesn't bundle
-its own cron daemon):
+**Host cron** (the original MVP for scheduling, still fully supported -
+this image doesn't bundle its own cron daemon):
 
 ```cron
 # Daily at 3 AM
@@ -207,6 +247,10 @@ its own cron daemon):
 `schedule` profile specifically for this - it's never started by a
 plain `docker compose up`, only when explicitly targeted (by name, as
 above, or via `docker compose --profile schedule up`).
+
+This approach is recommended if you're already comfortable with
+compose/cron, or want scheduling to keep working independently of
+whether the web UI container happens to be up.
 
 ## Updating
 

--- a/tests/test_migrate_config.py
+++ b/tests/test_migrate_config.py
@@ -89,6 +89,47 @@ class TestCoreSectionsIncludesLibraries:
         assert "libraries" in CORE_SECTIONS
 
 
+class TestCoreSectionsIncludesSchedule:
+    """#264 regression: build_core_config() only ever copies sections
+    listed in CORE_SECTIONS into the migrated config.yml - anything
+    else is silently dropped. Confirmed for real (in a live container,
+    verifying #264) that "schedule" would otherwise vanish the moment
+    a single-library (plex.movie_library/tv_library, no explicit
+    'libraries:' list) install ran its first migration - which is most
+    fresh installs, not an edge case."""
+
+    def test_schedule_in_core_sections(self):
+        assert "schedule" in CORE_SECTIONS
+
+    def test_schedule_section_survives_a_real_migration(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(
+            "plex:\n"
+            "  url: http://localhost:32400\n"
+            "  token: faketoken\n"
+            "  movie_library: Movies\n"
+            "  tv_library: TV Shows\n"
+            "users:\n"
+            "  list: alice\n"
+            "schedule:\n"
+            "  enabled: true\n"
+            '  time: "03:00"\n',
+            encoding="utf-8",
+        )
+
+        from utils.migrate_config import migrate_config
+
+        result = migrate_config(str(config_path))
+        assert result["migrated"] is True
+
+        import yaml
+
+        with open(config_path, encoding="utf-8") as f:
+            migrated = yaml.safe_load(f)
+
+        assert migrated.get("schedule") == {"enabled": True, "time": "03:00"}
+
+
 class TestMigrateToLibraries:
     """Tests for migrate_to_libraries (#157 Phase 1)"""
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,207 @@
+"""Tests for utils/scheduler.py - the #264 in-app scheduler's pure
+timezone-resolution/config-parsing/next-run-computation logic (no
+threads, no JobManager - see tests/test_scheduler_runner.py for the
+background-thread integration this feeds)."""
+
+import zoneinfo
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from utils.scheduler import (
+    WEEKDAY_NAMES,
+    compute_next_run,
+    describe_next_run,
+    parse_schedule_config,
+    resolve_scheduler_timezone,
+)
+
+UTC = zoneinfo.ZoneInfo("UTC")
+NY = zoneinfo.ZoneInfo("America/New_York")
+
+
+class TestResolveSchedulerTimezone:
+    def test_uses_tz_env_var(self, monkeypatch):
+        monkeypatch.setenv("TZ", "Australia/Melbourne")
+        result = resolve_scheduler_timezone()
+        assert str(result) == "Australia/Melbourne"
+
+    def test_falls_back_to_utc_when_unset(self, monkeypatch):
+        monkeypatch.delenv("TZ", raising=False)
+        result = resolve_scheduler_timezone()
+        assert str(result) == "UTC"
+
+    def test_falls_back_to_utc_when_blank(self, monkeypatch):
+        monkeypatch.setenv("TZ", "")
+        result = resolve_scheduler_timezone()
+        assert str(result) == "UTC"
+
+    @patch("utils.scheduler.log_warning")
+    def test_invalid_tz_falls_back_to_utc_and_warns(self, mock_warn, monkeypatch):
+        monkeypatch.setenv("TZ", "Not/A_Real_Zone")
+        result = resolve_scheduler_timezone()
+        assert str(result) == "UTC"
+        mock_warn.assert_called_once()
+
+    @patch("utils.scheduler.log_warning")
+    def test_unset_tz_does_not_warn(self, mock_warn, monkeypatch):
+        """An unset TZ defaulting to UTC is completely normal (most
+        images don't set it) - only a TYPO'd value should warn."""
+        monkeypatch.delenv("TZ", raising=False)
+        resolve_scheduler_timezone()
+        mock_warn.assert_not_called()
+
+
+class TestParseScheduleConfig:
+    def test_valid_time_no_weekdays(self):
+        hour, minute, weekdays = parse_schedule_config({"time": "03:00"})
+        assert (hour, minute, weekdays) == (3, 0, None)
+
+    def test_valid_time_with_weekdays(self):
+        hour, minute, weekdays = parse_schedule_config({"time": "23:45", "weekdays": ["monday", "Friday"]})
+        assert (hour, minute) == (23, 45)
+        assert weekdays == {0, 4}
+
+    def test_empty_weekdays_list_means_every_day(self):
+        _hour, _minute, weekdays = parse_schedule_config({"time": "03:00", "weekdays": []})
+        assert weekdays is None
+
+    def test_missing_weekdays_key_means_every_day(self):
+        _hour, _minute, weekdays = parse_schedule_config({"time": "03:00"})
+        assert weekdays is None
+
+    def test_midnight_and_end_of_day_are_valid(self):
+        assert parse_schedule_config({"time": "00:00"})[:2] == (0, 0)
+        assert parse_schedule_config({"time": "23:59"})[:2] == (23, 59)
+
+    def test_rejects_missing_time(self):
+        with pytest.raises(ValueError):
+            parse_schedule_config({})
+
+    def test_rejects_hour_24(self):
+        with pytest.raises(ValueError):
+            parse_schedule_config({"time": "24:00"})
+
+    def test_rejects_bad_format(self):
+        with pytest.raises(ValueError):
+            parse_schedule_config({"time": "3am"})
+
+    def test_rejects_unknown_weekday_name(self):
+        with pytest.raises(ValueError):
+            parse_schedule_config({"time": "03:00", "weekdays": ["someday"]})
+
+    def test_all_weekday_names_accepted(self):
+        _hour, _minute, weekdays = parse_schedule_config({"time": "03:00", "weekdays": list(WEEKDAY_NAMES)})
+        assert weekdays == set(range(7))
+
+
+class TestComputeNextRun:
+    def test_returns_today_when_time_has_not_passed(self):
+        now = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)  # Monday
+        result = compute_next_run(now, 14, 0, None)
+        assert result == datetime(2026, 6, 15, 14, 0, tzinfo=UTC)
+
+    def test_returns_tomorrow_when_time_has_already_passed_today(self):
+        now = datetime(2026, 6, 15, 15, 0, tzinfo=UTC)  # Monday, already past 14:00
+        result = compute_next_run(now, 14, 0, None)
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_never_returns_now_or_earlier(self):
+        """The core #264 restart-safety guarantee: always strictly future."""
+        now = datetime(2026, 6, 15, 14, 0, tzinfo=UTC)
+        result = compute_next_run(now, 14, 0, None)
+        assert result > now
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_restart_hours_after_missed_time_does_not_catch_up(self):
+        """#264: starting at 5pm with a 3am schedule must compute
+        tomorrow's 3am, never "immediately" / "today, late"."""
+        now = datetime(2026, 6, 15, 17, 0, tzinfo=UTC)
+        result = compute_next_run(now, 3, 0, None)
+        assert result == datetime(2026, 6, 16, 3, 0, tzinfo=UTC)
+        assert result > now
+
+    def test_weekday_filter_skips_non_matching_days(self):
+        # 2026-06-15 is a Monday. Schedule for Wednesday/Friday only.
+        now = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)
+        result = compute_next_run(now, 9, 0, {2, 4})  # Wed, Fri
+        assert result == datetime(2026, 6, 17, 9, 0, tzinfo=UTC)  # Wednesday
+
+    def test_weekday_filter_wraps_to_next_week(self):
+        # Monday 2026-06-15, only Monday allowed, already past today's time.
+        now = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)
+        result = compute_next_run(now, 9, 0, {0})
+        assert result == datetime(2026, 6, 22, 9, 0, tzinfo=UTC)
+
+    def test_empty_weekdays_set_raises(self):
+        now = datetime(2026, 6, 15, 10, 0, tzinfo=UTC)
+        with pytest.raises(ValueError):
+            compute_next_run(now, 9, 0, set())
+
+    def test_spring_forward_skipped_hour_runs_at_next_valid_time(self):
+        """US spring-forward 2026: America/New_York jumps 2:00 -> 3:00 on
+        March 8. A 02:30 schedule (inside the skipped hour) must not be
+        silently dropped for the day - it resolves to a real instant
+        shortly after the gap closes (see compute_next_run's own
+        docstring for the zoneinfo/PEP 495 mechanics)."""
+        now = datetime(2026, 3, 7, 12, 0, tzinfo=NY)
+        result = compute_next_run(now, 2, 30, None)
+        assert result.date() == datetime(2026, 3, 8, 0, 0).date()
+        # The nonexistent 2:30 resolves (fold=0, pre-transition offset)
+        # to a real UTC instant that - converted back to the ACTUAL
+        # local offset in effect at that instant - is after the 2am
+        # transition point, not before it or on a different day.
+        real_utc_offset_after_transition = -4 * 3600  # EDT, UTC-4, in seconds
+        assert result.utcoffset().total_seconds() in (-5 * 3600, real_utc_offset_after_transition)
+        # Convert to a fixed-offset UTC instant and confirm it's after
+        # the transition instant itself (2026-03-08 07:00 UTC).
+        transition_instant = datetime(2026, 3, 8, 7, 0, tzinfo=UTC)
+        assert result.astimezone(UTC) >= transition_instant
+
+    def test_fall_back_duplicated_hour_fires_only_once(self):
+        """US fall-back 2026: America/New_York repeats 1:00-2:00 on
+        Nov 1 (falls back from 2:00 EDT to 1:00 EST). A 01:30 schedule
+        must fire once for that day, not twice - simulates the
+        scheduler thread's own "recompute from the instant we just
+        fired at" pattern (web/scheduler_runner.py) and confirms the
+        second call skips straight to Nov 2, never re-triggering on
+        the repeated hour."""
+        before = datetime(2026, 10, 31, 12, 0, tzinfo=NY)
+        first_fire = compute_next_run(before, 1, 30, None)
+        assert first_fire.date() == datetime(2026, 11, 1, 0, 0).date()
+
+        second_fire = compute_next_run(first_fire, 1, 30, None)
+        assert second_fire.date() == datetime(2026, 11, 2, 0, 0).date()
+        assert second_fire > first_fire
+
+
+class TestDescribeNextRun:
+    def test_disabled_reports_no_next_run(self):
+        result = describe_next_run({"schedule": {"enabled": False, "time": "03:00"}})
+        assert result["enabled"] is False
+        assert result["next_run"] is None
+        assert result["error"] is None
+
+    def test_missing_schedule_section_reports_disabled(self):
+        result = describe_next_run({})
+        assert result["enabled"] is False
+        assert result["next_run"] is None
+
+    @patch("utils.scheduler.resolve_scheduler_timezone", return_value=UTC)
+    def test_enabled_reports_next_run_and_timezone(self, _mock_tz):
+        result = describe_next_run({"schedule": {"enabled": True, "time": "03:00"}})
+        assert result["enabled"] is True
+        assert result["timezone"] == "UTC"
+        assert result["next_run"] is not None
+        assert result["error"] is None
+
+    def test_enabled_with_invalid_time_reports_error_not_exception(self):
+        result = describe_next_run({"schedule": {"enabled": True, "time": "not-a-time"}})
+        assert result["enabled"] is True
+        assert result["next_run"] is None
+        assert result["error"] is not None
+
+    def test_enabled_with_invalid_weekday_reports_error_not_exception(self):
+        result = describe_next_run({"schedule": {"enabled": True, "time": "03:00", "weekdays": ["someday"]}})
+        assert result["error"] is not None

--- a/tests/test_scheduler_runner.py
+++ b/tests/test_scheduler_runner.py
@@ -1,0 +1,213 @@
+"""Tests for web/scheduler_runner.py - the #264 in-app scheduler's
+background-thread integration (JobManager wiring, fire/skip/error
+handling, state tracking). The scheduling MATH itself is tested
+independently in tests/test_scheduler.py; these tests call
+SchedulerThread._tick() directly rather than actually running the
+thread, except for one end-to-end smoke test confirming start()/stop()
+work at all.
+"""
+
+import os
+import sys
+import time
+import zoneinfo
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from web.job_runner import JobAlreadyRunningError, JobError
+from web.scheduler_runner import SchedulerState, SchedulerThread
+
+UTC = zoneinfo.ZoneInfo("UTC")
+
+
+def _thread(job_manager=None, config=None):
+    job_manager = job_manager or Mock()
+    return SchedulerThread(job_manager=job_manager, load_config_fn=lambda: config)
+
+
+class TestSchedulerState:
+    def test_starts_with_no_attempt_recorded(self):
+        state = SchedulerState()
+        snapshot = state.snapshot()
+        assert snapshot["last_attempt_at"] is None
+        assert snapshot["last_result"] is None
+
+    def test_record_updates_snapshot(self):
+        state = SchedulerState()
+        state.record("started")
+        snapshot = state.snapshot()
+        assert snapshot["last_result"] == "started"
+        assert snapshot["last_attempt_at"] is not None
+
+    def test_record_overwrites_previous(self):
+        state = SchedulerState()
+        state.record("started")
+        state.record("skipped - busy")
+        assert state.snapshot()["last_result"] == "skipped - busy"
+
+
+class TestSchedulerThreadTick:
+    def test_disabled_schedule_does_nothing(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={"schedule": {"enabled": False}})
+
+        thread._tick()
+
+        job_manager.start.assert_not_called()
+        assert thread._next_fire_target is None
+
+    def test_missing_schedule_section_does_nothing(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={})
+
+        thread._tick()
+
+        job_manager.start.assert_not_called()
+
+    def test_no_config_at_all_does_nothing(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config=None)
+
+        thread._tick()
+
+        job_manager.start.assert_not_called()
+
+    def test_enabled_computes_next_target_without_firing_immediately(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "03:00"}})
+
+        thread._tick()
+
+        job_manager.start.assert_not_called()
+        assert thread._next_fire_target is not None
+        assert thread._next_fire_target > datetime.now(thread._next_fire_target.tzinfo)
+
+    @patch("web.scheduler_runner.compute_next_run")
+    def test_fires_when_target_has_passed(self, mock_compute_next_run):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "03:00"}})
+
+        past_target = datetime.now(UTC) - timedelta(minutes=1)
+        thread._next_fire_target = past_target
+        thread._last_seen_schedule_key = (3, 0, None)
+        mock_compute_next_run.return_value = past_target + timedelta(days=1)
+
+        thread._tick()
+
+        job_manager.start.assert_called_once_with("full", "all", [])
+        assert thread.state.snapshot()["last_result"] == "started"
+        assert thread._next_fire_target == past_target + timedelta(days=1)
+
+    @patch("web.scheduler_runner.compute_next_run")
+    def test_skips_and_logs_when_run_already_in_progress(self, mock_compute_next_run):
+        job_manager = Mock()
+        job_manager.start.side_effect = JobAlreadyRunningError("A run is already in progress")
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "03:00"}})
+
+        past_target = datetime.now(UTC) - timedelta(minutes=1)
+        thread._next_fire_target = past_target
+        thread._last_seen_schedule_key = (3, 0, None)
+        mock_compute_next_run.return_value = past_target + timedelta(days=1)
+
+        with patch("web.scheduler_runner.log_warning") as mock_warn:
+            thread._tick()
+
+        job_manager.start.assert_called_once()
+        assert "skipped" in thread.state.snapshot()["last_result"]
+        mock_warn.assert_called_once()
+        # Never queues/retries - the target still advances to the NEXT
+        # occurrence, exactly as if the run had fired.
+        assert thread._next_fire_target == past_target + timedelta(days=1)
+
+    @patch("web.scheduler_runner.compute_next_run")
+    def test_records_error_on_job_error_without_crashing(self, mock_compute_next_run):
+        job_manager = Mock()
+        job_manager.start.side_effect = JobError("Unknown engine: full")
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "03:00"}})
+
+        past_target = datetime.now(UTC) - timedelta(minutes=1)
+        thread._next_fire_target = past_target
+        thread._last_seen_schedule_key = (3, 0, None)
+        mock_compute_next_run.return_value = past_target + timedelta(days=1)
+
+        thread._tick()  # must not raise
+
+        assert "error" in thread.state.snapshot()["last_result"]
+
+    def test_uses_configured_users(self):
+        job_manager = Mock()
+        config = {"schedule": {"enabled": True, "time": "03:00"}, "users": {"list": "alice, bob"}}
+        thread = _thread(job_manager, config=config)
+
+        past_target = datetime.now(UTC) - timedelta(minutes=1)
+        thread._next_fire_target = past_target
+        thread._last_seen_schedule_key = (3, 0, None)
+
+        with patch("web.scheduler_runner.compute_next_run", return_value=past_target + timedelta(days=1)):
+            thread._tick()
+
+        args = job_manager.start.call_args[0]
+        assert args[0] == "full"
+        assert args[1] == "all"
+        assert "alice" in args[2] and "bob" in args[2]
+
+    def test_invalid_schedule_config_warns_once_not_every_tick(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "not-a-time"}})
+
+        with patch("web.scheduler_runner.log_warning") as mock_warn:
+            thread._tick()
+            thread._tick()
+            thread._tick()
+
+        job_manager.start.assert_not_called()
+        mock_warn.assert_called_once()
+
+    def test_disabling_then_reenabling_recomputes_from_scratch(self):
+        job_manager = Mock()
+        config = {"schedule": {"enabled": True, "time": "03:00"}}
+        thread = _thread(job_manager, config=config)
+
+        thread._tick()
+        first_target = thread._next_fire_target
+        assert first_target is not None
+
+        thread._load_config = lambda: {"schedule": {"enabled": False}}
+        thread._tick()
+        assert thread._next_fire_target is None
+
+        thread._load_config = lambda: config
+        thread._tick()
+        assert thread._next_fire_target is not None
+
+    def test_changing_schedule_time_recomputes_immediately(self):
+        job_manager = Mock()
+        thread = _thread(job_manager, config={"schedule": {"enabled": True, "time": "03:00"}})
+        thread._tick()
+        first_target = thread._next_fire_target
+
+        thread._load_config = lambda: {"schedule": {"enabled": True, "time": "04:00"}}
+        thread._tick()
+
+        assert thread._next_fire_target != first_target
+        job_manager.start.assert_not_called()
+
+
+class TestSchedulerThreadRealRun:
+    """One lightweight real-thread smoke test - everything else above
+    calls _tick() directly for speed/determinism."""
+
+    def test_start_and_stop(self):
+        job_manager = Mock()
+        thread = SchedulerThread(
+            job_manager=job_manager,
+            load_config_fn=lambda: {"schedule": {"enabled": False}},
+            poll_interval_seconds=0.05,
+        )
+        thread.start()
+        time.sleep(0.2)
+        thread.stop()
+        thread.join(timeout=2)
+        assert not thread.is_alive()

--- a/tests/test_web_config_settings.py
+++ b/tests/test_web_config_settings.py
@@ -305,3 +305,106 @@ class TestNullSection:
 
         tuning = _read_yaml(root, "tuning")
         assert tuning["negative_signals"]["bad_ratings"]["threshold"] == 3
+
+
+class TestScheduleSettings:
+    """#264: the Scheduling fieldset on /config/settings - reads/writes
+    config.yml's schedule: section, validated via the same
+    utils.scheduler.parse_schedule_config() the background thread uses."""
+
+    def test_get_renders_defaults_when_unset(self, client):
+        c, app, root = client
+        resp = c.get("/config/settings")
+        assert resp.status_code == 200
+        assert b'name="schedule_time" value="03:00"' in resp.data
+        assert b"Scheduler is currently disabled" in resp.data
+
+    def test_saves_enabled_schedule_with_time_and_weekdays(self, client):
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form.update(
+            {
+                "schedule_enabled": "on",
+                "schedule_time": "04:30",
+                "schedule_weekday_monday": "on",
+                "schedule_weekday_friday": "on",
+            }
+        )
+        resp = c.post("/config/settings", data=form)
+
+        assert resp.status_code == 303
+        core = _read_yaml(root, "config")
+        assert core["schedule"]["enabled"] is True
+        assert core["schedule"]["time"] == "04:30"
+        assert set(core["schedule"]["weekdays"]) == {"monday", "friday"}
+
+    def test_no_weekdays_checked_omits_weekdays_key(self, client):
+        """Every day - see _apply_settings' own comment for why this is
+        an omitted key, not an empty list, on disk."""
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form["schedule_enabled"] = "on"
+        form["schedule_time"] = "03:00"
+        resp = c.post("/config/settings", data=form)
+
+        assert resp.status_code == 303
+        core = _read_yaml(root, "config")
+        assert "weekdays" not in core["schedule"]
+
+    def test_disabled_schedule_still_saves_time_for_next_time(self, client):
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form["schedule_time"] = "05:00"
+        resp = c.post("/config/settings", data=form)
+
+        assert resp.status_code == 303
+        core = _read_yaml(root, "config")
+        assert core["schedule"]["enabled"] is False
+        assert core["schedule"]["time"] == "05:00"
+
+    def test_invalid_time_rejected_with_field_error(self, client):
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form["schedule_enabled"] = "on"
+        form["schedule_time"] = "25:99"
+        resp = c.post("/config/settings", data=form)
+
+        assert resp.status_code == 400
+        assert b"HH:MM" in resp.data
+        core = _read_yaml(root, "config")
+        assert core.get("schedule", {}).get("time") != "25:99"  # the bad value never reached disk
+
+    def test_get_shows_next_run_when_enabled(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.setenv("TZ", "UTC")
+        config_path = module_path(root, "config")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write(
+                'plex:\n  url: "http://localhost:32400"\n  token: "not-a-real-token"\n'
+                'users:\n  list: "alice"\n'
+                'schedule:\n  enabled: true\n  time: "03:00"\n'
+            )
+
+        resp = c.get("/config/settings")
+
+        assert resp.status_code == 200
+        assert b"Next run" in resp.data
+        assert b"UTC" in resp.data
+
+    def test_get_shows_error_for_invalid_saved_schedule(self, client):
+        """A hand-edited tuning.yml/config.yml with a bad schedule.time
+        must show why, not 500 or silently show nothing (#264:
+        describe_next_run() never raises)."""
+        c, app, root = client
+        config_path = module_path(root, "config")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write(
+                'plex:\n  url: "http://localhost:32400"\n  token: "not-a-real-token"\n'
+                'users:\n  list: "alice"\n'
+                'schedule:\n  enabled: true\n  time: "not-a-time"\n'
+            )
+
+        resp = c.get("/config/settings")
+
+        assert resp.status_code == 200
+        assert b"Schedule is invalid" in resp.data

--- a/tests/test_web_docker_server.py
+++ b/tests/test_web_docker_server.py
@@ -44,6 +44,22 @@ def _restore_process_signal_handlers():
     signal.signal(signal.SIGTERM, original_sigterm)
 
 
+@pytest.fixture(autouse=True)
+def _mock_scheduler_thread():
+    """#264: main() now also constructs and start()s a real
+    SchedulerThread - every TestMain test below calls main() with
+    waitress.serve mocked out, so without this, each one would leave a
+    REAL (if idle - fake_app is a bare Mock, so every tick just hits
+    the "invalid schedule config" path once and goes quiet) background
+    thread running for the rest of the test session. Mocked out here so
+    no test in this module ever spawns one; TestSchedulerWiring below
+    explicitly un-mocks this to assert main() wires it up correctly.
+    """
+    with patch.object(docker_server, "SchedulerThread") as mock_cls:
+        mock_cls.return_value = Mock()
+        yield mock_cls
+
+
 class TestMain:
     """CURATARR_AUTH_TOKEN (or CURATARR_TRUSTED_NETWORK=true) is now
     required for every one of these to actually reach create_app()/
@@ -260,3 +276,34 @@ class TestShutdownHandling:
             sigint_handler(signal.SIGINT, None)
 
         fake_app.job_manager.terminate_running.assert_called_once()
+
+
+class TestSchedulerWiring:
+    """#264: main() must construct a real SchedulerThread (using the
+    app's job_manager and load_config_cached) and start() it - the
+    _mock_scheduler_thread autouse fixture above intercepts the class
+    itself, so these tests inspect what it was CALLED with rather than
+    letting a real thread spawn."""
+
+    def test_constructs_scheduler_thread_with_job_manager_and_config_loader(self, monkeypatch, _mock_scheduler_thread):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", _STRONG_TOKEN)
+        fake_app = Mock()
+        with (
+            patch.object(docker_server, "create_app", return_value=fake_app),
+            patch.object(docker_server.waitress, "serve"),
+        ):
+            docker_server.main()
+
+        _mock_scheduler_thread.assert_called_once_with(fake_app.job_manager, fake_app.load_config_cached)
+
+    def test_starts_the_scheduler_thread(self, monkeypatch, _mock_scheduler_thread):
+        monkeypatch.setenv("CURATARR_AUTH_TOKEN", _STRONG_TOKEN)
+        fake_app = Mock()
+        with (
+            patch.object(docker_server, "create_app", return_value=fake_app),
+            patch.object(docker_server.waitress, "serve"),
+        ):
+            docker_server.main()
+
+        fake_scheduler_thread = _mock_scheduler_thread.return_value
+        fake_scheduler_thread.start.assert_called_once()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -152,6 +152,58 @@ class TestDashboard:
         assert resp.status_code == 200
         assert b"_watchlist.html" not in resp.data
 
+    def test_scheduler_disabled_by_default(self, client):
+        c, app, root = client
+        resp = c.get("/")
+        assert b"Scheduler:" in resp.data
+        assert b"disabled" in resp.data
+
+    def test_scheduler_shows_next_run_when_enabled(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.setenv("TZ", "UTC")
+        config_path = os.path.join(root, "config", "config.yml")
+        with open(config_path, "w") as f:
+            f.write(
+                'plex:\n  url: "http://localhost:32400"\n  token: "not-a-real-token"\n'
+                'users:\n  list: "alice"\n'
+                'schedule:\n  enabled: true\n  time: "03:00"\n'
+            )
+        resp = c.get("/")
+        assert b"next run" in resp.data
+
+    def test_scheduler_shows_error_for_invalid_schedule(self, client):
+        c, app, root = client
+        config_path = os.path.join(root, "config", "config.yml")
+        with open(config_path, "w") as f:
+            f.write(
+                'plex:\n  url: "http://localhost:32400"\n  token: "not-a-real-token"\n'
+                'users:\n  list: "alice"\n'
+                'schedule:\n  enabled: true\n  time: "not-a-time"\n'
+            )
+        resp = c.get("/")
+        assert b"invalid schedule" in resp.data
+
+    def test_scheduler_shows_last_attempt_when_thread_attached(self, client):
+        """app.scheduler_thread is None under create_app() by default
+        (see that attribute's own comment) - a real SchedulerThread is
+        only attached by main(), so this simulates that to prove the
+        dashboard reads its state correctly when one IS attached."""
+        from datetime import datetime, timezone
+        from unittest.mock import Mock
+
+        c, app, root = client
+        fake_thread = Mock()
+        fake_thread.state.snapshot.return_value = {
+            "last_attempt_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
+            "last_result": "skipped - A run is already in progress",
+        }
+        app.scheduler_thread = fake_thread
+
+        resp = c.get("/")
+
+        assert b"last scheduled attempt" in resp.data
+        assert b"skipped" in resp.data
+
     def test_handles_missing_config_gracefully(self, tmp_path):
         (tmp_path / "logs").mkdir()
         (tmp_path / "recommendations" / "external").mkdir(parents=True)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -208,6 +208,15 @@ from .radarr import (
     create_radarr_client_from,
 )
 
+# Scheduler utilities (#264)
+from .scheduler import (
+    WEEKDAY_NAMES,
+    compute_next_run,
+    describe_next_run,
+    parse_schedule_config,
+    resolve_scheduler_timezone,
+)
+
 # Scoring utilities
 from .scoring import (
     GENRE_NORMALIZATION,
@@ -528,6 +537,11 @@ __all__ = [
     "DEFAULT_TV_NAME_TEMPLATE",
     "fetch_plex_users",
     "fetch_plex_libraries",
+    "resolve_scheduler_timezone",
+    "parse_schedule_config",
+    "compute_next_run",
+    "describe_next_run",
+    "WEEKDAY_NAMES",
     "get_configured_users",
     "get_current_users",
     "get_excluded_genres_for_user",

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.54"
+__version__ = "2.10.55"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/migrate_config.py
+++ b/utils/migrate_config.py
@@ -34,6 +34,23 @@ TUNING_SECTIONS = [
 ]
 
 # Sections that stay in main config.yml
+#
+# #264 note: this is a hardcoded whitelist, not "everything not routed
+# elsewhere" - build_core_config() below only ever copies sections
+# listed HERE into the migrated config.yml, so any top-level config.yml
+# section missing from this list is silently DROPPED (not preserved
+# anywhere) the moment a config triggers migration (needs_migration()
+# below - which, notably, includes every install still using the
+# single-library plex.movie_library/tv_library format instead of an
+# explicit 'libraries:' list, i.e. most fresh installs). "schedule"
+# is added here for exactly that reason - #264 shipped this as a new
+# config.yml section, and without this it would have been silently
+# wiped on a fresh install's very first migration. "huntarr" and
+# "tautulli" have the identical, PRE-EXISTING problem (confirmed by
+# reproducing it in a real container while verifying #264) and are
+# NOT included in this fix - that's a separate bug, reported rather
+# than silently fixed here, since it affects two unrelated features
+# and deserves its own look/decision.
 CORE_SECTIONS = [
     "plex",
     "tmdb",
@@ -43,6 +60,7 @@ CORE_SECTIONS = [
     "logging",
     "platform",
     "libraries",
+    "schedule",
 ]
 
 # Feature modules (each gets its own file)

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -1,0 +1,182 @@
+"""In-app scheduler (#264): fires a "full" recommender run at a
+configured daily wall-clock time, optionally restricted to specific
+weekdays, from inside the long-running web UI process (both native
+web/app.py and web/docker_server.py).
+
+This is deliberately NOT a replacement for the existing host-cron /
+docker-compose.yml `schedule` profile approach (see docs/DOCKER.md) -
+both are documented as coexisting alternatives, and this stays
+default-off. The two mechanisms share the exact same cross-container
+run lock (utils.run_lock.PosixRunLock, taken internally by
+web.job_runner.JobManager.start() for every run regardless of what
+triggered it) so a run this scheduler fires can never overlap with one
+docker-entrypoint.sh's `recommend` mode started in a sibling container -
+but nothing here can stop a user from ALSO having host cron trigger a
+run at a different time of day if they enable both; see docs/DOCKER.md
+for why that's a docs problem, not something detectable/preventable
+from in here (no Docker socket access, no host filesystem visibility
+from inside this container - there is no reliable way to see a sibling
+container's compose profile or a host crontab from here).
+
+Config shape (config.yml, alongside general/logging - see
+web/config_settings.py's Settings screen, "Scheduling" section):
+
+    schedule:
+      enabled: false
+      time: "03:00"                       # 24-hour HH:MM, local to TZ below
+      weekdays: [monday, wednesday, friday]  # optional; omit/empty = every day
+
+Timezone: the container's own TZ environment variable, nothing else -
+deliberately no separate schedule.timezone config key, so there is
+exactly one timezone concept in play (the same one that already governs
+every other system-clock-dependent thing in this process), not two that
+could silently disagree. Falls back to UTC when TZ is unset (Docker's
+own default when -e TZ=... isn't passed) or set to something the system
+tzdata doesn't recognize.
+"""
+
+import logging
+import os
+import re
+import zoneinfo
+from datetime import datetime
+from typing import Dict, Optional, Set, Tuple
+
+from .display import log_warning
+
+logger = logging.getLogger("curatarr")
+
+_TIME_RE = re.compile(r"^([01]?[0-9]|2[0-3]):([0-5][0-9])$")
+
+WEEKDAY_NAMES: Tuple[str, ...] = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+
+_WEEKDAY_NAME_TO_INDEX: Dict[str, int] = {name: i for i, name in enumerate(WEEKDAY_NAMES)}
+
+
+def resolve_scheduler_timezone() -> zoneinfo.ZoneInfo:
+    """The container TZ env var, nothing else (#264) - see module
+    docstring for why there's deliberately no separate config key for
+    this. Falls back to UTC when TZ is unset or unrecognized, logging a
+    warning in the latter case only (an unset TZ defaulting to UTC is
+    completely normal and not worth a warning every time this is
+    called; a TYPO'd TZ silently falling back to UTC is the actual
+    "which clock is this?" ambiguity #264 is about, so that case does
+    warn)."""
+    tz_name = os.environ.get("TZ", "").strip()
+    if not tz_name:
+        return zoneinfo.ZoneInfo("UTC")
+    try:
+        return zoneinfo.ZoneInfo(tz_name)
+    except Exception as e:
+        log_warning(f"TZ={tz_name!r} is not a recognized timezone ({e}) - scheduler falling back to UTC")
+        return zoneinfo.ZoneInfo("UTC")
+
+
+def parse_schedule_config(schedule_cfg: Dict) -> Tuple[int, int, Optional[Set[int]]]:
+    """
+    Parse+validate a schedule: config section into (hour, minute,
+    weekdays). weekdays is None for "every day" - schedule.weekdays
+    omitted entirely, or present but empty, are treated identically
+    (an admin unchecking every weekday checkbox in the web UI is far
+    more likely to be an accidental "select none" than an intentional
+    "never run" - "never run" is already spelled schedule.enabled:
+    false).
+
+    Raises ValueError (with a human-readable message) for a malformed
+    schedule.time or an unrecognized schedule.weekdays entry - callers
+    must catch this and fail safe (log + leave the scheduler idle this
+    tick), never let it crash the scheduler thread or, worse, a run.
+    """
+    time_str = str(schedule_cfg.get("time", "")).strip()
+    match = _TIME_RE.match(time_str)
+    if not match:
+        raise ValueError(f"schedule.time must be 24-hour HH:MM (e.g. '03:00') - got {time_str!r}")
+    hour, minute = int(match.group(1)), int(match.group(2))
+
+    raw_weekdays = schedule_cfg.get("weekdays")
+    if not raw_weekdays:
+        return hour, minute, None
+
+    weekdays: Set[int] = set()
+    for raw in raw_weekdays:
+        key = str(raw).strip().lower()
+        if key not in _WEEKDAY_NAME_TO_INDEX:
+            raise ValueError(
+                f"schedule.weekdays: unrecognized day {raw!r} - expected one of {', '.join(WEEKDAY_NAMES)}"
+            )
+        weekdays.add(_WEEKDAY_NAME_TO_INDEX[key])
+    return hour, minute, weekdays
+
+
+def compute_next_run(now: datetime, hour: int, minute: int, weekdays: Optional[Set[int]] = None) -> datetime:
+    """
+    Next occurrence of *hour*:*minute* local time (in now.tzinfo)
+    strictly after *now*, optionally restricted to *weekdays*
+    (datetime.weekday() indices - 0=Monday, matching WEEKDAY_NAMES'
+    order). Always returns a datetime AFTER now, never equal to or
+    before it - so calling this fresh (e.g. right after startup, or
+    right after a config change) can never "catch up" a missed
+    occurrence (#264: the scheduler must never fire missed runs on
+    restart - see web/scheduler_runner.py's own use of this, which
+    always recomputes from the current moment, never from a stale
+    prior target).
+
+    DST correctness (verified by tests/test_scheduler.py):
+    - Spring-forward (a wall-clock hour is skipped that day): zoneinfo
+      resolves a nonexistent local time (PEP 495, default fold=0)
+      using the pre-transition UTC offset, which lands at the first
+      real instant after the gap closes - the run happens, shifted
+      later by the gap size, never skipped entirely.
+    - Fall-back (a wall-clock hour repeats that day): zoneinfo's
+      default fold=0 always resolves to the FIRST of the two
+      occurrences, and this function only ever evaluates one candidate
+      per calendar day (advancing a full day per loop iteration, never
+      re-evaluating one) - so the repeated hour is never independently
+      considered a second time; it fires once.
+
+    Raises ValueError if weekdays is an empty set (distinguish this
+    from None="every day" at the call site - parse_schedule_config
+    above already normalizes an empty/omitted config value to None,
+    so an empty SET reaching here would be a caller bug, not a valid
+    "never" state).
+    """
+    if weekdays is not None and not weekdays:
+        raise ValueError("weekdays must be None (every day) or a non-empty set, not an empty set")
+
+    candidate_date = now.date()
+    for _ in range(8):  # a week out is always enough to hit a matching weekday
+        candidate = datetime(
+            candidate_date.year, candidate_date.month, candidate_date.day, hour, minute, tzinfo=now.tzinfo
+        )
+        if (weekdays is None or candidate.weekday() in weekdays) and candidate > now:
+            return candidate
+        candidate_date = candidate_date.fromordinal(candidate_date.toordinal() + 1)
+
+    raise ValueError("No matching weekday found within 8 days - this should be unreachable")
+
+
+def describe_next_run(config: Dict) -> Dict:
+    """
+    Read-only summary for the UI (Settings/Dashboard): whether the
+    schedule is enabled, the resolved timezone name, and the next run
+    time - or why there isn't one (disabled, or an invalid
+    schedule.time/weekdays). Never raises; a bad config shows up as
+    result["error"], not an exception - this is called from request
+    handlers rendering a page, which must never 500 over a typo in
+    tuning.yml/config.yml.
+
+    Returns:
+        {"enabled": bool, "timezone": str, "next_run": Optional[datetime], "error": Optional[str]}
+    """
+    schedule_cfg = (config or {}).get("schedule") or {}
+    enabled = bool(schedule_cfg.get("enabled"))
+    tz = resolve_scheduler_timezone()
+    result: Dict = {"enabled": enabled, "timezone": str(tz), "next_run": None, "error": None}
+    if not enabled:
+        return result
+    try:
+        hour, minute, weekdays = parse_schedule_config(schedule_cfg)
+        result["next_run"] = compute_next_run(datetime.now(tz), hour, minute, weekdays)
+    except ValueError as e:
+        result["error"] = str(e)
+    return result

--- a/web/app.py
+++ b/web/app.py
@@ -54,6 +54,7 @@ from werkzeug.datastructures import Headers
 
 from utils import (
     __version__,
+    describe_next_run,
     get_integration_status,
     get_project_root,
     get_update_mode,
@@ -68,6 +69,7 @@ from utils import (
 
 from .config_app import register_config_routes
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
+from .scheduler_runner import SchedulerThread
 from .security import redact, register_origin_host_guard, register_token_auth
 from .status import find_user_watchlist, get_last_run_status, list_log_files, read_log_tail
 from .update_apply import (
@@ -224,6 +226,15 @@ def create_app(
     # attachment (every route reads them back the same way), not a typo.
     app.job_manager = JobManager(project_root, logs_dir, code_root=code_root)  # type: ignore[attr-defined]
     app.update_manager = UpdateManager(project_root, logs_dir)  # type: ignore[attr-defined]
+    # #264: None here - every existing test/caller that only calls
+    # create_app() directly (which is nearly all of them) never gets a
+    # real background thread. Only main() (this module's own, and
+    # web/docker_server.py's) constructs a real SchedulerThread and
+    # replaces this, right before actually start()-ing it - see there
+    # for why it's deliberately NOT wired up inside create_app() itself.
+    # Every route that reads this must treat None as "scheduler not
+    # running" (e.g. under the test client), never assume it's set.
+    app.scheduler_thread = None  # type: ignore[attr-defined]
     app.test_client_class = _BrowserLikeTestClient
 
     register_origin_host_guard(app)
@@ -290,6 +301,13 @@ def create_app(
             _config_cache["mtimes"] = mtimes
             _config_cache["config"] = config
         return config
+
+    # #264: exposed so main() (this module's own, and web/docker_server.py's)
+    # can hand the SAME cached loader to the scheduler background
+    # thread it constructs - a schedule saved through the web UI takes
+    # effect on the thread's very next tick, no restart needed, exactly
+    # like every other config value this cache already serves.
+    app.load_config_cached = _load_config  # type: ignore[attr-defined]
 
     def _load_users():
         config = _load_config()
@@ -616,7 +634,18 @@ def create_app(
             }
             for user in (get_users_from_config(config) if config else [])
         ]
-        return render_template("dashboard.html", rows=rows, job=app.job_manager.status())
+        # #264: "next run"/"last scheduled attempt" - visible here rather
+        # than only on Settings, so a skipped occurrence (run lock held
+        # elsewhere) or a disabled/misconfigured schedule is never a
+        # silent mystery. app.scheduler_thread is None under the test
+        # client and any caller that only calls create_app() directly
+        # (see create_app's own comment on that attribute) - never
+        # assume it's set.
+        scheduler_status = describe_next_run(config or {})
+        scheduler_status["last_attempt"] = (
+            app.scheduler_thread.state.snapshot() if app.scheduler_thread is not None else None
+        )
+        return render_template("dashboard.html", rows=rows, job=app.job_manager.status(), scheduler=scheduler_status)
 
     @app.get("/run")
     def run_form():
@@ -804,6 +833,16 @@ def main():
     """
     port = int(os.environ.get("CURATARR_UI_PORT", DEFAULT_PORT))
     app = create_app()
+
+    # #264: started here (main()), never inside create_app() itself -
+    # every test/caller that only calls create_app() directly (nearly
+    # all of them) must never spawn a real background thread. Daemon
+    # thread (see SchedulerThread) - no explicit stop() wired into
+    # shutdown below; a scheduled run already in flight is killed the
+    # same way any other run is (JobManager.terminate_running(), right
+    # below - the scheduler and the web UI share one JobManager).
+    app.scheduler_thread = SchedulerThread(app.job_manager, app.load_config_cached)
+    app.scheduler_thread.start()
 
     # H3: a server shutdown (Ctrl+C, SIGTERM from a process manager, or
     # a clean interpreter exit) must never leave an orphaned recommender

--- a/web/config_settings.py
+++ b/web/config_settings.py
@@ -15,6 +15,7 @@ from flask import redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
 
 from utils.config import UPDATE_MODES, get_update_mode
+from utils.scheduler import WEEKDAY_NAMES, describe_next_run, parse_schedule_config
 
 from .config_io import (
     USER_MODE_CHOICES,
@@ -53,6 +54,7 @@ def register_settings_routes(app) -> None:
             "config_settings.html",
             saved=request.args.get("saved") == "1",
             errors={},
+            schedule_status=describe_next_run(core),
             **_settings_view(tuning, core, sonarr, radarr, trakt),
         )
 
@@ -71,6 +73,13 @@ def register_settings_routes(app) -> None:
                 "config_settings.html",
                 saved=False,
                 errors=errors,
+                # Pre-save on-disk schedule, not the (possibly invalid)
+                # submission - describe_next_run never raises, but a
+                # bad schedule_time here already has its own field error
+                # above; showing the CURRENT real status alongside it
+                # avoids implying a next-run time from input that
+                # didn't actually get saved.
+                schedule_status=describe_next_run(core),
                 **_settings_view(tuning, core, sonarr, radarr, trakt, overrides=parsed),
             ), 400
 
@@ -82,6 +91,7 @@ def register_settings_routes(app) -> None:
                 "config_settings.html",
                 saved=False,
                 errors={"_global": f"Could not save: {commit_error}"},
+                schedule_status=describe_next_run(reloaded[1]),
                 **_settings_view(*reloaded),
             ), 500
         return redirect(url_for("config_settings", saved="1"), code=303)
@@ -115,6 +125,7 @@ def _settings_view(
     external = tuning.get("external_recommendations") or {}
     general = core.get("general") or {}
     logging_cfg = core.get("logging") or {}
+    schedule_cfg = core.get("schedule") or {}
     trakt_export = trakt.get("export") or {}
 
     return {
@@ -187,6 +198,12 @@ def _settings_view(
         "logging": {
             "level": logging_cfg.get("level", "INFO"),
         },
+        "schedule": {
+            "enabled": bool(schedule_cfg.get("enabled", False)),
+            "time": schedule_cfg.get("time", "03:00"),
+            "weekdays": [str(d).strip().lower() for d in (schedule_cfg.get("weekdays") or [])],
+        },
+        "weekday_choices": WEEKDAY_NAMES,
         "sync_safety": {
             "sonarr": {
                 "auto_sync": bool(sonarr.get("auto_sync", False)),
@@ -314,6 +331,20 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
     logging_level = form.get("logging_level", "INFO")
     validate_choice(logging_level, "logging_level", errors, LOG_LEVEL_CHOICES)
 
+    # #264: reuses utils.scheduler.parse_schedule_config for validation
+    # instead of duplicating its HH:MM/weekday-name rules here - the
+    # scheduler thread and this form must always agree on what counts
+    # as valid.
+    schedule = {
+        "enabled": flag("schedule_enabled"),
+        "time": form.get("schedule_time", "03:00").strip(),
+        "weekdays": [day for day in WEEKDAY_NAMES if flag(f"schedule_weekday_{day}")],
+    }
+    try:
+        parse_schedule_config(schedule)
+    except ValueError as e:
+        errors["schedule_time"] = str(e)
+
     sync_safety = {}
     for svc in ("sonarr", "radarr", "trakt"):
         user_mode = form.get(f"{svc}_user_mode", "mapping")
@@ -333,6 +364,8 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
         "external": external,
         "general": general,
         "logging": {"level": logging_level},
+        "schedule": schedule,
+        "weekday_choices": WEEKDAY_NAMES,
         "sync_safety": sync_safety,
         "log_level_choices": LOG_LEVEL_CHOICES,
         "user_mode_choices": USER_MODE_CHOICES,
@@ -395,6 +428,19 @@ def _apply_settings(
 
     ensure_section(core, "general").update(parsed["general"])
     ensure_section(core, "logging")["level"] = parsed["logging"]["level"]
+
+    schedule_section = ensure_section(core, "schedule")
+    schedule_section["enabled"] = parsed["schedule"]["enabled"]
+    schedule_section["time"] = parsed["schedule"]["time"]
+    if parsed["schedule"]["weekdays"]:
+        schedule_section["weekdays"] = parsed["schedule"]["weekdays"]
+    else:
+        # Omit the key entirely for "every day" rather than writing an
+        # empty list - matches how the example documents it (commented
+        # out) and how utils.scheduler.parse_schedule_config treats a
+        # missing key and an empty list identically anyway, so this is
+        # purely a tidier on-disk file, not a behavior difference.
+        schedule_section.pop("weekdays", None)
 
     sonarr["auto_sync"] = parsed["sync_safety"]["sonarr"]["auto_sync"]
     sonarr["user_mode"] = parsed["sync_safety"]["sonarr"]["user_mode"]

--- a/web/docker_server.py
+++ b/web/docker_server.py
@@ -46,6 +46,7 @@ import sys
 import waitress
 
 from .app import create_app
+from .scheduler_runner import SchedulerThread
 from .security import (
     AUTH_TOKEN_ENV_VAR,
     MIN_AUTH_TOKEN_LENGTH,
@@ -133,6 +134,16 @@ def main() -> None:
     host = os.environ.get("CURATARR_UI_HOST", "0.0.0.0")
     _require_auth_token_or_exit(host)
     app = create_app(bind_host=host)
+
+    # #264: same scheduler wiring as web/app.py's own main() (native
+    # mode) - started here, never inside create_app() itself, so every
+    # test that only calls create_app() directly never spawns a real
+    # background thread. This is the primary intended use case for the
+    # in-app scheduler (see utils/scheduler.py's module docstring) - "a
+    # continuous docker running the web UI" is the exact scenario #264
+    # was reported against.
+    app.scheduler_thread = SchedulerThread(app.job_manager, app.load_config_cached)  # type: ignore[attr-defined]
+    app.scheduler_thread.start()  # type: ignore[attr-defined]
 
     # #263: this process is PID 1 in the container (no init system in
     # front of it), and until this fix it caught SIGINT but never

--- a/web/scheduler_runner.py
+++ b/web/scheduler_runner.py
@@ -1,0 +1,167 @@
+"""Background thread wiring for the #264 in-app scheduler - the part
+that actually watches the clock and fires JobManager.start("full", "all",
+...) at the configured time. The scheduling MATH itself (timezone
+resolution, HH:MM/weekday parsing, DST-correct next-run computation)
+lives in utils/scheduler.py, kept separate from and independent of
+Flask/JobManager so it is trivially unit-testable without any of this
+thread/lock machinery - see tests/test_scheduler.py for that, and
+tests/test_scheduler_runner.py for this module's own (thread-free,
+directly-call-_tick()) tests.
+
+Started explicitly from web/app.py's and web/docker_server.py's own
+main() - NOT from create_app() itself, so the hundreds of existing
+tests that call create_app() directly never spawn a real background
+thread (mirroring how atexit/signal registration for job-manager
+shutdown already works the same way - see those main()s).
+"""
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Callable, Dict, List, Optional
+
+from utils import get_users_from_config
+from utils.display import log_error, log_info, log_warning
+from utils.scheduler import compute_next_run, parse_schedule_config, resolve_scheduler_timezone
+
+from .job_runner import JobAlreadyRunningError, JobError, JobManager
+
+logger = logging.getLogger("curatarr")
+
+DEFAULT_POLL_INTERVAL_SECONDS = 30
+
+
+class SchedulerState:
+    """Thread-safe holder for the scheduler's last-fire-attempt result,
+    read by web routes (dashboard "last scheduled run" display), written
+    by SchedulerThread. Deliberately in-memory only, not persisted - a
+    fresh "nothing attempted yet this session" after a restart is
+    honest and correct, matching #264's own "never catch up on restart"
+    design: there is nothing from a previous process run worth showing
+    as if it just happened.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_attempt_at: Optional[datetime] = None
+        self._last_result: Optional[str] = None
+
+    def record(self, result: str) -> None:
+        with self._lock:
+            self._last_attempt_at = datetime.now(timezone.utc)
+            self._last_result = result
+
+    def snapshot(self) -> Dict:
+        with self._lock:
+            return {"last_attempt_at": self._last_attempt_at, "last_result": self._last_result}
+
+
+class SchedulerThread(threading.Thread):
+    """Daemon thread: wakes up every poll_interval_seconds, reloads the
+    live config (via *load_config_fn* - the SAME mtime-keyed cache
+    web/app.py's create_app() already uses, so a schedule saved through
+    the web UI takes effect on the very next tick, no restart needed -
+    #264), and fires job_manager.start("full", "all", ...) at the
+    computed next-run time.
+
+    Never fires a missed occurrence: next_fire_target is always
+    (re)computed strictly forward from the current moment, both at
+    startup and immediately after firing - see utils.scheduler.
+    compute_next_run's own docstring for why this structurally cannot
+    "catch up".
+
+    Relies entirely on job_manager.start() to enforce the cross-
+    container PosixRunLock (utils/run_lock.py) and the in-process
+    single-run lock - this thread does neither itself, it just calls
+    .start() and reacts to JobAlreadyRunningError by skipping (logging
+    why, at a visible level) rather than retrying/queuing.
+    """
+
+    def __init__(
+        self,
+        job_manager: JobManager,
+        load_config_fn: Callable[[], Optional[Dict]],
+        poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        super().__init__(name="curatarr-scheduler", daemon=True)
+        self._job_manager = job_manager
+        self._load_config = load_config_fn
+        self._poll_interval_seconds = poll_interval_seconds
+        self._stop_event = threading.Event()
+        self.state = SchedulerState()
+        self._next_fire_target: Optional[datetime] = None
+        self._last_seen_schedule_key: Optional[tuple] = None
+
+    def stop(self) -> None:
+        """Signal the loop to exit at its next wait boundary - best-
+        effort only (this is a daemon thread, so process exit does not
+        actually depend on this ever being called; JobManager.
+        terminate_running() already covers killing an in-flight
+        scheduled run the same as any web-UI-triggered one)."""
+        self._stop_event.set()
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._tick()
+            except Exception as exc:  # never let a bug here kill the thread
+                log_error(f"Scheduler tick failed unexpectedly: {exc}")
+            self._stop_event.wait(self._poll_interval_seconds)
+
+    def _tick(self) -> None:
+        config = self._load_config()
+        schedule_cfg = (config or {}).get("schedule") or {}
+        if not schedule_cfg.get("enabled"):
+            self._next_fire_target = None
+            self._last_seen_schedule_key = None
+            return
+
+        try:
+            hour, minute, weekdays = parse_schedule_config(schedule_cfg)
+        except ValueError as e:
+            # Warn once per distinct bad value, not once per 30s tick -
+            # _last_seen_schedule_key doubles as "the last thing we
+            # already logged about" so an admin staring at a broken
+            # config doesn't get spammed, but a NEW/different mistake
+            # (or the same one after a restart) still gets reported.
+            invalid_marker = ("invalid", str(e))
+            if self._last_seen_schedule_key != invalid_marker:
+                log_warning(f"Scheduler: invalid schedule config ({e}) - idle until fixed")
+                self._last_seen_schedule_key = invalid_marker
+            self._next_fire_target = None
+            return
+
+        tz = resolve_scheduler_timezone()
+        now = datetime.now(tz)
+        schedule_key = (hour, minute, tuple(sorted(weekdays)) if weekdays else None)
+
+        if self._next_fire_target is None or schedule_key != self._last_seen_schedule_key:
+            # Freshly enabled, just (re)started, or the schedule's own
+            # values changed since the last tick - always recompute
+            # strictly forward from NOW, never from a stale prior
+            # target (which might reflect config that no longer
+            # applies). This is what makes a live config edit take
+            # effect on the very next tick, and what guarantees this
+            # thread never fires anything "missed" right after startup.
+            self._next_fire_target = compute_next_run(now, hour, minute, weekdays)
+            self._last_seen_schedule_key = schedule_key
+            log_info(f"Scheduler: next run at {self._next_fire_target.isoformat()}")
+            return
+
+        if now >= self._next_fire_target:
+            self._fire(config)
+            self._next_fire_target = compute_next_run(now, hour, minute, weekdays)
+            log_info(f"Scheduler: next run at {self._next_fire_target.isoformat()}")
+
+    def _fire(self, config: Optional[Dict]) -> None:
+        users: List[str] = get_users_from_config(config) if config else []
+        try:
+            self._job_manager.start("full", "all", users)
+            self.state.record("started")
+            log_info("Scheduler: started scheduled 'full' run")
+        except JobAlreadyRunningError as exc:
+            self.state.record(f"skipped - {exc}")
+            log_warning(f"Scheduler: skipped this occurrence - {exc}")
+        except JobError as exc:
+            self.state.record(f"error - {exc}")
+            log_error(f"Scheduler: could not start scheduled run - {exc}")

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -437,6 +437,26 @@ fieldset.plex-fetch legend {
   font-size: 0.85rem;
 }
 
+/* #264 Scheduling fieldset (Settings screen) */
+.weekday-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 8px 0 12px;
+}
+
+.weekday-checkbox {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 4px;
+  margin: 0 !important;
+  width: auto;
+}
+
+.schedule-status {
+  margin-top: 10px;
+}
+
 .config-form h3 {
   color: var(--gold);
   font-size: 0.78rem;

--- a/web/templates/config_settings.html
+++ b/web/templates/config_settings.html
@@ -179,6 +179,43 @@
     {{ field_error(errors, 'logging_level') }}
   </fieldset>
 
+  <fieldset>
+    <legend>Scheduling</legend>
+    <p class="muted">
+      Runs the full recommendation pipeline (movie + tv + external) at a fixed daily time from inside this process -
+      no host cron or separate container needed. Coexists with, does NOT replace, host cron / the
+      docker-compose.yml <code>schedule</code> profile - if you already use one of those, pick only ONE scheduling
+      mechanism, or you'll get two separate runs at different times of day.
+    </p>
+    <label><input type="checkbox" name="schedule_enabled" {% if schedule.enabled %}checked{% endif %}> Enabled</label>
+    <label>Time (24-hour, in the timezone below)
+      <input type="time" name="schedule_time" value="{{ schedule.time }}">
+    </label>
+    {{ field_error(errors, 'schedule_time') }}
+    <label>Days - leave all unchecked to run every day</label>
+    <div class="weekday-checkboxes">
+      {% for day in weekday_choices %}
+      <label class="weekday-checkbox">
+        <input type="checkbox" name="schedule_weekday_{{ day }}" {% if day in schedule.weekdays %}checked{% endif %}>
+        {{ day|capitalize }}
+      </label>
+      {% endfor %}
+    </div>
+    {% if schedule_status %}
+    <p class="muted schedule-status">
+      Timezone: <strong>{{ schedule_status.timezone }}</strong> (the container's own <code>TZ</code> environment
+      variable - falls back to UTC if unset).
+      {% if not schedule_status.enabled %}
+        Scheduler is currently disabled.
+      {% elif schedule_status.error %}
+        Schedule is invalid: {{ schedule_status.error }}
+      {% elif schedule_status.next_run %}
+        Next run: <strong>{{ schedule_status.next_run.strftime('%Y-%m-%d %H:%M %Z') }}</strong>.
+      {% endif %}
+    </p>
+    {% endif %}
+  </fieldset>
+
   <button type="submit">Save</button>
 </form>
 {% endblock %}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -10,6 +10,24 @@
 </p>
 {% endif %}
 
+{% if scheduler %}
+<p class="muted scheduler-summary">
+  Scheduler:
+  {% if not scheduler.enabled %}
+    disabled (<a href="{{ url_for('config_settings') }}">enable on Settings</a>)
+  {% elif scheduler.error %}
+    <span class="field-error">invalid schedule - {{ scheduler.error }}</span>
+    (<a href="{{ url_for('config_settings') }}">fix on Settings</a>)
+  {% elif scheduler.next_run %}
+    next run <strong>{{ scheduler.next_run.strftime('%Y-%m-%d %H:%M %Z') }}</strong>
+  {% endif %}
+  {% if scheduler.last_attempt and scheduler.last_attempt.last_attempt_at %}
+    - last scheduled attempt: {{ scheduler.last_attempt.last_attempt_at.strftime('%Y-%m-%d %H:%M UTC') }}
+    ({{ scheduler.last_attempt.last_result }})
+  {% endif %}
+</p>
+{% endif %}
+
 <div class="table-scroll">
 <table class="status-table">
   <thead>


### PR DESCRIPTION
## Summary
- Adds an optional, default-off daily scheduler inside the web UI process (native and Docker) so users can trigger the full recommendation pipeline without host cron or a separate compose profile.
- Timezone is the container's own `TZ` env var only; no new config key for that. Settings/Dashboard show the resolved timezone and computed next-run time.
- Shares the existing cross-container `PosixRunLock` (utils/run_lock.py) used by the compose `schedule` profile - a scheduled run can never overlap another run; a conflicting occurrence is skipped (never queued) and recorded for the dashboard.
- No catch-up runs on restart/redeploy; only the next real occurrence ever fires. DST-correct (spring-forward and fall-back both covered by dedicated unit tests).
- docs/DOCKER.md and the Settings page both document host-cron/compose-profile vs. the in-app scheduler as alternatives, and say to pick one.

## Test plan
- [x] Full suite green (2725 passed, 1 skipped)
- [x] `ruff check .` clean
- [x] `mypy .` clean
- [x] Verified in a real container: schedule fired at the configured time, took the cross-container lock, produced real recommender log output
- [x] Verified an overlapping trigger (lock held by a simulated sibling container) is skipped, not queued, and the next occurrence correctly advances to the next day
- [x] Verified a schedule change saved through the web UI takes effect on the very next tick with no restart
- [x] Verified `docker stop` still exits in ~0.17s / exit 0 with the scheduler thread running (no regression to the 2.10.50 SIGTERM fix)