### PR TITLE
Fix inconsistent, broken Trakt re-auth instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.57] - 2026-07-27
+
+### Fixed
+
+- **Trakt re-authentication instructions were inconsistent across three locations, and all three could fail with `ModuleNotFoundError: No module named 'cryptography'` when run with the wrong interpreter.** `run.ps1` said `python utils/trakt_auth.py`, `config/trakt.example.yml` said `python3 utils/trakt_auth.py`, and the Connections screen said `python3 -m utils.trakt_auth` - three different invocations, none mentioning that this needs the project's own dependencies (a virtual environment, if you're using one), which is what actually broke for a reporter running the documented command against their system Python. Confirmed `python3 -m utils.trakt_auth` and `python3 utils/trakt_auth.py` behave identically (`-m` still runs the same `__main__` block); standardized all three locations, plus the script's own internal re-auth hint, on the `-m` form, and added a plain reminder to activate a virtual environment if applicable.
+
+  Testing this surfaced a second, more serious bug in the same area: `utils/trakt_auth.py`'s own `get_config_dir()` resolved against wherever the script itself lives on disk, not against `utils.helpers.get_project_root()` like everything else in the app - correct for a source checkout, but wrong in Docker, where the code lives at a fixed `/app` while `config/trakt.yml` actually lives on the separately mounted `/data` volume. A `docker exec` re-auth before this fix would have silently read/written the wrong, non-persisted path - confirmed in a real container. `get_config_dir()` now delegates to `get_project_root()`, and the Connections screen and `docs/DOCKER.md` both now give Docker users the `docker exec -it <container> python3 -m utils.trakt_auth` command that actually works against the real config, instead of a source-install command they have no way to run.
+
+  Checked the frozen (PyInstaller) binary separately: unlike `movie`/`tv`/`external`/`full`, there is currently no way to run Trakt re-auth from a packaged build at all (no loose `utils/trakt_auth.py`, no `--run-recommender`-equivalent dispatch). The Connections screen now says so plainly instead of showing a command that can't work there; closing this gap needs its own follow-up.
+
+  `config/trakt.example.yml` now also documents `--reauth` for relinking an already-linked account, not just first-time setup.
+
 ## [2.10.56] - 2026-07-27
 
 ### Fixed

--- a/config/trakt.example.yml
+++ b/config/trakt.example.yml
@@ -11,8 +11,11 @@ client_secret: YOUR_CLIENT_SECRET
 # to date automatically as they're refreshed (access tokens currently
 # last about 24 hours - refreshed transparently before/on expiry, no
 # action needed unless the refresh itself is rejected, in which case
-# re-run trakt_auth.py below with --reauth).
-# Run: python3 utils/trakt_auth.py
+# re-run the command below with --reauth to relink).
+#
+# Run (from the project root, with your virtual environment active if
+# you're using one): python3 -m utils.trakt_auth [--reauth]
+# Docker: docker exec -it curatarr python3 -m utils.trakt_auth [--reauth]
 access_token: null
 refresh_token: null
 # token_created_at / token_expires_in: also set automatically (used to

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -356,3 +356,16 @@ docker compose build --no-cache
   expected: `/healthz` is only served by the `web` mode. A one-shot
   `recommend` container is meant to run to completion and exit, not
   stay up.
+- **Re-linking or re-authenticating Trakt** - the Connections screen
+  can't complete Trakt's device-code OAuth flow itself (it's a live
+  poll loop, not a single form submit); run it inside the container
+  instead:
+
+  ```bash
+  docker exec -it curatarr python3 -m utils.trakt_auth
+  ```
+
+  (`curatarr` is this image's container name in `docker-compose.yml` -
+  substitute your own if you run/named it differently.) Add `--reauth`
+  to relink an account that's already linked (e.g. after a refresh
+  failure) instead of hand-editing `config/trakt.yml` first.

--- a/run.ps1
+++ b/run.ps1
@@ -662,7 +662,8 @@ except Exception as e:
 
             if ($traktError) {
                 Write-Red "Failed to get device code: $traktError"
-                Write-Yellow "You can authenticate later with: python utils/trakt_auth.py"
+                Write-Yellow "You can authenticate later with: python -m utils.trakt_auth"
+                Write-Yellow "(activate your virtual environment first, if you're using one)"
             } elseif ($traktCode) {
                 Write-Host ""
                 Write-Host "1. Go to: " -NoNewline; Write-Cyan $traktUrl
@@ -691,7 +692,8 @@ else:
                 if ($traktAccessToken) {
                     Write-Green "OK Trakt authenticated!"
                 } else {
-                    Write-Yellow "Authentication not completed. You can retry later with: python utils/trakt_auth.py"
+                    Write-Yellow "Authentication not completed. You can retry later with: python -m utils.trakt_auth"
+                    Write-Yellow "(activate your virtual environment first, if you're using one)"
                 }
             }
 

--- a/tests/test_trakt_auth.py
+++ b/tests/test_trakt_auth.py
@@ -7,6 +7,48 @@ import pytest
 import yaml
 
 
+class TestGetConfigDir:
+    """get_config_dir() must resolve against utils.helpers.
+    get_project_root() (CURATARR_CONFIG_DIR override in Docker,
+    ~/.curatarr for a frozen binary, repo root for a source checkout -
+    see that function's own docstring), never against this script's
+    own directory on disk. It used to always resolve to
+    dirname(dirname(__file__)) - correct for a source checkout, but
+    /app in Docker: the code's fixed WORKDIR, not the separately
+    mounted /data config/trakt.yml actually lives in (confirmed in a
+    real container - a `docker exec ... python3 -m utils.trakt_auth`
+    before this fix silently read/wrote the wrong, non-persisted
+    path)."""
+
+    def test_uses_get_project_root_not_own_file_location(self, monkeypatch):
+        from utils import trakt_auth
+
+        monkeypatch.setattr(trakt_auth, "get_project_root", lambda: "/data")
+        assert trakt_auth.get_config_dir() == os.path.join("/data", "config")
+        assert "/app" not in trakt_auth.get_config_dir()
+
+    def test_respects_curatarr_config_dir_env_var(self, tmp_path, monkeypatch):
+        """End-to-end through the real (unpatched) get_project_root() -
+        CURATARR_CONFIG_DIR is exactly how Docker points
+        get_project_root() at /data while the code stays at the
+        image's fixed /app (tmp_path stands in for /data here so this
+        test never touches a real filesystem root). get_project_root()
+        is @lru_cache(maxsize=1) - cleared before (so this test's own
+        call isn't served a value cached by some earlier, unrelated
+        test) and after (so this test's own result doesn't leak into
+        whatever runs next), matching tests/test_helpers.py's own
+        convention for this same cache."""
+        from utils import trakt_auth
+        from utils.helpers import get_project_root
+
+        monkeypatch.setenv("CURATARR_CONFIG_DIR", str(tmp_path))
+        get_project_root.cache_clear()
+        try:
+            assert trakt_auth.get_config_dir() == os.path.join(str(tmp_path), "config")
+        finally:
+            get_project_root.cache_clear()
+
+
 class TestTraktAuthLoadConfig:
     """Tests for trakt_auth load_config function."""
 

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -65,6 +65,54 @@ class TestGet:
         assert b"configured" in resp.data
 
 
+class TestTraktReauthHint:
+    """The Trakt re-auth instructions shown below the fields must match
+    how a user can actually reach this screen in the first place - a
+    Docker user can't shell into a source-checkout venv, and a
+    packaged (frozen) binary user has no loose utils/trakt_auth.py or
+    --run-recommender-style dispatch to run it with at all. See
+    web/config_connections.py's own _connections_view docstring on
+    "trakt_reauth"."""
+
+    @staticmethod
+    def _text(resp):
+        """Collapse the template's own line-wrapping (real whitespace
+        the browser would collapse too) so multi-word assertions below
+        don't depend on exactly where a line happens to wrap in the
+        .html source."""
+        return " ".join(resp.data.decode().split())
+
+    def test_source_install_shows_module_invocation_and_venv_hint(self, client, monkeypatch):
+        monkeypatch.delenv("RUNNING_IN_DOCKER", raising=False)
+        c, app, root = client
+        resp = c.get("/config/connections")
+        text = self._text(resp)
+        assert "python3 -m utils.trakt_auth</code> to link/relink" in text
+        assert "virtual environment active" in text
+        assert "docker exec" not in text
+
+    def test_docker_shows_docker_exec_command(self, client, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        c, app, root = client
+        resp = c.get("/config/connections")
+        text = self._text(resp)
+        assert "docker exec -it" in text
+        assert "python3 -m utils.trakt_auth" in text
+
+    def test_frozen_states_gap_plainly_instead_of_a_dead_command(self, client, monkeypatch):
+        monkeypatch.delenv("RUNNING_IN_DOCKER", raising=False)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        c, app, root = client
+        resp = c.get("/config/connections")
+        text = self._text(resp)
+        assert "isn't available yet" in text
+        assert "docker exec" not in text
+        # Never claim the module invocation works here - it can't
+        # (recommenders/<x>.py's own equivalent is --run-recommender,
+        # not a loose script - see this module's docstring).
+        assert "python3 -m utils.trakt_auth</code> to link" not in text
+
+
 class TestSave:
     def test_saves_plex_and_tmdb_to_config_yml(self, client):
         c, app, root = client

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.56"
+__version__ = "2.10.57"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/trakt_auth.py
+++ b/utils/trakt_auth.py
@@ -15,12 +15,29 @@ from typing import Optional
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.config import load_config as _load_canonical_config
+from utils.helpers import get_project_root
 from utils.trakt import TraktAuthError, TraktClient, save_trakt_tokens
 
 
 def get_config_dir():
-    """Get the config directory path."""
-    return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config")
+    """Get the config directory path.
+
+    Delegates to utils.helpers.get_project_root() - CURATARR_CONFIG_DIR
+    override for Docker, ~/.curatarr for a frozen binary, repo root for
+    a source checkout (see that function's own docstring) - instead of
+    this script's own directory. This used to always resolve to
+    dirname(dirname(__file__)), i.e. wherever trakt_auth.py itself
+    lives on disk: correct for a source checkout, but /app in Docker -
+    the code's fixed WORKDIR, not the separately mounted /data volume
+    config/trakt.yml actually lives in (confirmed in a real container -
+    the same code_root-vs-project_root divergence #260 already fixed
+    for web/job_runner.py's JobManager, just never touched here). A
+    `docker exec ... python3 -m utils.trakt_auth` before this fix would
+    have silently read/written /app/config/trakt.yml - a path that
+    isn't even bind-mounted, so it neither sees the real existing
+    config nor persists whatever it saves past the container's life.
+    """
+    return os.path.join(get_project_root(), "config")
 
 
 def load_config():
@@ -113,7 +130,7 @@ def main(argv=None):
     # access_token first, and even a source install shouldn't have to).
     if not args.reauth and trakt_config.get("access_token") and trakt_config.get("access_token") != "null":
         print("Already authenticated!")
-        print("To re-authenticate, run: python3 utils/trakt_auth.py --reauth")
+        print("To re-authenticate, run: python3 -m utils.trakt_auth --reauth")
         sys.exit(0)
 
     # Create client

--- a/web/config_connections.py
+++ b/web/config_connections.py
@@ -17,6 +17,8 @@ existing installs keep working without this screen ever writing those
 two fields again.
 """
 
+import os
+import sys
 from typing import Any, Dict, Optional
 
 from flask import jsonify, redirect, render_template, request, url_for
@@ -251,6 +253,20 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
             "auto_sync": pick("trakt", "auto_sync", bool(trakt_export.get("auto_sync", False))),
             "user_mode": pick("trakt", "user_mode", trakt_export.get("user_mode", "mapping")),
             "plex_users": pick("trakt", "plex_users", format_csv_list(trakt_export.get("plex_users"))),
+        },
+        # Which re-auth instructions to show below the Trakt fields -
+        # the device-code flow itself (utils/trakt_auth.py) is the same
+        # everywhere, but how a user actually RUNS it differs by
+        # deployment shape: `docker exec` into the running container in
+        # Docker (a source install's `python3 -m utils.trakt_auth`
+        # can't reach a Docker container's shell at all), and not
+        # reachable yet at all from a packaged (frozen) binary - no
+        # loose utils/trakt_auth.py to run, and no --run-recommender-
+        # style dispatch for it (unlike movie/tv/external/full) has
+        # been built. See config_connections.html for the exact text.
+        "trakt_reauth": {
+            "docker": os.environ.get("RUNNING_IN_DOCKER") == "true",
+            "frozen": getattr(sys, "frozen", False),
         },
         "user_mode_choices": USER_MODE_CHOICES,
     }

--- a/web/templates/config_connections.html
+++ b/web/templates/config_connections.html
@@ -129,8 +129,21 @@
     </label>
     <p class="muted">
       Account link: {{ trakt.access_token_status }}.
-      Run <code>python3 -m utils.trakt_auth</code> from the project root to link/relink a Trakt account
-      (device-code OAuth can't be completed from this form).
+      {% if trakt_reauth.docker %}
+      Device-code OAuth needs a live terminal, so it can't be completed from this form - run
+      <code>docker exec -it &lt;container&gt; python3 -m utils.trakt_auth</code> instead (add
+      <code>--reauth</code> to relink an account that's already linked). <code>&lt;container&gt;</code> is
+      this image's container name in <code>docker-compose.yml</code> (<code>curatarr</code> by default) -
+      substitute your own if you run/named it differently.
+      {% elif trakt_reauth.frozen %}
+      Linking/relinking Trakt isn't available yet from a packaged app build - there's no in-app way to run
+      the device-code flow from here. This is a known gap for packaged installs; see the project's issue
+      tracker for status.
+      {% else %}
+      Device-code OAuth can't be completed from this form - from the project root, with your virtual
+      environment active if you're using one, run <code>python3 -m utils.trakt_auth</code> to link/relink a
+      Trakt account (add <code>--reauth</code> to relink one that's already linked).
+      {% endif %}
     </p>
     <button type="button" class="test-connection" data-service="trakt"
             data-field-map='{"client_id": "trakt_client_id", "client_secret": "trakt_client_secret"}'>Test Connection</button>


### PR DESCRIPTION
## Summary
- Three documented invocations for `utils/trakt_auth.py` never agreed (`run.ps1`: `python utils/trakt_auth.py`; `config/trakt.example.yml`: `python3 utils/trakt_auth.py`; the Connections screen: `python3 -m utils.trakt_auth`), and none mentioned that this needs the project's own dependencies - which is what actually broke for a reporter running the documented command against system Python (`ModuleNotFoundError: No module named 'cryptography'`).
- Settled with evidence (not guessed): `python3 -m utils.trakt_auth` and `python3 utils/trakt_auth.py` behave identically - confirmed by running both, and confirmed the failure reproduces identically with either form against system Python. Standardized all locations on the `-m` form, plus a plain reminder to activate a virtual environment if using one.
- Testing across deployment shapes surfaced a second, more serious bug in the same area: `get_config_dir()` resolved against wherever `trakt_auth.py` itself lives on disk, not against `utils.helpers.get_project_root()` like everything else in the app - correct for a source checkout, but wrong in Docker (code at `/app`, real config at the separately-mounted `/data`). Confirmed in a real container that this would have silently read/written the wrong, non-persisted path. Fixed to delegate to `get_project_root()`; the Connections screen and `docs/DOCKER.md` now give Docker users a `docker exec` command that actually works against the real, persistent config.
- Checked the frozen (PyInstaller) binary: unlike `movie`/`tv`/`external`/`full`, there is currently no way to run Trakt re-auth from a packaged build at all (no loose script, no `--run-recommender`-equivalent dispatch). Rather than invent an unverified workaround, the Connections screen now says so plainly. Flagging this as a real gap worth a follow-up decision, not fixed in this PR (scope: docs/UI text plus the small entrypoint fix the testing proved necessary).
- `config/trakt.example.yml` now also documents `--reauth` for relinking an existing account, not just first-time setup.

## Test plan
- [x] Full suite green (2737 passed, 1 skipped)
- [x] `ruff check .` clean
- [x] `mypy .` clean
- [x] New tests: `get_config_dir()` resolves via `get_project_root()` (not its own file location, respects `CURATARR_CONFIG_DIR`); Connections screen shows the right instructions for source/Docker/frozen
- [x] Verified in a real container: `get_config_dir()` resolves to `/data/config`; `docker exec <container> python3 -m utils.trakt_auth` loads the real config and reaches Trakt's real API (expected `invalid_client` with fake test credentials - proves the plumbing, not a fake pass)