### PR TITLE
Fix Settings/Connections silently clobbering sync-safety fields (2.10.69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.69] - 2026-07-27
+
+### Fixed
+
+- **Settings and Connections silently clobbered each other's Sonarr/Radarr/Trakt sync-safety fields (#290).** `/config/settings` and `/config/connections` both rendered live editable inputs for the same fields (`sonarr_auto_sync`/`user_mode`/`plex_users` and the radarr/trakt equivalents) and both wrote all of them unconditionally on save, from whatever THEIR OWN form last showed - saving either page silently reverted any change made on the other, with both still showing "Saved." either way, no warning, no log line. Since these fields gate real writes to a user's Sonarr/Radarr/Trakt instances, this was treated as higher severity than a cosmetic UI bug.
+
+  Made Connections the sole writer (it already had "more context" - each field sits directly below that service's own URL/API key, matching the module's own pre-existing docstring) and Settings display-only: `web/config_settings.py`'s `_apply_settings()` no longer touches `sonarr.yml`/`radarr.yml`/`trakt.yml` at all (dropped those three params/writes entirely, and dropped them from the modules it commits), and `web/templates/config_settings.html`'s Export Safety fieldset now shows the current on-disk value as plain text with a link to Connections, instead of `<input>`/`<select>` elements - this is the approach that cannot silently lose a setting: Settings' own `<form>` structurally has no field named e.g. `sonarr_auto_sync` for a submission to ever carry, rather than relying on save-time scoping logic to get this right every time.
+
+  **Verified in a real container**: saved distinct sync-safety values via Connections over real HTTP (`sonarr.auto_sync: true`, `user_mode: combined`), then saved Settings' own unrelated fields - `sonarr.yml` was byte-identical afterward, and the Settings page correctly showed the Connections-saved values read-only. New regression coverage in `tests/test_web_config_settings.py::TestSaveNeverTouchesSyncSafety`: a Settings save leaves `sonarr.yml`/`radarr.yml`/`trakt.yml`'s mtimes unchanged; the full clobber scenario (save Connections, then Settings, assert Connections' values survive); and the Settings screen never renders an input/select named for any of these fields.
+
 ## [2.10.68] - 2026-07-27
 
 ### Fixed

--- a/tests/test_web_config_settings.py
+++ b/tests/test_web_config_settings.py
@@ -1,7 +1,15 @@
 """Tests for the /config/settings screen: tuning.yml weights (with
 sum-to-1.0 validation), quality filters, recency decay, rating
-multipliers, negative signals, external recommendations, general/
-logging, and the sonarr/radarr/trakt export-safety toggles."""
+multipliers, negative signals, external recommendations, and general/
+logging.
+
+#290: the sonarr/radarr/trakt export-safety fields (auto_sync/
+user_mode/plex_users) used to ALSO be editable and saved from here,
+duplicating the Connections screen's own editable copy of the exact
+same fields - saving either page silently reverted whatever the other
+had last saved, with no warning. This screen now only ever displays
+those fields read-only (Connections is the sole writer) - see
+TestSaveNeverTouchesSyncSafety below for the regression coverage."""
 
 import os
 import sys
@@ -80,12 +88,6 @@ VALID_FORM = {
     "ext_language": "",
     "general_log_retention_days": "7",
     "logging_level": "INFO",
-    "sonarr_user_mode": "mapping",
-    "sonarr_plex_users": "alice",
-    "radarr_user_mode": "mapping",
-    "radarr_plex_users": "alice",
-    "trakt_user_mode": "mapping",
-    "trakt_plex_users": "alice",
 }
 
 
@@ -203,17 +205,6 @@ class TestSave:
         assert get_update_mode(core) == "off"
         assert core["general"]["auto_update"] is True
 
-    def test_saves_sync_safety_toggles_to_module_files(self, client):
-        c, app, root = client
-        form = dict(VALID_FORM)
-        form["sonarr_auto_sync"] = "on"
-        c.post("/config/settings", data=form)
-
-        sonarr = _read_yaml(root, "sonarr")
-        assert sonarr["auto_sync"] is True
-        assert sonarr["user_mode"] == "mapping"
-        assert sonarr["plex_users"] == ["alice"]
-
     def test_round_trip_preserves_untouched_keys(self, client):
         c, app, root = client
         tuning_path = module_path(root, "tuning")
@@ -226,6 +217,90 @@ class TestSave:
         content = open(tuning_path, encoding="utf-8").read()
         assert "# Curatarr Tuning Configuration" in content
         assert "label_name: Recommended" in content
+
+
+class TestSaveNeverTouchesSyncSafety:
+    """#290: Settings must never write sonarr/radarr/trakt.yml's
+    auto_sync/user_mode/plex_users - Connections (web/config_connections.py)
+    is the sole writer. Before this fix, saving either page silently
+    reverted whatever the other had last saved, with no warning - both
+    still said "Saved." either way."""
+
+    # Minimal valid Connections form - the fields under test
+    # (sonarr_user_mode/plex_users) plus whatever else that screen's
+    # own validation requires to accept the submission at all.
+    CONNECTIONS_FORM = {
+        "plex_url": "http://localhost:32400",
+        "plex_token": "",
+        "tmdb_api_key": "",
+        "tautulli_url": "",
+        "tautulli_api_key": "",
+        "sonarr_url": "http://localhost:8989",
+        "sonarr_api_key": "sonarr-key-123",
+        "sonarr_auto_sync": "on",
+        "sonarr_user_mode": "combined",
+        "sonarr_plex_users": "",
+        "radarr_url": "http://localhost:7878",
+        "radarr_api_key": "radarr-key-123",
+        "radarr_user_mode": "mapping",
+        "radarr_plex_users": "bob",
+        "trakt_client_id": "client-id-123",
+        "trakt_client_secret": "client-secret-123",
+        "trakt_user_mode": "mapping",
+        "trakt_plex_users": "alice",
+    }
+
+    def test_settings_save_does_not_write_sonarr_radarr_trakt_files(self, client):
+        c, app, root = client
+        sonarr_path = module_path(root, "sonarr")
+        radarr_path = module_path(root, "radarr")
+        trakt_path = module_path(root, "trakt")
+        before = tuple(
+            os.path.getmtime(p) if os.path.isfile(p) else None for p in (sonarr_path, radarr_path, trakt_path)
+        )
+
+        c.post("/config/settings", data=VALID_FORM)
+
+        after = tuple(
+            os.path.getmtime(p) if os.path.isfile(p) else None for p in (sonarr_path, radarr_path, trakt_path)
+        )
+        assert before == after
+
+    def test_settings_save_does_not_revert_a_connections_save(self, client):
+        """The actual #290 clobber scenario end to end: save distinct
+        sync-safety values via Connections, then save Settings (its own
+        unrelated fields) - the Connections values must survive
+        untouched."""
+        c, app, root = client
+        c.post("/config/connections", data=self.CONNECTIONS_FORM)
+
+        sonarr = _read_yaml(root, "sonarr")
+        assert sonarr["auto_sync"] is True
+        assert sonarr["user_mode"] == "combined"
+
+        c.post("/config/settings", data=VALID_FORM)
+
+        sonarr_after = _read_yaml(root, "sonarr")
+        radarr_after = _read_yaml(root, "radarr")
+        assert sonarr_after["auto_sync"] is True
+        assert sonarr_after["user_mode"] == "combined"
+        assert radarr_after["user_mode"] == "mapping"
+        assert radarr_after["plex_users"] == ["bob"]
+
+    def test_settings_screen_renders_sync_safety_read_only(self, client):
+        """No <input>/<select> named {svc}_auto_sync/user_mode/
+        plex_users on this screen at all - the only way a save here can
+        structurally never carry a value for them (see this module's
+        own docstring)."""
+        c, app, root = client
+        c.post("/config/connections", data=self.CONNECTIONS_FORM)
+        resp = c.get("/config/settings")
+        text = resp.data.decode()
+        for svc in ("sonarr", "radarr", "trakt"):
+            for field in ("auto_sync", "user_mode", "plex_users"):
+                assert f'name="{svc}_{field}"' not in text
+        # Still shows the current (Connections-owned) value read-only.
+        assert "combined" in text  # sonarr_user_mode from CONNECTIONS_FORM above
 
 
 class TestValidation:

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.68"
+__version__ = "2.10.69"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/config_settings.py
+++ b/web/config_settings.py
@@ -1,7 +1,22 @@
 """Settings / Tuning screen: scoring weights, quality filters, recency
 decay, rating multipliers, negative signals, external-recommendations
-tuning, general/logging options, and the sync-safety fields also
-editable (with less context) on the Connections screen.
+tuning, and general/logging options.
+
+#290: the sync-safety fields (Sonarr/Radarr/Trakt auto_sync/user_mode/
+plex_users) used to ALSO be a fully editable, separately-submitted copy
+on this screen, right alongside the Connections screen's own editable
+copy of the exact same fields. Since both screens' POST handlers wrote
+those fields unconditionally from whatever THEIR OWN form last showed,
+saving either page silently reverted any change made on the other -
+both still said "Saved." either way, with no warning and no log line.
+Given these fields gate real writes to a user's Sonarr/Radarr/Trakt
+instances (see the in-page warning banner), silent loss here is worse
+than a cosmetic UI bug, so this screen no longer submits them at all -
+Connections (web/config_connections.py) is the sole writer; this
+screen only ever displays their current on-disk value read-only, with
+a link there to actually change them. This structurally cannot clobber
+Connections' own save, since this screen's <form> has no input named
+sonarr_auto_sync/etc for a submission to even carry.
 
 Split out of web/config_app.py (audit remediation batch F/I, PR1(a)) -
 see that module's docstring for the overall package layout this is one
@@ -18,13 +33,11 @@ from utils.config import UPDATE_MODES, get_update_mode
 from utils.scheduler import WEEKDAY_NAMES, describe_next_run, parse_schedule_config
 
 from .config_io import (
-    USER_MODE_CHOICES,
     commit_modules,
     ensure_section,
     format_csv_list,
     load_module,
     module_path,
-    parse_csv_list,
 )
 from .config_validate import validate_choice, validate_float, validate_int, validate_weights_sum
 
@@ -83,7 +96,7 @@ def register_settings_routes(app) -> None:
                 **_settings_view(tuning, core, sonarr, radarr, trakt, overrides=parsed),
             ), 400
 
-        modules = _apply_settings(project_root, tuning, core, sonarr, radarr, trakt, parsed)
+        modules = _apply_settings(project_root, tuning, core, parsed)
         commit_error = commit_modules(project_root, modules)
         if commit_error:
             reloaded = _load_all()
@@ -107,9 +120,36 @@ def _settings_view(
 ) -> Dict:
     """Build the template context for config_settings.html: the on-disk
     values across all five module files (or, after a failed submission,
-    *overrides* verbatim - already in this same shape)."""
+    *overrides* for everything this screen actually submits).
+
+    sync_safety (#290, read-only on this screen - see this module's own
+    docstring) is always read fresh from sonarr/radarr/trakt here,
+    regardless of *overrides*: it is never part of a Settings
+    submission, so there is nothing for a validation-error redisplay to
+    override it WITH - showing the current real value is the only
+    option, same as it would be for any other read-only field.
+    """
+    trakt_export = trakt.get("export") or {}
+    sync_safety = {
+        "sonarr": {
+            "auto_sync": bool(sonarr.get("auto_sync", False)),
+            "user_mode": sonarr.get("user_mode", "mapping"),
+            "plex_users": format_csv_list(sonarr.get("plex_users")),
+        },
+        "radarr": {
+            "auto_sync": bool(radarr.get("auto_sync", False)),
+            "user_mode": radarr.get("user_mode", "mapping"),
+            "plex_users": format_csv_list(radarr.get("plex_users")),
+        },
+        "trakt": {
+            "auto_sync": bool(trakt_export.get("auto_sync", False)),
+            "user_mode": trakt_export.get("user_mode", "mapping"),
+            "plex_users": format_csv_list(trakt_export.get("plex_users")),
+        },
+    }
+
     if overrides is not None:
-        return overrides
+        return {**overrides, "sync_safety": sync_safety}
 
     movies = tuning.get("movies") or {}
     tv = tuning.get("tv") or {}
@@ -126,7 +166,6 @@ def _settings_view(
     general = core.get("general") or {}
     logging_cfg = core.get("logging") or {}
     schedule_cfg = core.get("schedule") or {}
-    trakt_export = trakt.get("export") or {}
 
     return {
         "movies": {
@@ -204,25 +243,8 @@ def _settings_view(
             "weekdays": [str(d).strip().lower() for d in (schedule_cfg.get("weekdays") or [])],
         },
         "weekday_choices": WEEKDAY_NAMES,
-        "sync_safety": {
-            "sonarr": {
-                "auto_sync": bool(sonarr.get("auto_sync", False)),
-                "user_mode": sonarr.get("user_mode", "mapping"),
-                "plex_users": format_csv_list(sonarr.get("plex_users")),
-            },
-            "radarr": {
-                "auto_sync": bool(radarr.get("auto_sync", False)),
-                "user_mode": radarr.get("user_mode", "mapping"),
-                "plex_users": format_csv_list(radarr.get("plex_users")),
-            },
-            "trakt": {
-                "auto_sync": bool(trakt_export.get("auto_sync", False)),
-                "user_mode": trakt_export.get("user_mode", "mapping"),
-                "plex_users": format_csv_list(trakt_export.get("plex_users")),
-            },
-        },
+        "sync_safety": sync_safety,
         "log_level_choices": LOG_LEVEL_CHOICES,
-        "user_mode_choices": USER_MODE_CHOICES,
         "update_mode_choices": UPDATE_MODES,
     }
 
@@ -345,16 +367,12 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
     except ValueError as e:
         errors["schedule_time"] = str(e)
 
-    sync_safety = {}
-    for svc in ("sonarr", "radarr", "trakt"):
-        user_mode = form.get(f"{svc}_user_mode", "mapping")
-        validate_choice(user_mode, f"{svc}_user_mode", errors, USER_MODE_CHOICES)
-        sync_safety[svc] = {
-            "auto_sync": flag(f"{svc}_auto_sync"),
-            "user_mode": user_mode,
-            "plex_users": format_csv_list(parse_csv_list(form.get(f"{svc}_plex_users", ""))),
-        }
-
+    # #290: sync_safety (Sonarr/Radarr/Trakt auto_sync/user_mode/
+    # plex_users) is deliberately NOT parsed here - this screen's own
+    # <form> has no input for those fields anymore (Connections is the
+    # sole writer - see this module's own docstring). _settings_view()
+    # always re-reads their current on-disk value fresh regardless of
+    # *overrides* for exactly this reason.
     return {
         "movies": movies,
         "tv": tv,
@@ -366,9 +384,7 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
         "logging": {"level": logging_level},
         "schedule": schedule,
         "weekday_choices": WEEKDAY_NAMES,
-        "sync_safety": sync_safety,
         "log_level_choices": LOG_LEVEL_CHOICES,
-        "user_mode_choices": USER_MODE_CHOICES,
         "update_mode_choices": UPDATE_MODES,
     }
 
@@ -377,14 +393,17 @@ def _apply_settings(
     project_root: str,
     tuning: CommentedMap,
     core: CommentedMap,
-    sonarr: CommentedMap,
-    radarr: CommentedMap,
-    trakt: CommentedMap,
     parsed: Dict,
 ) -> Dict[str, CommentedMap]:
     """Mutate the in-memory CommentedMaps for this screen and return them
     keyed by module name, WITHOUT writing to disk - see
-    config_connections._apply_connections' docstring for why."""
+    config_connections._apply_connections' docstring for why.
+
+    #290: no longer takes sonarr/radarr/trakt - this screen never
+    writes to those files anymore (sync_safety is read-only here now -
+    see this module's own docstring), so there's nothing in them for
+    this function to mutate or for its caller to commit.
+    """
     movies_section = ensure_section(tuning, "movies")
     movies_section["limit_results"] = parsed["movies"]["limit_results"]
     ensure_section(movies_section, "weights").update(parsed["movies"]["weights"])
@@ -442,18 +461,4 @@ def _apply_settings(
         # purely a tidier on-disk file, not a behavior difference.
         schedule_section.pop("weekdays", None)
 
-    sonarr["auto_sync"] = parsed["sync_safety"]["sonarr"]["auto_sync"]
-    sonarr["user_mode"] = parsed["sync_safety"]["sonarr"]["user_mode"]
-    sonarr["plex_users"] = parse_csv_list(parsed["sync_safety"]["sonarr"]["plex_users"])
-
-    radarr["auto_sync"] = parsed["sync_safety"]["radarr"]["auto_sync"]
-    radarr["user_mode"] = parsed["sync_safety"]["radarr"]["user_mode"]
-    radarr["plex_users"] = parse_csv_list(parsed["sync_safety"]["radarr"]["plex_users"])
-
-    trakt_export = trakt.get("export") or CommentedMap()
-    trakt_export["auto_sync"] = parsed["sync_safety"]["trakt"]["auto_sync"]
-    trakt_export["user_mode"] = parsed["sync_safety"]["trakt"]["user_mode"]
-    trakt_export["plex_users"] = parse_csv_list(parsed["sync_safety"]["trakt"]["plex_users"])
-    trakt["export"] = trakt_export
-
-    return {"tuning": tuning, "config": core, "sonarr": sonarr, "radarr": radarr, "trakt": trakt}
+    return {"tuning": tuning, "config": core}

--- a/web/templates/config_settings.html
+++ b/web/templates/config_settings.html
@@ -16,31 +16,21 @@
   <fieldset>
     <legend>Export safety - Sonarr / Radarr / Trakt</legend>
     <p class="banner warn">
-      Turning <strong>Auto-sync</strong> ON here means curatarr starts writing to your
-      download clients (adding movies/shows to Sonarr/Radarr, or syncing lists to Trakt) on
-      every run, with no confirmation prompt. <strong>User mode</strong> and
-      <strong>Plex users</strong> control whose recommendations get synced - double-check
-      both before enabling auto-sync for anyone but yourself.
+      These fields control whether curatarr starts writing to your download clients (adding
+      movies/shows to Sonarr/Radarr, or syncing lists to Trakt) on every run, with no
+      confirmation prompt - <a href="{{ url_for('config_connections') }}">edit them on the
+      Connections screen</a>, right alongside each service's own connection details. Shown
+      here read-only so Settings can never silently revert a change made there (#290).
     </p>
 
     {% for svc in ['sonarr', 'radarr', 'trakt'] %}
     <div class="sync-safety-row">
       <h3>{{ svc|capitalize }}</h3>
-      <label>
-        <input type="checkbox" name="{{ svc }}_auto_sync" {% if sync_safety[svc].auto_sync %}checked{% endif %}>
-        Auto-sync every run
-      </label>
-      <label>User mode
-        <select name="{{ svc }}_user_mode">
-          {% for choice in user_mode_choices %}
-          <option value="{{ choice }}" {% if sync_safety[svc].user_mode == choice %}selected{% endif %}>{{ choice }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      {{ field_error(errors, svc ~ '_user_mode') }}
-      <label>Plex users to sync (comma-separated, used when user mode is "mapping")
-        <input type="text" name="{{ svc }}_plex_users" value="{{ sync_safety[svc].plex_users }}">
-      </label>
+      <p>
+        Auto-sync every run: <strong>{{ 'on' if sync_safety[svc].auto_sync else 'off' }}</strong>
+        &middot; User mode: <strong>{{ sync_safety[svc].user_mode }}</strong>
+        &middot; Plex users to sync: <strong>{{ sync_safety[svc].plex_users or '(none)' }}</strong>
+      </p>
     </div>
     {% endfor %}
   </fieldset>


### PR DESCRIPTION
## Summary

Closes #290.

- `/config/settings` and `/config/connections` both rendered live editable inputs for the SAME Sonarr/Radarr/Trakt fields (`{svc}_auto_sync`/`user_mode`/`plex_users`) and both wrote all of them unconditionally on save, from whatever THEIR OWN form last showed - saving either page silently reverted any change made on the other, with both still showing "Saved." either way, no warning, no log line. Since these fields gate real writes to a user's Sonarr/Radarr/Trakt instances, treated this as higher severity than a cosmetic UI bug.
- Made **Connections** the sole writer (it already had "more context" per this module's own pre-existing docstring - each field sits directly below that service's own URL/API key) and **Settings display-only**: `_apply_settings()` no longer takes or touches `sonarr`/`radarr`/`trakt`, and the template shows the current value as plain text with a link to Connections instead of `<input>`/`<select>` elements.
- Chose this over field-scoped saves because it **cannot silently lose a setting** by construction: Settings' own `<form>` has no field named e.g. `sonarr_auto_sync` for a submission to ever carry, rather than relying on save-time scoping logic to get right every time.

## Real-container verification

Saved distinct sync-safety values via Connections over real HTTP (`sonarr.auto_sync: true`, `user_mode: combined`, `radarr.user_mode: mapping`/`plex_users: bob`), then saved Settings' own unrelated fields (weights, quality filters, etc.) - `sonarr.yml` was byte-identical afterward, and the Settings page correctly rendered the Connections-saved values read-only with no editable inputs for them.

## Test plan

- [x] New `tests/test_web_config_settings.py::TestSaveNeverTouchesSyncSafety`: a Settings save leaves `sonarr.yml`/`radarr.yml`/`trakt.yml` mtimes unchanged; the full clobber scenario end to end (save Connections, then Settings, assert Connections' values survive); the Settings screen never renders an input/select named for any of these fields.
- [x] Full suite (2814 passed, 1 skipped), `ruff check .`, `ruff format --check .`, `mypy .` all green.
- [x] Real-container verification above.
