### PR TITLE
Fix web UI freeze under load (2.10.66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dist/
 *.buildvenv/
 .buildvenv/
 .venv/
+.venv-*/
 
 # Self-update fast local stub test harness compiled output (see
 # scripts/selfupdate_stub_e2e/build_stubs.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.67] - 2026-07-27
+
+### Fixed
+
+- **Web UI freeze under load - P0 (#287).** Reporter's own diagnosis (a late SSE subscriber to an already-finished job never receiving `done` and parking forever) turned out to be already-correct, existing behavior - verified directly in a real container: connecting to `/run/stream` after a job has already finished replays its backlog and closes within milliseconds, exactly as `Job.subscribe()`'s pre-existing `if self.returncode is not None: queue DONE_SENTINEL immediately` branch is supposed to. The freeze itself was real and reproduced independently: waitress dispatches a streaming (SSE) WSGI response to ONE task thread for the connection's ENTIRE lifetime (confirmed against `waitress/task.py`'s own source - it synchronously iterates the response generator on that one thread), and `THREADS = 8` (`web/docker_server.py`) is explicitly sized "for one open SSE live-log stream" per its own comment. Confirmed in a real container: opening as few as 8 concurrent, perfectly legitimate (not stuck, not misbehaving) `/run/stream` connections during one still-running job completely exhausted the pool - a subsequent `/run/status` request (a trivial JSON read) then hung indefinitely until a stream closed, exactly matching the reporter's `docker stats`/`/proc/1/task` findings and "significantly worse when the script is running."
+
+  Three changes, all in `web/app.py`/`web/job_runner.py`/`static/app.js`:
+  1. `run.html`/`app.js` now only open an `EventSource` when a job is genuinely `running` (`window.CURATARR_JOB_RUNNING`, replacing the old `window.CURATARR_HAS_JOB`, which was true for any job record at all, including one that finished hours ago) - unnecessary given point 1 above already worked, but still pointless connection churn worth not doing.
+  2. New `Job.try_subscribe(max_subscribers)` (the same lock-protected path `subscribe()` itself now calls through to with no cap) lets `/run/stream` cap concurrent viewers of the SAME running job at `MAX_STREAM_SUBSCRIBERS_PER_JOB = 4` - only one job ever runs at a time, so every viewer beyond that is a fully redundant stream of identical output, each pinning one more of only 8 threads. A viewer over the cap gets a new `busy` SSE event instead of a connection that would just make the exhaustion worse; `app.js` falls back to polling `/run/status` for that tab instead.
+  3. `run_stream()`'s `generate()` now bounds any single connection to `MAX_STREAM_SECONDS = 120.0` regardless of how long the job itself takes, closing (not erroring) once reached - `EventSource`'s own default auto-reconnect behavior (never overridden by an `onerror` handler that calls `.close()` - deliberately removed) picks the stream back up a few seconds later, replaying the backlog exactly like any other new subscriber.
+
+  Deliberately did not blindly raise `THREADS` - a bigger pool only raises how many concurrent viewers it takes to reproduce the same freeze, it doesn't remove the underlying one-thread-per-open-stream design; capping concurrent viewers per job (point 2) and bounding how long any one of them can hold a thread (point 3) address the capacity problem directly instead.
+
+  **Verified in a real container**: reproduced the freeze pre-fix (8 concurrent live streams during one running job → a fresh `/run/status` request hung indefinitely, recovered only once enough streams were closed); post-fix, opening 10 concurrent streams during one running job yields exactly 4 real streams and 6 immediate `busy` events, and `/run/status` stays responsive (~5ms) throughout. New regression coverage in `tests/test_web_job_runner.py` (`Job.try_subscribe()` cap enforcement, and that a finished job's `subscribe()` is never capped) and `tests/test_web_routes.py` (`/run/stream` emits `busy` once over the cap and never registers the rejected connection as a subscriber; a connection is proactively closed - without a `done` event - once `MAX_STREAM_SECONDS` elapses, and the job itself is unaffected).
+
 ## [2.10.66] - 2026-07-27
 
 ### Fixed

--- a/tests/test_web_job_runner.py
+++ b/tests/test_web_job_runner.py
@@ -497,6 +497,54 @@ class TestJobSubscribe:
         assert last == f"line {job_runner_mod.SUBSCRIBER_QUEUE_MAXSIZE + 499}"
 
 
+class TestJobTrySubscribe:
+    """#287: Job.try_subscribe() - the concurrent-viewer cap
+    web/app.py's run_stream() uses to bound how many threads one
+    still-running job's SSE viewers can pin at once."""
+
+    def test_subscribe_is_try_subscribe_with_no_cap(self, curatarr_web_root):
+        """subscribe() itself must stay uncapped - only run_stream()
+        opts into a cap via try_subscribe() directly."""
+        manager = _manager(curatarr_web_root)
+        job = manager.start("external", "all", ["alice"])
+        _wait_until_done(job)
+        assert job.subscribe() is not None
+
+    def test_try_subscribe_rejects_once_running_job_is_at_cap(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_TEST_SLOW", "2")
+        manager = _manager(curatarr_web_root)
+        job = manager.start("movie", "alice", ["alice"])
+
+        q1 = job.try_subscribe(1)
+        assert q1 is not None
+        assert job.try_subscribe(1) is None  # already at the cap of 1
+
+        job.unsubscribe(q1)
+        assert job.try_subscribe(1) is not None  # freed a slot
+        _wait_until_done(job)
+
+    def test_try_subscribe_cap_does_not_apply_to_a_finished_job(self, curatarr_web_root):
+        """A finished job's subscribe always succeeds regardless of the
+        cap - it replays the backlog and queues DONE_SENTINEL rather
+        than registering a live subscriber that would occupy anything
+        for any meaningful length of time (confirmed in a real
+        container: this was never the actual thread-exhaustion
+        mechanism - see web/app.py's MAX_STREAM_SUBSCRIBERS_PER_JOB)."""
+        manager = _manager(curatarr_web_root)
+        job = manager.start("external", "all", ["alice"])
+        _wait_until_done(job)
+        for _ in range(5):
+            assert job.try_subscribe(1) is not None
+
+    def test_try_subscribe_none_cap_never_rejects(self, curatarr_web_root, monkeypatch):
+        monkeypatch.setenv("CURATARR_TEST_SLOW", "2")
+        manager = _manager(curatarr_web_root)
+        job = manager.start("movie", "alice", ["alice"])
+        for _ in range(10):
+            assert job.try_subscribe(None) is not None
+        _wait_until_done(job)
+
+
 class TestPumpFailureHandling:
     """Tests for _pump()'s failure paths - H1 (open() failure must not
     wedge the job/lock forever) and M1 (non-UTF8 output, always reaping

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -345,6 +345,61 @@ class TestRunPage:
         assert len(job._subscribers) == 0
         _wait_until_idle(app)
 
+    def test_run_stream_over_subscriber_cap_gets_busy_event(self, client, monkeypatch):
+        """#287: confirmed in a real container that as few as THREADS
+        (8) concurrently open, perfectly legitimate SSE streams for one
+        still-running job exhausts waitress's whole thread pool and
+        freezes the entire app. MAX_STREAM_SUBSCRIBERS_PER_JOB caps
+        concurrent viewers of the SAME job well below that - a viewer
+        over the cap gets a `busy` event (app.js falls back to polling
+        /run/status - see static/app.js) instead of a connection that
+        would just make the exhaustion this cap exists to prevent one
+        connection closer, and is never added to job._subscribers."""
+        c, app, root = client
+        monkeypatch.setattr(app_module, "MAX_STREAM_SUBSCRIBERS_PER_JOB", 1)
+        monkeypatch.setenv("CURATARR_TEST_SLOW", "2")
+        c.post("/run", data={"engine": "movie", "user": "alice"})
+        job = app.job_manager.current_job()
+
+        resp1 = c.get("/run/stream")
+        chunks = iter(resp1.response)
+        next(chunks)  # pull one chunk so the first stream has actually subscribed
+        assert len(job._subscribers) == 1
+
+        resp2 = c.get("/run/stream")
+        assert resp2.status_code == 200
+        body2 = resp2.get_data(as_text=True)
+        assert "event: busy" in body2
+        assert len(job._subscribers) == 1  # the rejected stream was never added
+
+        resp1.close()
+        _wait_until_idle(app)
+
+    def test_run_stream_max_seconds_closes_without_done_event(self, client, monkeypatch):
+        """#287: a single stream must never be allowed to hold its
+        server-side thread indefinitely regardless of how long the job
+        itself takes (confirmed in a real container: a run can take
+        many minutes with no prior upper bound at all on one
+        connection's lifetime). Closing without a `done` event (not an
+        error) lets EventSource's own default auto-reconnect behavior
+        pick the stream back up - app.js deliberately has no onerror
+        handler that would call .close() and defeat that (see
+        static/app.js)."""
+        c, app, root = client
+        monkeypatch.setattr(app_module, "MAX_STREAM_SECONDS", 0.05)
+        monkeypatch.setenv("CURATARR_TEST_SLOW", "2")
+        c.post("/run", data={"engine": "movie", "user": "alice"})
+        job = app.job_manager.current_job()
+
+        resp = c.get("/run/stream")
+        body = resp.get_data(as_text=True)
+        assert "event: done" not in body
+        assert len(job._subscribers) == 0  # unsubscribed on the way out
+        assert app.job_manager.is_running()  # the job itself is unaffected
+
+        _wait_until_idle(app)
+        _wait_until_idle(app)
+
     def test_run_status_json_idle(self, client):
         c, app, root = client
         resp = c.get("/run/status")

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.66"
+__version__ = "2.10.67"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/app.py
+++ b/web/app.py
@@ -84,6 +84,39 @@ DEFAULT_PORT = 8787
 # keepalive comment - see run_stream()'s generate().
 SSE_HEARTBEAT_SECONDS = 15.0
 
+# #287: bounds how long a single /run/stream connection may occupy one
+# of waitress's THREADS worker threads (see web/docker_server.py's own
+# comment - sized "for one open SSE live-log stream", not many)
+# before this proactively closes it. Confirmed in a real container:
+# waitress dispatches a streaming WSGI response to ONE task thread for
+# the connection's ENTIRE lifetime (it synchronously iterates the
+# generator - see waitress/task.py's WSGITask.execute), so a run that
+# takes many minutes previously let a single stream pin a thread for
+# that whole time with no upper bound at all. EventSource's own
+# default behavior auto-reconnects after any server-initiated close
+# that isn't a fatal HTTP-level error (see generate() below - it just
+# returns, ending the response normally, no error event) - the browser
+# picks the stream back up on its own a few seconds later, replaying
+# the backlog via Job.subscribe(), with no code needed here to make
+# that happen.
+MAX_STREAM_SECONDS = 120.0
+
+# #287: caps concurrent /run/stream subscribers for the SAME running
+# job. Only one job ever runs at a time (JobManager enforces this), so
+# every additional viewer watching it live is a fully redundant stream
+# of identical output, each pinning one more of only THREADS (8)
+# waitress worker threads for as long as it stays open. Confirmed in a
+# real container: as few as THREADS concurrently open streams during
+# one live run - not stuck, not misbehaving, just genuinely still
+# watching - exhausts the pool and freezes the ENTIRE app (every
+# route, not just streaming ones) until a stream closes or the run
+# ends. Reserves at least half the pool for everything else (the
+# dashboard, /run/status polling, /results, config screens) even in
+# the worst case where every viewer leaves a tab open. A viewer over
+# the cap isn't left with nothing - app.js falls back to polling
+# /run/status (see static/app.js) instead of a live-tailing stream.
+MAX_STREAM_SUBSCRIBERS_PER_JOB = 4
+
 # Applied to served watchlist HTML (see results_watchlist()). Primary
 # XSS defense is escaping at generation time (recommenders/
 # external_render.py); this is defense-in-depth so that even a gap
@@ -675,12 +708,53 @@ def create_app(
         if job is None:
             abort(404)
 
+        # #287: a late subscriber to an already-finished job already
+        # gets its full backlog replayed followed by an immediate
+        # `done` (Job.subscribe()/try_subscribe() below - confirmed
+        # correct in a real container, this was never the actual
+        # thread-exhaustion mechanism) and closes right away rather
+        # than hanging - cheap enough that it's simplest to let that
+        # existing path handle it rather than special-casing it here.
+        # app.js now only opens a stream at all for a job it already
+        # knows is running (see static/app.js) - this route still
+        # serves any other caller that reaches it directly for an
+        # already-finished job exactly as it always has.
+        q = job.try_subscribe(MAX_STREAM_SUBSCRIBERS_PER_JOB)
+        if q is None:
+            # #287: already at the concurrent-viewer cap for this job -
+            # tell the client to fall back to polling instead of
+            # opening a connection that would just make the thread
+            # exhaustion this cap exists to prevent one connection
+            # closer.
+            def generate_busy():
+                yield (
+                    "event: busy\n"
+                    "data: too many viewers already watching this run - "
+                    "falling back to polling /run/status\n\n"
+                )
+
+            return Response(
+                stream_with_context(generate_busy()),
+                mimetype="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+
         def generate():
-            q = job.subscribe()
+            start = time.monotonic()
             try:
                 while True:
+                    remaining = MAX_STREAM_SECONDS - (time.monotonic() - start)
+                    if remaining <= 0:
+                        # #287: proactively end this response instead of
+                        # ever letting one connection hold its thread
+                        # indefinitely (see MAX_STREAM_SECONDS's own
+                        # comment) - not an error, so EventSource
+                        # reconnects on its own and picks up right where
+                        # it left off via Job.subscribe()'s backlog
+                        # replay.
+                        return
                     try:
-                        item = q.get(timeout=SSE_HEARTBEAT_SECONDS)
+                        item = q.get(timeout=min(SSE_HEARTBEAT_SECONDS, remaining))
                     except queue.Empty:
                         # No new output in a while - send a keepalive
                         # comment instead of blocking forever. A closed

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -270,8 +270,30 @@ class Job:
         a browser tab that connects mid-run still sees the backlog
         before live lines start arriving.
         """
-        q: "queue.Queue" = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
+        return self.try_subscribe(None)  # type: ignore[return-value]
+
+    def try_subscribe(self, max_subscribers: Optional[int]) -> Optional["queue.Queue"]:
+        """Like subscribe(), but returns None instead of registering a
+        new live subscriber if this job is still running AND already
+        has max_subscribers watching it (#287 - see
+        MAX_STREAM_SUBSCRIBERS_PER_JOB in web/app.py). max_subscribers
+        of None means no cap (this is what subscribe() itself calls
+        through to), so existing callers/tests are unaffected.
+
+        The cap only ever applies while running: a finished job's
+        subscribe() always succeeds regardless, since it replays the
+        backlog and immediately queues DONE_SENTINEL below rather than
+        registering a live subscriber that would occupy a thread for
+        any meaningful length of time - confirmed in a real container,
+        this path was never the actual thread-exhaustion mechanism
+        (that was many genuinely-still-watching subscribers of one
+        still-RUNNING job - see MAX_STREAM_SUBSCRIBERS_PER_JOB/
+        MAX_STREAM_SECONDS's own comments).
+        """
         with self._data_lock:
+            if self.returncode is None and max_subscribers is not None and len(self._subscribers) >= max_subscribers:
+                return None
+            q: "queue.Queue" = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
             for line in self.lines:
                 _safe_queue_put(q, line)
             if self.returncode is not None:

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -17,8 +17,43 @@
   }
 
   var output = document.getElementById('output');
-  if (output && window.CURATARR_HAS_JOB) {
-    var stateEl = document.getElementById('job-state');
+  var stateEl = document.getElementById('job-state');
+
+  function markDone(returncode) {
+    if (stateEl) {
+      stateEl.textContent = (String(returncode) === '0') ? 'succeeded' : 'failed';
+    }
+    var btn = document.querySelector('#run-form button[type="submit"]');
+    if (btn) btn.disabled = false;
+  }
+
+  // #287: falls back to polling /run/status instead of a live stream
+  // when the server's MAX_STREAM_SUBSCRIBERS_PER_JOB cap rejects a new
+  // EventSource (see web/app.py's run_stream()) - still reflects the
+  // run finishing, just without live-tailed output for this tab.
+  function pollStatus() {
+    var timer = setInterval(function () {
+      fetch('/run/status')
+        .then(function (resp) { return resp.json(); })
+        .then(function (data) {
+          if (data && data.state && data.state !== 'running') {
+            clearInterval(timer);
+            markDone(data.returncode);
+          }
+        })
+        .catch(function () {
+          // Transient fetch failure - just try again on the next tick.
+        });
+    }, 5000);
+  }
+
+  // #287: only ever open a stream for a job actually running right
+  // now - a job record existing at all (even one that finished hours
+  // ago) used to be enough to open one, which was needless: a
+  // finished job's own subscribe() replays its backlog and closes
+  // immediately (see web/app.py's run_stream()), so the only thing
+  // that bug added was one more pointless connection.
+  if (output && window.CURATARR_JOB_RUNNING) {
     var source = new EventSource('/run/stream');
 
     source.onmessage = function (event) {
@@ -27,16 +62,24 @@
     };
 
     source.addEventListener('done', function (event) {
-      if (stateEl) {
-        stateEl.textContent = (event.data === '0') ? 'succeeded' : 'failed';
-      }
-      var btn = document.querySelector('#run-form button[type="submit"]');
-      if (btn) btn.disabled = false;
+      markDone(event.data);
       source.close();
     });
 
-    source.onerror = function () {
+    source.addEventListener('busy', function (event) {
+      output.textContent += event.data + '\n';
+      output.scrollTop = output.scrollHeight;
       source.close();
-    };
+      pollStatus();
+    });
+
+    // Deliberately no onerror handler that closes the source: a
+    // dropped or timed-out connection (see web/app.py's
+    // MAX_STREAM_SECONDS - a run can take many minutes, and a single
+    // stream is never allowed to hold its server-side thread for the
+    // whole thing) is not fatal - EventSource retries automatically on
+    // its own unless the server responds with a non-2xx status (e.g.
+    // the job record is gone entirely), which stops retrying for that
+    // case on its own per spec.
   }
 })();

--- a/web/templates/run.html
+++ b/web/templates/run.html
@@ -69,7 +69,13 @@
 <pre id="output" class="log-output"></pre>
 
 <script>
-  window.CURATARR_HAS_JOB = {{ 'true' if job else 'false' }};
+  // #287: a job RECORD existing (even one that finished hours ago) is
+  // not the same thing as a job actually running - app.js used to open
+  // an EventSource for either, which the fix in web/app.py's
+  // run_stream() no longer even needs as a safety net, but there's
+  // still no reason to open a connection at all for a job that isn't
+  // running.
+  window.CURATARR_JOB_RUNNING = {{ 'true' if job and job.state == 'running' else 'false' }};
 </script>
 <script src="{{ url_for('static', filename='app.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Closes #287.

**The reporter's stated root cause does not match the code and was NOT the fix here** - the "late subscriber to an already-finished job never receives done" behavior was verified, in a real container, to already work correctly (`Job.subscribe()`'s pre-existing `if self.returncode is not None: queue DONE_SENTINEL immediately` branch). Implementing that as originally specified would have been a no-op that closed the issue while leaving the real defect in place.

**The actual, reproduced root cause:** waitress (`web/docker_server.py`, `THREADS = 8`) dispatches a streaming (SSE) response to ONE task thread for the connection's entire lifetime (confirmed against `waitress/task.py`'s own source - `for chunk in app_iter` runs synchronously on that thread). `THREADS = 8` is explicitly sized for one open SSE live-log stream per its own comment. Confirmed directly in a real container: opening as few as 8 concurrent, perfectly legitimate (not stuck, not misbehaving) `/run/stream` connections during one still-running job exhausts the pool completely - a subsequent `/run/status` request then hangs indefinitely until a stream closes, matching the reporter's own `docker stats`/`/proc/1/task` findings and significantly worse when the script is running.

## Changes

1. `run.html`/`app.js`: only open an `EventSource` when a job is genuinely `running` (`window.CURATARR_JOB_RUNNING`), not for any job record that exists at all.
2. New `Job.try_subscribe(max_subscribers)` caps concurrent viewers of the SAME running job at `MAX_STREAM_SUBSCRIBERS_PER_JOB = 4` (well below `THREADS`) - a viewer over the cap gets a `busy` SSE event and `app.js` falls back to polling `/run/status`. The cap never applies to an already-finished job (that path is cheap/non-blocking regardless, per the point above).
3. `run_stream()`'s `generate()` bounds any single connection to `MAX_STREAM_SECONDS = 120.0` regardless of job duration, closing (never erroring) once reached - `EventSource`'s own default auto-reconnect (no `onerror` handler calls `.close()` anymore) picks the stream back up seamlessly a few seconds later.

Deliberately did **not** raise `THREADS` - a bigger pool only raises how many concurrent viewers it takes to reproduce the identical freeze; it doesn't address the one-thread-per-open-stream design. Capping concurrent viewers per job plus bounding how long any one can hold a thread addresses the actual capacity problem.

## Real-container verification

- Reproduced the freeze pre-fix: triggered a real, long-running job, opened exactly 8 concurrent `/run/stream` connections (matching `THREADS`), then a fresh `/run/status` request hung indefinitely (confirmed via `curl -m 5`/`-m 10` timing out); recovered only after closing enough of the 8 streams.
- Post-fix, same setup: opened 10 concurrent `/run/stream` connections during one running job - exactly 4 became real streams (receiving live tick data), the other 6 immediately got `event: busy`, and `/run/status` responded in ~5ms throughout, never blocked.

## Test plan

- [x] New tests in `tests/test_web_job_runner.py` (`Job.try_subscribe()` cap enforcement; a finished job's `subscribe()`/`try_subscribe()` is never capped) and `tests/test_web_routes.py` (`/run/stream` emits `busy` once over the cap without registering the rejected connection as a subscriber; a connection closes without a `done` event once `MAX_STREAM_SECONDS` elapses, and the underlying job is unaffected).
- [x] Full suite (2804 passed, 1 skipped), `ruff check .`, `ruff format --check .`, `mypy .` all green.
- [x] Real-container verification above.
