### PR TITLE
Harden self-update env sanitizer against dynamic-loader-path inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.60] - 2026-07-27
+
+### Fixed
+
+- **Hardened `sanitize_frozen_relaunch_env` (utils/self_update.py) against PyInstaller onefile's dynamic-loader-path env-var inheritance hazard.** Follows up the v2.10.57 release verification, where a real self-update from v2.10.48 hit a SIGSEGV in the post-swap version readback (rolled itself back correctly; could not be reproduced in 10/10 clean reruns and CI's own smoke test) - not chased further per its own inconclusiveness, but it surfaced a real, separate, verified gap: the sanitizer stripped only `_MEIPASS2`/`_PYI_*`/`_PYINSTALLER_*`, never `LD_LIBRARY_PATH` - the classic PyInstaller onefile hazard where a parent's own extraction-directory-pointing loader path leaks into a relaunched child.
+
+  Verified directly against PyInstaller 6.21.0's own bootloader source (the version this repo's build-requirements.lock pins - both the compiled bootloader binaries this repo's own release CI ships, and the upstream C source) rather than assumed: Linux's onefile bootloader unconditionally prepends its extraction directory onto `LD_LIBRARY_PATH` on every launch, saving any pre-existing value under `LD_LIBRARY_PATH_ORIG` first. macOS's bootloader does **not** touch `DYLD_LIBRARY_PATH`/`DYLD_FRAMEWORK_PATH` at all ("we rewrite the library paths on collected binaries" - PyInstaller's own source comment); confirmed empirically too (the compiled Darwin bootloader binaries contain no such strings, unlike the Linux one, which contains both `LD_LIBRARY_PATH` and `LD_LIBRARY_PATH_ORIG` verbatim).
+
+  `sanitize_frozen_relaunch_env` now resolves all three variables using PyInstaller's own `<VAR>_ORIG` convention: restores the original value and drops the `_ORIG` marker when present, and - only for `LD_LIBRARY_PATH` on Linux, the one (variable, platform) pair confirmed to always be bootloader-injected when absent - removes the variable outright when no `_ORIG` exists. Everywhere else (the macOS variables, and `LD_LIBRARY_PATH` on any non-Linux platform), a value with no `_ORIG` is left completely untouched rather than risk clobbering something a user genuinely set themselves. All three of this module's real relaunch/subprocess call sites (the self-update worker spawn, the post-swap `--version` readback, and the web UI's external hand-off script launch) already routed through this same function, so all three are covered by this one change; the hand-off shell script templates' own redundant belt-and-suspenders re-stripping deliberately does not duplicate the loader-path handling, since that decision can only be made correctly once, before the `_ORIG` marker is consumed.
+
+  Verified end-to-end against a real, actually-built Linux onefile binary (matching this repo's own release CI exactly): captured the real bootloader-injected environment of a live running instance in two scenarios (no pre-existing `LD_LIBRARY_PATH`, and a genuine pre-existing one) and confirmed the sanitizer strips the former outright and correctly restores the latter to its original value. The macOS side of this fix is confirmed correct by source/unit tests but is precautionary for this project specifically - PyInstaller doesn't touch these variables for a Qt-less build like curatarr's, so there was nothing to observe mutating them in a real macOS build. The original SIGSEGV itself was not re-attempted, per its own inconclusiveness.
+
 ## [2.10.59] - 2026-07-27
 
 ### Fixed

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1302,6 +1302,158 @@ class TestSanitizeFrozenRelaunchEnv:
         assert "_PYI_ARCHIVE_FILE" in env
 
 
+class TestSanitizeFrozenRelaunchEnvDynamicLoaderPaths:
+    """LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/DYLD_FRAMEWORK_PATH handling -
+    see _DYNAMIC_LOADER_PATH_VARS' own comment in utils/self_update.py
+    for the verified (against PyInstaller 6.21.0's own bootloader
+    source, both the compiled binaries this repo's release CI actually
+    ships and the upstream C source) per-platform PyInstaller behavior
+    this follows:
+      - LD_LIBRARY_PATH is confirmed to be unconditionally set by
+        curatarr's own Linux bootloader on every launch - "present, no
+        _ORIG" there can only mean the bootloader's own fresh
+        injection, safe to strip outright.
+      - DYLD_LIBRARY_PATH/DYLD_FRAMEWORK_PATH (macOS), and
+        LD_LIBRARY_PATH on any non-Linux platform, are NOT confirmed to
+        be touched by this build's bootloader at all (macOS: "No
+        changes to library search path are required... we rewrite the
+        library paths on collected binaries" - PyInstaller's own
+        source comment; curatarr bundles no Qt binding, the only other
+        code that ever touches these) - "present, no _ORIG" there must
+        be left alone, never stripped.
+
+    _BOOTLOADER_ALWAYS_SETS_ON_PLATFORM is computed once at import time
+    from the real sys.platform - tests monkeypatch it directly (same
+    convention already used elsewhere in this file for other
+    module-level constants) so both branches get real coverage
+    regardless of which OS actually runs this test suite.
+    """
+
+    def test_ld_library_path_removed_when_no_orig_on_linux(self, monkeypatch):
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {"PATH": "/usr/bin", "LD_LIBRARY_PATH": "/tmp/_MEI123456"}
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert "LD_LIBRARY_PATH" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_ld_library_path_restored_from_orig_on_linux(self, monkeypatch):
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {
+            "LD_LIBRARY_PATH": "/tmp/_MEI123456:/opt/real/libs",
+            "LD_LIBRARY_PATH_ORIG": "/opt/real/libs",
+        }
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["LD_LIBRARY_PATH"] == "/opt/real/libs"
+        assert "LD_LIBRARY_PATH_ORIG" not in result
+
+    def test_ld_library_path_survives_untouched_when_no_orig_and_not_linux(self, monkeypatch):
+        """A user-set value with no PyInstaller involvement (this
+        build's bootloader is only confirmed to touch LD_LIBRARY_PATH
+        on Linux - see class docstring) must never be stripped just
+        because no `_ORIG` backup exists."""
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", False)
+        env = {"PATH": "/usr/bin", "LD_LIBRARY_PATH": "/opt/some/other/tool/libs"}
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["LD_LIBRARY_PATH"] == "/opt/some/other/tool/libs"
+
+    def test_dyld_library_path_restored_from_orig(self):
+        """DYLD_LIBRARY_PATH restore-from-_ORIG must work regardless of
+        _BOOTLOADER_ALWAYS_SETS_ON_PLATFORM (that gate only controls
+        the unconditional-strip-when-absent branch, never restore)."""
+        env = {
+            "DYLD_LIBRARY_PATH": "/tmp/_MEI123456:/opt/real/libs",
+            "DYLD_LIBRARY_PATH_ORIG": "/opt/real/libs",
+        }
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["DYLD_LIBRARY_PATH"] == "/opt/real/libs"
+        assert "DYLD_LIBRARY_PATH_ORIG" not in result
+
+    def test_dyld_library_path_survives_untouched_when_no_orig(self, monkeypatch):
+        """PyInstaller never sets DYLD_LIBRARY_PATH for a Qt-less build
+        like curatarr's (see class docstring) - a value present with no
+        `_ORIG` is a genuine user setting and must survive untouched,
+        even on the platform LD_LIBRARY_PATH itself WOULD be stripped
+        on (this assertion is what actually catches a future refactor
+        that accidentally treats all three vars identically)."""
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {"DYLD_LIBRARY_PATH": "/Users/me/some/tool/libs"}
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["DYLD_LIBRARY_PATH"] == "/Users/me/some/tool/libs"
+
+    def test_dyld_framework_path_restored_from_orig(self):
+        env = {
+            "DYLD_FRAMEWORK_PATH": "/tmp/_MEI123456:/Library/Frameworks",
+            "DYLD_FRAMEWORK_PATH_ORIG": "/Library/Frameworks",
+        }
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["DYLD_FRAMEWORK_PATH"] == "/Library/Frameworks"
+        assert "DYLD_FRAMEWORK_PATH_ORIG" not in result
+
+    def test_dyld_framework_path_survives_untouched_when_no_orig(self, monkeypatch):
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {"DYLD_FRAMEWORK_PATH": "/Library/Frameworks"}
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result["DYLD_FRAMEWORK_PATH"] == "/Library/Frameworks"
+
+    def test_all_three_orig_markers_never_survive_regardless_of_restore_outcome(self, monkeypatch):
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {
+            "LD_LIBRARY_PATH": "/tmp/_MEI/a",
+            "LD_LIBRARY_PATH_ORIG": "/a",
+            "DYLD_LIBRARY_PATH": "/tmp/_MEI/b",
+            "DYLD_LIBRARY_PATH_ORIG": "/b",
+            "DYLD_FRAMEWORK_PATH": "/tmp/_MEI/c",
+            "DYLD_FRAMEWORK_PATH_ORIG": "/c",
+        }
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result == {
+            "LD_LIBRARY_PATH": "/a",
+            "DYLD_LIBRARY_PATH": "/b",
+            "DYLD_FRAMEWORK_PATH": "/c",
+        }
+
+    def test_does_not_mutate_the_original_dict(self, monkeypatch):
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {"LD_LIBRARY_PATH": "/tmp/_MEI/a", "DYLD_LIBRARY_PATH_ORIG": "/b"}
+
+        self_update.sanitize_frozen_relaunch_env(env)
+
+        assert env == {"LD_LIBRARY_PATH": "/tmp/_MEI/a", "DYLD_LIBRARY_PATH_ORIG": "/b"}
+
+    def test_combined_with_pyinstaller_handoff_vars_in_one_call(self, monkeypatch):
+        """Realistic end-to-end shape: a real inherited frozen-process
+        environment carries both classes of hazard (_MEIPASS2/_PYI_*
+        AND a mutated LD_LIBRARY_PATH) at once - both must be resolved
+        correctly in the same call."""
+        monkeypatch.setattr(self_update, "_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM", True)
+        env = {
+            "PATH": "/usr/bin",
+            "_MEIPASS2": "/tmp/_MEI123456",
+            "_PYI_ARCHIVE_FILE": "/opt/curatarr/curatarr",
+            "LD_LIBRARY_PATH": "/tmp/_MEI123456",
+        }
+
+        result = self_update.sanitize_frozen_relaunch_env(env)
+
+        assert result == {"PATH": "/usr/bin"}
+
+
 # =============================================================================
 # Orchestration
 # =============================================================================

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.59"
+__version__ = "2.10.60"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/self_update.py
+++ b/utils/self_update.py
@@ -959,17 +959,138 @@ def swap_binary(current_path: str, new_binary_path: str) -> None:
 _PYINSTALLER_CHILD_ENV_VAR_PREFIXES = ("_PYI_", "_PYINSTALLER_")
 _PYINSTALLER_CHILD_ENV_VARS_TO_STRIP = ("_MEIPASS2",)
 
+# Dynamic-loader search-path variables PyInstaller's onefile bootloader
+# is known to mutate - a second, DIFFERENT class of hand-off hazard
+# from _MEIPASS2/_PYI_*/_PYINSTALLER_* above, closed separately here:
+# a onefile parent prepends its own extraction directory onto one of
+# these so bundled shared libraries can be found, and a relaunched
+# CHILD that blindly inherits it can end up resolving dynamic libraries
+# against the PARENT build's (possibly different-version, possibly
+# already-torn-down) extraction directory instead of its own.
+#
+# Verified directly against PyInstaller 6.21.0's own bootloader source
+# (the exact version this repo's build-requirements.lock pins - both
+# the compiled bootloader binaries this project's own release CI
+# actually ships, and the upstream C source, were inspected; not
+# assumed from documentation or general recollection):
+#   - bootloader/src/pyi_utils_posix.c's pyi_utils_set_library_search_path()
+#     - called from bootloader/src/pyi_main.c's onefile-parent-process
+#     branch, specifically the `#else /* Other POSIX OSes */` case
+#     (i.e. Linux; AIX uses an analogous LIBPATH/LIBPATH_ORIG pair, not
+#     used here - no AIX builds) - PREPENDS the extraction directory
+#     onto LD_LIBRARY_PATH, and FIRST saves whatever value already
+#     existed there under LD_LIBRARY_PATH_ORIG, specifically so it can
+#     be restored later. Confirmed this runs on every normal (no splash
+#     screen, which curatarr's build never uses) onefile launch - not a
+#     conditional/rare code path.
+#   - The SAME pyi_main.c's `#elif defined(__APPLE__)` branch is a
+#     single comment: "No changes to library search path are required
+#     on macOS, because we rewrite the library paths on collected
+#     binaries [i.e. baked-in RPATH, not an env var]." Confirmed
+#     empirically too: the actual compiled Darwin-64bit bootloader
+#     binaries (run/run_d/runw/runw_d) contain no DYLD_LIBRARY_PATH,
+#     DYLD_FRAMEWORK_PATH, or `_ORIG` strings at all, unlike the Linux
+#     bootloader binary, which contains both `LD_LIBRARY_PATH` and
+#     `LD_LIBRARY_PATH_ORIG` verbatim. The only DYLD_LIBRARY_PATH/
+#     DYLD_FRAMEWORK_PATH-touching code anywhere in PyInstaller
+#     (PyInstaller/fake-modules/_pyi_rth_utils's
+#     prepend_path_to_environment_variable) is wired up ONLY by the
+#     PySide6/PyQt6 runtime hooks, which curatarr's build never
+#     triggers (no Qt binding in requirements.txt/curatarr.spec) - and
+#     even that function only ever prepends, it never saves an `_ORIG`
+#     backup at all, so it isn't this convention regardless.
+#
+# Net effect - NOT symmetric across platforms/variables, deliberately:
+#   - LD_LIBRARY_PATH IS confirmed to be unconditionally set by
+#     curatarr's own Linux bootloader on every launch - so on Linux,
+#     "present with no _ORIG" can ONLY mean "the bootloader set this
+#     fresh because nothing was there before it ran" (PyInstaller's own
+#     code only skips writing `_ORIG` in exactly that case), never a
+#     genuine pre-existing user value - safe to strip outright.
+#   - DYLD_LIBRARY_PATH/DYLD_FRAMEWORK_PATH (macOS) and LD_LIBRARY_PATH
+#     itself on any non-Linux platform (macOS; Windows, where PyInstaller
+#     uses SetDllDirectoryW instead, never an env var) are NOT
+#     confirmed to be touched by this build's bootloader at all - "no
+#     _ORIG" there is genuinely ambiguous (could easily be a value with
+#     nothing to do with PyInstaller) and must never be unconditionally
+#     stripped, per this same function's own no-blind-delete rule.
+#     `_ORIG`-restore is still honored everywhere as harmless,
+#     future-proofing insurance (a later PyInstaller version, or a
+#     future Qt dependency, could start doing this on macOS too - if it
+#     ever does and saves an `_ORIG`, this already handles it
+#     correctly), it just never triggers an unconditional strip.
+_DYNAMIC_LOADER_PATH_VARS = ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH")
+
+# The one (var, platform) combination confirmed above where PyInstaller's
+# own bootloader unconditionally sets the variable on every launch -
+# see _DYNAMIC_LOADER_PATH_VARS' own comment for why this is the only
+# case safe to strip outright when no `_ORIG` backup is present.
+_BOOTLOADER_ALWAYS_SETS_VAR = "LD_LIBRARY_PATH"
+_BOOTLOADER_ALWAYS_SETS_ON_PLATFORM = sys.platform.startswith("linux")
+
 
 def sanitize_frozen_relaunch_env(env: Mapping[str, str]) -> Dict[str, str]:
     """Returns a copy of `env` with PyInstaller onefile's internal
     bootloader hand-off variables removed - see the module-level
     comment above. Safe to call on a non-frozen/non-Windows env too
-    (no-op if the vars aren't present)."""
-    return {
+    (no-op if the vars aren't present).
+
+    Also resolves each of _DYNAMIC_LOADER_PATH_VARS (see that
+    constant's own comment for the verified, per-platform PyInstaller
+    behavior this follows) using PyInstaller's own `<VAR>_ORIG`
+    convention:
+      - `<VAR>_ORIG` present: that's the value which existed BEFORE
+        this process's own bootloader (or an ancestor's) ever touched
+        `<VAR>` - restore it as `<VAR>`'s real value and drop
+        `<VAR>_ORIG` itself (meaningless to a fresh child; carrying it
+        forward would just let it get "restored" again, redundantly,
+        by whatever next inherits this same env).
+      - `<VAR>_ORIG` absent AND this is _BOOTLOADER_ALWAYS_SETS_VAR on
+        _BOOTLOADER_ALWAYS_SETS_ON_PLATFORM (i.e. LD_LIBRARY_PATH on
+        Linux): `<VAR>` (if present at all) can only be something the
+        bootloader injected fresh with nothing legitimate underneath it
+        to preserve (PyInstaller's own code only skips writing
+        `<VAR>_ORIG` when `<VAR>` was unset beforehand) - remove it
+        outright.
+      - `<VAR>_ORIG` absent, anywhere else: leave `<VAR>` exactly as
+        found. There is no confirmed PyInstaller mechanism that sets it
+        on this platform, so it can just as easily be a value a user
+        genuinely set for reasons having nothing to do with PyInstaller
+        - removing it here would be exactly the "blindly delete a
+        legitimate user setting" bug this whole function exists to
+        avoid, not a fix for anything.
+
+    This `_ORIG` check (and the platform gate above) is why this whole
+    resolution can only safely happen HERE - reading the frozen
+    process's own freshly-inherited os.environ, before anything
+    downstream (e.g. the relaunch hand-off shell scripts in
+    utils/self_update_handoff.py) has already consumed or stripped that
+    marker. Once `<VAR>_ORIG` has been resolved away by this function,
+    there is no way for anything further downstream to redo this same
+    restore-or-remove decision correctly - which is exactly why the
+    hand-off scripts' own belt-and-suspenders re-stripping (see their
+    own comments) deliberately covers only the unconditionally-safe-to-
+    repeat _MEIPASS2/_PYI_*/_PYINSTALLER_* names above, never these.
+    """
+    result = {
         k: v
         for k, v in env.items()
         if k not in _PYINSTALLER_CHILD_ENV_VARS_TO_STRIP and not k.startswith(_PYINSTALLER_CHILD_ENV_VAR_PREFIXES)
     }
+
+    for var in _DYNAMIC_LOADER_PATH_VARS:
+        orig_key = f"{var}_ORIG"
+        if orig_key in result:
+            result[var] = result[orig_key]
+            del result[orig_key]
+        elif var == _BOOTLOADER_ALWAYS_SETS_VAR and _BOOTLOADER_ALWAYS_SETS_ON_PLATFORM:
+            result.pop(var, None)
+        # else: no `_ORIG` to restore from, and this (var, platform)
+        # combination isn't a confirmed PyInstaller mutation - leave it
+        # untouched rather than risk clobbering a genuine, unrelated
+        # user setting.
+
+    return result
 
 
 # =============================================================================

--- a/utils/self_update_handoff.py
+++ b/utils/self_update_handoff.py
@@ -153,6 +153,23 @@ function Start-CuratarrDetached {{
     # sanitize_frozen_relaunch_env already strips these from this
     # script's OWN environment before it's launched - this is
     # deliberate belt-and-suspenders at the actual final launch point.
+    #
+    # Deliberately does NOT also re-handle LD_LIBRARY_PATH/
+    # DYLD_LIBRARY_PATH/DYLD_FRAMEWORK_PATH here (sanitize_frozen_
+    # relaunch_env DOES resolve those, using PyInstaller's own
+    # `<VAR>_ORIG` save/restore convention - see that function's
+    # docstring for the verified PyInstaller source reference): that
+    # resolution can only be done correctly ONCE, against the frozen
+    # worker's own freshly-inherited environment, where a genuine
+    # `<VAR>_ORIG` marker (if any) is still visible. By the time this
+    # script's own environment is inspected here, sanitize_frozen_
+    # relaunch_env has already consumed/resolved that marker - blindly
+    # re-stripping LD_LIBRARY_PATH etc. at this point, the way _PYI_*/
+    # _MEIPASS2 are unconditionally re-stripped above, would instead
+    # clobber a value that function may have just correctly RESTORED
+    # (e.g. a user's own pre-existing LD_LIBRARY_PATH), which is exactly
+    # the "never blindly delete a user's real setting" bug this whole
+    # mechanism exists to avoid.
     $staleKeys = @($psi.EnvironmentVariables.Keys) | Where-Object {{ $_ -eq '_MEIPASS2' -or $_ -like '_PYI_*' -or $_ -like '_PYINSTALLER_*' }}
     foreach ($key in $staleKeys) {{
         $psi.EnvironmentVariables.Remove($key) | Out-Null
@@ -300,6 +317,19 @@ launch_detached() {{
     # deliberate belt-and-suspenders at the actual final launch point.
     # Built dynamically (not a fixed list) since PyInstaller can add
     # more _PYI_*/_PYINSTALLER_* variables across versions.
+    #
+    # Deliberately does NOT also re-handle LD_LIBRARY_PATH/
+    # DYLD_LIBRARY_PATH/DYLD_FRAMEWORK_PATH here - see this same
+    # comment in _windows_script_content's Start-CuratarrDetached for
+    # why: sanitize_frozen_relaunch_env already resolves those against
+    # the frozen worker's own environment using PyInstaller's own
+    # `<VAR>_ORIG` save/restore convention, and that decision can only
+    # be made correctly ONCE, before this script's own (already
+    # resolved) environment is all that's left to inspect. Redoing it
+    # here with a blind unconditional unset (the way _PYI_*/_MEIPASS2
+    # are unconditionally re-stripped above) risks clobbering a value
+    # that function just correctly RESTORED for a user who genuinely
+    # set e.g. LD_LIBRARY_PATH themselves.
     unset_args=""
     for v in $(env | awk -F= '/^_PYI_/{{print $1}} /^_PYINSTALLER_/{{print $1}} /^_MEIPASS2=/{{print $1}}'); do
         unset_args="$unset_args -u $v"


### PR DESCRIPTION
## Summary
- `sanitize_frozen_relaunch_env` (utils/self_update.py) only ever stripped `_MEIPASS2`/`_PYI_*`/`_PYINSTALLER_*` - never `LD_LIBRARY_PATH`, the classic PyInstaller onefile hazard where a parent's own extraction-directory-pointing loader path leaks into a relaunched child.
- Verified directly against PyInstaller 6.21.0's own bootloader source (both the compiled binaries this repo's release CI ships, and the upstream C source) rather than assumed: Linux's onefile bootloader unconditionally prepends its extraction dir onto `LD_LIBRARY_PATH` on every launch, saving any pre-existing value under `LD_LIBRARY_PATH_ORIG` first. macOS's bootloader does **not** touch `DYLD_LIBRARY_PATH`/`DYLD_FRAMEWORK_PATH` at all - confirmed both in PyInstaller's own source comment and empirically (no such strings in the compiled Darwin bootloader binaries).
- `sanitize_frozen_relaunch_env` now resolves all three variables using PyInstaller's own `<VAR>_ORIG` convention: restore-and-drop-marker when present; remove outright when absent **only** for `LD_LIBRARY_PATH` on Linux (the one confirmed-always-bootloader-injected case) - everywhere else, a value with no `_ORIG` is left untouched to avoid clobbering a genuine user setting.
- All three real relaunch/subprocess call sites (worker spawn, post-swap `--version` readback, external hand-off script launch) already route through this one function - no additional call site needed rewiring.
- Did **not** attempt to reproduce the original SIGSEGV (v2.10.57 release verification) - unreproducible in 10/10 reruns, not the point of this change.

## Verification
- [x] Verified PyInstaller's actual `_ORIG` convention from primary source (bootloader C source + compiled binaries), not assumed.
- [x] Unit tests cover: removed when no `_ORIG` (Linux), restored when `_ORIG` present, a user-set value with no PyInstaller involvement survives untouched, and the macOS variables.
- [x] End-to-end: built a real Linux onefile binary matching this repo's own release CI exactly, captured a live running instance's actual bootloader-injected environment in two scenarios (no pre-existing `LD_LIBRARY_PATH`; a genuine pre-existing one), and confirmed the real `sanitize_frozen_relaunch_env` strips the former and correctly restores the latter to the original value.
- [ ] NOT verified: the full real self-update download/verify/swap/relaunch flow against a live GitHub release (needs a real published release to update to/from - out of scope for local verification). The macOS side of this fix is confirmed correct by source inspection and unit tests but precautionary in practice - PyInstaller doesn't mutate these vars for a Qt-less build like curatarr's.
- [x] Full suite (2769 passed, 1 skipped), ruff, mypy all green.