### PR TITLE
fix: weight managed-users watched-data builder (2.10.63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.63] - 2026-07-27
+
+### Fixed
+
+- **`recommenders/base.py`'s `_get_managed_users_watched_data()` (used when `plex.managed_users` is configured instead of `users.list`) applied NO weighting at all - every watched item counted exactly 1.0, regardless of how many times it was rewatched, how the user rated it, or how recently it was watched (#273 PR2).** Verified: every real managed-users-mode profile's counter values were plain integers with zero negative signals, unlike `movie.py`'s/`tv.py`'s own per-user builders, which already apply recency/rating/rewatch weighting. Now calls the exact same formula those two use (`calculate_recency_multiplier` x `_calculate_rating_multiplier` x `calculate_rewatch_multiplier`, sourced from the same `switchUser()`-scoped library item this method already fetched via `#273` PR1's per-user token fix), including negative-signal support for low ratings.
+
+  No config flag - unlike PR1, this is a straightforward internal-consistency fix (apply the SAME weighting formula the other three builders already use to this fourth one), not a new opt-in behavior with a slower-rollout rationale.
+
+  **Verified against the real, live Plex library** (read-only): this install's real users aren't Plex Home/managed-users (they're configured via `users.list`, matched by login-style username - `get_configured_users()`'s `managed_users` validation only matches Plex's display-name `.title`, a separate, pre-existing mismatch out of this PR's scope), so this was verified via the one `managed_users` value that always resolves regardless (`"admin"`), isolating the comparison to weighting alone by patching only `process_counters_from_cache`'s call shape between an "old" and "new" pass over the exact same real watched-item set (132 watched movies both ways, confirming an isolated comparison): every counter dimension went from 100% integer-valued with zero negative signals (`genres`: min 1.0, 0 negative; `actors`: min 1.0, 0 negative; `directors`: min 1.0, 0 negative; `tmdb_keywords`: min 1.0, 0 negative) to widely fractional with real negative signals (`actors`: 271/293 non-integer, 12 negative; `directors`: 106/117 non-integer, 5 negative; `genres`: 23/24 non-integer; `tmdb_keywords`: 1273/1383 non-integer, 88 negative) - exactly the predicted shape, written down before the run.
+
 ## [2.10.62] - 2026-07-27
 
 ### Added

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -49,6 +49,8 @@ from utils import (
     add_labels_to_items,
     apply_user_label_restrictions,
     build_label_name,
+    calculate_recency_multiplier,
+    calculate_rewatch_multiplier,
     categorize_labeled_items,
     check_cache_version,
     cleanup_legacy_unnamed_collection,
@@ -716,6 +718,11 @@ class BaseRecommender(ABC):
         else:
             users_to_process = self.users["managed_users"] or [admin_user]
 
+        negative_signal_count = 0
+        ns_config = self.config.get("negative_signals", {})
+        cap_penalty = ns_config.get("bad_ratings", {}).get("cap_penalty", 0.5)
+        recency_config = self.config.get("recency_decay", {})
+
         for username in users_to_process:
             try:
                 if username.lower() == admin_user.lower():
@@ -733,7 +740,43 @@ class BaseRecommender(ABC):
 
                     item_info = self._get_media_cache().cache[self.media_key].get(str(item.ratingKey))
                     if item_info:
-                        process_counters_from_cache(item_info, counters, media_type=self.media_type)
+                        # #273 PR2: this path previously called
+                        # process_counters_from_cache() with no weight,
+                        # rating, view_count, or viewed_at at all - every
+                        # watched item counted exactly 1.0 regardless of
+                        # how many times it was rewatched, how it was
+                        # rated, or how recently it was watched (verified:
+                        # every real managed-users profile's counter
+                        # values were plain integers, no fractional
+                        # weighting whatsoever). Now uses the exact same
+                        # recency/rating/rewatch formula movie.py's and
+                        # tv.py's own per-user builders already apply,
+                        # sourced from this same switchUser()-scoped
+                        # library item (already fixed to be per-user, not
+                        # shared-admin, by #273 PR1's
+                        # _get_all_library_items_for_user - this method
+                        # already called search() through that same
+                        # per-user connection before this PR, only the
+                        # weighting itself was missing).
+                        last_viewed_at = getattr(item, "lastViewedAt", None)
+                        viewed_at = int(last_viewed_at.timestamp()) if last_viewed_at else None
+                        recency_multiplier = (
+                            calculate_recency_multiplier(viewed_at, recency_config) if viewed_at else 1.0
+                        )
+                        rating_multiplier = self._calculate_rating_multiplier(getattr(item, "userRating", None))
+                        rewatch_multiplier = calculate_rewatch_multiplier(getattr(item, "viewCount", None) or 1)
+                        weight = recency_multiplier * rating_multiplier * rewatch_multiplier
+
+                        if weight < 0:
+                            negative_signal_count += 1
+                            logger.debug(
+                                f"Negative signal: {item_info.get('title')} "
+                                f"(rating: {getattr(item, 'userRating', None)}, weight: {weight:.2f})"
+                            )
+
+                        process_counters_from_cache(
+                            item_info, counters, media_type=self.media_type, weight=weight, cap_penalty=cap_penalty
+                        )
 
                         if tmdb_id := item_info.get("tmdb_id"):
                             counters["tmdb_ids"].add(tmdb_id)
@@ -743,6 +786,8 @@ class BaseRecommender(ABC):
                 continue
 
         logger.debug(f"Collected {len(counters['tmdb_ids'])} unique TMDB IDs from managed users")
+        if negative_signal_count > 0:
+            logger.info(f"Processed {negative_signal_count} {self.media_key} as negative signals (low ratings)")
 
         return counters
 

--- a/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
+++ b/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
@@ -160,28 +160,28 @@
   },
   "movie_managed_users": {
     "actors": {
-      "Alex Monroe": "0x1.0000000000000p+2",
-      "Casey Rhodes": "0x1.8000000000000p+1",
-      "Jordan Vance": "0x1.0000000000000p+2",
-      "Robin Alvarez": "0x1.8000000000000p+1",
-      "Sam Kestrel": "0x1.0000000000000p+2",
-      "Taylor Nguyen": "0x1.8000000000000p+1"
+      "Alex Monroe": "0x1.18a339c1b228dp+2",
+      "Casey Rhodes": "0x1.e479a6b69784ep+1",
+      "Jordan Vance": "0x1.a479a6b69784ep+1",
+      "Robin Alvarez": "0x1.599999999999ap+1",
+      "Sam Kestrel": "0x1.4ccccccccccccp+0",
+      "Taylor Nguyen": "0x1.599999999999ap+1"
     },
     "collections": {},
     "directors": {
-      "Marcus Webb": "0x1.8000000000000p+1",
-      "Nora Lin": "0x1.8000000000000p+1",
-      "Priya Anand": "0x1.0000000000000p+1",
-      "Ridley Stone": "0x1.0000000000000p+1"
+      "Marcus Webb": "0x1.cccccccccccccp+0",
+      "Nora Lin": "0x1.599999999999ap+1",
+      "Priya Anand": "0x1.3333333333333p+0",
+      "Ridley Stone": "0x1.0ae00d1cfdeb4p+1"
     },
     "genres": {
-      "action": "0x1.0000000000000p+2",
-      "comedy": "0x1.8000000000000p+1",
-      "romance": "0x1.0000000000000p+1",
-      "sci-fi": "0x1.8000000000000p+1"
+      "action": "0x1.a479a6b69784ep+1",
+      "comedy": "0x1.599999999999ap+1",
+      "romance": "0x1.0cccccccccccdp+1",
+      "sci-fi": "0x1.e479a6b69784ep+1"
     },
     "languages": {
-      "english": "0x1.4000000000000p+3"
+      "english": "0x1.f23cd35b4bc26p+2"
     },
     "tmdb_ids": [
       "101",
@@ -196,15 +196,15 @@
       "110"
     ],
     "tmdb_keywords": {
-      "coming-of-age": "0x1.0000000000000p+1",
-      "heist": "0x1.0000000000000p+1",
-      "revenge": "0x1.0000000000000p+0",
-      "road-trip": "0x1.0000000000000p+1",
-      "space-station": "0x1.8000000000000p+1",
-      "survival": "0x1.0000000000000p+1",
-      "time-travel": "0x1.0000000000000p+0",
-      "undercover": "0x1.0000000000000p+1",
-      "wedding": "0x1.0000000000000p+1"
+      "coming-of-age": "0x1.3333333333333p+0",
+      "heist": "0x1.97acd9e9cab81p+1",
+      "revenge": "-0x1.0000000000000p-1",
+      "road-trip": "0x1.0cccccccccccdp+1",
+      "space-station": "0x1.e479a6b69784ep+1",
+      "survival": "0x1.9999999999998p-4",
+      "time-travel": "0x1.3333333333333p-1",
+      "undercover": "0x1.3333333333333p+0",
+      "wedding": "0x1.0cccccccccccdp+1"
     }
   },
   "movie_plex_watched_alice": {
@@ -284,26 +284,26 @@
   },
   "tv_managed_users": {
     "actors": {
-      "Derek Cho": "0x1.0000000000000p+1",
-      "Elena Frost": "0x1.0000000000000p+1",
-      "Lucas Wren": "0x1.0000000000000p+1",
-      "Mira Solano": "0x1.8000000000000p+1",
-      "Nadia Okafor": "0x1.0000000000000p+1",
-      "Theo Baptiste": "0x1.8000000000000p+1"
+      "Derek Cho": "0x1.4cccccccccccdp+1",
+      "Elena Frost": "0x1.238346deb0141p+0",
+      "Lucas Wren": "0x1.3333333333333p+0",
+      "Mira Solano": "0x1.999999999999ap+1",
+      "Nadia Okafor": "0x1.3333333333333p+0",
+      "Theo Baptiste": "0x1.bd1ce07849adap+0"
     },
     "genres": {
-      "comedy": "0x1.8000000000000p+1",
-      "crime": "0x1.0000000000000p+1",
-      "sci-fi": "0x1.0000000000000p+1"
+      "comedy": "0x1.91c1a36f580a1p+1",
+      "crime": "-0x1.999999999999cp-3",
+      "sci-fi": "0x1.4cccccccccccdp+1"
     },
     "languages": {
-      "english": "0x1.c000000000000p+2"
+      "english": "0x1.627a6b51459e9p+2"
     },
     "studios": {
-      "bluecrest media": "0x1.0000000000000p+1",
-      "ferrous pictures": "0x1.0000000000000p+0",
-      "lumen works": "0x1.0000000000000p+1",
-      "northgate studios": "0x1.0000000000000p+1"
+      "bluecrest media": "-0x1.999999999999cp-3",
+      "ferrous pictures": "0x1.3333333333333p-1",
+      "lumen works": "0x1.44f4d6a28b3d4p+1",
+      "northgate studios": "0x1.4cccccccccccdp+1"
     },
     "tmdb_ids": [
       "201",
@@ -315,14 +315,14 @@
       "207"
     ],
     "tmdb_keywords": {
-      "exploration": "0x1.0000000000000p+1",
-      "first-contact": "0x1.0000000000000p+0",
-      "heist": "0x1.0000000000000p+0",
-      "investigation": "0x1.0000000000000p+1",
-      "noir": "0x1.0000000000000p+0",
-      "roommates": "0x1.0000000000000p+1",
-      "survival": "0x1.0000000000000p+0",
-      "workplace": "0x1.0000000000000p+1"
+      "exploration": "0x1.4cccccccccccdp+1",
+      "first-contact": "0x1.0000000000000p+1",
+      "heist": "0x1.3333333333333p-1",
+      "investigation": "-0x1.999999999999cp-3",
+      "noir": "-0x1.999999999999ap-1",
+      "roommates": "0x1.44f4d6a28b3d4p+1",
+      "survival": "0x1.3333333333333p-1",
+      "workplace": "0x1.44f4d6a28b3d4p+1"
     }
   },
   "tv_plex_watched_alice": {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2057,7 +2057,7 @@ class TestGetManagedUsersWatchedData:
         recommender = _make_recommender(users={"plex_users": [], "managed_users": ["admin"], "admin_user": "admin"})
         recommender.watched_data_counters = {}
         recommender.plex = Mock()
-        item = Mock(ratingKey="10")
+        item = Mock(ratingKey="10", lastViewedAt=None, userRating=None, viewCount=1)
         recommender.plex.library.section.return_value.search.return_value = [item]
         media_cache = Mock()
         media_cache.cache = {"movies": {"10": {"tmdb_id": 555}}}

--- a/tests/test_profile_builder_harness.py
+++ b/tests/test_profile_builder_harness.py
@@ -138,19 +138,34 @@ class TestProfileBuilderHarnessCatchesTheFourBugs:
                     "PR1), which would make this pinned-bug assertion stale."
                 )
 
-    def test_bug4_managed_users_builder_applies_no_weighting_today(self):
-        """Bug #4: base.py's _get_managed_users_watched_data() passes no
-        `weight` to process_counters_from_cache() - every watched item
-        counts exactly 1.0 (no recency/rewatch/rating multiplier at
-        all), so every counter value should be a plain positive
-        integer."""
+    def test_bug4_managed_users_builder_now_applies_real_weighting(self):
+        """Bug #4 - FIXED (#273 PR2): base.py's _get_managed_users_watched_data()
+        used to pass no weight to process_counters_from_cache() at all -
+        every watched item counted exactly 1.0 (no recency/rewatch/rating
+        multiplier whatsoever). It now applies the same
+        recency/rating/rewatch formula movie.py's/tv.py's own per-user
+        builders already use. This is the golden-fixture-diff PR0's own
+        docstring predicted: a future #273 PR intentionally changing one
+        of the four builders regenerates the snapshot and updates this
+        test to assert the FIXED shape instead of the bug - not every
+        counter value is a plain integer anymore, and alice's fixture
+        override (a movie rated 2.0 - a real dislike) now produces a
+        genuine negative signal here too, same as it already does for
+        movie.py's/tv.py's own per-user builders (see
+        TestProfileBuilderHarnessCatchesTheFourBugs.test_bug1... above)."""
         live = run_profile_builders()
-        for key in ("movie_managed_users", "tv_managed_users"):
-            genres = live[key]["genres"]
-            assert genres, f"expected at least one genre counted for {key}"
-            for value_hex in genres.values():
-                value = float.fromhex(value_hex)
-                assert value == int(value), f"{key}: expected an integer (weight=1.0 always), got {value}"
+        movie_genres = live["movie_managed_users"]["genres"]
+        assert movie_genres, "expected at least one genre counted for movie_managed_users"
+        assert any(float.fromhex(v) != int(float.fromhex(v)) for v in movie_genres.values()), (
+            "every movie_managed_users genre weight is still a plain integer - the #273 PR2 "
+            "weighting fix may have regressed."
+        )
+        movie_keywords = live["movie_managed_users"]["tmdb_keywords"]
+        assert any(float.fromhex(v) < 0 for v in movie_keywords.values()), (
+            "expected at least one negative-signal keyword weight in movie_managed_users "
+            "(alice's fixture-override dislike on movie 102) - the #273 PR2 weighting fix "
+            "may have regressed."
+        )
 
     def test_bug3_external_build_user_profile_ignores_username(self):
         """Bug #3: build_user_profile()'s username parameter has zero

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.62"
+__version__ = "2.10.63"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary

PR2 of the #273 remediation sequence. `recommenders/base.py`'s `_get_managed_users_watched_data()` (the shared builder used when `plex.managed_users` is configured instead of `users.list`) called `process_counters_from_cache()` with no `weight`/`rating`/`view_count`/`viewed_at` at all - every watched item counted exactly 1.0 regardless of how many times it was rewatched, how the user rated it, or how recently it was watched.

## What changed

- `recommenders/base.py`: the managed-users loop now computes `recency_multiplier * rating_multiplier * rewatch_multiplier` from the same `switchUser()`-scoped library item this method already fetches (per #273 PR1's per-user token fix), using the exact same helper functions (`calculate_recency_multiplier`, `_calculate_rating_multiplier`, `calculate_rewatch_multiplier`) `movie.py`'s/`tv.py`'s own per-user builders already use, and passes it through to `process_counters_from_cache(..., weight=weight, cap_penalty=cap_penalty)`. Includes negative-signal logging matching the other two builders' convention.
- No config flag - unlike PR1, this is a straightforward internal-consistency fix (apply the SAME formula the other three builders already use to this fourth one), not a new opt-in behavior with a slower-rollout rationale.
- `tests/test_base.py`: updated one existing test's Mock item to set explicit `lastViewedAt`/`userRating`/`viewCount` (previously auto-Mock attributes, which broke once the code started reading them).
- `tests/test_profile_builder_harness.py` / golden fixture: regenerated (PR0's own predicted mechanism - a #273 PR intentionally changing one of the four builders regenerates the snapshot). `test_bug4_managed_users_builder_applies_no_weighting_today` renamed to `test_bug4_managed_users_builder_now_applies_real_weighting` and inverted to assert the FIXED shape (fractional weights present, at least one negative signal) instead of the bug.

## Real-library verification (read-only)

This install's real users aren't Plex Home/managed-users (`users.list` mode, matched by login-style username) - `get_configured_users()`'s `managed_users` validation only matches Plex's display-name `.title` (e.g. "Eric Arutyunov", not "ericarutyunov"), a separate, pre-existing mismatch out of this PR's scope. Verified via the one `managed_users` value that always resolves regardless (`"admin"`), isolating the comparison to weighting alone by patching only `process_counters_from_cache`'s call shape between an "old" (drops weight/rating/view_count/viewed_at, matching the pre-fix call site exactly) and "new" pass over the exact same real watched-item set:

| Dimension | old: non-integer / negative | new: non-integer / negative |
|---|---|---|
| genres (24 total) | 0 / 0 | 23 / 0 |
| actors (293 total) | 0 / 0 | 271 / 12 |
| directors (117 total) | 0 / 0 | 106 / 5 |
| tmdb_keywords (1383 total) | 0 / 0 | 1273 / 88 |

`watched_count` and `tmdb_ids_count` identical (132/132) both passes, confirming the comparison is isolated to weighting only, not a different watched-item set. Predictions written down before the run (fractional values appear; at least one negative signal appears) both confirmed.

No Plex writes, no Trakt calls at any point in this verification.

## Test plan

- [x] pytest tests/ (2790 passed, 1 skipped, 96.83% coverage, threshold 85%)
- [x] ruff check . / ruff format --check .
- [x] mypy .
- [x] Real-library before/after verification (table above)
- [x] gitleaks (pre-push hook): no leaks found
