### PR TITLE
fix: delete broken build_user_profile, guard key-name assumptions (2.10.64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.64] - 2026-07-27
+
+### Fixed
+
+- **`recommenders/external.py`'s `build_user_profile()` had a fatal, unfixable-in-place bug (#273 PR3): its `username` parameter had zero effect on the output** - it always scanned whatever `plex` connection the caller already had (the one shared admin-token connection every caller in this file uses), never `username`'s own. Deleted entirely and replaced with `_build_profile_via_recommender()`, which constructs the real `PlexMovieRecommender`/`PlexTVRecommender` for `username` directly - the same "shared path" `recommenders/movie.py`'s and `recommenders/tv.py`'s own watched-data builders already use (and already benefit from #273 PR1's/PR2's fixes). As a side effect, this also persists a real, correctly-weighted watched-cache file to disk on first use, so `load_user_profile_from_cache()` finds it on the very next call instead of paying the same slow full-Plex-scan cost forever (`build_user_profile()`'s own docstring already called itself out as slow).
+
+  `is_thin_profile()` and `discover_popular_by_genre()`'s genre/keyword iteration both called `.most_common()` directly on `user_profile["genres"]`/`user_profile["keywords"]`, assuming the caller always handed over `Counter` objects keyed exactly `"genres"`/`"keywords"` - true for `load_user_profile_from_cache()`'s own return shape, but not guaranteed for every caller (in particular, a caller handing over `watched_data_counters` in its raw, `"tmdb_keywords"`-keyed, not-necessarily-`Counter`-typed shape directly). Both now coerce to `Counter` if not already one, and the keyword lookup accepts either `"keywords"` or `"tmdb_keywords"`.
+
+  **Verified against the real, live Plex library** (read-only: only real Plex history/library-listing calls, no writes, no Trakt calls): `_build_profile_via_recommender()` is only ever reached as a fallback when no watched cache exists yet for a user/media type - already true for every one of this install's 6 real configured users, so there's no meaningful before/after to observe in normal use. Instead verified the function's previously-broken core behavior directly: two different real users (`ericarutyunov`, `homehouse165`) now get genuinely different profiles - 27 and 15 `tmdb_ids` respectively, exactly matching each user's own real watched-movie count already independently established in #273 PR1's verification (`ericarutyunov`: 27, `homehouse165`: 15) - both `Counter`-typed and both correctly under a `"keywords"` key, not `"tmdb_keywords"`.
+
+  While verifying, found (but did not fix - out of this PR's scope) a pre-existing, unrelated test-isolation gap: `recommenders/external_sync.py` resolves its own cache directory via a `get_project_root()` binding conftest.py's `_isolated_recommender_cache_dir` autouse fixture doesn't patch (it only patches `recommenders.base`'s and `recommenders.external`'s own bindings), so any test exercising its Trakt-export-status recording writes a real (small, harmless) `cache/integration_status_trakt_export.json` into the actual repo instead of an isolated tmp dir.
+
 ## [2.10.63] - 2026-07-27
 
 ### Fixed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -57,7 +57,6 @@ from recommenders.huntarr import (
 from recommenders.streaming import categorize_by_streaming_service
 from utils import (
     CYAN,
-    DEFAULT_RATING_MULTIPLIERS,
     GREEN,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_TV,
@@ -66,8 +65,6 @@ from utils import (
     TMDB_RATE_LIMIT_DELAY,
     TMDB_REQUEST_TIMEOUT,
     YELLOW,
-    calculate_recency_multiplier,
-    calculate_rewatch_multiplier,
     calculate_similarity_score,
     clickable_link,
     enhance_profile_with_trakt,
@@ -80,7 +77,6 @@ from utils import (
     get_streaming_services_for_user,
     get_tmdb_config,
     get_tmdb_id_from_imdb,
-    get_tmdb_keywords,
     get_trakt_discovery_candidates,
     load_config,
     load_json_cache,
@@ -269,13 +265,28 @@ def discover_candidates_by_profile(
     candidates: Dict[int, Dict] = {}  # tmdb_id -> basic info
     media = "movie" if media_type == "movie" else "tv"
 
-    # Get genres for this iteration's range
-    all_genres = list(user_profile["genres"].most_common(20))
+    # Get genres for this iteration's range. Coerced to Counter (#273
+    # PR3) rather than assumed - user_profile can come from
+    # load_user_profile_from_cache()/_build_profile_via_recommender()
+    # (already Counter-valued) or, in principle, a caller handing over
+    # plain-dict-shaped data directly (e.g. straight off a JSON cache
+    # read), which .most_common() can't be called on.
+    genres_counter = user_profile.get("genres")
+    if not isinstance(genres_counter, Counter):
+        genres_counter = Counter(genres_counter or {})
+    all_genres = list(genres_counter.most_common(20))
     top_genres = all_genres[genre_start:genre_end]
     genre_id_map = TMDB_MOVIE_GENRE_IDS if media_type == "movie" else TMDB_TV_GENRE_IDS
 
-    # Get keywords for this iteration's range
-    all_keywords = list(user_profile["keywords"].most_common(40))
+    # Get keywords for this iteration's range. Accepts either 'keywords'
+    # (this file's own internal convention - see
+    # load_user_profile_from_cache()'s/_build_profile_via_recommender()'s
+    # return shape) or 'tmdb_keywords' (the raw watched_data_counters key
+    # name recommenders/movie.py's/tv.py's own builders use) - #273 PR3.
+    keywords_counter = user_profile.get("keywords", user_profile.get("tmdb_keywords"))
+    if not isinstance(keywords_counter, Counter):
+        keywords_counter = Counter(keywords_counter or {})
+    all_keywords = list(keywords_counter.most_common(40))
     top_keywords = all_keywords[keyword_start:keyword_end]
 
     # Search by genres for this iteration
@@ -417,7 +428,14 @@ def discover_candidates_by_profile(
 
 def is_thin_profile(user_profile: Dict) -> bool:
     """Check if profile has too few items for reliable matching."""
-    total_items = sum(user_profile.get("genres", Counter()).values())
+    # Coerced to Counter (#273 PR3) - see discover_popular_by_genre's own
+    # identical note above; .values() happens to work on a plain dict
+    # too, but coercing here keeps this function's input contract
+    # consistent with every other user_profile consumer in this file.
+    genres = user_profile.get("genres")
+    if not isinstance(genres, Counter):
+        genres = Counter(genres or {})
+    total_items = sum(genres.values())
     return total_items < THIN_PROFILE_THRESHOLD
 
 
@@ -568,117 +586,66 @@ def load_user_profile_from_cache(config: Dict, username: str, media_type: str = 
         return None
 
 
-def build_user_profile(plex: Any, config: Dict, username: str, media_type: str = "movie") -> Dict:
+def _build_profile_via_recommender(username: str, media_type: str) -> Dict:
+    """Replaces the deleted build_user_profile() (#273 PR3).
+
+    build_user_profile() had a fatal, unfixable-in-place bug (#3): its
+    `username` parameter had zero effect on the output - it always
+    scanned whatever `plex` connection the caller already had (the one
+    shared admin-token connection every caller in this file uses),
+    never username's own. Rather than maintaining a second,
+    independent, username-aware Plex-scanning implementation here (a
+    third copy of logic recommenders/movie.py's and recommenders/tv.py's
+    own watched-data builders already get right, including #273 PR1's
+    per-user token fix), this constructs the real
+    PlexMovieRecommender/PlexTVRecommender for `username` directly - the
+    same "shared path" those internal recommenders already use. That
+    also means this benefits from every one of #273 PR1's/PR2's fixes
+    automatically, and - unlike build_user_profile() - persists a real,
+    correctly-weighted watched-cache file to disk as a side effect of
+    construction, so load_user_profile_from_cache() finds it on the very
+    next call for this user instead of paying this same slow full-Plex-
+    scan cost forever.
+
+    Constructs its own config_path via get_project_root() (matching
+    _main_impl()'s own resolution) rather than threading one through
+    every caller's signature (process_user()/process_user_movie_library()/
+    process_user_tv_library()/_pu_build_profiles() never otherwise need
+    one - callers here already hold an in-memory `config`/`plex`, which
+    this intentionally does NOT reuse; a second Plex connection is the
+    cost of reusing the real, correct recommender construction instead
+    of a bespoke scan, and this is only ever reached when no cache
+    exists yet for this user/media type - not the common case).
+
+    Returns the profile in the exact same shape
+    load_user_profile_from_cache() returns (Counter-valued, 'keywords'
+    not 'tmdb_keywords') for consistency between the two - though
+    is_thin_profile()/discover_popular_by_genre() (the two real
+    consumers) defensively accept either key name and coerce to Counter
+    regardless, since a future caller could still hand either shape.
     """
-    Build weighted user profile from ALL watch history.
-    Uses same weighting as internal recommenders: ratings + rewatches + recency.
+    from recommenders.movie import PlexMovieRecommender
+    from recommenders.tv import PlexTVRecommender
 
-    NOTE: This is slow! Use load_user_profile_from_cache() first when possible.
+    config_path = os.path.join(get_project_root(), "config/config.yml")
+    recommender_cls = PlexMovieRecommender if media_type == "movie" else PlexTVRecommender
 
-    Returns:
-        dict: Weighted counters for genres, actors, directors/studios, keywords, languages
-    """
-    library_name = config["plex"].get("movie_library" if media_type == "movie" else "tv_library")
-    library = plex.library.section(library_name)
-    all_items = library.all()
-    total_items = len(all_items)
-    print(f"Building {media_type} profile for {username} ({total_items} items to scan)...")
+    wdc: Dict[str, Any] = {}
+    try:
+        recommender = recommender_cls(config_path, single_user=username)
+        wdc = recommender.watched_data_counters or {}
+    except Exception as e:
+        log_warning(f"Could not build {media_type} profile for {username} via recommender: {e}")
 
-    # Get recency config
-    recency_config = config.get("recency_decay", {})
-    recency_enabled = recency_config.get("enabled", True)
-
-    counters: Dict[str, Any] = {
-        "genres": Counter(),
-        "directors": Counter(),  # movies
-        "studios": Counter(),  # TV shows
-        "actors": Counter(),
-        "keywords": Counter(),
-        "languages": Counter(),
-        "tmdb_ids": set(),
+    return {
+        "genres": Counter(wdc.get("genres", {})),
+        "directors": Counter(wdc.get("directors", {})),
+        "studios": Counter(wdc.get("studios", {})),
+        "actors": Counter(wdc.get("actors", {})),
+        "keywords": Counter(wdc.get("tmdb_keywords", wdc.get("keywords", {}))),
+        "languages": Counter(wdc.get("languages", {})),
+        "tmdb_ids": set(wdc.get("tmdb_ids", [])),
     }
-
-    # Get account for user checking - construction alone validates the
-    # token (raises if invalid), same as before; the account object
-    # itself was never used past this point.
-    MyPlexAccount(token=config["plex"]["token"])
-    tmdb_api_key = get_tmdb_config(config)["api_key"]
-
-    watched_count = 0
-
-    for i, item in enumerate(all_items, 1):
-        # Show progress periodically or at the end
-        if i % PROGRESS_UPDATE_FREQUENCY == 0 or i == total_items:
-            print(f"\r  Scanning library: {i}/{total_items} ({int(i / total_items * 100)}%)", end="", flush=True)
-
-        if not item.isWatched:
-            continue
-
-        watched_count += 1
-
-        # Get view count for rewatch multiplier
-        view_count = getattr(item, "viewCount", 1) or 1
-        rewatch_mult = calculate_rewatch_multiplier(view_count)
-
-        # Get last viewed date for recency multiplier
-        recency_mult = 1.0
-        if recency_enabled and hasattr(item, "lastViewedAt") and item.lastViewedAt:
-            # Plex returns datetime object, convert to timestamp for calculate_recency_multiplier
-            last_viewed = item.lastViewedAt
-            if hasattr(last_viewed, "timestamp"):
-                last_viewed = int(last_viewed.timestamp())
-            recency_mult = calculate_recency_multiplier(last_viewed, recency_config)
-
-        # Get user rating (convert 1-10 to multiplier)
-        user_rating = getattr(item, "userRating", None)
-        if user_rating:
-            rating_int = max(0, min(10, int(round(user_rating))))
-            rating_mult = DEFAULT_RATING_MULTIPLIERS.get(rating_int, 1.0)
-        else:
-            # Use audience rating as fallback, but with less weight
-            audience_rating = getattr(item, "audienceRating", 5.0) or 5.0
-            rating_int = max(0, min(10, int(round(audience_rating))))
-            rating_mult = DEFAULT_RATING_MULTIPLIERS.get(rating_int, 1.0) * 0.5  # Half weight for audience rating
-
-        # Combined multiplier
-        multiplier = rewatch_mult * recency_mult * rating_mult
-
-        # Extract attributes from Plex item
-        for genre in item.genres:
-            counters["genres"][genre.tag] += multiplier
-
-        if media_type == "movie":
-            for director in getattr(item, "directors", []):
-                counters["directors"][director.tag] += multiplier
-        else:
-            if hasattr(item, "studio") and item.studio:
-                counters["studios"][item.studio.lower()] += multiplier
-
-        # Top 3 actors
-        for actor in list(getattr(item, "roles", []))[:3]:
-            counters["actors"][actor.tag] += multiplier
-
-        # Get TMDB keywords (need to fetch from TMDB)
-        tmdb_id = None
-        for guid in item.guids:
-            if "tmdb://" in guid.id:
-                try:
-                    tmdb_id = int(guid.id.split("tmdb://")[1])
-                    counters["tmdb_ids"].add(tmdb_id)
-                    break
-                except (ValueError, IndexError) as e:
-                    logger.debug(f"Error parsing TMDB ID from guid {guid.id}: {e}")
-
-        if tmdb_id:
-            keywords = get_tmdb_keywords(tmdb_api_key, tmdb_id, media_type)
-            for keyword in keywords:
-                counters["keywords"][keyword] += multiplier
-
-    print()  # Newline after progress indicator
-    print(f"  Found {watched_count} watched {media_type}s")
-    print(f"  Top genres: {dict(counters['genres'].most_common(5))}")
-
-    return counters
 
 
 def get_library_items(plex: Any, library_name: str, media_type: str = "movie") -> Dict[str, Set]:
@@ -1346,11 +1313,11 @@ def _pu_build_profiles(plex, config, username):
     # Cache is pre-computed by internal recommenders with proper weighting
     movie_profile = load_user_profile_from_cache(config, username, "movie")
     if not movie_profile:
-        movie_profile = build_user_profile(plex, config, username, "movie")
+        movie_profile = _build_profile_via_recommender(username, "movie")
 
     show_profile = load_user_profile_from_cache(config, username, "tv")
     if not show_profile:
-        show_profile = build_user_profile(plex, config, username, "show")
+        show_profile = _build_profile_via_recommender(username, "tv")
 
     # Enhance profiles with Trakt watch history (streaming services not in Plex)
     # Only for users in the Trakt mapping
@@ -1866,7 +1833,7 @@ def process_user_movie_library(config, plex, username, library):
 
     movie_profile = load_user_profile_from_cache(config, username, "movie")
     if not movie_profile:
-        movie_profile = build_user_profile(plex, config, username, "movie")
+        movie_profile = _build_profile_via_recommender(username, "movie")
 
     tmdb_api_key = get_tmdb_config(config)["api_key"]
     trakt_config = config.get("trakt", {})
@@ -2079,7 +2046,7 @@ def process_user_tv_library(config, plex, username, library):
 
     show_profile = load_user_profile_from_cache(config, username, "tv")
     if not show_profile:
-        show_profile = build_user_profile(plex, config, username, "show")
+        show_profile = _build_profile_via_recommender(username, "tv")
 
     tmdb_api_key = get_tmdb_config(config)["api_key"]
     trakt_config = config.get("trakt", {})

--- a/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
+++ b/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
@@ -1,22 +1,4 @@
 {
-  "external_build_user_profile_movie_alice": {
-    "actors": {},
-    "directors": {},
-    "genres": {},
-    "keywords": {},
-    "languages": {},
-    "studios": {},
-    "tmdb_ids": []
-  },
-  "external_build_user_profile_movie_bob": {
-    "actors": {},
-    "directors": {},
-    "genres": {},
-    "keywords": {},
-    "languages": {},
-    "studios": {},
-    "tmdb_ids": []
-  },
   "external_load_cache_movie_alice": {
     "actors": {
       "Alex Monroe": "0x1.70a3d70a3d70ap-3",
@@ -156,6 +138,81 @@
       "205",
       "206",
       "207"
+    ]
+  },
+  "external_profile_via_recommender_movie_alice": {
+    "actors": {
+      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
+      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
+    },
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.eb851eb851eb8p-5",
+      "Priya Anand": "0x1.eb851eb851eb8p-5",
+      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+    },
+    "genres": {
+      "action": "0x1.eb851eb851eb8p-3",
+      "sci-fi": "0x1.70a3d70a3d70ap-3"
+    },
+    "keywords": {
+      "heist": "0x1.eb851eb851eb8p-4",
+      "revenge": "0x1.eb851eb851eb8p-5",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "space-station": "0x1.70a3d70a3d70ap-3",
+      "survival": "0x1.eb851eb851eb8p-4",
+      "time-travel": "0x1.eb851eb851eb8p-5",
+      "undercover": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.70a3d70a3d70ap-2"
+    },
+    "studios": {},
+    "tmdb_ids": [
+      "101",
+      "102",
+      "103",
+      "104",
+      "105",
+      "106"
+    ]
+  },
+  "external_profile_via_recommender_movie_bob": {
+    "actors": {
+      "Alex Monroe": "0x1.eb851eb851eb8p-5",
+      "Casey Rhodes": "0x1.eb851eb851eb8p-5",
+      "Jordan Vance": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+    },
+    "directors": {
+      "Marcus Webb": "0x1.eb851eb851eb8p-5",
+      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Priya Anand": "0x1.eb851eb851eb8p-5"
+    },
+    "genres": {
+      "comedy": "0x1.70a3d70a3d70ap-3",
+      "romance": "0x1.eb851eb851eb8p-4"
+    },
+    "keywords": {
+      "coming-of-age": "0x1.eb851eb851eb8p-4",
+      "road-trip": "0x1.eb851eb851eb8p-5",
+      "wedding": "0x1.eb851eb851eb8p-4"
+    },
+    "languages": {
+      "english": "0x1.eb851eb851eb8p-3"
+    },
+    "studios": {},
+    "tmdb_ids": [
+      "107",
+      "108",
+      "109",
+      "110"
     ]
   },
   "movie_managed_users": {

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -277,7 +277,6 @@ def run_profile_builders() -> dict:
             patch("recommenders.external.MyPlexAccount", FakeMyPlexAccount),
             patch("recommenders.base.migrate_legacy_cache_dir", lambda legacy_dir, new_dir: None),
             patch("utils.plex._capped_get", make_fake_capped_get()),
-            patch("recommenders.external.get_tmdb_keywords", lambda *a, **kw: []),
         ):
             # --- (1) & (2): movie.py's / tv.py's own per-user builders ---
             os.environ["CURATARR_CONFIG_DIR"] = plex_users_root
@@ -295,13 +294,12 @@ def run_profile_builders() -> dict:
             managed_tv_rec = PlexTVRecommender(managed_config_path)
             snapshot["tv_managed_users"] = _counters_to_jsonable(managed_tv_rec.watched_data_counters)
 
-            # --- (4) & (5): external.py's load_user_profile_from_cache()
+            # --- (4): external.py's load_user_profile_from_cache()
             # (reads the REAL on-disk cache files (1) above just wrote,
             # via each recommender's own __init__-time _save_watched_cache()
-            # call) and build_user_profile() (bug #3: username is inert -
-            # see this module's own report). Neither reads config.yml off
-            # disk, so CURATARR_CONFIG_DIR is irrelevant here; a small,
-            # standalone config dict is enough. ---
+            # call). Doesn't read config.yml off disk, so
+            # CURATARR_CONFIG_DIR is irrelevant here; a small, standalone
+            # config dict is enough. ---
             external_config = {
                 "plex": {
                     "url": "http://127.0.0.1:32400",
@@ -320,9 +318,19 @@ def run_profile_builders() -> dict:
                         _counters_to_jsonable(loaded) if loaded else None
                     )
 
+            # --- (5): external.py's _build_profile_via_recommender()
+            # (#273 PR3 - replaces the deleted build_user_profile(),
+            # which had bug #3: username was inert). Unlike
+            # load_user_profile_from_cache() above, this constructs a
+            # REAL PlexMovieRecommender internally (the "shared path" -
+            # see its own docstring), resolving config_path via
+            # get_project_root(), so CURATARR_CONFIG_DIR must be pointed
+            # at the plex_users project again (left set to managed_root
+            # by step (3) above). ---
+            os.environ["CURATARR_CONFIG_DIR"] = plex_users_root
             for username in ("alice", "bob"):
-                built = external_module.build_user_profile(fake_plex, external_config, username, "movie")
-                snapshot[f"external_build_user_profile_movie_{username}"] = _counters_to_jsonable(built)
+                built = external_module._build_profile_via_recommender(username, "movie")
+                snapshot[f"external_profile_via_recommender_movie_{username}"] = _counters_to_jsonable(built)
     finally:
         if old_cwd_env is None:
             os.environ.pop("CURATARR_CONFIG_DIR", None)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -25,6 +25,7 @@ from recommenders.external import (
     TMDB_ANIMATION_GENRE_ID,
     TMDB_PROVIDERS,
     TV_MOVIE_GENRE_ID,
+    _build_profile_via_recommender,
     _empty_categorized,
     _merge_categorized,
     _merge_user_runs,
@@ -33,6 +34,7 @@ from recommenders.external import (
     _pu_resolve_context,
     _stamp_library_id,
     categorize_by_streaming_service,
+    discover_candidates_by_profile,
     discover_popular_by_genre,
     export_to_trakt,
     find_horizon_movies,
@@ -4194,7 +4196,7 @@ class TestProcessUserMovieLibraryBranches:
 
     @patch("recommenders.external.generate_markdown")
     @patch("recommenders.external.categorize_by_streaming_service")
-    @patch("recommenders.external.build_user_profile")
+    @patch("recommenders.external._build_profile_via_recommender")
     @patch("recommenders.external.save_cache")
     @patch("recommenders.external.load_cache")
     @patch("recommenders.external.load_ignore_list")
@@ -4425,7 +4427,7 @@ class TestProcessUserTvLibraryBranches:
 
     @patch("recommenders.external.generate_markdown")
     @patch("recommenders.external.categorize_by_streaming_service")
-    @patch("recommenders.external.build_user_profile")
+    @patch("recommenders.external._build_profile_via_recommender")
     @patch("recommenders.external.save_cache")
     @patch("recommenders.external.load_cache")
     @patch("recommenders.external.load_ignore_list")
@@ -4646,6 +4648,142 @@ class TestThinProfile:
     def test_thin_profile_threshold_constant(self):
         """Test threshold constant is set correctly"""
         assert THIN_PROFILE_THRESHOLD == 40
+
+    def test_is_thin_profile_coerces_plain_dict_genres(self):
+        """#273 PR3: genres doesn't have to already be a Counter - a
+        plain dict (e.g. straight off a JSON cache read) works too."""
+        plain_dict_profile = {"genres": {"Action": 20, "Comedy": 15, "Drama": 10, "Thriller": 5}}
+        assert is_thin_profile(plain_dict_profile) is False
+
+    def test_is_thin_profile_missing_genres_key(self):
+        """#273 PR3: no 'genres' key at all is treated as an empty (thin) profile."""
+        assert is_thin_profile({}) is True
+
+
+class TestDiscoverCandidatesByProfileKeyCoercion:
+    """#273 PR3: discover_candidates_by_profile's genre/keyword lookups
+    (user_profile["genres"].most_common()/user_profile["keywords"].most_common())
+    used to assume the caller always handed over Counter objects keyed
+    exactly "genres"/"keywords" - true for load_user_profile_from_cache()'s
+    own return shape, but not guaranteed for every caller. Both are now
+    coerced to Counter if not already one, and keywords accepts either
+    "keywords" or "tmdb_keywords" (the raw watched_data_counters key
+    name)."""
+
+    @patch("recommenders.external.requests.get")
+    def test_plain_dict_genres_and_tmdb_keywords_key_do_not_raise(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        # Plain dicts (not Counter), and "tmdb_keywords" (not "keywords") -
+        # the raw watched_data_counters shape recommenders/movie.py's/
+        # tv.py's own builders produce, as opposed to
+        # load_user_profile_from_cache()'s renamed-to-Counter shape.
+        user_profile = {"genres": {"nonexistent-genre-xyz": 5}, "tmdb_keywords": {"some-keyword": 3}}
+
+        # Must not raise (AttributeError: 'dict' object has no attribute
+        # 'most_common', or KeyError: 'keywords') - the whole point of
+        # this test.
+        candidates = discover_candidates_by_profile(
+            tmdb_api_key="fake_key",
+            user_profile=user_profile,
+            library_data={"tmdb_ids": set(), "titles": set()},
+            media_type="movie",
+        )
+        assert isinstance(candidates, dict)
+
+    @patch("recommenders.external.requests.get")
+    def test_counter_genres_and_keywords_key_still_work(self, mock_get):
+        """Regression: the pre-existing shape (Counter-valued, 'keywords'
+        key - load_user_profile_from_cache()'s own return shape) must
+        keep working identically."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        user_profile = {
+            "genres": Counter({"nonexistent-genre-xyz": 5}),
+            "keywords": Counter({"some-keyword": 3}),
+        }
+        candidates = discover_candidates_by_profile(
+            tmdb_api_key="fake_key",
+            user_profile=user_profile,
+            library_data={"tmdb_ids": set(), "titles": set()},
+            media_type="movie",
+        )
+        assert isinstance(candidates, dict)
+
+    @patch("recommenders.external.requests.get")
+    def test_missing_genres_and_keywords_keys_do_not_raise(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        candidates = discover_candidates_by_profile(
+            tmdb_api_key="fake_key",
+            user_profile={},
+            library_data={"tmdb_ids": set(), "titles": set()},
+            media_type="movie",
+        )
+        assert candidates == {}
+
+
+class TestBuildProfileViaRecommender:
+    """Tests for _build_profile_via_recommender (#273 PR3) - replaces
+    the deleted build_user_profile(). Constructs the real
+    PlexMovieRecommender/PlexTVRecommender for `username` directly
+    (the same "shared path" recommenders/movie.py's/tv.py's own
+    builders use) rather than re-implementing a second, independently
+    buggy Plex scan."""
+
+    @patch("recommenders.external.get_project_root", return_value="/fake/root")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    def test_movie_returns_counter_profile_from_recommender(self, mock_recommender_cls, mock_root):
+        mock_recommender = Mock()
+        mock_recommender.watched_data_counters = {
+            "genres": {"action": 2.0},
+            "directors": {"Some Director": 1.0},
+            "actors": {"Some Actor": 1.5},
+            "tmdb_keywords": {"heist": 0.6},
+            "languages": {"english": 2.0},
+            "tmdb_ids": {101, 102},
+        }
+        mock_recommender_cls.return_value = mock_recommender
+
+        profile = _build_profile_via_recommender("alice", "movie")
+
+        mock_recommender_cls.assert_called_once_with("/fake/root/config/config.yml", single_user="alice")
+        assert isinstance(profile["genres"], Counter)
+        assert profile["genres"]["action"] == 2.0
+        # tmdb_keywords -> keywords, matching load_user_profile_from_cache()'s
+        # own renaming convention.
+        assert profile["keywords"]["heist"] == 0.6
+        assert profile["tmdb_ids"] == {101, 102}
+
+    @patch("recommenders.external.get_project_root", return_value="/fake/root")
+    @patch("recommenders.tv.PlexTVRecommender")
+    def test_tv_media_type_uses_plex_tv_recommender(self, mock_recommender_cls, mock_root):
+        mock_recommender = Mock()
+        mock_recommender.watched_data_counters = {"genres": {"drama": 1.0}}
+        mock_recommender_cls.return_value = mock_recommender
+
+        profile = _build_profile_via_recommender("alice", "tv")
+
+        mock_recommender_cls.assert_called_once_with("/fake/root/config/config.yml", single_user="alice")
+        assert profile["genres"]["drama"] == 1.0
+
+    @patch("recommenders.external.log_warning")
+    @patch("recommenders.external.get_project_root", return_value="/fake/root")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    def test_construction_failure_returns_empty_profile_not_raise(self, mock_recommender_cls, mock_root, mock_warn):
+        mock_recommender_cls.side_effect = Exception("Plex unreachable")
+
+        profile = _build_profile_via_recommender("alice", "movie")
+
+        assert profile["genres"] == Counter()
+        assert profile["tmdb_ids"] == set()
+        mock_warn.assert_called_once()
 
 
 class TestDiscoverPopularByGenre:

--- a/tests/test_profile_builder_harness.py
+++ b/tests/test_profile_builder_harness.py
@@ -167,13 +167,27 @@ class TestProfileBuilderHarnessCatchesTheFourBugs:
             "may have regressed."
         )
 
-    def test_bug3_external_build_user_profile_ignores_username(self):
-        """Bug #3: build_user_profile()'s username parameter has zero
-        effect on its output - alice's and bob's calls (against the
-        exact same shared admin-token `plex` connection every builder
-        here receives) produce byte-identical results."""
+    def test_bug3_external_build_user_profile_now_respects_username(self):
+        """Bug #3 - FIXED (#273 PR3): build_user_profile() (which had
+        zero username effect - it always scanned whatever `plex`
+        connection the caller already had) has been DELETED entirely
+        and replaced by _build_profile_via_recommender(), which
+        constructs a real, username-scoped PlexMovieRecommender/
+        PlexTVRecommender directly - the same "shared path" the other
+        three builders already use. alice's and bob's calls now
+        produce genuinely different profiles, matching their own
+        distinct fixture watch histories (see MOVIE_WATCHED_BY in
+        tests/e2e_plex_fixture.py) - the opposite of the pinned bug
+        this test used to assert."""
         live = run_profile_builders()
-        assert live["external_build_user_profile_movie_alice"] == live["external_build_user_profile_movie_bob"]
+        alice = live["external_profile_via_recommender_movie_alice"]
+        bob = live["external_profile_via_recommender_movie_bob"]
+        assert alice != bob, (
+            "alice's and bob's _build_profile_via_recommender() profiles are identical again - "
+            "the #273 PR3 username fix may have regressed."
+        )
+        assert alice["tmdb_ids"] == ["101", "102", "103", "104", "105", "106"]
+        assert bob["tmdb_ids"] == ["107", "108", "109", "110"]
 
     def test_external_load_cache_adapter_renames_tmdb_keywords_to_keywords(self):
         """recommenders/external.py's load_user_profile_from_cache() is

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.63"
+__version__ = "2.10.64"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary

PR3 of the #273 remediation sequence. `recommenders/external.py`'s `build_user_profile()` had a fatal, unfixable-in-place bug (#3): its `username` parameter had zero effect on the output - it always scanned whatever `plex` connection the caller already had (the one shared admin-token connection every caller in this file uses), never `username`'s own.

## What changed

- Deleted `build_user_profile()` entirely, replaced with `_build_profile_via_recommender(username, media_type)`, which constructs the real `PlexMovieRecommender`/`PlexTVRecommender` for `username` directly - the same "shared path" `recommenders/movie.py`'s and `recommenders/tv.py`'s own watched-data builders already use (and already benefit from #273 PR1's/PR2's fixes), rather than maintaining a second, independently-buggy Plex-scanning implementation. Resolves its own `config_path` via `get_project_root()` (matching `_main_impl()`'s own convention) rather than threading one through every caller's signature. As a side effect of construction, this also persists a real, correctly-weighted watched-cache file to disk, so `load_user_profile_from_cache()` finds it on the very next call for that user instead of paying the same slow full-Plex-scan cost forever (`build_user_profile()`'s own docstring already called itself out as "slow").
- All 3 fallback call sites (`_pu_build_profiles`, `process_user_movie_library`, `process_user_tv_library`) updated to use the new function when `load_user_profile_from_cache()` returns `None`.
- `is_thin_profile()` and `discover_popular_by_genre()`'s genre/keyword iteration both called `.most_common()` directly on `user_profile["genres"]`/`user_profile["keywords"]`, assuming the caller always handed over `Counter` objects keyed exactly `"genres"`/`"keywords"` - true for `load_user_profile_from_cache()`'s own return shape, but not guaranteed for every caller. Both now coerce to `Counter` if not already one, and the keyword lookup accepts either `"keywords"` or `"tmdb_keywords"` (the raw `watched_data_counters` key name).
- `tests/harness.py`'s `run_profile_builders()` (#273 PR0) updated: the `build_user_profile` call is gone (function deleted); added a `_build_profile_via_recommender` call instead, and removed the now-unused `get_tmdb_keywords` patch (the new function never calls it directly - it goes through the real recommender, which resolves TMDB the normal way, already `None` in the harness's scratch config). Golden snapshot regenerated; `tests/test_profile_builder_harness.py`'s bug #3 test updated from "proves the bug" to "proves the fix" (alice and bob now get genuinely different profiles), matching the same pattern PR2 already established for bug #4.
- New unit tests: `TestBuildProfileViaRecommender` (movie/tv dispatch, key renaming, Counter coercion, construction-failure fallback), `TestDiscoverCandidatesByProfileKeyCoercion` (plain-dict + `tmdb_keywords` input doesn't raise, existing Counter + `keywords` shape still works, missing keys don't raise), plus two new `TestThinProfile` cases for the same coercion.

## Real-library verification (read-only)

`_build_profile_via_recommender()` is only ever reached as a fallback when no watched cache exists yet for a user/media type - already true for all 6 real configured users on this install, so there's no meaningful production before/after to observe. Instead verified the function's previously-broken core behavior directly against two different real users:

| User | tmdb_ids | genres | keywords key | tmdb_keywords key | genres type |
|---|---|---|---|---|---|
| ericarutyunov | 27 | 20 | present | absent | Counter |
| homehouse165 | 15 | 15 | present | absent | Counter |

`ericarutyunov`'s 27 and `homehouse165`'s 15 exactly match each user's own real watched-movie count already independently established in #273 PR1's verification - confirming `_build_profile_via_recommender()` now correctly reflects each user's own real watch history (the opposite of the deleted function's "identical regardless of username" bug).

While verifying, found (not fixed - out of scope) a pre-existing, unrelated test-isolation gap: `recommenders/external_sync.py` resolves its own cache directory via a `get_project_root()` binding `conftest.py`'s `_isolated_recommender_cache_dir` autouse fixture doesn't patch, so a test exercising its Trakt-export-status recording writes a small, harmless `cache/integration_status_trakt_export.json` into the real repo instead of an isolated tmp dir. Cleaned up the one stray file this produced; did not fix the underlying gap (unrelated to #273's four profile builders).

No Plex writes, no Trakt calls at any point in this verification.

## Test plan

- [x] pytest tests/ (2798 passed, 1 skipped, 96.99% coverage, threshold 85%)
- [x] ruff check . / ruff format --check .
- [x] mypy .
- [x] Real-library verification (table above)
- [x] gitleaks (pre-push hook): no leaks found
