### PR TITLE
Fix trakt_auth silent hang: stdout buffered without a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.58] - 2026-07-27
+
+### Fixed
+
+- **`python3 -m utils.trakt_auth --reauth` produced zero output and appeared to hang when run without a TTY** (`ssh host "cmd" > log` with no `-t`, or `docker exec` without `-t`) - the device code and `trakt.tv/activate` URL were written to stdout right before the script blocks in `poll_for_token`'s device-auth polling loop (up to 10 minutes), but CPython fully block-buffers stdout whenever it isn't a real terminal, so none of that text ever reached the log/pipe until the process eventually exited - there was nothing to approve, so the flow could never complete. Reproduced directly (a real, non-TTY child process showed zero bytes of output while still genuinely blocked in the poll wait) before fixing.
+
+  `utils/trakt_auth.py`'s `main()` now reconfigures stdout to line-buffered on entry, so every print - the device code and URL in particular - is flushed immediately regardless of how the script is invoked, without relying on the caller passing `-u` or setting `PYTHONUNBUFFERED`. `utils/trakt.py`'s `poll_for_token()` also gained an optional `on_wait` callback, which `trakt_auth.py` uses to print a throttled "...still waiting for approval" line roughly every 30 seconds, so a user watching a long wait over SSH/a log can tell it's working, not hung.
+
+  Audited `utils/simkl.py`'s equivalent PIN-code flow and `setup.sh`'s/`run.ps1`'s own inline Trakt/Simkl device-auth blocks for the same pattern - unaffected: both are bounded to a 30-second poll, gated behind an explicit `read -p`/`Read-Host` "press Enter after you've approved" prompt (already requiring a real interactive terminal), and their device-code output is captured via command substitution from a short-lived process that exits (and therefore flushes) almost immediately, never left sitting in a buffer during a long, otherwise-invisible wait.
+
 ## [2.10.57] - 2026-07-27
 
 ### Fixed

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -334,6 +334,60 @@ class TestTraktClientDeviceAuth:
 
         assert result is False
 
+    @patch("utils.trakt.requests.post")
+    def test_poll_for_token_calls_on_wait_once_per_pending_iteration(self, mock_post):
+        """on_wait (see utils/trakt_auth.py's periodic progress printer)
+        must fire once per still-waiting (400) iteration, and never on
+        the final success iteration."""
+        pending = Mock()
+        pending.status_code = 400
+
+        success = Mock()
+        success.status_code = 200
+        success.json.return_value = {"access_token": "access", "refresh_token": "refresh"}
+
+        mock_post.side_effect = [pending, pending, success]
+
+        on_wait = Mock()
+        client = TraktClient("id", "secret")
+        result = client.poll_for_token("device_code", interval=0, expires_in=10, on_wait=on_wait)
+
+        assert result is True
+        assert on_wait.call_count == 2
+
+    @patch("utils.trakt.requests.post")
+    def test_poll_for_token_without_on_wait_still_works(self, mock_post):
+        """on_wait defaults to None - existing callers (and every
+        existing test above) that never pass it must be unaffected."""
+        pending = Mock()
+        pending.status_code = 400
+
+        success = Mock()
+        success.status_code = 200
+        success.json.return_value = {"access_token": "access", "refresh_token": "refresh"}
+
+        mock_post.side_effect = [pending, success]
+
+        client = TraktClient("id", "secret")
+        result = client.poll_for_token("device_code", interval=0, expires_in=10)
+
+        assert result is True
+
+    @patch("utils.trakt.requests.post")
+    def test_poll_for_token_on_wait_not_called_on_denied(self, mock_post):
+        """on_wait is specifically for the still-waiting (400) branch -
+        never for a terminal outcome like 418 (denied)."""
+        mock_response = Mock()
+        mock_response.status_code = 418
+        mock_post.return_value = mock_response
+
+        on_wait = Mock()
+        client = TraktClient("id", "secret")
+        result = client.poll_for_token("device_code", interval=0, expires_in=10, on_wait=on_wait)
+
+        assert result is False
+        on_wait.assert_not_called()
+
 
 class TestTraktClientTokenRefresh:
     """Tests for token refresh."""

--- a/tests/test_trakt_auth.py
+++ b/tests/test_trakt_auth.py
@@ -1,10 +1,17 @@
 """Tests for utils/trakt_auth.py"""
 
 import os
+import subprocess
+import sys
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 import yaml
+
+# tests/ lives directly under the repo root - same one-level-up
+# resolution get_code_root() itself uses (see utils/helpers.py).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class TestGetConfigDir:
@@ -352,3 +359,261 @@ class TestTraktAuthMain:
         with pytest.raises(SystemExit) as exc_info:
             main([])
         assert exc_info.value.code == 1
+
+
+class TestTraktAuthStdoutLineBuffering:
+    """main() reconfigures stdout to line-buffered on entry - see that
+    function's own comment for the full "why" (CPython fully
+    block-buffers stdout whenever it isn't a real terminal, which
+    silently held the device code/verification URL in memory for the
+    whole poll_for_token wait when invoked over e.g. `ssh host "cmd" >
+    log` with no -t)."""
+
+    @patch("utils.trakt_auth.TraktClient")
+    @patch("utils.trakt_auth.load_config")
+    def test_reconfigures_stdout_to_line_buffered(self, mock_load, mock_client_class, monkeypatch):
+        from utils.trakt_auth import main
+
+        mock_load.return_value = {
+            "trakt": {"enabled": True, "client_id": "id", "client_secret": "secret", "access_token": None}
+        }
+        mock_client = Mock()
+        mock_client.get_device_code.return_value = {
+            "device_code": "abc123",
+            "user_code": "XYZ789",
+            "verification_url": "https://trakt.tv/activate",
+        }
+        mock_client.poll_for_token.return_value = True
+        mock_client.get_username.return_value = "testuser"
+        mock_client_class.return_value = mock_client
+
+        fake_stdout = Mock()
+        fake_stdout.reconfigure = Mock()
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+
+        main([])
+
+        fake_stdout.reconfigure.assert_called_once_with(line_buffering=True)
+
+    @patch("utils.trakt_auth.TraktClient")
+    @patch("utils.trakt_auth.load_config")
+    def test_tolerates_stdout_without_reconfigure(self, mock_load, mock_client_class, monkeypatch, capsys):
+        """Some sys.stdout stand-ins (certain test/capture harnesses)
+        don't implement reconfigure() at all - main() must not crash
+        on those, it just skips the line-buffering step."""
+        from utils.trakt_auth import main
+
+        mock_load.return_value = {
+            "trakt": {"enabled": True, "client_id": "id", "client_secret": "secret", "access_token": None}
+        }
+        mock_client = Mock()
+        mock_client.get_device_code.return_value = {
+            "device_code": "abc123",
+            "user_code": "XYZ789",
+            "verification_url": "https://trakt.tv/activate",
+        }
+        mock_client.poll_for_token.return_value = True
+        mock_client.get_username.return_value = "testuser"
+        mock_client_class.return_value = mock_client
+
+        class _NoReconfigureStdout:
+            def write(self, s):
+                pass
+
+            def flush(self):
+                pass
+
+        monkeypatch.setattr("sys.stdout", _NoReconfigureStdout())
+
+        # Must not raise - hasattr(sys.stdout, "reconfigure") is False here.
+        main([])
+
+
+class TestTraktAuthProgressCallback:
+    """main() passes poll_for_token an on_wait callback that prints a
+    throttled 'still waiting' progress line - see
+    PROGRESS_PRINT_INTERVAL_SECONDS and main()'s own comment."""
+
+    @patch("utils.trakt_auth.TraktClient")
+    @patch("utils.trakt_auth.load_config")
+    def test_on_wait_throttled_to_progress_interval(self, mock_load, mock_client_class, monkeypatch, capsys):
+        from utils import trakt_auth
+        from utils.trakt_auth import main
+
+        mock_load.return_value = {
+            "trakt": {"enabled": True, "client_id": "id", "client_secret": "secret", "access_token": None}
+        }
+        mock_client = Mock()
+        mock_client.get_device_code.return_value = {
+            "device_code": "abc123",
+            "user_code": "XYZ789",
+            "verification_url": "https://trakt.tv/activate",
+        }
+        mock_client.get_username.return_value = "testuser"
+        mock_client_class.return_value = mock_client
+
+        # Fake a clock: main()'s _on_wait uses time.monotonic() - drive
+        # it through several calls, some inside the throttle window,
+        # some past it, without any real sleeping.
+        fake_now = [0.0]
+        monkeypatch.setattr(trakt_auth.time, "monotonic", lambda: fake_now[0])
+
+        def fake_poll_for_token(device_code, interval, expires_in, on_wait=None):
+            assert on_wait is not None
+            fake_now[0] = 5.0
+            on_wait()  # inside the throttle window (< 30s) - no print
+            fake_now[0] = 10.0
+            on_wait()  # still inside the window - no print
+            fake_now[0] = 31.0
+            on_wait()  # past PROGRESS_PRINT_INTERVAL_SECONDS - prints
+            fake_now[0] = 40.0
+            on_wait()  # only 9s since the last print - no print
+            return True
+
+        mock_client.poll_for_token.side_effect = fake_poll_for_token
+
+        main([])
+
+        captured = capsys.readouterr()
+        assert captured.out.count("...still waiting for approval") == 1
+
+
+class TestTraktAuthStdoutNotBuffered:
+    """Regression test for the real bug: `ssh host "python3 -m
+    utils.trakt_auth --reauth" > log` (no -t - no TTY) produced ZERO
+    output while the process sat there polling - the device code and
+    activation URL were written into a buffer that was never flushed
+    because the process was blocked in poll_for_token's loop, not
+    exiting.
+
+    A test that only asserts main()/print() were called (mocking
+    sys.stdout) would pass even against the OLD, broken code - Python's
+    own statement order is always synchronous regardless of buffering.
+    This has to actually observe bytes arriving on a REAL, non-TTY
+    stdout pipe - `subprocess.Popen(..., stdout=subprocess.PIPE)` is
+    never a pty - while a real child process is still genuinely
+    blocked, to mean anything. That distinction is the entire bug."""
+
+    def _write_fake_auth_script(self, tmp_path, poll_sleep_seconds: float) -> str:
+        """A standalone script (never imports pytest) that runs the
+        real utils.trakt_auth.main() against a fake TraktClient - no
+        real Trakt device code is ever requested/consumed, no
+        config/trakt.yml outside this test's own tmp_path is ever
+        touched (CURATARR_CONFIG_DIR is pointed at tmp_path)."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "config.yml").write_text("plex:\n  url: http://localhost\n", encoding="utf-8")
+        (config_dir / "trakt.yml").write_text(
+            "enabled: true\nclient_id: fake-id\nclient_secret: fake-secret\n", encoding="utf-8"
+        )
+
+        script_path = tmp_path / "run_fake_trakt_auth.py"
+        script_path.write_text(
+            f"""
+import os
+import sys
+import time
+
+sys.path.insert(0, {_REPO_ROOT!r})
+os.environ["CURATARR_CONFIG_DIR"] = {str(tmp_path)!r}
+
+import utils.trakt_auth as trakt_auth
+from utils.helpers import get_project_root
+
+get_project_root.cache_clear()
+
+
+class FakeTraktClient:
+    def __init__(self, client_id, client_secret, token_callback):
+        pass
+
+    def get_device_code(self):
+        return {{
+            "device_code": "fake-device-code",
+            "user_code": "FAKE-CODE",
+            "verification_url": "https://trakt.tv/activate",
+            "interval": 1,
+            "expires_in": 600,
+        }}
+
+    def poll_for_token(self, device_code, interval, expires_in, on_wait=None):
+        time.sleep({poll_sleep_seconds!r})
+        return True
+
+    def get_username(self):
+        return "repro-user"
+
+
+trakt_auth.TraktClient = FakeTraktClient
+trakt_auth.main([])
+""",
+            encoding="utf-8",
+        )
+        return str(script_path)
+
+    def test_device_code_visible_before_poll_completes_when_not_a_tty(self, tmp_path):
+        # Generous relative to interpreter startup/import overhead
+        # (utils.trakt_auth transitively imports requests/yaml/etc) so
+        # this isn't flaky on a slow/cold CI runner - the deadline below
+        # is a fraction of this, still comfortably before the fake
+        # poll's sleep completes.
+        poll_sleep_seconds = 6.0
+        script = self._write_fake_auth_script(tmp_path, poll_sleep_seconds)
+
+        # stdout=subprocess.PIPE is a real OS pipe, never a pty/tty -
+        # exactly the "no TTY" condition `ssh host "cmd" > log` (no -t)
+        # and plain `docker exec` (no -t) both produce.
+        proc = subprocess.Popen(
+            [sys.executable, script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        collected = []
+        try:
+            deadline = time.monotonic() + (poll_sleep_seconds * 0.7)
+            while time.monotonic() < deadline:
+                line = proc.stdout.readline()
+                if line:
+                    collected.append(line)
+                    if "FAKE-CODE" in line:
+                        break
+                else:
+                    time.sleep(0.02)
+
+            output_so_far = "".join(collected)
+            assert "FAKE-CODE" in output_so_far, (
+                "device code never appeared on the (non-TTY) pipe before the "
+                f"fake poll_for_token wait finished - got: {output_so_far!r}"
+            )
+            assert "https://trakt.tv/activate" in output_so_far
+
+            # The fake poll_for_token is still sleeping at this point
+            # (deadline is 80% of its sleep duration) - the process
+            # must still be alive, i.e. this really was observed WHILE
+            # blocked, not after it already exited.
+            assert proc.poll() is None, "process should still be blocked in poll_for_token at this point"
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    def test_tty_path_still_works(self, tmp_path):
+        """Sanity check for the other half of the verification ask:
+        confirm the TTY path (the case that already worked before this
+        fix, via line-buffering-by-default on a real terminal) still
+        completes normally - run to completion rather than a pty
+        capture (spawning a real pty is platform-specific/POSIX-only),
+        just confirming the fix doesn't somehow break a normal run."""
+        poll_sleep_seconds = 0.2
+        script = self._write_fake_auth_script(tmp_path, poll_sleep_seconds)
+
+        result = subprocess.run(
+            [sys.executable, script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "FAKE-CODE" in result.stdout
+        assert "Authentication Successful" in result.stdout

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.57"
+__version__ = "2.10.58"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -270,7 +270,13 @@ class TraktClient(BaseAPIClient):
 
         return response.json()
 
-    def poll_for_token(self, device_code: str, interval: int = 5, expires_in: int = 600) -> bool:
+    def poll_for_token(
+        self,
+        device_code: str,
+        interval: int = 5,
+        expires_in: int = 600,
+        on_wait: Optional[Callable[[], None]] = None,
+    ) -> bool:
         """
         Poll for user authorization completion.
 
@@ -278,6 +284,16 @@ class TraktClient(BaseAPIClient):
             device_code: Device code from get_device_code()
             interval: Polling interval in seconds
             expires_in: Expiration time in seconds
+            on_wait: optional zero-arg callback invoked once per
+                still-waiting (HTTP 400) iteration, right before the
+                interval sleep - lets a caller (see utils/trakt_auth.py)
+                print its own periodic "still waiting" progress so a
+                user watching this genuinely long (up to expires_in,
+                normally 600s) blocking call can tell "working" from
+                "hung" apart, without this method itself owning any
+                console/display concerns. Never called on the
+                success/denied/expired/error branches below, only while
+                actually still polling.
 
         Returns:
             True if authorized, False if expired/denied
@@ -313,6 +329,8 @@ class TraktClient(BaseAPIClient):
 
             elif response.status_code == 400:
                 # Still waiting for user
+                if on_wait is not None:
+                    on_wait()
                 time.sleep(interval)
                 continue
 

--- a/utils/trakt_auth.py
+++ b/utils/trakt_auth.py
@@ -9,6 +9,7 @@ Tokens are saved to trakt.yml for future use.
 import argparse
 import os
 import sys
+import time
 from typing import Optional
 
 # Add project root to path
@@ -76,6 +77,15 @@ def save_tokens(
     print("\033[92mTokens saved to config/trakt.yml\033[0m")
 
 
+# How often poll_for_token's on_wait callback (utils/trakt.py) is
+# allowed to print a "still waiting" progress line - throttled well
+# below the polling interval itself (typically 5s from Trakt) so a
+# ~10-minute wait doesn't spam ~120 lines, while still giving a user
+# watching a log/SSH session something periodic to distinguish
+# "working" from "hung" - see main()'s _on_wait below.
+PROGRESS_PRINT_INTERVAL_SECONDS = 30
+
+
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(description="Trakt device-code authentication for Curatarr")
     parser.add_argument(
@@ -98,6 +108,24 @@ def main(argv=None):
     picking up whatever's actually in sys.argv (e.g. pytest's own CLI
     args when this is called directly from a test)."""
     args = parse_args(argv)
+
+    # Line-buffer stdout so every print below (in particular the
+    # device code/verification URL just before the blocking
+    # poll_for_token call) reaches whoever's watching IMMEDIATELY,
+    # rather than sitting in a buffer until the process eventually
+    # exits. CPython fully block-buffers stdout whenever it isn't a
+    # real terminal (`ssh host "python3 -m utils.trakt_auth --reauth" >
+    # log` with no -t, `docker exec` without -t, any captured/piped
+    # invocation) - that silently held the device code and activation
+    # URL in memory for the entire (up to 10-minute) polling wait,
+    # with nothing ever appearing for the user to act on. Reconfigured
+    # here (the entry point), not via a global PYTHONUNBUFFERED/-u
+    # requirement, so this is correct standalone regardless of how the
+    # caller invokes it. hasattr-guarded since not every sys.stdout
+    # stand-in (e.g. some test/capture harnesses) implements
+    # reconfigure().
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
 
     print("\033[96m=== Trakt Authentication ===\033[0m")
     print()
@@ -149,11 +177,26 @@ def main(argv=None):
         print("(Press Ctrl+C to cancel)")
         print()
 
+        # Periodic "still here" progress so a user watching this over
+        # SSH/a log/docker logs can tell an in-progress wait apart from
+        # a hung one - throttled to PROGRESS_PRINT_INTERVAL_SECONDS
+        # (poll_for_token's own interval, normally 5s, would otherwise
+        # print far too often over a wait that can last minutes).
+        last_progress_at = time.monotonic()
+
+        def _on_wait() -> None:
+            nonlocal last_progress_at
+            now = time.monotonic()
+            if now - last_progress_at >= PROGRESS_PRINT_INTERVAL_SECONDS:
+                print("...still waiting for approval")
+                last_progress_at = now
+
         # Poll for token
         success = client.poll_for_token(
             device_code=device_info["device_code"],
             interval=device_info.get("interval", 5),
             expires_in=device_info.get("expires_in", 600),
+            on_wait=_on_wait,
         )
 
         if success:


### PR DESCRIPTION
## Summary
- `utils/trakt_auth.py --reauth` produced zero output and appeared to hang when run without a TTY (`ssh host \"cmd\" > log` with no `-t`, `docker exec` without `-t`) - the device code and activation URL sat in a block-buffered stdout while the process blocked in `poll_for_token`'s polling loop for up to 10 minutes.
- `main()` now reconfigures stdout to line-buffered on entry so every print is flushed immediately, regardless of caller/PYTHONUNBUFFERED/-u.
- `poll_for_token()` gained an optional `on_wait` callback; `trakt_auth.py` uses it to print a throttled "...still waiting for approval" line roughly every 30s.
- Audited `setup.sh`/`run.ps1`'s own inline Trakt/Simkl device-auth blocks and `utils/simkl.py`'s equivalent PIN flow for the same pattern - confirmed unaffected (bounded 30s poll, gated behind an interactive prompt, output captured from a short-lived process that exits/flushes quickly).

## Test plan
- [x] Reproduced directly: a real non-TTY child process showed 0 bytes of output while genuinely still blocked in a simulated polling wait, before the fix.
- [x] New regression test spawns a real subprocess with `stdout=subprocess.PIPE` (never a tty) and asserts the device code/URL are readable from the pipe while the process is still alive/blocked - not merely that print() was called.
- [x] Verified in a real Docker image built from this branch via plain `docker exec` (no `-t`): device code appears within 3s of a 6s simulated block.
- [x] Full suite (2745 passed, 1 skipped), ruff, mypy all green.