### PR TITLE
Fix full engine in Docker (issue #260 remainder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.56] - 2026-07-27
+
+### Fixed
+
+- **The last piece of issue #260: the `full` engine (Run button, and now the #264 scheduler) failed inside Docker.** 2.10.51 fixed movie/tv/external but left `full` going through `run.sh` itself, which separately assumes the directory it lives in (`/app`) doubles as the data directory it reads `config/`, `cache/`, and `logs/` from - true for a source checkout, never true in Docker, where those are a separately mounted `/data` (`CURATARR_CONFIG_DIR`). Two symptoms of that one mismatch: `check_and_install_dependencies()`'s pip install always failed (the runtime image never ships `requirements.lock`/`requirements.txt` at all - only the venv those built at image-build time, confirmed against a real container), and `is_first_run()` always saw a missing `config/config.yml` and dropped into the interactive setup wizard, which isn't shipped in the image either.
+
+  Rather than teach the whole of `run.sh` (also used by every non-Docker install, where its assumption is correct) about `CURATARR_CONFIG_DIR`, the web UI's `full` trigger now bypasses `run.sh` entirely inside the real image, chaining `movie.py` -> `tv.py` -> `external.py` directly instead - the exact order `docker-entrypoint.sh`'s own `recommend full` mode (and the frozen binary's `--run-recommender full`) already use successfully in this same image. Source checkouts and native (non-Docker) web-UI runs are untouched and still go through `run.sh`/`run.ps1` exactly as before.
+
+  The frozen (PyInstaller) binary never had this problem - its `full` dispatch already calls `movie`/`tv`/`external` in-process and never touches `run.sh`/`run.ps1` at all.
+
+  Verified in a real container: launching `full` now clears dependency resolution and config loading, and reaches a real `recommenders/movie.py` traceback (a fake Plex token rejected with 401) instead of a pip failure or a dead subprocess - movie/tv/external individually confirmed still launching correctly too.
+
 ## [2.10.55] - 2026-07-27
 
 ### Added

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -7,6 +7,7 @@ fast and hermetic - they never touch Plex/TMDB or the real repo.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -144,6 +145,75 @@ class TestBuildCommandCodeRootDivergence:
             assert not any("/data" in part or "/app" in part for part in cmd)
 
 
+class TestBuildCommandDockerFullEngine:
+    """#260 (second half, continued): the `full` engine still failed
+    inside the real Docker image even after the code_root fix above -
+    run.sh's own is_first_run() does an identical SCRIPT_DIR-relative
+    config/config.yml check (and its dependency-install step assumes
+    requirements.lock/.txt are on disk, which they never are in the
+    runtime image - see Dockerfile) - both false in Docker, where
+    SCRIPT_DIR (/app) and the real data directory (/data,
+    CURATARR_CONFIG_DIR) are different places. Inside the real image
+    (RUNNING_IN_DOCKER=true), `full` now bypasses run.sh entirely and
+    chains movie -> tv -> external directly instead - the same order
+    docker-entrypoint.sh's own `recommend full` mode (and frozen's
+    `--run-recommender full`) already use in this same image.
+    """
+
+    def _manager(self, project_root, code_root):
+        return JobManager(project_root, os.path.join(project_root, "logs"), code_root=code_root)
+
+    def test_docker_full_engine_bypasses_run_sh(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        assert cmd[0] == "bash"
+        assert cmd[1] == "-c"
+        assert "run.sh" not in cmd[2]
+
+    def test_docker_full_engine_chains_movie_tv_external_in_order(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        assert " && " in script
+        movie_pos = script.index("movie.py")
+        tv_pos = script.index("tv.py")
+        external_pos = script.index("external.py")
+        assert movie_pos < tv_pos < external_pos
+
+    def test_docker_full_engine_uses_code_root_not_project_root(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        assert os.path.join("/app", "recommenders", "movie.py") in script
+        assert "/data" not in script
+
+    def test_docker_full_engine_invokes_sys_executable(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        assert script.count(shlex.quote(job_runner_mod.sys.executable)) == 3
+
+    def test_non_docker_full_engine_still_uses_run_sh(self, monkeypatch):
+        monkeypatch.delenv("RUNNING_IN_DOCKER", raising=False)
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        assert cmd == ["bash", os.path.join("/app", "run.sh")]
+
+    def test_frozen_full_engine_wins_even_if_running_in_docker_is_set(self, monkeypatch):
+        """The frozen check is first in the if/elif chain - it must
+        never be shadowed by RUNNING_IN_DOCKER (not a real combination
+        today, but the ordering itself is what makes that safe)."""
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        monkeypatch.setattr(job_runner_mod.sys, "frozen", True, raising=False)
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        assert cmd == [job_runner_mod.sys.executable, "--run-recommender", "full"]
+
+
 class TestJobManagerStart:
     """Tests for JobManager.start()"""
 
@@ -170,6 +240,24 @@ class TestJobManagerStart:
         _wait_until_done(job)
         assert job.returncode == 0
         assert any("full run" in line for line in job.lines)
+
+    def test_runs_full_engine_in_docker_without_run_sh(self, curatarr_web_root, monkeypatch):
+        """#260: inside the real Docker image, `full` bypasses run.sh
+        entirely (see TestBuildCommandDockerFullEngine) and chains the
+        three recommenders directly instead - confirms that actually
+        executes end to end (not just that _build_command constructs
+        the right argv), in the right order, exit code 0."""
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = _manager(curatarr_web_root)
+        job = manager.start("full", "all", ["alice", "bob"])
+        _wait_until_done(job)
+        assert job.returncode == 0
+        assert not any("full run" in line for line in job.lines)  # run.sh never ran
+
+        movie_idx = job.lines.index("Movie recommendations done")
+        tv_idx = job.lines.index("TV recommendations done")
+        external_idx = job.lines.index("External watchlists done")
+        assert movie_idx < tv_idx < external_idx
 
     def test_runs_external_engine(self, curatarr_web_root):
         manager = _manager(curatarr_web_root)

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.55"
+__version__ = "2.10.56"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -29,6 +29,7 @@ sys.exit() behavior above stays safe.
 import logging
 import os
 import queue
+import shlex
 import signal
 import subprocess
 import sys
@@ -382,13 +383,51 @@ class JobManager:
         if engine == "full":
             if frozen:
                 cmd = [sys.executable, "--run-recommender", "full"]
+            elif os.environ.get("RUNNING_IN_DOCKER") == "true":
+                # #260: run.sh assumes the directory it lives in
+                # (SCRIPT_DIR, its own `cd` target) doubles as the data
+                # directory it reads config/cache/logs from - true for
+                # a source checkout, false in the Docker image, where
+                # code lives at /app but config/cache/logs are a
+                # separately mounted /data (CURATARR_CONFIG_DIR - see
+                # this function's own docstring above re:
+                # get_code_root()). run.sh's dependency-install step
+                # was the first symptom (it always fails there - the
+                # runtime image never ships requirements.lock/.txt at
+                # all, only the already-built venv - see Dockerfile),
+                # but is_first_run()'s identical SCRIPT_DIR-relative
+                # config/config.yml check is a second, deeper instance
+                # of the same assumption - teaching the whole,
+                # host-oriented run.sh script (also used by non-Docker
+                # installs, where that assumption is correct) about
+                # CURATARR_CONFIG_DIR everywhere it reads a path would
+                # be a much bigger change than this needs. Docker
+                # already has a working, already-shipped way to run all
+                # three recommenders in sequence that never goes
+                # through run.sh at all - docker-entrypoint.sh's own
+                # `recommend full` mode - so this mirrors that exact
+                # movie -> tv -> external order directly, same as
+                # frozen's own `--run-recommender full` (see
+                # curatarr_app.py) bypassing run.sh/run.ps1 entirely.
+                movie_script = os.path.join(code_root, "recommenders", "movie.py")
+                tv_script = os.path.join(code_root, "recommenders", "tv.py")
+                external_script = os.path.join(code_root, "recommenders", "external.py")
+                py = shlex.quote(sys.executable)
+                cmd = [
+                    "bash",
+                    "-c",
+                    f"{py} {shlex.quote(movie_script)} && "
+                    f"{py} {shlex.quote(tv_script)} && "
+                    f"{py} {shlex.quote(external_script)}",
+                ]
             elif os.name == "nt":
                 cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", os.path.join(code_root, "run.ps1")]
             else:
                 cmd = ["bash", os.path.join(code_root, "run.sh")]
             # Skip the interactive setup wizard / auto-update git-checkout
-            # dance for UI-triggered runs - config is assumed already
-            # set up, same bypass run.sh already supports for Docker.
+            # dance for UI-triggered runs on a source checkout - config
+            # is assumed already set up. Unused (but harmless) for the
+            # Docker branch above, which never touches run.sh at all.
             env["RUNNING_IN_DOCKER"] = "true"
             target = "all"
         elif engine in ("movie", "tv"):


### PR DESCRIPTION
## Summary
- Diagnosed the remaining part of issue #260: the web UI's `full` engine still routed through `run.sh` in Docker, which assumes its own script directory (`/app`) doubles as the data directory (`config/`, `cache/`, `logs/` - true for a source checkout, never true in Docker, where those live at a separately mounted `/data`). Two real symptoms of that one mismatch, confirmed in a real container: the dependency-install step always failed (the runtime image never ships `requirements.lock`/`requirements.txt` at all, only the venv those built at image-build time), and `is_first_run()` always saw a missing config and dropped into a setup wizard that isn't shipped in the image either.
- Rather than teach the whole of `run.sh` (also used by every non-Docker install) about `CURATARR_CONFIG_DIR`, the web UI's `full` trigger now bypasses `run.sh` entirely inside the real Docker image (detected via `RUNNING_IN_DOCKER`), chaining `movie.py -> tv.py -> external.py` directly - the same order `docker-entrypoint.sh`'s own `recommend full` mode and the frozen binary's dispatcher already use successfully in this same image.
- Source checkouts and native (non-Docker) web-UI runs are unaffected - unchanged, still go through `run.sh`/`run.ps1`.
- Checked the frozen (PyInstaller) binary separately: it never had this problem - its `full` dispatch already calls movie/tv/external in-process and never touches `run.sh`/`run.ps1`.

## Test plan
- [x] Full suite green (2732 passed, 1 skipped)
- [x] `ruff check .` clean
- [x] `mypy .` clean
- [x] New unit tests for the Docker-detected dispatch branch (argv shape, ordering, code_root resolution) and an end-to-end test that actually executes the chained fake recommenders in order
- [x] Verified in a real container: `full` now clears dependency resolution and config loading, and reaches a real `recommenders/movie.py` traceback (fake Plex token rejected with 401) instead of a pip failure or a dead subprocess
- [x] Verified movie/tv/external individually still launch correctly in the same container