### PR TITLE
fix: remove dead keywords/tmdb_keywords compat shims (2.10.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.67] - 2026-07-27
+
+### Fixed
+
+- **Removed dead "keywords" / "tmdb_keywords" dual-key compatibility fallbacks (#273 PR4, final PR of the #273 remediation sequence).** `utils/scoring.py`'s `calculate_similarity_score()`/`normalize_user_profile()` (4 call sites) and `recommenders/external.py`'s `discover_popular_by_genre()`/`_build_profile_via_recommender()` (2 call sites, both added by #273 PR3) all defensively accepted a profile keyed either `"keywords"` (this codebase's scoring-layer convention) or `"tmdb_keywords"` (the raw `watched_data_counters`/on-disk cache storage key `utils/counters.py`'s `create_empty_counters()` uses).
+
+  Audited every real caller of these functions - `recommenders/movie.py`'s and `recommenders/tv.py`'s own `_calculate_similarity_from_cache()`, `recommenders/external.py`'s `load_user_profile_from_cache()`/`_build_profile_via_recommender()`/its own TMDB-candidate `content_info` construction, and `tests/harness.py`'s own scoring-harness fixture - every single one already, always, translates `"tmdb_keywords"` (the storage-layer name) to `"keywords"` (the scoring-layer name) before ever calling into `calculate_similarity_score()`. The `"tmdb_keywords"` fallback branch was therefore dead code no real caller had ever actually exercised - confirmed directly: two of `tests/test_scoring.py`'s existing tests had been constructing profiles keyed `"tmdb_keywords"` specifically to test this fallback, and a third's assertion (a score-capping ceiling check) had silently stopped exercising its keyword-matching arm entirely without ever failing. All three updated to use `"keywords"` (their own tests' original intent), along with one `tests/test_external.py` test that exercised the now-removed `discover_popular_by_genre()` fallback.
+
+  This does NOT touch the storage-layer convention at all - `create_empty_counters()`, `process_counters_from_cache()`, and every real `watched_cache_plex_<user>.json`/`tv_watched_cache_plex_<user>.json` on disk still use `"tmdb_keywords"` exactly as before; only the scoring-layer boundary's now-provably-unreachable tolerance for that same name was removed.
+
+  **Verified against the real, live Plex library** (read-only: no Plex writes, no Trakt calls): re-scored all 161 real unwatched-movie candidates for a real user against their real, freshly-built watched profile using the current (post-PR4) code - 50 candidates still received a non-zero keyword-score contribution (confirming `"keywords"`, the one surviving key, still matches real TMDB keyword data correctly end to end), and two consecutive scoring passes produced byte-identical results (determinism unaffected). Zero behavioral delta was predicted for this PR (a pure dead-code removal, unlike PR1/PR2/PR3's genuine behavior changes) and none was observed.
+
 ## [2.10.66] - 2026-07-27
 
 ### Fixed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -278,12 +278,14 @@ def discover_candidates_by_profile(
     top_genres = all_genres[genre_start:genre_end]
     genre_id_map = TMDB_MOVIE_GENRE_IDS if media_type == "movie" else TMDB_TV_GENRE_IDS
 
-    # Get keywords for this iteration's range. Accepts either 'keywords'
-    # (this file's own internal convention - see
-    # load_user_profile_from_cache()'s/_build_profile_via_recommender()'s
-    # return shape) or 'tmdb_keywords' (the raw watched_data_counters key
-    # name recommenders/movie.py's/tv.py's own builders use) - #273 PR3.
-    keywords_counter = user_profile.get("keywords", user_profile.get("tmdb_keywords"))
+    # Get keywords for this iteration's range. Coerced to Counter (#273
+    # PR3) rather than assumed - every real caller (load_user_profile_
+    # from_cache()/_build_profile_via_recommender() below) always uses
+    # 'keywords' as the key (never the raw watched_data_counters
+    # 'tmdb_keywords' storage name - both translate that before
+    # returning), so no dual-key fallback is needed here (#273 PR4
+    # removed one that was never actually reachable - see CHANGELOG).
+    keywords_counter = user_profile.get("keywords")
     if not isinstance(keywords_counter, Counter):
         keywords_counter = Counter(keywords_counter or {})
     all_keywords = list(keywords_counter.most_common(40))
@@ -619,10 +621,12 @@ def _build_profile_via_recommender(username: str, media_type: str) -> Dict:
 
     Returns the profile in the exact same shape
     load_user_profile_from_cache() returns (Counter-valued, 'keywords'
-    not 'tmdb_keywords') for consistency between the two - though
-    is_thin_profile()/discover_popular_by_genre() (the two real
-    consumers) defensively accept either key name and coerce to Counter
-    regardless, since a future caller could still hand either shape.
+    not 'tmdb_keywords') - the ONE shape every real consumer of a
+    profile dict in this file (is_thin_profile(),
+    discover_popular_by_genre(), calculate_similarity_score()) expects;
+    #273 PR4 removed the dual-key ('keywords' or 'tmdb_keywords')
+    tolerance that used to sit at each of those call sites, since no
+    real caller ever needed it - see CHANGELOG.
     """
     from recommenders.movie import PlexMovieRecommender
     from recommenders.tv import PlexTVRecommender
@@ -642,7 +646,7 @@ def _build_profile_via_recommender(username: str, media_type: str) -> Dict:
         "directors": Counter(wdc.get("directors", {})),
         "studios": Counter(wdc.get("studios", {})),
         "actors": Counter(wdc.get("actors", {})),
-        "keywords": Counter(wdc.get("tmdb_keywords", wdc.get("keywords", {}))),
+        "keywords": Counter(wdc.get("tmdb_keywords", {})),
         "languages": Counter(wdc.get("languages", {})),
         "tmdb_ids": set(wdc.get("tmdb_ids", [])),
     }

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -4666,25 +4666,27 @@ class TestDiscoverCandidatesByProfileKeyCoercion:
     used to assume the caller always handed over Counter objects keyed
     exactly "genres"/"keywords" - true for load_user_profile_from_cache()'s
     own return shape, but not guaranteed for every caller. Both are now
-    coerced to Counter if not already one, and keywords accepts either
-    "keywords" or "tmdb_keywords" (the raw watched_data_counters key
-    name)."""
+    coerced to Counter if not already one.
+
+    #273 PR4: no longer accepts "tmdb_keywords" as an alternate keyword
+    key (removed along with the other now-provably-dead #273 compat
+    shims - see CHANGELOG: every real caller of this function always
+    uses "keywords", never the raw watched_data_counters storage key
+    "tmdb_keywords")."""
 
     @patch("recommenders.external.requests.get")
-    def test_plain_dict_genres_and_tmdb_keywords_key_do_not_raise(self, mock_get):
+    def test_plain_dict_genres_and_keywords_do_not_raise(self, mock_get):
         mock_response = Mock()
         mock_response.status_code = 404
         mock_get.return_value = mock_response
 
-        # Plain dicts (not Counter), and "tmdb_keywords" (not "keywords") -
-        # the raw watched_data_counters shape recommenders/movie.py's/
-        # tv.py's own builders produce, as opposed to
-        # load_user_profile_from_cache()'s renamed-to-Counter shape.
-        user_profile = {"genres": {"nonexistent-genre-xyz": 5}, "tmdb_keywords": {"some-keyword": 3}}
+        # Plain dicts (not Counter) - the .most_common() coercion is the
+        # thing under test here, not the key name (see class docstring
+        # for why "tmdb_keywords" is no longer an accepted alternative).
+        user_profile = {"genres": {"nonexistent-genre-xyz": 5}, "keywords": {"some-keyword": 3}}
 
         # Must not raise (AttributeError: 'dict' object has no attribute
-        # 'most_common', or KeyError: 'keywords') - the whole point of
-        # this test.
+        # 'most_common') - the whole point of this test.
         candidates = discover_candidates_by_profile(
             tmdb_api_key="fake_key",
             user_profile=user_profile,

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -303,7 +303,11 @@ class TestCalculateSimilarityScore:
     def test_keyword_match(self):
         """Test keyword matching."""
         content = {"keywords": ["superhero", "origin story"]}
-        profile = {"tmdb_keywords": {"superhero": 10, "origin story": 5}}
+        # "keywords" (#273 PR4 - the one canonical name every real caller
+        # uses; the "tmdb_keywords" dual-key tolerance this test used to
+        # exercise was dead code no real caller ever needed - see
+        # CHANGELOG).
+        profile = {"keywords": {"superhero": 10, "origin story": 5}}
 
         score, breakdown = calculate_similarity_score(content, profile)
 
@@ -362,7 +366,7 @@ class TestCalculateSimilarityScore:
         profile = {
             "genres": {"action": 100, "comedy": 100, "drama": 100, "thriller": 100},
             "actors": {"A": 100, "B": 100, "C": 100, "D": 100, "E": 100},
-            "tmdb_keywords": {"kw1": 100, "kw2": 100, "kw3": 100, "kw4": 100, "kw5": 100},
+            "keywords": {"kw1": 100, "kw2": 100, "kw3": 100, "kw4": 100, "kw5": 100},  # #273 PR4
             "directors": {"Dir1": 100},
         }
 
@@ -538,8 +542,9 @@ class TestNegativeSignalsScoring:
     def test_negative_keyword_reduces_score(self):
         """Test that negative keyword preference reduces score."""
         content = {"keywords": ["superhero", "origin story"]}
-        profile_positive = {"tmdb_keywords": {"superhero": 10, "origin story": 5}}
-        profile_with_negative = {"tmdb_keywords": {"superhero": 10, "origin story": -3}}
+        # "keywords" (#273 PR4) - see test_keyword_match's own note above.
+        profile_positive = {"keywords": {"superhero": 10, "origin story": 5}}
+        profile_with_negative = {"keywords": {"superhero": 10, "origin story": -3}}
 
         score_positive, _ = calculate_similarity_score(content, profile_positive)
         score_negative, _ = calculate_similarity_score(content, profile_with_negative)

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.66"
+__version__ = "2.10.67"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -60,7 +60,17 @@ def normalize_user_profile(user_prefs: Dict, tfidf_penalty_threshold: float = 0.
         "studios": max_positive(user_prefs.get("studios", {})),
         "actors": max_positive(user_prefs.get("actors", {})),
         "languages": max_positive(user_prefs.get("languages", {})),
-        "keywords": max_positive(user_prefs.get("keywords", user_prefs.get("tmdb_keywords", {}))),
+        # #273 PR4: "keywords" is the ONLY key any real caller ever uses
+        # here (recommenders/movie.py's/tv.py's/external.py's own
+        # watched-data builders all translate their storage-layer
+        # 'tmdb_keywords' key to 'keywords' before calling into this
+        # module - see each builder's own _calculate_similarity_from_cache/
+        # load_user_profile_from_cache/_build_profile_via_recommender).
+        # The "or user_prefs.get('tmdb_keywords', ...)" fallback that used
+        # to sit here was dead code no real caller ever exercised -
+        # removed along with the other #273-related compat shims (see
+        # CHANGELOG).
+        "keywords": max_positive(user_prefs.get("keywords", {})),
     }
     user_prefs["_max_counts"] = max_counts
 
@@ -245,7 +255,7 @@ def _redistribute_weights(weights: Dict, user_profile: Dict, media_type: str = "
     has_studios = bool(user_profile.get("studios", {})) if media_type == "tv" else False
     has_actors = bool(user_profile.get("actors", {}))
     has_languages = bool(user_profile.get("languages", {}))
-    has_keywords = bool(user_profile.get("keywords", user_profile.get("tmdb_keywords", {})))
+    has_keywords = bool(user_profile.get("keywords", {}))
 
     # Get original weights
     genre_w = weights.get("genre", weights.get("genre_weight", 0.20))
@@ -829,7 +839,7 @@ def calculate_similarity_score(
             "studios": Counter(user_profile.get("studios", {})),
             "actors": Counter(user_profile.get("actors", {})),
             "languages": Counter(user_profile.get("languages", {})),
-            "keywords": Counter(user_profile.get("keywords", user_profile.get("tmdb_keywords", {}))),
+            "keywords": Counter(user_profile.get("keywords", {})),
         }
 
         # Use pre-computed max counts if available (from normalize_user_profile)
@@ -915,7 +925,7 @@ def calculate_similarity_score(
         score_breakdown["details"]["language"] = lang_detail
 
         # --- Keyword Score (with embedded TF-IDF penalty) ---
-        content_keywords = content_info.get("keywords", content_info.get("tmdb_keywords", []))
+        content_keywords = content_info.get("keywords", [])
         keyword_weight = effective_weights.get("keyword", 0.45)
         keyword_tfidf_threshold = _tfidf_threshold(user_profile, "keywords", max_counts["keywords"], options)
         keyword_final, _keyword_penalty_w, keyword_details = _score_keyword_component(


### PR DESCRIPTION
## Summary

PR4 (final) of the #273 remediation sequence. Removes the "keywords" / "tmdb_keywords" dual-key compatibility fallbacks that had accumulated across `utils/scoring.py` (4 call sites, pre-existing) and `recommenders/external.py` (2 call sites, both added by #273 PR3 out of appropriate caution at the time) - confirmed by exhaustive call-site audit that no real caller ever needed them.

## Why this is safe

Audited every real production/test caller of `calculate_similarity_score()`/`normalize_user_profile()`:

- `recommenders/movie.py`'s and `recommenders/tv.py`'s own `_calculate_similarity_from_cache()` both explicitly translate `"tmdb_keywords"` (their storage-layer key, matching `create_empty_counters()`/the real on-disk cache format) to `"keywords"` (the scoring-layer key) before ever calling into scoring.
- `recommenders/external.py`'s `load_user_profile_from_cache()` and (post-PR3) `_build_profile_via_recommender()` both already do the same translation.
- `recommenders/external.py`'s own TMDB-candidate `content_info` construction uses `"keywords"` directly (from `fetch_tmdb_details_for_profile()`'s own return shape).
- `tests/harness.py`'s scoring-harness fixture (`tests/fixtures/scoring_harness/user_profile_fixture.json`) uses `"keywords"`.

Every single real caller, everywhere, always uses `"keywords"`. The `"tmdb_keywords"` fallback was dead code - confirmed directly: removing it only broke 3 tests, all of which had been specifically constructing `"tmdb_keywords"`-keyed profiles to exercise the fallback itself (one via an assertion, `assert score <= 1.0`, that had silently stopped exercising its keyword-matching arm at all without ever failing - a real, if harmless, coverage gap this PR also fixes).

## What changed

- `utils/scoring.py`: removed the `"tmdb_keywords"` fallback at 4 call sites (`normalize_user_profile`'s max-count precompute, `_apply_weight_redistribution`'s has-keywords check, `calculate_similarity_score`'s `user_prefs`/`content_keywords` construction).
- `recommenders/external.py`: removed the same fallback from `discover_popular_by_genre()`'s keyword-Counter guard and simplified `_build_profile_via_recommender()`'s now-redundant inner fallback (`wdc` - raw `watched_data_counters` - never has a `"keywords"` key at all, only `"tmdb_keywords"`).
- Does NOT touch the storage-layer convention anywhere - `create_empty_counters()`, `process_counters_from_cache()`, and every real cache file on disk still use `"tmdb_keywords"` exactly as before.
- Updated 2 `tests/test_scoring.py` tests (`test_keyword_match`, `test_negative_keyword_reduces_score`) and 1 score-capping test that had silently stopped testing keyword matching, plus 1 `tests/test_external.py` test - all now use `"keywords"` (their own original intent) instead of exercising the removed fallback.

## Real-library verification (read-only)

This is a pure dead-code removal with a predicted **zero** behavioral delta (unlike PR1/PR2/PR3's genuine behavior changes) - registered before running. Re-scored all 161 real unwatched-movie candidates for a real user (jasonsmith523) against their real, freshly-built watched profile using the current (post-PR4) code:

- 50 of 161 candidates still received a non-zero keyword-score contribution - confirming `"keywords"` (the one surviving key) still matches real TMDB keyword data correctly end to end.
- Two consecutive scoring passes produced byte-identical results - determinism unaffected.

Zero delta predicted, zero delta observed. No Plex writes, no Trakt calls at any point in this verification.

## Test plan

- [x] pytest tests/ (2812 passed, 1 skipped, 97.00% coverage, threshold 85%)
- [x] ruff check . / ruff format --check .
- [x] mypy .
- [x] Real-library verification (above)
- [x] gitleaks (pre-push hook): no leaks found

Closes #273.
