### PR TITLE
Fix Docker full run silently skipping tv/external stages (2.10.64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.64] - 2026-07-27
+
+### Fixed
+
+- **Docker `full` run (#282): TV/external recommendations never ran, with zero indication why.** The web UI's `full` engine, in Docker, chains `movie.py -> tv.py -> external.py` in one `bash -c "cmd1 && cmd2 && cmd3"` invocation (`web/job_runner.py`, since v2.10.56/#277). Verified in a real container against the real production recommenders: that chain already ran every stage correctly whenever each one exited 0, and correctly stopped at whichever stage failed - the same fail-fast behavior `docker-entrypoint.sh`'s own `recommend full` has under `set -e` (also independently verified in a real container: it does not run every stage unconditionally either). The actual defect was that a stage being skipped because an earlier one failed was completely silent - no banner in the log (unlike `docker-entrypoint.sh`'s own `=== X ===` lines) and nothing in `Job.to_dict()` beyond one overall `state`/`returncode` - so a movie failure correctly skipping tv/external was indistinguishable, from `/run` and `/run/status`, from tv/external having been dropped for no reason at all.
+
+  Replaced the bare `&&` chain with an explicit, per-stage script (`_build_docker_full_script`) that keeps the exact same semantics (movie failing stops tv and external; tv failing stops external; the script's own exit code is whichever stage failed) but adds an `=== X ===` banner per stage - including an explicit `(skipped: ... failed)` banner for whichever stage(s) never ran - plus a machine-readable `__CURATARR_STAGE__:<stage>:<returncode-or-skipped>` marker line that `_pump()` parses into a new `Job.stage_results` dict, now exposed via `/run/status`/`/status.json` and rendered on the Run page as a per-stage breakdown.
+
+- **`/results` and `/run` never distinguished "succeeded" from "succeeded but produced nothing" (#288).** Confirmed directly in a real container: `recommenders/external.py` can catch a per-user exception internally, log it, and still print its own "Watchlists saved to: ..." success line having written nothing new - exit code 0, `state: succeeded`, and `/results` showing the same generic "No watchlists generated yet" it shows before anyone has ever run anything at all. Added `Job.external_produced_output` (`JobManager._check_external_output`): after a `full`/`external` run whose external stage exited 0, checks whether `recommendations/external/` actually gained a file newer than the run's own start time. `/results` and `/run` now show a specific message distinguishing three cases instead of one generic one: external skipped because an earlier stage failed, external itself failed, or external "succeeded" but wrote nothing - each pointing at the run log. Deliberately does not second-guess `external_recommendations.enabled: false` (tuning.yml, #271) as a cause - a deliberately disabled stage legitimately produces no new file, which is not a bug.
+
+  New regression coverage in `tests/test_web_job_runner.py`: the full chain invokes all three stages and records `stage_results` when everything succeeds; a movie failure stops tv/external with `stage_results` showing `skipped`; a tv failure stops external the same way; `external_produced_output` is `True`/`False`/`None` (not applicable) in the write/no-write/failed cases respectively.
+
 ## [2.10.63] - 2026-07-27
 
 ### Fixed

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -176,11 +176,36 @@ class TestBuildCommandDockerFullEngine:
         manager = self._manager("/data", "/app")
         cmd, _env, _log_name = manager._build_command("full", "all")
         script = cmd[2]
-        assert " && " in script
         movie_pos = script.index("movie.py")
         tv_pos = script.index("tv.py")
         external_pos = script.index("external.py")
         assert movie_pos < tv_pos < external_pos
+
+    def test_docker_full_engine_no_longer_uses_bare_and_chain(self, monkeypatch):
+        """#282/#288: a bare `cmd1 && cmd2 && cmd3` gave no indication of
+        *which* stage a failure stopped at - see _build_docker_full_script's
+        docstring. Replaced with explicit per-stage gating + markers."""
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        assert " && " not in script
+
+    def test_docker_full_engine_emits_stage_markers_for_every_stage(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        for stage in ("movie", "tv", "external"):
+            assert f"{job_runner_mod.STAGE_MARKER_PREFIX}:{stage}:" in script
+
+    def test_docker_full_engine_skips_later_stages_on_movie_failure(self, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = self._manager("/data", "/app")
+        cmd, _env, _log_name = manager._build_command("full", "all")
+        script = cmd[2]
+        assert f"{job_runner_mod.STAGE_MARKER_PREFIX}:tv:skipped" in script
+        assert f"{job_runner_mod.STAGE_MARKER_PREFIX}:external:skipped" in script
 
     def test_docker_full_engine_uses_code_root_not_project_root(self, monkeypatch):
         monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
@@ -246,7 +271,12 @@ class TestJobManagerStart:
         entirely (see TestBuildCommandDockerFullEngine) and chains the
         three recommenders directly instead - confirms that actually
         executes end to end (not just that _build_command constructs
-        the right argv), in the right order, exit code 0."""
+        the right argv), in the right order, exit code 0.
+
+        #282/#288: also confirms Job.stage_results shows all three
+        stages actually ran and succeeded - the structured signal
+        /run/status and /status.json now expose (see web/job_runner.py's
+        STAGE_MARKER_PREFIX)."""
         monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
         manager = _manager(curatarr_web_root)
         job = manager.start("full", "all", ["alice", "bob"])
@@ -258,6 +288,99 @@ class TestJobManagerStart:
         tv_idx = job.lines.index("TV recommendations done")
         external_idx = job.lines.index("External watchlists done")
         assert movie_idx < tv_idx < external_idx
+
+        assert job.stage_results == {"movie": "0", "tv": "0", "external": "0"}
+
+    def test_full_engine_in_docker_stops_after_movie_failure(self, tmp_path, monkeypatch):
+        """#282 regression: movie failing must stop tv/external from
+        ever running (matching the pre-existing `&&`/docker-
+        entrypoint.sh `set -e` semantics - verified against the real
+        production scripts in a real container, not just this fixture)
+        - AND must now say so structurally via stage_results instead of
+        leaving the web UI to guess why tv/external never ran."""
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        root = _make_root(tmp_path, 'import sys\nprint("Movie recommendations starting")\nsys.exit(3)\n')
+        manager = _manager(root)
+        job = manager.start("full", "all", ["alice", "bob"])
+        _wait_until_done(job)
+
+        assert job.returncode == 3
+        assert job.state == "failed"
+        # tv.py/external.py (the fixture's default fakes - see
+        # _make_root) never actually ran at all - only the skip
+        # banners do, which is the whole point of this fix (#282's own
+        # report: previously there was no banner or marker at all, just
+        # silence about why tv/external were missing).
+        assert not any("tv done" in line for line in job.lines)
+        assert not any("external done" in line for line in job.lines)
+        assert any("skipped: movie recommendations failed" in line for line in job.lines)
+        assert job.stage_results == {"movie": "3", "tv": "skipped", "external": "skipped"}
+
+    def test_full_engine_in_docker_stops_after_tv_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        root = _make_root(tmp_path, 'print("Movie recommendations done")\n')
+        with open(os.path.join(root, "recommenders", "tv.py"), "w", encoding="utf-8") as f:
+            f.write("import sys\nprint('TV recommendations starting')\nsys.exit(2)\n")
+        manager = _manager(root)
+        job = manager.start("full", "all", ["alice", "bob"])
+        _wait_until_done(job)
+
+        assert job.returncode == 2
+        assert job.state == "failed"
+        assert any("Movie recommendations done" in line for line in job.lines)
+        assert any("TV recommendations starting" in line for line in job.lines)
+        # external.py (the fixture's default fake) never actually ran.
+        assert not any("external done" in line for line in job.lines)
+        assert any("skipped: TV recommendations failed" in line for line in job.lines)
+        assert job.stage_results == {"movie": "0", "tv": "2", "external": "skipped"}
+
+    def test_full_engine_external_produced_output_true_when_file_written(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        root = _make_root(tmp_path, 'print("Movie recommendations done")\n')
+        external_dir = os.path.join(root, "recommendations", "external")
+        with open(os.path.join(root, "recommenders", "external.py"), "w", encoding="utf-8") as f:
+            f.write(
+                "import os\n"
+                f"open(os.path.join({external_dir!r}, 'alice.html'), 'w').close()\n"
+                "print('External watchlists done')\n"
+            )
+        manager = _manager(root)
+        job = manager.start("full", "all", ["alice", "bob"])
+        _wait_until_done(job)
+
+        assert job.returncode == 0
+        assert job.stage_results == {"movie": "0", "tv": "0", "external": "0"}
+        assert job.external_produced_output is True
+
+    def test_full_engine_external_produced_output_false_when_no_file_written(self, curatarr_web_root, monkeypatch):
+        """#288: external.py exiting 0 without writing anything new
+        (e.g. a per-user exception it caught internally, as observed in
+        a real container run) must be distinguishable from a genuine
+        success with output - the fixture's own fake external.py only
+        prints, it never writes recommendations/external/*, so this is
+        exactly that shape."""
+        monkeypatch.setenv("RUNNING_IN_DOCKER", "true")
+        manager = _manager(curatarr_web_root)
+        job = manager.start("full", "all", ["alice", "bob"])
+        _wait_until_done(job)
+
+        assert job.returncode == 0
+        assert job.external_produced_output is False
+
+    def test_external_engine_produced_output_not_applicable_on_failure(self, curatarr_web_root):
+        """external_produced_output stays None (not False) when the
+        stage itself failed - that failure already has its own signal
+        (returncode); a second, contradictory "no output" flag on top
+        of it would be confusing, not additionally informative."""
+        root = curatarr_web_root
+        with open(os.path.join(root, "recommenders", "external.py"), "w", encoding="utf-8") as f:
+            f.write("import sys\nsys.exit(1)\n")
+        manager = _manager(root)
+        job = manager.start("external", "all", ["alice", "bob"])
+        _wait_until_done(job)
+
+        assert job.returncode == 1
+        assert job.external_produced_output is None
 
     def test_runs_external_engine(self, curatarr_web_root):
         manager = _manager(curatarr_web_root)

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.63"
+__version__ = "2.10.64"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/app.py
+++ b/web/app.py
@@ -724,7 +724,22 @@ def create_app(
                             "mtime": datetime.fromtimestamp(os.path.getmtime(path)),
                         }
                     )
-        return render_template("results.html", watchlists=watchlists, logs=list_log_files(logs_dir))
+        # #288: "No watchlists generated yet" is the right message
+        # before anyone has ever run anything, but was ALSO the only
+        # message ever shown when a full/external run had already
+        # completed and produced nothing - whether because an earlier
+        # stage failed (stage_results), external itself failed, or
+        # external ran and reported success while writing nothing (see
+        # web/job_runner.py's external_produced_output). Passing the
+        # last job's status dict lets results.html tell those apart
+        # instead of always showing the same "run recommendations
+        # first" text even right after a run that clearly did.
+        return render_template(
+            "results.html",
+            watchlists=watchlists,
+            logs=list_log_files(logs_dir),
+            job=app.job_manager.status(),
+        )
 
     @app.get("/results/watchlist/<path:filename>")
     def results_watchlist(filename):

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -29,6 +29,7 @@ sys.exit() behavior above stays safe.
 import logging
 import os
 import queue
+import re
 import shlex
 import signal
 import subprocess
@@ -45,6 +46,15 @@ from .security import redact
 logger = logging.getLogger("curatarr")
 
 ENGINES = ("full", "movie", "tv", "external")
+
+# Prefix for the per-stage result lines the Docker `full` engine's
+# generated bash script (_build_docker_full_script) writes to stdout -
+# "__CURATARR_STAGE__:<stage>:<returncode-or-skipped>" - so _pump() can
+# tell a stage that never ran apart from one that ran and failed,
+# something the raw log/output alone doesn't otherwise convey (#282/
+# #288 - see _build_docker_full_script's docstring).
+STAGE_MARKER_PREFIX = "__CURATARR_STAGE__"
+_STAGE_MARKER_RE = re.compile(re.escape(STAGE_MARKER_PREFIX) + r":(\w+):(\S+)$")
 
 # Sentinel pushed onto subscriber queues when a job finishes, so SSE
 # consumers know to stop waiting for more output.
@@ -125,6 +135,61 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
+def _build_docker_full_script(py: str, movie_script: str, tv_script: str, external_script: str) -> str:
+    """Build the `bash -c` script body for the Docker `full` engine:
+    movie -> tv -> external, explicitly gated and labeled (#282/#288 -
+    see the call site in _build_command's own comment for the full
+    history this replaces).
+
+    Semantics (deliberately identical to the pre-existing `&&` chain,
+    and to docker-entrypoint.sh's own `recommend full` under `set -e` -
+    both verified in a real container, not just read): if movie exits
+    non-zero, tv and external never run at all; if tv exits non-zero,
+    external never runs. Either way the script's own exit code is that
+    failing stage's returncode, so Job.state ("succeeded"/"failed") is
+    unchanged from today. What's added is purely observability: an
+    "=== X ===" banner per stage (matching docker-entrypoint.sh's own
+    convention) - including an explicit "(skipped: ... failed)" banner
+    for whichever stage(s) never ran, so the raw log itself says why,
+    not just silence - plus an f"{STAGE_MARKER_PREFIX}:<stage>:<result>"
+    line per stage (result is the stage's returncode, or the literal
+    "skipped") that _pump() parses into Job.stage_results.
+
+    py/movie_script/tv_script/external_script are all already
+    shlex.quote()'d by the caller - kept as plain str params (not
+    re-quoted here) so a test can assert on the exact paths/executable
+    it passed in.
+    """
+    return (
+        "set +e\n"
+        "echo '=== Movie recommendations ==='\n"
+        f"{py} {movie_script}\n"
+        "MOVIE_RC=$?\n"
+        f'echo "{STAGE_MARKER_PREFIX}:movie:$MOVIE_RC"\n'
+        'if [ "$MOVIE_RC" -ne 0 ]; then\n'
+        "  echo '=== TV recommendations === (skipped: movie recommendations failed)'\n"
+        f"  echo '{STAGE_MARKER_PREFIX}:tv:skipped'\n"
+        "  echo '=== External watchlists === (skipped: movie recommendations failed)'\n"
+        f"  echo '{STAGE_MARKER_PREFIX}:external:skipped'\n"
+        '  exit "$MOVIE_RC"\n'
+        "fi\n"
+        "echo '=== TV recommendations ==='\n"
+        f"{py} {tv_script}\n"
+        "TV_RC=$?\n"
+        f'echo "{STAGE_MARKER_PREFIX}:tv:$TV_RC"\n'
+        'if [ "$TV_RC" -ne 0 ]; then\n'
+        "  echo '=== External watchlists === (skipped: TV recommendations failed)'\n"
+        f"  echo '{STAGE_MARKER_PREFIX}:external:skipped'\n"
+        '  exit "$TV_RC"\n'
+        "fi\n"
+        "echo '=== External watchlists ==='\n"
+        f"{py} {external_script}\n"
+        "EXT_RC=$?\n"
+        f'echo "{STAGE_MARKER_PREFIX}:external:$EXT_RC"\n'
+        'exit "$EXT_RC"\n'
+    )
+
+
 class Job:
     """State for a single triggered run. Construct via JobManager.start()."""
 
@@ -147,6 +212,25 @@ class Job:
         self.lines: List[str] = []
         self._subscribers: List["queue.Queue"] = []
 
+        # Per-stage breakdown for the Docker `full` engine (#282/#288) -
+        # {"movie": "0", "tv": "1", "external": "skipped"}, in
+        # completion order, populated as STAGE_MARKER_PREFIX lines are
+        # read (see _pump()). Empty for every other engine/branch
+        # (single-engine runs, frozen's --run-recommender full, the
+        # non-Docker run.sh/run.ps1 path) - none of those emit stage
+        # markers, so there is nothing finer-grained than `state` to
+        # show for them.
+        self.stage_results: "Dict[str, str]" = {}
+        # Set (only ever to False) once _pump() confirms a `full`/
+        # `external` run's external stage exited 0 but wrote no new
+        # file under recommendations/external/ - the exact "succeeded,
+        # but produced nothing" shape #288 reported. None means this
+        # engine/run doesn't apply (external stage skipped, failed, or
+        # never part of this run) - deliberately distinct from True so
+        # a caller can tell "checked and fine" apart from "not
+        # applicable" instead of collapsing both into one boolean.
+        self.external_produced_output: Optional[bool] = None
+
     @property
     def state(self) -> str:
         if self.returncode is None:
@@ -158,6 +242,19 @@ class Job:
             self.lines.append(line)
             for q in self._subscribers:
                 _safe_queue_put(q, line)
+        # Stage markers (see STAGE_MARKER_PREFIX/_STAGE_MARKER_RE) are
+        # plain stdout lines from the recommender's point of view -
+        # they still go through the redact()/log-file/subscriber path
+        # above like any other line - this just additionally captures
+        # them structurally. Checked on every line (cheap: one regex
+        # match against an already-redacted, already-short line) rather
+        # than only for engine == "full", so a future engine reusing
+        # this marker format doesn't need a second call site.
+        match = _STAGE_MARKER_RE.search(line)
+        if match:
+            stage, result = match.group(1), match.group(2)
+            with self._data_lock:
+                self.stage_results[stage] = result
 
     def _finish(self, returncode: int) -> None:
         with self._data_lock:
@@ -197,6 +294,14 @@ class Job:
             "finished_at": self.finished_at,
             "returncode": self.returncode,
             "log_file": os.path.basename(self.log_path),
+            # See stage_results/external_produced_output's own
+            # docstrings above (#282/#288) - both default to "nothing
+            # to report" values ({} / None) for every engine/branch
+            # that doesn't populate them, so existing consumers of
+            # to_dict() that don't know about these two new keys are
+            # unaffected.
+            "stage_results": dict(self.stage_results),
+            "external_produced_output": self.external_produced_output,
         }
 
 
@@ -409,6 +514,30 @@ class JobManager:
                 # movie -> tv -> external order directly, same as
                 # frozen's own `--run-recommender full` (see
                 # curatarr_app.py) bypassing run.sh/run.ps1 entirely.
+                # #282/#288: a bare `cmd1 && cmd2 && cmd3` ran every
+                # stage fine whenever each one exited 0 (verified in a
+                # real container against the real recommenders), and
+                # correctly stopped at whichever stage failed - `&&`
+                # short-circuiting there matches docker-entrypoint.sh's
+                # own `recommend full` under `set -e` (also verified in
+                # a real container: it does NOT run every stage
+                # unconditionally either). What was actually missing
+                # was any indication, anywhere the web UI could see, of
+                # *which* stage a failure stopped at - a movie failure
+                # correctly skipping tv/external looked, from /run and
+                # /run/status, identical to tv/external having been
+                # silently dropped for no reason: no stage banners in
+                # the log (docker-entrypoint.sh at least has its own
+                # echo lines) and nothing in Job.to_dict() beyond one
+                # overall state/returncode.
+                # _build_docker_full_script keeps the exact same
+                # fail-fast semantics (never a fourth variant of "what
+                # does `full` mean" alongside run.sh/docker-
+                # entrypoint.sh/the frozen dispatcher's
+                # --run-recommender full) but adds explicit "=== X ==="
+                # banners plus a machine-readable
+                # f"{STAGE_MARKER_PREFIX}:<stage>:<rc-or-skipped>" line
+                # per stage that _pump() parses into Job.stage_results.
                 movie_script = os.path.join(code_root, "recommenders", "movie.py")
                 tv_script = os.path.join(code_root, "recommenders", "tv.py")
                 external_script = os.path.join(code_root, "recommenders", "external.py")
@@ -416,9 +545,9 @@ class JobManager:
                 cmd = [
                     "bash",
                     "-c",
-                    f"{py} {shlex.quote(movie_script)} && "
-                    f"{py} {shlex.quote(tv_script)} && "
-                    f"{py} {shlex.quote(external_script)}",
+                    _build_docker_full_script(
+                        py, shlex.quote(movie_script), shlex.quote(tv_script), shlex.quote(external_script)
+                    ),
                 ]
             elif os.name == "nt":
                 cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", os.path.join(code_root, "run.ps1")]
@@ -509,7 +638,47 @@ class JobManager:
             self._remove_lock()
             if job._run_lock is not None:
                 job._run_lock.release()
+            self._check_external_output(job)
             job._finish(returncode if returncode is not None else -1)
+
+    def _check_external_output(self, job: Job) -> None:
+        """#288: external.py can catch a per-user exception internally
+        and still exit 0 having written nothing new - "succeeded" with
+        no output is exactly the confusing shape that issue reported
+        (confirmed directly: a real container run hit an unrelated
+        per-user error, external.py logged it and moved on, and still
+        printed its own "Watchlists saved to: ..." success line).
+
+        Sets job.external_produced_output to False when the external
+        stage ran (engine == "external", or engine == "full" with
+        stage_results showing it wasn't skipped/failed - see
+        STAGE_MARKER_PREFIX) and exited 0 but recommendations/external/
+        has no file newer than the job's own start time; True when it
+        does. Left at its default None ("not applicable") for every
+        other case - a failed or skipped external stage already has its
+        own, more specific signal (returncode/stage_results), and a
+        second, contradictory "no output" flag on top of that would
+        only be confusing. Deliberately does NOT know about
+        tuning.yml's external_recommendations.enabled (a deliberately-
+        disabled stage legitimately produces no *new* file either) -
+        that's a display-layer concern for whatever renders this
+        alongside the current config, not this subprocess-result data.
+        """
+        if job.engine == "full":
+            if job.stage_results.get("external") != "0":
+                return  # failed, skipped, or never reached a marker at all
+        elif job.engine != "external" or job.returncode != 0:
+            return
+
+        external_dir = os.path.join(self.project_root, "recommendations", "external")
+        cutoff = job.started_at.timestamp()
+        try:
+            produced = any(
+                os.path.getmtime(os.path.join(external_dir, name)) >= cutoff for name in os.listdir(external_dir)
+            )
+        except OSError:
+            produced = False
+        job.external_produced_output = produced
 
     def terminate_running(self) -> None:
         """Best-effort: terminate the in-flight subprocess (and its

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -344,6 +344,12 @@ button:disabled {
 .banner.error { border-left-color: var(--fail); color: var(--fail); }
 .banner.warn { border-left-color: var(--warn); color: var(--warn); }
 
+/* --- Per-stage run breakdown (#282/#288 - see run.html/results.html) --- */
+.stage-results { list-style: none; padding: 0; margin: 0 0 12px; }
+.stage-results li { padding: 2px 0; }
+.stage-results .ok { color: var(--ok); }
+.stage-results .error { color: var(--fail); }
+
 .update-banner {
   display: flex;
   align-items: center;

--- a/web/templates/results.html
+++ b/web/templates/results.html
@@ -13,6 +13,23 @@
   </li>
   {% endfor %}
 </ul>
+{% elif job and job.stage_results and job.stage_results.get('external') == 'skipped' %}
+<p class="banner error">
+  No watchlists: external watchlist generation was skipped because an earlier stage
+  ({{ 'movie recommendations' if job.stage_results.get('movie') != '0' else 'TV recommendations' }}) failed.
+  See <a href="{{ url_for('results_log', filename=job.log_file) }}">the run log</a> for details.
+</p>
+{% elif job and job.stage_results and job.stage_results.get('external') not in (None, '0') %}
+<p class="banner error">
+  No watchlists: external watchlist generation failed (exit code {{ job.stage_results.get('external') }}).
+  See <a href="{{ url_for('results_log', filename=job.log_file) }}">the run log</a> for details.
+</p>
+{% elif job and job.get('external_produced_output') is sameas false %}
+<p class="banner error">
+  No watchlists: the last run completed but did not write any watchlist file - check
+  <a href="{{ url_for('results_log', filename=job.log_file) }}">the run log</a> for a per-user error,
+  or confirm <code>external_recommendations.enabled</code> in tuning.yml.
+</p>
 {% else %}
 <p>No watchlists generated yet - run recommendations first.</p>
 {% endif %}

--- a/web/templates/run.html
+++ b/web/templates/run.html
@@ -37,6 +37,35 @@
   No run yet.
   {% endif %}
 </p>
+{% if job and job.stage_results %}
+{# #282/#288: a "full" run's per-stage breakdown - previously the only
+   signal was one overall state, so a movie failure that correctly (and
+   silently) skipped tv/external looked identical to them being dropped
+   for no reason. See web/job_runner.py's STAGE_MARKER_PREFIX. #}
+<ul id="stage-results" class="stage-results">
+  {% for stage in ['movie', 'tv', 'external'] %}
+  {% set result = job.stage_results.get(stage) %}
+  {% if result is not none %}
+  <li>
+    {{ stage }}:
+    {% if result == 'skipped' %}
+    <span class="muted">skipped (an earlier stage failed)</span>
+    {% elif result == '0' %}
+    <span class="ok">succeeded</span>
+    {% else %}
+    <span class="error">failed (exit code {{ result }})</span>
+    {% endif %}
+  </li>
+  {% endif %}
+  {% endfor %}
+</ul>
+{% if job.external_produced_output is sameas false %}
+<p class="banner error">
+  External watchlist generation reported success but wrote no file - see the log below for a
+  per-user error, or confirm <code>external_recommendations.enabled</code> in tuning.yml.
+</p>
+{% endif %}
+{% endif %}
 <pre id="output" class="log-output"></pre>
 
 <script>


### PR DESCRIPTION
## Summary

Closes #282, closes #288.

- The web UI's Docker `full` engine chains `movie.py -> tv.py -> external.py` via a bare `bash -c "cmd1 && cmd2 && cmd3"` (since v2.10.56/#277). Verified in a real container against the real production recommenders (fake-but-reachable Plex + plex.tv over HTTPS) that this chain already runs every stage correctly when each exits 0, and correctly stops at whichever stage fails - matching `docker-entrypoint.sh`'s own `recommend full` under `set -e`, also independently verified in a real container (it does NOT run every stage unconditionally). The actual defect: a skipped stage was completely silent - no banner in the log, nothing in `Job.to_dict()` beyond one overall state/returncode - so a movie failure correctly skipping tv/external looked, from `/run`/`/run/status`, identical to them being dropped for no reason.
- Replaced the bare `&&` chain with an explicit per-stage script (`_build_docker_full_script`) - same fail-fast semantics, but with an `=== X ===` banner per stage (including an explicit skip banner) and a machine-readable `__CURATARR_STAGE__:<stage>:<rc-or-skipped>` marker line, parsed into a new `Job.stage_results` exposed via `/run/status`/`/status.json` and rendered on the Run page.
- Added `Job.external_produced_output`: confirmed directly in a real container that `external.py` can catch a per-user exception internally and still exit 0 having written nothing new. `/results`/`/run` now distinguish skipped due to an earlier failure / external itself failed / succeeded but wrote nothing instead of one generic no watchlists yet message.

## Real-container verification

Built the image from this branch and ran it against a from-scratch fake Plex + plex.tv (HTTPS, real cert) fixture, driving the REAL web UI over HTTP (not the CLI, not a mock):

- Success path: `POST /run` engine=full -> `stage_results: {movie:0,tv:0,external:0}`, `external_produced_output: true`, real `.html`/`.md` files appeared under `recommendations/external/` and showed up on `/results`.
- Failure path (movie hits a genuine connection error): `stage_results: {movie:1,tv:skipped,external:skipped}`, `state: failed`, log shows explicit `=== TV recommendations === (skipped: movie recommendations failed)` banners, `/run` page renders the per-stage breakdown, `/results` explains why there are no watchlists instead of the old generic message.

## Test plan

- [x] `tests/test_web_job_runner.py` - 14 new/updated tests: full chain invokes all three stages with `stage_results` populated on success; movie failure stops tv/external with `stage_results` showing `skipped`; tv failure stops external the same way; `external_produced_output` True/False/None across the write/no-write/failed cases.
- [x] Full suite (2798 passed, 1 skipped), `ruff check .`, `mypy .` all green.
- [x] Real-container verification above.
