### PR TITLE
test: #273 profile-builder harness pinning current 4-builder behavior (2.10.61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to Curatarr will be documented in this file.
 
-## [2.10.60] - 2026-07-27
+## [2.10.61] - 2026-07-27
+
+### Added
+
+- **Profile-builder harness (#273 PR0) - hard gate before any of #273's production-code fixes.** Issue #273 found FOUR divergent user-profile builders - recommenders/movie.py's `_get_plex_watched_data()`, recommenders/tv.py's `_get_plex_watched_shows_data()`, recommenders/base.py's `_get_managed_users_watched_data()`, and recommenders/external.py's `build_user_profile()`/`load_user_profile_from_cache()` - three with verified production bugs. None of that sequence's downstream PRs are verifiable without a harness that can actually catch those bugs first.
+
+  `tests/e2e_plex_fixture.py`'s existing catalog **could not** catch any of them as shipped: it emits watch-history XML with no `userRating` (faithfully reproducing the real Plex `/status/sessions/history/all` endpoint, which never carries it either), and its `FakeMediaItem` had no `userRating` attribute at all, no per-user `viewCount` variation, and no `switchUser()`/per-user-token support. Extended it with `MOVIE_PER_USER_LIBRARY_STATE`/`SHOW_PER_USER_LIBRARY_STATE` (two users, alice and bob, with genuinely different nonzero `view_count`/`user_rating` values on items they've each actually watched), `FakePlexServer.switchUser()`, `FakeMyPlexAccount.user()`, `build_fake_plex_server_for_user()`, and `FakeSection.search(unwatched=...)` support (for `base.py`'s managed-users path) - without this, a harness built on the fixture as it shipped would have pinned the bugs as correct behavior, not caught them.
+
+  `tests/harness.py` (previously scoring-only) gained `run_profile_builders()`, driving all four builders directly against that extended fixture and snapshotting every counter key, magnitude (as `float.hex()` - exact bit pattern, same non-associativity reasoning the existing scoring harness already uses), sign, and populated-vs-empty dimension into a committed golden fixture (`tests/fixtures/profile_builder_harness/profile_builder_snapshot.json`, written via `python -m tests.harness --profile-builders --write`). `tests/test_profile_builder_harness.py` pins the live snapshot against that golden fixture, and separately proves the harness can tell buggy from fixed behavior (not just freeze whatever it happens to see today) with four direct assertions on the verified bugs:
+  - Movie ratings are never negative today (Plex history never carries `userRating`, and `movie.py` only reads it off history items).
+  - Both `movie.py`'s and `tv.py`'s own per-user builders show zero rewatch/rating signal for either fixture user today, despite the fixture giving them genuinely different watch state - both read that state through the one shared ADMIN-token library snapshot, not their own.
+  - `base.py`'s managed-users builder weights every watched item exactly 1.0 (no `weight` argument reaches `process_counters_from_cache()` at all).
+  - `external.py`'s `build_user_profile()` produces byte-identical output for two different usernames - the username parameter has zero effect on what gets scanned.
+
+  A future #273 PR that intentionally changes one of the four builders regenerates the golden fixture and explains the diff in that PR's description, per the same convention `tests/golden_external_harness.py` already established for `recommenders/external_render.py`. No production code changed in this PR - tests and fixtures only.
 
 ### Fixed
 

--- a/tests/e2e_plex_fixture.py
+++ b/tests/e2e_plex_fixture.py
@@ -35,6 +35,8 @@ full rationale):
 from typing import Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 
+from plexapi.exceptions import NotFound
+
 from utils.config import CACHE_VERSION
 
 # ---------------------------------------------------------------------------
@@ -302,6 +304,42 @@ MOVIE_ROMANCE_IDS = {"119", "120"}
 
 
 # ---------------------------------------------------------------------------
+# Per-user library state (#273) - viewCount/userRating are PER-ACCOUNT Plex
+# state: the admin's own token can only ever see the admin's own values for
+# these two attributes on a library item, never another user's (see
+# recommenders/base.py's _get_all_library_items_for_user and this repo's
+# CHANGELOG for the verified real-library finding this fixture reproduces).
+# alice and bob below get DELIBERATELY DIFFERENT, nonzero values on movies
+# they've each actually watched (see MOVIE_WATCHED_BY above) - a builder
+# that reads this state through the wrong (shared admin-token) connection
+# can never tell them apart (build_fake_plex_server() below always reports
+# 0/None for every item, admin included); one that switches to each user's
+# OWN connection first (build_fake_plex_server_for_user() below) can.
+# ---------------------------------------------------------------------------
+MOVIE_PER_USER_LIBRARY_STATE: Dict[str, Dict[int, Dict]] = {
+    "alice": {
+        101: {"view_count": 3, "user_rating": 9.0},  # loved it, rewatched
+        102: {"view_count": 1, "user_rating": 2.0},  # hated it - negative signal once sourced correctly
+        # Remaining alice-watched movies (see MOVIE_WATCHED_BY) get a plain
+        # baseline view_count=1/no rating - just enough for
+        # FakeSection.search(unwatched=False) (the managed-users path) to
+        # correctly report them as watched, without the 101/102 overrides'
+        # differentiated signal.
+        103: {"view_count": 1, "user_rating": None},
+        104: {"view_count": 1, "user_rating": None},
+        105: {"view_count": 1, "user_rating": None},
+        106: {"view_count": 1, "user_rating": None},
+    },
+    "bob": {
+        107: {"view_count": 2, "user_rating": 8.0},
+        108: {"view_count": 1, "user_rating": None},
+        109: {"view_count": 1, "user_rating": None},
+        110: {"view_count": 1, "user_rating": None},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
 # TV catalog
 # ---------------------------------------------------------------------------
 def _s(rating_key, title, year, genres, studio, cast, keywords) -> Dict:
@@ -421,6 +459,20 @@ SHOW_WATCHED_BY = {
 
 SHOW_HORROR_IDS = {"208", "209", "210"}
 
+SHOW_PER_USER_LIBRARY_STATE: Dict[str, Dict[int, Dict]] = {
+    "alice": {
+        201: {"view_count": 2, "user_rating": 10.0},
+        202: {"view_count": 1, "user_rating": 1.0},  # hated it
+        203: {"view_count": 1, "user_rating": None},
+        204: {"view_count": 1, "user_rating": None},
+    },
+    "bob": {
+        205: {"view_count": 3, "user_rating": 7.0},
+        206: {"view_count": 1, "user_rating": None},
+        207: {"view_count": 1, "user_rating": None},
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Pre-seeded media caches - see module docstring for why this replaces the
@@ -455,26 +507,49 @@ class FakeGuid:
 
 
 class FakeMediaItem:
-    """Minimal duck-typed stand-in for a plexapi Movie/Show object.
+    """Duck-typed stand-in for a plexapi Movie/Show object.
 
-    Only carries the attributes the real (unmocked) code paths this test
-    exercises actually touch: BaseCache.update_cache()'s item-identity
-    bookkeeping (ratingKey only, since the cache is pre-seeded and
-    up-to-date - see module docstring), _get_library_movies_set()/
-    _get_library_shows_set()/_get_library_imdb_ids() (ratingKey/title/year/
-    guids), and the optional viewCount/userRating watched-item bookkeeping
-    in recommenders/movie.py's/tv.py's own watched-data builders. Deliberately
-    has no .genres/.directors/.roles/.media - those only matter to
-    BaseCache._process_item(), which never runs here (see module docstring).
+    Originally minimal (ratingKey/title/year/guids/viewCount only - see
+    git history), extended for #273's profile-builder harness
+    (tests/harness.py's run_profile_builders()) to also carry a settable
+    userRating (not just a hardcoded None) plus the handful of extra
+    attributes recommenders/external.py's build_user_profile() reads
+    directly off a library item (isWatched, genres/directors/roles as
+    empty-by-default lists, lastViewedAt, audienceRating) - that
+    function is the one #273 builder that reads a RICHER item shape
+    than the other three, since it (still) does its own from-scratch
+    Plex scan rather than going through the pre-seeded movie/show cache
+    the other three consume via self._get_media_cache().
+    BaseCache._process_item() itself still never runs here (the cache
+    stays pre-seeded/up-to-date - see module docstring), so
+    genres/directors/roles default to empty rather than modeling this
+    fixture's real catalog data.
     """
 
-    def __init__(self, rating_key: str, title: str, year: Optional[int], view_count: int = 0):
+    def __init__(
+        self,
+        rating_key: str,
+        title: str,
+        year: Optional[int],
+        view_count: int = 0,
+        user_rating: Optional[float] = None,
+    ):
         self.ratingKey = int(rating_key)
         self.title = title
         self.year = year
-        self.guids = [FakeGuid(f"imdb://tt{rating_key}")]
+        self.guids = [FakeGuid(f"imdb://tt{rating_key}"), FakeGuid(f"tmdb://{rating_key}")]
         self.viewCount = view_count
-        self.userRating = None
+        self.userRating = user_rating
+        # Real plexapi computes isWatched from viewCount>0 server-side;
+        # mirrored here (rather than hardcoded True/False) so a fixture
+        # item with a nonzero view_count (per-user overrides below) is
+        # correctly "watched" for build_user_profile()'s own isWatched gate.
+        self.isWatched = view_count > 0
+        self.lastViewedAt = None
+        self.audienceRating = None
+        self.genres: list = []
+        self.directors: list = []
+        self.roles: list = []
 
     def reload(self):
         """No-op - real code only calls this on items about to be
@@ -491,6 +566,15 @@ class FakeSection:
         return list(self._items)
 
     def search(self, **kwargs):
+        # #273: recommenders/base.py's _get_managed_users_watched_data()
+        # calls section.search(unwatched=False) to fetch a (switchUser-
+        # scoped) user's own watched items - a real, legitimate caller,
+        # not the label/collection-writing stage the AssertionError below
+        # guards against. Narrow, exact-kwarg-shape check so any OTHER
+        # (unexpected) search() call still raises as before.
+        if set(kwargs.keys()) == {"unwatched"}:
+            want_unwatched = kwargs["unwatched"]
+            return [item for item in self._items if (item.viewCount > 0) != want_unwatched]
         raise AssertionError(
             "FakeSection.search() was called - the label/collection-writing stage "
             "must stay mocked in this test (patch PlexMovieRecommender/"
@@ -509,11 +593,34 @@ class FakeLibrary:
 class FakePlexServer:
     def __init__(self, sections: Dict[str, FakeSection]):
         self.library = FakeLibrary(sections)
+        # #273: machineIdentifier is what real plexapi's switchUser()
+        # passes to MyPlexUser.get_token() - not used by this fake's own
+        # switchUser() below (which skips the token/HTTP hop entirely and
+        # returns a per-user server directly), but set for parity with
+        # the real attribute in case future code reads it directly.
+        self.machineIdentifier = "fake-machine-id"
+        # None = this server represents the shared admin-token view
+        # (build_fake_plex_server()); set to a username by
+        # build_fake_plex_server_for_user() / switchUser() below.
+        self.current_user: Optional[str] = None
 
     def fetchItem(self, rating_key):
         raise AssertionError(
             "FakePlexServer.fetchItem() was called - the label/collection-writing stage must stay mocked in this test."
         )
+
+    def switchUser(self, user):
+        """Duck-typed stand-in for plexapi.server.PlexServer.switchUser()
+        (#273): real plexapi resolves `user.get_token(machineIdentifier)`
+        then reconnects with that token; this fake skips the token/HTTP
+        round trip and returns a fully independent per-user server
+        directly (see build_fake_plex_server_for_user) - same end result
+        (a PlexServer scoped to that user's own account state), narrower
+        fake. Keyed off the user's own `.title` (mirrors
+        FakeMyPlexAccount.user()'s title-keyed lookup below).
+        """
+        username = getattr(user, "title", str(user))
+        return build_fake_plex_server_for_user(username)
 
 
 def build_fake_plex_server() -> FakePlexServer:
@@ -526,6 +633,46 @@ def build_fake_plex_server() -> FakePlexServer:
     return FakePlexServer(sections)
 
 
+def build_fake_plex_server_for_user(username: str) -> FakePlexServer:
+    """A second, independent FakePlexServer scoped to `username`'s own
+    Plex account (#273) - what FakePlexServer.switchUser() above returns,
+    modeling what a builder correctly using that user's own connection
+    (instead of the shared admin-token build_fake_plex_server() above)
+    would see: MOVIE_PER_USER_LIBRARY_STATE/SHOW_PER_USER_LIBRARY_STATE's
+    view_count/user_rating overrides instead of the admin-view defaults
+    (0/None) every item gets otherwise.
+    """
+    movie_overrides = MOVIE_PER_USER_LIBRARY_STATE.get(username, {})
+    show_overrides = SHOW_PER_USER_LIBRARY_STATE.get(username, {})
+    movies = [
+        FakeMediaItem(
+            m["rating_key"],
+            m["title"],
+            m["year"],
+            view_count=movie_overrides.get(int(m["rating_key"]), {}).get("view_count", 0),
+            user_rating=movie_overrides.get(int(m["rating_key"]), {}).get("user_rating"),
+        )
+        for m in MOVIE_CATALOG
+    ]
+    shows = [
+        FakeMediaItem(
+            s["rating_key"],
+            s["title"],
+            s["year"],
+            view_count=show_overrides.get(int(s["rating_key"]), {}).get("view_count", 0),
+            user_rating=show_overrides.get(int(s["rating_key"]), {}).get("user_rating"),
+        )
+        for s in SHOW_CATALOG
+    ]
+    sections = {
+        "Movies": FakeSection("1", movies),
+        "TV Shows": FakeSection("2", shows),
+    }
+    server = FakePlexServer(sections)
+    server.current_user = username
+    return server
+
+
 class FakeUser:
     def __init__(self, title: str, user_id: int):
         self.title = title
@@ -536,7 +683,10 @@ class FakeMyPlexAccount:
     """Stand-in for plexapi.myplex.MyPlexAccount - only the surface
     utils/plex.py's get_configured_users()/_resolve_myplex_account_ids()/
     fetch_plex_watch_history_movies() actually call (.username, .id,
-    .users())."""
+    .users()), plus .user() (#273: recommenders/base.py's
+    _get_managed_users_watched_data() and the new
+    _get_all_library_items_for_user() both call account.user(username)
+    to resolve a MyPlexUser before switchUser())."""
 
     def __init__(self, token: Optional[str] = None):
         self.token = token
@@ -545,6 +695,17 @@ class FakeMyPlexAccount:
 
     def users(self):
         return [FakeUser(name, int(account_id)) for name, account_id in ACCOUNT_IDS.items()]
+
+    def user(self, username: str) -> FakeUser:
+        """Mirrors plexapi.myplex.MyPlexAccount.user()'s title-keyed
+        lookup (case-insensitive) and its NotFound-on-miss contract, so
+        callers' existing `except plexapi.exceptions.PlexApiException`
+        handling is exercised for real on a miss, not just the happy
+        path."""
+        for name, account_id in ACCOUNT_IDS.items():
+            if name.lower() == str(username).lower():
+                return FakeUser(name, int(account_id))
+        raise NotFound(f"Unable to find user {username}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
+++ b/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
@@ -1,0 +1,394 @@
+{
+  "external_build_user_profile_movie_alice": {
+    "actors": {},
+    "directors": {},
+    "genres": {},
+    "keywords": {},
+    "languages": {},
+    "studios": {},
+    "tmdb_ids": []
+  },
+  "external_build_user_profile_movie_bob": {
+    "actors": {},
+    "directors": {},
+    "genres": {},
+    "keywords": {},
+    "languages": {},
+    "studios": {},
+    "tmdb_ids": []
+  },
+  "external_load_cache_movie_alice": {
+    "actors": {
+      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
+      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
+    },
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.eb851eb851eb8p-5",
+      "Priya Anand": "0x1.eb851eb851eb8p-5",
+      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+    },
+    "genres": {
+      "action": "0x1.eb851eb851eb8p-3",
+      "sci-fi": "0x1.70a3d70a3d70ap-3"
+    },
+    "keywords": {
+      "heist": "0x1.eb851eb851eb8p-4",
+      "revenge": "0x1.eb851eb851eb8p-5",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "space-station": "0x1.70a3d70a3d70ap-3",
+      "survival": "0x1.eb851eb851eb8p-4",
+      "time-travel": "0x1.eb851eb851eb8p-5",
+      "undercover": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.70a3d70a3d70ap-2"
+    },
+    "studios": {},
+    "tmdb_ids": [
+      "101",
+      "102",
+      "103",
+      "104",
+      "105",
+      "106"
+    ]
+  },
+  "external_load_cache_movie_bob": {
+    "actors": {
+      "Alex Monroe": "0x1.eb851eb851eb8p-5",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-5",
+      "Jordan Vance": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+    },
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-5",
+      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Priya Anand": "0x1.eb851eb851eb8p-5"
+    },
+    "genres": {
+      "comedy": "0x1.70a3d70a3d70ap-3",
+      "romance": "0x1.eb851eb851eb8p-4"
+    },
+    "keywords": {
+      "coming-of-age": "0x1.eb851eb851eb8p-4",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "wedding": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.eb851eb851eb8p-3"
+    },
+    "studios": {},
+    "tmdb_ids": [
+      "107",
+      "108",
+      "109",
+      "110"
+    ]
+  },
+  "external_load_cache_tv_alice": {
+    "actors": {
+      "Derek Cho": "0x1.eb851eb851eb8p-4",
+      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Lucas Wren": "0x1.eb851eb851eb8p-5",
+      "Mira Solano": "0x1.eb851eb851eb8p-4",
+      "Nadia Okafor": "0x1.eb851eb851eb8p-5",
+      "Theo Baptiste": "0x1.eb851eb851eb8p-5"
+    },
+    "directors": {},
+    "genres": {
+      "crime": "0x1.eb851eb851eb8p-4",
+      "sci-fi": "0x1.eb851eb851eb8p-4"
+    },
+    "keywords": {
+      "exploration": "0x1.eb851eb851eb8p-4",
+      "first-contact": "0x1.eb851eb851eb8p-5",
+      "heist": "0x1.eb851eb851eb8p-5",
+      "investigation": "0x1.eb851eb851eb8p-4",
+      "noir": "0x1.eb851eb851eb8p-5",
+      "survival": "0x1.eb851eb851eb8p-5"
+    },
+    "languages": {
+      "english": "0x1.eb851eb851eb8p-3"
+    },
+    "studios": {
+      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "ferrous pictures": "0x1.eb851eb851eb8p-5",
+      "northgate studios": "0x1.eb851eb851eb8p-4"
+    },
+    "tmdb_ids": [
+      "201",
+      "202",
+      "203",
+      "204"
+    ]
+  },
+  "external_load_cache_tv_bob": {
+    "actors": {
+      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Lucas Wren": "0x1.eb851eb851eb8p-5",
+      "Mira Solano": "0x1.eb851eb851eb8p-5",
+      "Nadia Okafor": "0x1.eb851eb851eb8p-5",
+      "Theo Baptiste": "0x1.eb851eb851eb8p-4"
+    },
+    "directors": {},
+    "genres": {
+      "comedy": "0x1.70a3d70a3d70ap-3"
+    },
+    "keywords": {
+      "roommates": "0x1.eb851eb851eb8p-4",
+      "workplace": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.70a3d70a3d70ap-3"
+    },
+    "studios": {
+      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "lumen works": "0x1.eb851eb851eb8p-4"
+    },
+    "tmdb_ids": [
+      "205",
+      "206",
+      "207"
+    ]
+  },
+  "movie_managed_users": {
+    "actors": {
+      "Alex Monroe": "0x1.0000000000000p+2",
+      "Casey Rhodes": "0x1.8000000000000p+1",
+      "Jordan Vance": "0x1.0000000000000p+2",
+      "Robin Alvarez": "0x1.8000000000000p+1",
+      "Sam Kestrel": "0x1.0000000000000p+2",
+      "Taylor Nguyen": "0x1.8000000000000p+1"
+    },
+    "collections": {},
+    "directors": {
+      "Marcus Webb": "0x1.8000000000000p+1",
+      "Nora Lin": "0x1.8000000000000p+1",
+      "Priya Anand": "0x1.0000000000000p+1",
+      "Ridley Stone": "0x1.0000000000000p+1"
+    },
+    "genres": {
+      "action": "0x1.0000000000000p+2",
+      "comedy": "0x1.8000000000000p+1",
+      "romance": "0x1.0000000000000p+1",
+      "sci-fi": "0x1.8000000000000p+1"
+    },
+    "languages": {
+      "english": "0x1.4000000000000p+3"
+    },
+    "tmdb_ids": [
+      "101",
+      "102",
+      "103",
+      "104",
+      "105",
+      "106",
+      "107",
+      "108",
+      "109",
+      "110"
+    ],
+    "tmdb_keywords": {
+      "coming-of-age": "0x1.0000000000000p+1",
+      "heist": "0x1.0000000000000p+1",
+      "revenge": "0x1.0000000000000p+0",
+      "road-trip": "0x1.0000000000000p+1",
+      "space-station": "0x1.8000000000000p+1",
+      "survival": "0x1.0000000000000p+1",
+      "time-travel": "0x1.0000000000000p+0",
+      "undercover": "0x1.0000000000000p+1",
+      "wedding": "0x1.0000000000000p+1"
+    }
+  },
+  "movie_plex_watched_alice": {
+    "actors": {
+      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
+      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
+    },
+    "collections": {},
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.eb851eb851eb8p-5",
+      "Priya Anand": "0x1.eb851eb851eb8p-5",
+      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+    },
+    "genres": {
+      "action": "0x1.eb851eb851eb8p-3",
+      "sci-fi": "0x1.70a3d70a3d70ap-3"
+    },
+    "languages": {
+      "english": "0x1.70a3d70a3d70ap-2"
+    },
+    "tmdb_ids": [
+      "101",
+      "102",
+      "103",
+      "104",
+      "105",
+      "106"
+    ],
+    "tmdb_keywords": {
+      "heist": "0x1.eb851eb851eb8p-4",
+      "revenge": "0x1.eb851eb851eb8p-5",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "space-station": "0x1.70a3d70a3d70ap-3",
+      "survival": "0x1.eb851eb851eb8p-4",
+      "time-travel": "0x1.eb851eb851eb8p-5",
+      "undercover": "0x1.eb851eb851eb8p-4"
+    }
+  },
+  "movie_plex_watched_bob": {
+    "actors": {
+      "Alex Monroe": "0x1.eb851eb851eb8p-5",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-5",
+      "Jordan Vance": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+    },
+    "collections": {},
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-5",
+      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Priya Anand": "0x1.eb851eb851eb8p-5"
+    },
+    "genres": {
+      "comedy": "0x1.70a3d70a3d70ap-3",
+      "romance": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.eb851eb851eb8p-3"
+    },
+    "tmdb_ids": [
+      "107",
+      "108",
+      "109",
+      "110"
+    ],
+    "tmdb_keywords": {
+      "coming-of-age": "0x1.eb851eb851eb8p-4",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "wedding": "0x1.eb851eb851eb8p-4"
+    }
+  },
+  "tv_managed_users": {
+    "actors": {
+      "Derek Cho": "0x1.0000000000000p+1",
+      "Elena Frost": "0x1.0000000000000p+1",
+      "Lucas Wren": "0x1.0000000000000p+1",
+      "Mira Solano": "0x1.8000000000000p+1",
+      "Nadia Okafor": "0x1.0000000000000p+1",
+      "Theo Baptiste": "0x1.8000000000000p+1"
+    },
+    "genres": {
+      "comedy": "0x1.8000000000000p+1",
+      "crime": "0x1.0000000000000p+1",
+      "sci-fi": "0x1.0000000000000p+1"
+    },
+    "languages": {
+      "english": "0x1.c000000000000p+2"
+    },
+    "studios": {
+      "bluecrest media": "0x1.0000000000000p+1",
+      "ferrous pictures": "0x1.0000000000000p+0",
+      "lumen works": "0x1.0000000000000p+1",
+      "northgate studios": "0x1.0000000000000p+1"
+    },
+    "tmdb_ids": [
+      "201",
+      "202",
+      "203",
+      "204",
+      "205",
+      "206",
+      "207"
+    ],
+    "tmdb_keywords": {
+      "exploration": "0x1.0000000000000p+1",
+      "first-contact": "0x1.0000000000000p+0",
+      "heist": "0x1.0000000000000p+0",
+      "investigation": "0x1.0000000000000p+1",
+      "noir": "0x1.0000000000000p+0",
+      "roommates": "0x1.0000000000000p+1",
+      "survival": "0x1.0000000000000p+0",
+      "workplace": "0x1.0000000000000p+1"
+    }
+  },
+  "tv_plex_watched_alice": {
+    "actors": {
+      "Derek Cho": "0x1.eb851eb851eb8p-4",
+      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Lucas Wren": "0x1.eb851eb851eb8p-5",
+      "Mira Solano": "0x1.eb851eb851eb8p-4",
+      "Nadia Okafor": "0x1.eb851eb851eb8p-5",
+      "Theo Baptiste": "0x1.eb851eb851eb8p-5"
+    },
+    "genres": {
+      "crime": "0x1.eb851eb851eb8p-4",
+      "sci-fi": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.eb851eb851eb8p-3"
+    },
+    "production_companies": {},
+    "studios": {
+      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "ferrous pictures": "0x1.eb851eb851eb8p-5",
+      "northgate studios": "0x1.eb851eb851eb8p-4"
+    },
+    "tmdb_ids": [
+      "201",
+      "202",
+      "203",
+      "204"
+    ],
+    "tmdb_keywords": {
+      "exploration": "0x1.eb851eb851eb8p-4",
+      "first-contact": "0x1.eb851eb851eb8p-5",
+      "heist": "0x1.eb851eb851eb8p-5",
+      "investigation": "0x1.eb851eb851eb8p-4",
+      "noir": "0x1.eb851eb851eb8p-5",
+      "survival": "0x1.eb851eb851eb8p-5"
+    }
+  },
+  "tv_plex_watched_bob": {
+    "actors": {
+      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Lucas Wren": "0x1.eb851eb851eb8p-5",
+      "Mira Solano": "0x1.eb851eb851eb8p-5",
+      "Nadia Okafor": "0x1.eb851eb851eb8p-5",
+      "Theo Baptiste": "0x1.eb851eb851eb8p-4"
+    },
+    "genres": {
+      "comedy": "0x1.70a3d70a3d70ap-3"
+    },
+    "languages": {
+      "english": "0x1.70a3d70a3d70ap-3"
+    },
+    "production_companies": {},
+    "studios": {
+      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "lumen works": "0x1.eb851eb851eb8p-4"
+    },
+    "tmdb_ids": [
+      "205",
+      "206",
+      "207"
+    ],
+    "tmdb_keywords": {
+      "roommates": "0x1.eb851eb851eb8p-4",
+      "workplace": "0x1.eb851eb851eb8p-4"
+    }
+  }
+}

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -36,6 +36,36 @@ the exact float non-associativity this harness's Task 4 use case is
 checking for) and the final tiered-selection title order. Two invocations
 with the same PYTHONHASHSEED and seed must be byte-identical; see
 tests/test_harness.py for the assertions this backs.
+
+---------------------------------------------------------------------------
+Profile-builder harness (#273) - run_profile_builders()
+---------------------------------------------------------------------------
+Issue #273 found FOUR divergent user-profile builders (recommenders/
+movie.py's _get_plex_watched_data, recommenders/tv.py's
+_get_plex_watched_shows_data, recommenders/base.py's
+_get_managed_users_watched_data, recommenders/external.py's
+build_user_profile/load_user_profile_from_cache), three with verified
+production bugs. This is the PR0 hard gate for that issue: nothing in
+that sequence is verifiable without a harness that can actually catch
+those bugs first - the existing tests/e2e_plex_fixture.py fixture alone
+CANNOT (it emits history XML with no userRating, faithfully reproducing
+the real Plex endpoint, and its FakeMediaItem had no userRating attribute
+at all before this same PR extended it - see that module's own updated
+docstrings).
+
+run_profile_builders() drives all four builders directly (not through
+run_recommender_main's CLI wrapper) against that extended fixture and
+returns a JSON-serializable snapshot dict, one key per builder call,
+capturing every counter key name, magnitude (as float.hex() - same
+non-associativity reasoning as Task 4 above), sign (negative-signal
+counters), and which dimensions are populated vs empty. `python -m
+tests.harness --profile-builders` prints that snapshot; `--write`
+(re)writes the committed golden fixture
+(tests/fixtures/profile_builder_harness/profile_builder_snapshot.json)
+that tests/test_profile_builder_harness.py pins the live snapshot
+against. A future #273 PR that intentionally changes one of the four
+builders' output regenerates this golden fixture and explains the diff
+in that PR's description - see that test module's own docstring.
 """
 
 import json
@@ -48,6 +78,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils.scoring import calculate_similarity_score, select_tiered_recommendations  # noqa: E402
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "scoring_harness")
+PROFILE_BUILDER_FIXTURES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures", "profile_builder_harness"
+)
+PROFILE_BUILDER_GOLDEN_FILENAME = "profile_builder_snapshot.json"
 
 # Arbitrary, pinned - not meaningful beyond "always the same value" so
 # repeated harness runs are comparable.
@@ -116,7 +150,232 @@ def run(seed: int = DEFAULT_SEED, limit: int = DEFAULT_LIMIT) -> dict:
     }
 
 
+def _counters_to_jsonable(counters: dict) -> dict:
+    """Convert a #273 builder's returned counters dict (Counter objects,
+    a plain int-keyed dict for tv.py's production_companies, and a
+    tmdb_ids set) into a deterministic, JSON-serializable snapshot.
+
+    Every value is reported as float.hex() (exact bit pattern - same
+    non-associativity reasoning as run()'s score_hex above) rather than a
+    rounded display value, sorted by str(key) so int-keyed and str-keyed
+    dicts both sort the same way, and sets become sorted lists.
+    """
+    out: dict = {}
+    for key, value in sorted(counters.items(), key=lambda kv: str(kv[0])):
+        if isinstance(value, set):
+            out[key] = sorted(str(v) for v in value)
+        elif isinstance(value, dict):
+            out[key] = {str(k): float(v).hex() for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+        else:
+            out[key] = value
+    return out
+
+
+def _write_profile_builder_project(root: str, *, managed_users: bool) -> str:
+    """Writes a real, on-disk config.yml + tuning.yml + pre-seeded caches
+    for a throwaway project root (mirrors tests/test_e2e_pipeline.py's
+    own _write_project_root helper), returning the config.yml path.
+
+    managed_users=False: users.list = "alice, bob" - drives movie.py's/
+    tv.py's OWN watched-data builders (_get_plex_watched_data /
+    _get_plex_watched_shows_data).
+    managed_users=True: plex.managed_users = "alice, bob" instead, no
+    users.list at all - drives recommenders/base.py's shared
+    _get_managed_users_watched_data() (the path taken when no
+    users.list is configured).
+    """
+    import yaml
+
+    os.makedirs(os.path.join(root, "config"), exist_ok=True)
+    os.makedirs(os.path.join(root, "cache"), exist_ok=True)
+    os.makedirs(os.path.join(root, "logs"), exist_ok=True)
+
+    config_yaml: dict = {
+        "plex": {"url": "http://127.0.0.1:32400", "token": "test-harness-token"},
+        "tmdb": {"api_key": None},
+        "general": {"update_mode": "off", "log_retention_days": 0, "cache_prune": {"enabled": False}},
+        "libraries": [
+            {"id": "movies", "name": "Movies", "section": "Movies", "media_type": "movie"},
+            {"id": "tv-shows", "name": "TV Shows", "section": "TV Shows", "media_type": "tv"},
+        ],
+    }
+    if managed_users:
+        config_yaml["plex"]["managed_users"] = "alice, bob"
+    else:
+        config_yaml["users"] = {"list": "alice, bob"}
+
+    tuning_yaml = {
+        "movies": {"quality_filters": {"min_rating": 0.0, "min_vote_count": 0}},
+        "tv": {"quality_filters": {"min_rating": 0.0, "min_vote_count": 0}},
+        "negative_signals": {"enabled": True, "dropped_shows": {"enabled": False}},
+    }
+
+    config_path = os.path.join(root, "config", "config.yml")
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config_yaml, f, sort_keys=False)
+    with open(os.path.join(root, "config", "tuning.yml"), "w", encoding="utf-8") as f:
+        yaml.safe_dump(tuning_yaml, f, sort_keys=False)
+
+    from tests.e2e_plex_fixture import build_movies_cache_payload, build_shows_cache_payload
+
+    with open(os.path.join(root, "cache", "all_movies_cache.json"), "w", encoding="utf-8") as f:
+        json.dump(build_movies_cache_payload(), f)
+    with open(os.path.join(root, "cache", "all_shows_cache.json"), "w", encoding="utf-8") as f:
+        json.dump(build_shows_cache_payload(), f)
+
+    return config_path
+
+
+def run_profile_builders() -> dict:
+    """Drives all four #273 profile-builder entry points against the
+    (extended - see module docstring) tests/e2e_plex_fixture.py catalog
+    and returns a JSON-serializable snapshot dict. See module docstring
+    for the full rationale.
+
+    Safe to call standalone (`python -m tests.harness --profile-builders`,
+    outside pytest) or in-process from a test: explicitly no-ops
+    recommenders.base.migrate_legacy_cache_dir for the duration of this
+    call rather than relying on tests/conftest.py's autouse fixture of
+    the same name (which only applies under pytest) - left un-mocked,
+    that function is reachable in exactly this harness's own shape
+    (source install, CURATARR_CONFIG_DIR set - see its own docstring)
+    and would silently MOVE real production watched_cache_plex_<user>.json
+    files out of the real repo's cache/ dir into this function's
+    throwaway temp dir, which is then deleted on the way out - i.e.
+    permanently destroying real user data. Never touches the real repo's
+    cache/ dir, never opens a real socket (utils.plex._capped_get and
+    every MyPlexAccount binding this call graph touches are patched to
+    the synthetic tests/e2e_plex_fixture.py fakes for the duration).
+    """
+    import shutil
+    import tempfile
+    from unittest.mock import patch
+
+    from recommenders import external as external_module
+    from recommenders.movie import PlexMovieRecommender
+    from recommenders.tv import PlexTVRecommender
+    from tests.e2e_plex_fixture import FakeMyPlexAccount, build_fake_plex_server, make_fake_capped_get
+
+    tmp_root = tempfile.mkdtemp(prefix="curatarr_profile_harness_")
+    snapshot: dict = {}
+    old_cwd_env = os.environ.get("CURATARR_CONFIG_DIR")
+    try:
+        plex_users_root = os.path.join(tmp_root, "plex_users_project")
+        managed_root = os.path.join(tmp_root, "managed_users_project")
+        os.makedirs(plex_users_root)
+        os.makedirs(managed_root)
+
+        plex_users_config_path = _write_profile_builder_project(plex_users_root, managed_users=False)
+        managed_config_path = _write_profile_builder_project(managed_root, managed_users=True)
+
+        fake_plex = build_fake_plex_server()
+
+        with (
+            patch("recommenders.base.init_plex", lambda config: fake_plex),
+            patch("utils.plex.MyPlexAccount", FakeMyPlexAccount),
+            patch("recommenders.base.MyPlexAccount", FakeMyPlexAccount),
+            patch("recommenders.external.MyPlexAccount", FakeMyPlexAccount),
+            patch("recommenders.base.migrate_legacy_cache_dir", lambda legacy_dir, new_dir: None),
+            patch("utils.plex._capped_get", make_fake_capped_get()),
+            patch("recommenders.external.get_tmdb_keywords", lambda *a, **kw: []),
+        ):
+            # --- (1) & (2): movie.py's / tv.py's own per-user builders ---
+            os.environ["CURATARR_CONFIG_DIR"] = plex_users_root
+            for username in ("alice", "bob"):
+                movie_rec = PlexMovieRecommender(plex_users_config_path, single_user=username)
+                snapshot[f"movie_plex_watched_{username}"] = _counters_to_jsonable(movie_rec.watched_data_counters)
+
+                tv_rec = PlexTVRecommender(plex_users_config_path, single_user=username)
+                snapshot[f"tv_plex_watched_{username}"] = _counters_to_jsonable(tv_rec.watched_data_counters)
+
+            # --- (3): base.py's shared managed-users builder ---
+            os.environ["CURATARR_CONFIG_DIR"] = managed_root
+            managed_movie_rec = PlexMovieRecommender(managed_config_path)
+            snapshot["movie_managed_users"] = _counters_to_jsonable(managed_movie_rec.watched_data_counters)
+            managed_tv_rec = PlexTVRecommender(managed_config_path)
+            snapshot["tv_managed_users"] = _counters_to_jsonable(managed_tv_rec.watched_data_counters)
+
+            # --- (4) & (5): external.py's load_user_profile_from_cache()
+            # (reads the REAL on-disk cache files (1) above just wrote,
+            # via each recommender's own __init__-time _save_watched_cache()
+            # call) and build_user_profile() (bug #3: username is inert -
+            # see this module's own report). Neither reads config.yml off
+            # disk, so CURATARR_CONFIG_DIR is irrelevant here; a small,
+            # standalone config dict is enough. ---
+            external_config = {
+                "plex": {
+                    "url": "http://127.0.0.1:32400",
+                    "token": "test-harness-token",
+                    "movie_library": "Movies",
+                    "tv_library": "TV Shows",
+                },
+                "tmdb": {"api_key": "test_key"},
+                "cache_dir": os.path.join(plex_users_root, "cache"),
+                "recency_decay": {"enabled": True},
+            }
+            for username in ("alice", "bob"):
+                for media_type in ("movie", "tv"):
+                    loaded = external_module.load_user_profile_from_cache(external_config, username, media_type)
+                    snapshot[f"external_load_cache_{media_type}_{username}"] = (
+                        _counters_to_jsonable(loaded) if loaded else None
+                    )
+
+            for username in ("alice", "bob"):
+                built = external_module.build_user_profile(fake_plex, external_config, username, "movie")
+                snapshot[f"external_build_user_profile_movie_{username}"] = _counters_to_jsonable(built)
+    finally:
+        if old_cwd_env is None:
+            os.environ.pop("CURATARR_CONFIG_DIR", None)
+        else:
+            os.environ["CURATARR_CONFIG_DIR"] = old_cwd_env
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+    return snapshot
+
+
+def _profile_builder_golden_path() -> str:
+    return os.path.join(PROFILE_BUILDER_FIXTURES_DIR, PROFILE_BUILDER_GOLDEN_FILENAME)
+
+
+def write_profile_builder_golden(snapshot: dict) -> None:
+    """(Re)writes the committed golden snapshot fixture - see
+    tests/test_profile_builder_harness.py for what pins against it."""
+    os.makedirs(PROFILE_BUILDER_FIXTURES_DIR, exist_ok=True)
+    with open(_profile_builder_golden_path(), "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def load_profile_builder_golden() -> dict:
+    with open(_profile_builder_golden_path(), encoding="utf-8") as f:
+        return json.load(f)
+
+
 def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profile-builders",
+        action="store_true",
+        help="Run the #273 profile-builder harness (run_profile_builders()) instead of the scoring harness.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="(--profile-builders only) (re)write the committed golden snapshot fixture instead of printing it.",
+    )
+    args = parser.parse_args()
+
+    if args.profile_builders:
+        snapshot = run_profile_builders()
+        if args.write:
+            write_profile_builder_golden(snapshot)
+            print(f"Wrote golden snapshot ({len(snapshot)} builder calls) to {_profile_builder_golden_path()}")
+        else:
+            print(json.dumps(snapshot, indent=2, sort_keys=True))
+        return
+
     result = run()
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/tests/test_profile_builder_harness.py
+++ b/tests/test_profile_builder_harness.py
@@ -1,0 +1,177 @@
+"""
+Tests for tests/harness.py's #273 profile-builder harness
+(run_profile_builders()) - the PR0 hard gate for issue #273 (four
+divergent user-profile builders, recommenders/movie.py's
+_get_plex_watched_data, recommenders/tv.py's
+_get_plex_watched_shows_data, recommenders/base.py's
+_get_managed_users_watched_data, recommenders/external.py's
+build_user_profile/load_user_profile_from_cache).
+
+TestProfileBuilderHarnessPinsCurrentBehavior pins the CURRENT (bug-
+present) output of all four builders against a committed golden
+snapshot (tests/fixtures/profile_builder_harness/
+profile_builder_snapshot.json) so a future #273 PR's intentional
+behavior change shows up as an explicit, reviewed golden-fixture diff
+(regenerate via `python -m tests.harness --profile-builders --write`
+and explain the diff in that PR's description) rather than silently
+passing because nothing was actually asserting on these four functions'
+output shape before this PR.
+
+TestProfileBuilderHarnessCatchesTheFourBugs goes one step further and
+proves the harness can actually TELL buggy from fixed behavior, not just
+freeze whatever it happens to see today - seeded directly by the
+verified real-library findings in this issue's own report:
+  - Bug #1 (recommenders/movie.py): Plex's history API
+    (/status/sessions/history/all) never carries userRating; movie.py's
+    _get_plex_watched_data() only ever reads userRating off HISTORY
+    items (unlike recommenders/tv.py, which correctly reads it off the
+    LIBRARY item) - so a movie profile's negative-signal rating weight
+    never fires, even for a movie the user has genuinely rated low.
+  - Bug #2 (recommenders/movie.py + tv.py): viewCount/userRating are
+    per-account Plex state, but both builders fetch the library
+    snapshot through the shared ADMIN token
+    (BaseRecommender._get_all_library_items()) - so every configured
+    user's profile reads the exact same (here: always-empty) admin view
+    instead of their own.
+  - Bug #4 (recommenders/base.py): _get_managed_users_watched_data()
+    passes no `weight` to process_counters_from_cache() at all - every
+    watched item counts exactly 1.0, with no recency/rewatch/rating
+    signal whatsoever.
+  - Bug #3 (recommenders/external.py): build_user_profile()'s
+    `username` parameter has zero effect on its output - the
+    MyPlexAccount it constructs to "validate" the user is immediately
+    discarded, and the actual scan runs against whatever `plex`
+    connection the caller already had.
+
+tests/e2e_plex_fixture.py's MOVIE_PER_USER_LIBRARY_STATE/
+SHOW_PER_USER_LIBRARY_STATE (added by this same PR) give alice and bob
+genuinely different, nonzero view_count/user_rating values on movies/
+shows they've each actually watched - exactly the per-account state the
+shared admin-token snapshot (build_fake_plex_server(), used by every
+builder here) can never see, and always reports as 0/None for every
+item, regardless of user. Without that fixture extension, none of the
+four assertions below could ever fail - which is the exact gap this
+PR's issue called out: "the existing e2e fixture CANNOT catch these
+bugs... it will pin the bug instead of the behavior."
+"""
+
+import json
+
+from tests.harness import load_profile_builder_golden, run_profile_builders
+from utils import RATING_MULTIPLIER_UNRATED
+from utils.scoring import calculate_recency_multiplier, calculate_rewatch_multiplier
+
+
+class TestProfileBuilderHarnessPinsCurrentBehavior:
+    def test_snapshot_matches_committed_golden_fixture(self):
+        live = run_profile_builders()
+        golden = load_profile_builder_golden()
+        assert live == golden, (
+            "Live profile-builder output no longer matches the committed golden "
+            "snapshot (tests/fixtures/profile_builder_harness/"
+            "profile_builder_snapshot.json). If this is an INTENTIONAL change "
+            "(e.g. a #273 PR fixing one of the four builders), regenerate it - "
+            "`python -m tests.harness --profile-builders --write` - and explain "
+            "the diff in that PR's description."
+        )
+
+    def test_two_independent_runs_are_byte_identical(self):
+        """Determinism: the harness's own recompute must be stable run to
+        run - the fixture is fully synthetic/deterministic, nothing in
+        this call graph depends on real time-of-run or randomness (the
+        one thing that could - recency decay - is pinned to fixture
+        timestamps far enough in the past to stay in the same decay
+        bucket indefinitely; see tests/e2e_plex_fixture.py)."""
+        first = run_profile_builders()
+        second = run_profile_builders()
+        assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+class TestProfileBuilderHarnessCatchesTheFourBugs:
+    """See module docstring - proves the harness distinguishes buggy from
+    fixed behavior, not just freezes whatever it happens to see today."""
+
+    def test_bug1_movie_rating_never_negative_today(self):
+        """Bug #1: alice's fixture override gives her a rating of 2.0 on
+        movie 102 ("Iron Horizon", genre "action") - a real dislike,
+        below DEFAULT_NEGATIVE_THRESHOLD. Today, every one of her
+        genre-counter values is still >= 0: movie.py's own
+        _get_plex_watched_data() never sees that rating (it only reads
+        userRating off Plex history items, which never carry it)."""
+        live = run_profile_builders()
+        genres = live["movie_plex_watched_alice"]["genres"]
+        assert genres, "expected at least one genre counted for alice's movie profile"
+        assert all(float.fromhex(v) >= 0 for v in genres.values()), (
+            "a genre counter went negative for alice's movie profile - movie.py's "
+            "rating-source fix (#273 PR1) may have already landed, which would "
+            "make this pinned-bug assertion stale."
+        )
+
+    def test_bug2_movie_watched_data_shows_no_rewatch_or_rating_signal_today(self):
+        """Bug #2: alice's and bob's fixture overrides give them
+        genuinely different, nonzero view_counts/ratings on the movies
+        they've each watched (see MOVIE_PER_USER_LIBRARY_STATE) - but
+        movie.py's _get_plex_watched_data() only ever reads that state
+        through the shared ADMIN-token library snapshot
+        (_get_all_library_items()), which reports 0/None for every item
+        regardless of user. The only per-movie unit weight in play
+        today is therefore RATING_MULTIPLIER_UNRATED (unrated) times
+        whatever recency bucket this fixture's watch timestamps fall
+        into (tests/e2e_plex_fixture.py's history timestamps are fixed
+        at ~2023-11-14 - already >365 days in the past and only growing
+        more so, always the oldest/smallest decay bucket) times
+        rewatch_multiplier(1) (view_count is never seen at all on this
+        legacy path) - every genre-counter value for BOTH users should
+        be a plain integer multiple of that one unit."""
+        live = run_profile_builders()
+        unit = RATING_MULTIPLIER_UNRATED * calculate_recency_multiplier(0, {}) * calculate_rewatch_multiplier(1)
+        for username in ("alice", "bob"):
+            genres = live[f"movie_plex_watched_{username}"]["genres"]
+            assert genres, f"expected at least one genre counted for {username}'s movie profile"
+            for value_hex in genres.values():
+                value = float.fromhex(value_hex)
+                multiple = value / unit
+                assert abs(multiple - round(multiple)) < 1e-9, (
+                    f"{username}'s genre weight {value} is not a plain multiple of the "
+                    f"unrated/oldest-recency-bucket unit weight ({unit}) - per-user "
+                    "rewatch/rating weighting may already be wired up correctly (#273 "
+                    "PR1), which would make this pinned-bug assertion stale."
+                )
+
+    def test_bug4_managed_users_builder_applies_no_weighting_today(self):
+        """Bug #4: base.py's _get_managed_users_watched_data() passes no
+        `weight` to process_counters_from_cache() - every watched item
+        counts exactly 1.0 (no recency/rewatch/rating multiplier at
+        all), so every counter value should be a plain positive
+        integer."""
+        live = run_profile_builders()
+        for key in ("movie_managed_users", "tv_managed_users"):
+            genres = live[key]["genres"]
+            assert genres, f"expected at least one genre counted for {key}"
+            for value_hex in genres.values():
+                value = float.fromhex(value_hex)
+                assert value == int(value), f"{key}: expected an integer (weight=1.0 always), got {value}"
+
+    def test_bug3_external_build_user_profile_ignores_username(self):
+        """Bug #3: build_user_profile()'s username parameter has zero
+        effect on its output - alice's and bob's calls (against the
+        exact same shared admin-token `plex` connection every builder
+        here receives) produce byte-identical results."""
+        live = run_profile_builders()
+        assert live["external_build_user_profile_movie_alice"] == live["external_build_user_profile_movie_bob"]
+
+    def test_external_load_cache_adapter_renames_tmdb_keywords_to_keywords(self):
+        """recommenders/external.py's load_user_profile_from_cache() is
+        the one adapter that survives #273's later PRs unchanged (PR3
+        reuses it) - pin its key-renaming contract directly: the
+        on-disk cache key `tmdb_keywords` (utils/counters.py's
+        create_empty_counters shape - what every real
+        watched_cache_plex_<user>.json on disk actually uses) comes back
+        out as `keywords` (recommenders/external.py's own internal
+        naming - see #273's PR3/PR4 notes on this exact mismatch)."""
+        live = run_profile_builders()
+        loaded = live["external_load_cache_movie_alice"]
+        assert loaded is not None
+        assert "keywords" in loaded
+        assert "tmdb_keywords" not in loaded
+        assert loaded["keywords"], "expected alice's cached movie keywords to be non-empty"

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.60"
+__version__ = "2.10.61"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary

PR0 of the #273 remediation sequence (four divergent user-profile builders, three with verified production bugs). This is a **hard gate** - no production code changes here, tests/fixtures only. Nothing in the downstream fix PRs (movie.py rating source, per-user token scoping, base.py managed-users weighting, external.py builder deletion) is verifiable without a harness that can actually catch these bugs first.

## Why the existing fixture couldn't catch this

tests/e2e_plex_fixture.py as it shipped:
- Emits watch-history XML with no userRating (faithfully reproducing the real Plex /status/sessions/history/all endpoint, which never carries it either)
- FakeMediaItem had no userRating attribute at all, no per-user viewCount variation
- No switchUser()/per-user-token support at all

A harness built on that fixture unmodified would have pinned bugs #1/#2 as correct behavior, not caught them.

## What changed

- tests/e2e_plex_fixture.py: added MOVIE_PER_USER_LIBRARY_STATE / SHOW_PER_USER_LIBRARY_STATE (alice and bob get genuinely different, nonzero view_count/user_rating on movies/shows they've each actually watched), FakePlexServer.switchUser(), FakeMyPlexAccount.user(), build_fake_plex_server_for_user(), and FakeSection.search(unwatched=...) support (needed by base.py's managed-users path).
- tests/harness.py: added run_profile_builders(), driving all four #273 builders directly (movie.py's _get_plex_watched_data, tv.py's _get_plex_watched_shows_data, base.py's _get_managed_users_watched_data, external.py's build_user_profile/load_user_profile_from_cache) against the extended fixture, snapshotting every counter key/magnitude(float.hex)/sign/populated-dimension. python -m tests.harness --profile-builders [--write].
- tests/fixtures/profile_builder_harness/profile_builder_snapshot.json: committed golden snapshot of CURRENT (bug-present) behavior.
- tests/test_profile_builder_harness.py: pins live output against the golden snapshot, plus 4 standalone assertions proving the harness distinguishes buggy from fixed behavior (not just freezing whatever it sees today).

## Snapshot diff evidence (current behavior, as pinned)

- **Bug #1 (movie.py rating source)**: alice's fixture override gives her a rating of 2.0 on a movie she watched (a real dislike). Every genre-counter value in her movie profile is still >= 0 today - movie.py only reads userRating off Plex history items, which never carry it.
- **Bug #2 (shared admin-token snapshot)**: alice and bob get genuinely different fixture view_count/user_rating overrides, but movie.py's/tv.py's own builders show ZERO rewatch or rating signal for either of them - every genre-counter value is an exact integer multiple of the single unrated, oldest-recency-bucket unit weight (0.6 x 0.1 = 0.06), for both users identically.
- **Bug #4 (base.py managed-users, no weight)**: every counter value in the managed-users profile is a plain positive integer (weight=1.0 per watched item, confirmed for both movies and shows) - no recency/rewatch/rating multiplier reaches process_counters_from_cache() at all.
- **Bug #3 (external.py build_user_profile ignores username)**: build_user_profile() calls for alice and bob against the identical admin-token connection produce byte-identical output.
- **load_user_profile_from_cache adapter** (survives into PR3): confirmed it renames tmdb_keywords -> keywords and silently drops the collections dimension entirely (present in the on-disk cache shape, absent from the adapter's output) - noted as a real finding, not fixed here (out of PR0 scope).

## Safety notes

- Explicitly no-ops recommenders.base.migrate_legacy_cache_dir for the duration of the harness call, regardless of whether it's running under pytest or standalone (python -m tests.harness --profile-builders) - left unmocked, that function is reachable in exactly this harness's own shape (source install, CURATARR_CONFIG_DIR set) and would silently MOVE real production watched_cache_plex_<user>.json files out of the real repo's cache/ dir into the harness's own throwaway temp dir, which is then deleted on exit - i.e. permanently destroying real user data. Caught and fixed before this ever ran against anything but a fresh throwaway tmp dir.
- Never opens a real socket; every MyPlexAccount binding and utils.plex._capped_get this call graph touches are patched to the synthetic fixture for the duration.

## Test plan

- [x] pytest tests/ (2776 passed, 1 skipped, 96.79% coverage, threshold 85%)
- [x] ruff check . / ruff format --check .
- [x] mypy .
- [x] Verified none of the new/changed files trip gitleaks (pre-push hook: no leaks found)