### PR TITLE
Fix status badge false success and log viewer truncation (2.10.70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.70] - 2026-07-27
+
+### Fixed
+
+- **Web UI status badge reported "success" on a real failure (#292), and the log viewer couldn't reach the start of a long log (#283) - same `TAIL_BYTES` truncation behind both.** `web/status.py`'s `get_last_run_status()` used to infer success/failure entirely by grepping the last 200KB of whichever log file `latest_user_log()` picked for three fixed English substrings ("traceback (most recent call last)", "fatal error", "an error occurred"). Two confirmed, real failure modes: (1) a failure logged any other way (e.g. `recommenders/external_sync.py`'s `log_error(f"Failed to export {user} to Trakt: {e}")`, no traceback dump) reads as success - the exact shape that let a Trakt auth failure report success for six months before `utils/integration_status.py` (v2.10.54) covered that one specific case; (2) `movie.py`/`tv.py` both write to the identical `recommendations_<user>_<timestamp>.log` naming, so the newest-by-mtime pick can show one engine's outcome while masking a different, older failure from the other.
+
+  **Stopped inferring status from English prose.** New `utils/run_status.py` (same explicit, structured, atomic-write shape as `utils/integration_status.py`): `recommenders/movie.py`'s and `tv.py`'s `process_recommendations()` and `recommenders/external.py`'s per-user loops now record their own real observed outcome - did processing for this user raise at all - immediately after each (engine, user) pair finishes, independent of whether `movie.py`'s own fatal-keyword check additionally decides to `sys.exit()` over it. `get_last_run_status()` now reads this back directly per user, comparing each engine's own recorded timestamp (never file mtime) to resolve which is newest - fixing failure mode 2 as a side effect. Falls back to the legacy log-tail heuristic only when neither engine has ever recorded a status for a user yet (an install predating this fix, or a run from before it shipped) - every already-written log on every existing install has no recorded status to prefer, so the fallback is permanent, not a migration step.
+
+  `/status.json` now also includes `last_job`: the most recent (or in-progress) web-UI-triggered job's full per-stage breakdown (`stage_results`/`external_produced_output` - #282/#288, v2.10.64) - a "succeeded" job-level exit code and a "failed" per-user `last_run` are now both visible together instead of only one or the other.
+
+  **Log viewer (#283):** new `read_log_full()` (up to `LOG_VIEW_MAX_BYTES` = 50MB, a memory-safety backstop well above `cleanup_old_logs()`'s ~20MB retention target) alongside the existing `read_log_tail()` (still the default, last 500 lines). `/results/log/<file>?view=full` and a "Show full log" / "Show last 500 lines" toggle link on the log-view page.
+
+  **Verified in a real container**: triggered a real `external` run whose per-user processing raised inside the actual subprocess pipeline - `/run/status`/`last_job` correctly showed the job itself `succeeded` (exit 0, matching the exact "silently reports success" shape this issue described), while `/status.json`'s `last_run` and the dashboard correctly showed that user as `failed`, with the real exception message surfaced as the badge's tooltip - the accurate signal the job-level exit code alone can't express. Confirmed the log-view toggle serves the full file vs. the last-500-line tail correctly for a real generated log.
+
+  New regression coverage in `tests/test_web_status.py` (explicit signal overrides conflicting log content in both directions; cross-engine timestamp comparison resolves which of movie/tv is newest; fallback to the legacy heuristic when no explicit signal exists; `read_log_full()`'s truncation/redaction/traversal-safety behavior) and `tests/test_movie.py`/`test_tv.py`/`test_external.py` (record_run_status called with the right engine/user/outcome).
+
 ## [2.10.69] - 2026-07-27
 
 ### Fixed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -85,6 +85,7 @@ from utils import (
     normalize_genre,
     normalize_user_profile,
     record_recommender_run,
+    record_run_status,
     record_unhandled_error,
     save_json_cache,
     smart_open_html,
@@ -2296,6 +2297,12 @@ def _main_impl():
     project_root = get_project_root()
     config_path = os.path.join(project_root, "config/config.yml")
     config = load_config(config_path)
+    # #292: same directory get_last_run_status()/record_run_status()
+    # already use for movie.py/tv.py - external.py has no setup_log_file()
+    # call of its own (it writes recommendations/external/* output, not
+    # a logs/*.log file), so this is purely for the explicit run-status
+    # signal below, not an actual log file.
+    log_dir = os.path.join(project_root, "logs")
 
     # Suppress urllib3's InsecureRequestWarning ONLY when this config
     # actually opts out of certificate verification (verify_ssl: false,
@@ -2414,9 +2421,14 @@ def _main_impl():
                     )
                     if user_data:
                         all_users_data.append(user_data)
+                    # #292: explicit, structured outcome for this user's
+                    # external run - see utils/run_status.py's own
+                    # docstring and recommenders/movie.py's matching hook.
+                    record_run_status(log_dir, "external", username, True)
                 except Exception as e:
                     log_error(f"Error processing {username}: {e}")
                     traceback.print_exc()
+                    record_run_status(log_dir, "external", username, False, str(e))
 
             arr_export_data = all_users_data
         else:
@@ -2447,9 +2459,11 @@ def _main_impl():
 
                     if movie_runs or tv_runs:
                         all_users_data.append(_merge_user_runs(username, movie_runs, tv_runs))
+                    record_run_status(log_dir, "external", username, True)
                 except Exception as e:
                     log_error(f"Error processing {username}: {e}")
                     traceback.print_exc()
+                    record_run_status(log_dir, "external", username, False, str(e))
 
         # Build shared counts: how many users want each item
         total_users = len(all_users_data)

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -40,6 +40,7 @@ from utils import (
     log_warning,
     merge_movie_history,
     process_counters_from_cache,
+    record_run_status,
     run_recommender_main,
     setup_log_file,
     show_progress,
@@ -612,6 +613,16 @@ def process_recommendations(
     log_dir = os.path.join(get_project_root(), "logs")
     setup_log_file(log_dir, log_retention_days, single_user, "recommendations")
 
+    # #292: explicit, structured outcome for THIS user's movie run -
+    # see utils/run_status.py's own docstring for why this replaces
+    # grepping the log tail for English error strings. Records the
+    # real observed outcome (did processing for this user raise at
+    # all) independently of whether the fatal-keyword check below
+    # additionally decides to sys.exit() over it - recorded in the
+    # `finally` below so it always runs, including on that exit path.
+    run_success = True
+    run_detail = ""
+
     try:
         # Create recommender with single user context
         recommender = PlexMovieRecommender(
@@ -651,6 +662,8 @@ def process_recommendations(
     except Exception as e:
         print(f"\n{RED}An error occurred: {e}{RESET}")
         print(traceback.format_exc())
+        run_success = False
+        run_detail = str(e)
 
         # Check if this is a fatal error that should stop all processing
         error_msg = str(e).lower()
@@ -662,6 +675,8 @@ def process_recommendations(
             sys.exit(1)
 
     finally:
+        if single_user:
+            record_run_status(log_dir, "movie", single_user, run_success, run_detail)
         teardown_log_file(original_stdout, log_retention_days)
 
 

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -43,6 +43,7 @@ from utils import (
     log_warning,
     merge_show_watched_data,
     process_counters_from_cache,
+    record_run_status,
     run_recommender_main,
     setup_log_file,
     show_progress,
@@ -641,6 +642,12 @@ def process_recommendations(
     log_dir = os.path.join(get_project_root(), "logs")
     setup_log_file(log_dir, log_retention_days, single_user, "recommendations")
 
+    # #292: explicit, structured outcome for THIS user's TV run - see
+    # utils/run_status.py's own docstring and recommenders/movie.py's
+    # matching hook for the full rationale.
+    run_success = True
+    run_detail = ""
+
     try:
         # Create recommender with single user context
         recommender = PlexTVRecommender(
@@ -673,8 +680,12 @@ def process_recommendations(
     except Exception as e:
         print(f"\n{RED}An error occurred: {e}{RESET}")
         print(traceback.format_exc())
+        run_success = False
+        run_detail = str(e)
 
     finally:
+        if single_user:
+            record_run_status(log_dir, "tv", single_user, run_success, run_detail)
         teardown_log_file(original_stdout, log_retention_days)
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -2943,6 +2943,130 @@ class TestMainLibraryResolution:
         assert mock_sonarr.call_args[0][1] is mock_radarr.call_args[0][1]
         assert mock_sonarr.call_args[0][1] == mock_trakt.call_args[0][1]
 
+
+class TestMainImplRecordsRunStatus:
+    """#292: the per-user loop (non-fan-out path) records its own real
+    observed outcome via utils.run_status.record_run_status() -
+    independent of the job-level exit code, which stays 0 either way
+    (this loop's own except block never re-raises) - see
+    recommenders/movie.py's matching hook and web/status.py's
+    get_last_run_status() docstring for the full rationale, and this
+    module's own real-container precedent (recommenders/external_sync.py's
+    Trakt-export log_error calls, which the legacy log-tail heuristic
+    never caught for six months)."""
+
+    @patch("recommenders.external.record_run_status")
+    @patch("recommenders.external.export_to_simkl")
+    @patch("recommenders.external.export_to_mdblist")
+    @patch("recommenders.external.export_to_radarr")
+    @patch("recommenders.external.export_to_sonarr")
+    @patch("recommenders.external.export_to_trakt")
+    @patch("recommenders.external.generate_combined_html")
+    @patch("recommenders.external.find_horizon_movies")
+    @patch("recommenders.external.find_missing_sequels")
+    @patch("recommenders.external.process_user")
+    @patch("recommenders.external.PlexServer")
+    @patch("recommenders.external.get_tmdb_config")
+    @patch("recommenders.external.load_config")
+    @patch("recommenders.external.get_project_root")
+    @patch("sys.argv", ["external.py"])
+    def test_success_records_true_per_user(
+        self,
+        mock_root,
+        mock_load_config,
+        mock_get_tmdb,
+        mock_plex_server,
+        mock_process_user,
+        mock_sequels,
+        mock_horizon,
+        mock_html,
+        mock_trakt,
+        mock_sonarr,
+        mock_radarr,
+        mock_mdblist,
+        mock_simkl,
+        mock_record,
+    ):
+        mock_root.return_value = "/fake/root"
+        mock_load_config.return_value = {
+            "plex": {"url": "http://x", "token": "y", "movie_library": "Movies", "tv_library": "TV Shows"},
+            "users": {"list": "alice"},
+            "huntarr": {"sequel_huntarr": False, "horizon_huntarr": False},
+        }
+        mock_get_tmdb.return_value = {"api_key": "key", "use_keywords": True}
+        mock_plex_server.return_value = Mock()
+        mock_process_user.return_value = {
+            "username": "alice",
+            "display_name": "alice",
+            "movies_categorized": {"user_services": {}, "other_services": {}, "acquire": []},
+            "shows_categorized": {"user_services": {}, "other_services": {}, "acquire": []},
+            "movie_profile": {},
+            "show_profile": {},
+            "user_services": [],
+            "library_id": None,
+        }
+        mock_html.return_value = None
+
+        from recommenders.external import main
+
+        main()
+
+        mock_record.assert_called_once_with(os.path.join("/fake/root", "logs"), "external", "alice", True)
+
+    @patch("recommenders.external.record_run_status")
+    @patch("recommenders.external.export_to_simkl")
+    @patch("recommenders.external.export_to_mdblist")
+    @patch("recommenders.external.export_to_radarr")
+    @patch("recommenders.external.export_to_sonarr")
+    @patch("recommenders.external.export_to_trakt")
+    @patch("recommenders.external.generate_combined_html")
+    @patch("recommenders.external.find_horizon_movies")
+    @patch("recommenders.external.find_missing_sequels")
+    @patch("recommenders.external.process_user")
+    @patch("recommenders.external.PlexServer")
+    @patch("recommenders.external.get_tmdb_config")
+    @patch("recommenders.external.load_config")
+    @patch("recommenders.external.get_project_root")
+    @patch("sys.argv", ["external.py"])
+    def test_error_records_false_with_detail_per_user(
+        self,
+        mock_root,
+        mock_load_config,
+        mock_get_tmdb,
+        mock_plex_server,
+        mock_process_user,
+        mock_sequels,
+        mock_horizon,
+        mock_html,
+        mock_trakt,
+        mock_sonarr,
+        mock_radarr,
+        mock_mdblist,
+        mock_simkl,
+        mock_record,
+    ):
+        """The concrete #292 precedent shape: a caught per-user exception
+        logged without a traceback dump - the explicit signal is the only
+        thing that catches this, not the legacy log-tail marker check."""
+        mock_root.return_value = "/fake/root"
+        mock_load_config.return_value = {
+            "plex": {"url": "http://x", "token": "y", "movie_library": "Movies", "tv_library": "TV Shows"},
+            "users": {"list": "alice"},
+            "huntarr": {"sequel_huntarr": False, "horizon_huntarr": False},
+        }
+        mock_get_tmdb.return_value = {"api_key": "key", "use_keywords": True}
+        mock_plex_server.return_value = Mock()
+        mock_process_user.side_effect = Exception("Cannot get lists: not authenticated")
+        mock_html.return_value = None
+
+        from recommenders.external import main
+
+        main()
+
+        mock_record.assert_called_once_with(
+            os.path.join("/fake/root", "logs"), "external", "alice", False, "Cannot get lists: not authenticated"
+        )
+
     @patch("recommenders.external.export_to_simkl")
     @patch("recommenders.external.export_to_mdblist")
     @patch("recommenders.external.export_to_radarr")

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1624,6 +1624,78 @@ class TestProcessRecommendationsMovie:
         mock_exit.assert_not_called()
 
 
+class TestProcessRecommendationsRecordsRunStatus:
+    """#292: process_recommendations() records its own real observed
+    outcome via utils.run_status.record_run_status(), independent of
+    whether the fatal-keyword check separately decides to sys.exit()
+    over it - see web/status.py's get_last_run_status() docstring for
+    why this replaced grepping the log tail for English error strings."""
+
+    @patch("recommenders.movie.record_run_status")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    @patch("recommenders.movie.teardown_log_file")
+    @patch("recommenders.movie.setup_log_file")
+    def test_success_records_true(self, mock_setup, mock_teardown, mock_recommender_cls, mock_record):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
+        mock_instance.config = {"general": {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
+
+        mock_record.assert_called_once()
+        args, _kwargs = mock_record.call_args
+        assert args[1:] == ("movie", "alice", True, "")
+
+    @patch("recommenders.movie.record_run_status")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    @patch("recommenders.movie.teardown_log_file")
+    @patch("recommenders.movie.setup_log_file")
+    def test_non_fatal_error_records_false_with_detail(
+        self, mock_setup, mock_teardown, mock_recommender_cls, mock_record
+    ):
+        mock_recommender_cls.side_effect = ValueError("Something else broke")
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
+
+        args, _kwargs = mock_record.call_args
+        assert args[1:4] == ("movie", "alice", False)
+        assert "Something else broke" in args[4]
+
+    @patch("recommenders.movie.record_run_status")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    @patch("recommenders.movie.teardown_log_file")
+    @patch("recommenders.movie.setup_log_file")
+    def test_fatal_error_still_records_before_exiting(
+        self, mock_setup, mock_teardown, mock_recommender_cls, mock_record
+    ):
+        """The finally block must run - and record - even on the
+        sys.exit(1) path (fatal errors), never skipped."""
+        mock_recommender_cls.side_effect = RuntimeError("Plex server unreachable")
+
+        with patch("recommenders.movie.sys.exit"):
+            process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
+
+        args, _kwargs = mock_record.call_args
+        assert args[1:4] == ("movie", "alice", False)
+
+    @patch("recommenders.movie.record_run_status")
+    @patch("recommenders.movie.PlexMovieRecommender")
+    @patch("recommenders.movie.teardown_log_file")
+    @patch("recommenders.movie.setup_log_file")
+    def test_no_single_user_never_records(self, mock_setup, mock_teardown, mock_recommender_cls, mock_record):
+        """An 'all users' caller with no single_user resolved yet must
+        never write a nonsensical run_status_movie_None.json."""
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
+        mock_instance.config = {"general": {}}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0)
+
+        mock_record.assert_not_called()
+
+
 class TestLibraryFetchedOnceNotSixTimes:
     """#233 audit remediation batch D / PR1(a) regression coverage.
 

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1726,3 +1726,50 @@ class TestProcessRecommendationsTV:
         process_recommendations({"general": {}}, "/path/to/config.yml", 0)
 
         mock_teardown.assert_called_once()
+
+
+class TestProcessRecommendationsRecordsRunStatus:
+    """#292: process_recommendations() records its own real observed
+    outcome via utils.run_status.record_run_status() - see
+    recommenders/movie.py's matching hook and web/status.py's
+    get_last_run_status() docstring for the full rationale."""
+
+    @patch("recommenders.tv.record_run_status")
+    @patch("recommenders.tv.PlexTVRecommender")
+    @patch("recommenders.tv.teardown_log_file")
+    @patch("recommenders.tv.setup_log_file")
+    def test_success_records_true(self, mock_setup, mock_teardown, mock_recommender_cls, mock_record):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
+
+        args, _kwargs = mock_record.call_args
+        assert args[1:] == ("tv", "alice", True, "")
+
+    @patch("recommenders.tv.record_run_status")
+    @patch("recommenders.tv.PlexTVRecommender")
+    @patch("recommenders.tv.teardown_log_file")
+    @patch("recommenders.tv.setup_log_file")
+    def test_error_records_false_with_detail(self, mock_setup, mock_teardown, mock_recommender_cls, mock_record):
+        mock_recommender_cls.side_effect = RuntimeError("boom")
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0, single_user="alice")
+
+        args, _kwargs = mock_record.call_args
+        assert args[1:4] == ("tv", "alice", False)
+        assert "boom" in args[4]
+
+    @patch("recommenders.tv.record_run_status")
+    @patch("recommenders.tv.PlexTVRecommender")
+    @patch("recommenders.tv.teardown_log_file")
+    @patch("recommenders.tv.setup_log_file")
+    def test_no_single_user_never_records(self, mock_setup, mock_teardown, mock_recommender_cls, mock_record):
+        mock_instance = Mock()
+        mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
+        mock_recommender_cls.return_value = mock_instance
+
+        process_recommendations({"general": {}}, "/path/to/config.yml", 0)
+
+        mock_record.assert_not_called()

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -9,12 +9,15 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pytest
 
 import web.status as status_mod
+from utils.run_status import record_run_status
 from web.status import (
+    LOG_VIEW_MAX_BYTES,
     TAIL_BYTES,
     display_name_safe_slug,
     find_user_watchlist,
     get_last_run_status,
     list_log_files,
+    read_log_full,
     read_log_tail,
 )
 
@@ -161,6 +164,89 @@ class TestGetLastRunStatus:
         assert result["timestamp"] is None
 
 
+class TestGetLastRunStatusExplicitSignal:
+    """#292: get_last_run_status() prefers utils.run_status's explicit,
+    structured signal over the legacy log-tail marker-matching
+    heuristic - see that module's own docstring for the two confirmed
+    failure modes this replaces (an error phrased outside the fixed
+    marker list; movie.py/tv.py sharing one log-filename pattern)."""
+
+    def test_prefers_explicit_success_over_log_content_saying_otherwise(self, tmp_path):
+        """The log content itself would say 'failed' under the legacy
+        heuristic - the explicit signal (what the code itself actually
+        observed) must win regardless."""
+        _write_log(
+            tmp_path,
+            "recommendations_alice_20260101_030000.log",
+            "Traceback (most recent call last):\nValueError\n",
+        )
+        record_run_status(str(tmp_path), "movie", "alice", True)
+        result = get_last_run_status(str(tmp_path), "alice")
+        assert result["status"] == "success"
+        assert result["reason"] is None
+
+    def test_prefers_explicit_failure_over_log_content_saying_otherwise(self, tmp_path):
+        """The concrete #292 precedent: a failure phrased in a way the
+        marker list never catches (e.g. "Cannot get lists: not
+        authenticated") must still surface as failed via the explicit
+        signal, and the failure detail itself is now available as
+        `reason` - previously only set for 'unknown', never 'failed'."""
+        _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "Everything looks fine\n")
+        record_run_status(str(tmp_path), "movie", "alice", False, "Cannot get lists: not authenticated")
+        result = get_last_run_status(str(tmp_path), "alice")
+        assert result["status"] == "failed"
+        assert result["reason"] == "Cannot get lists: not authenticated"
+
+    def test_compares_movie_and_tv_by_their_own_recorded_timestamp_not_log_mtime(self, tmp_path, monkeypatch):
+        """movie.py and tv.py both write to the identical
+        "recommendations_<user>_*.log" naming - get_last_run_status()
+        must resolve "which engine ran last" from each explicit
+        record's OWN timestamp, never from comparing log file mtimes
+        (which is exactly the ambiguity that let one engine's failure
+        hide behind the other's later, unrelated success)."""
+        import utils.run_status as run_status_mod
+
+        real_now = run_status_mod.datetime
+
+        class _FixedNow(real_now):
+            @classmethod
+            def now(cls, tz=None):
+                return real_now(2026, 1, 1, 3, 0, 0, tzinfo=tz)
+
+        monkeypatch.setattr(run_status_mod, "datetime", _FixedNow)
+        record_run_status(str(tmp_path), "movie", "alice", False, "movie blew up")
+
+        class _LaterNow(real_now):
+            @classmethod
+            def now(cls, tz=None):
+                return real_now(2026, 1, 1, 4, 0, 0, tzinfo=tz)
+
+        monkeypatch.setattr(run_status_mod, "datetime", _LaterNow)
+        record_run_status(str(tmp_path), "tv", "alice", True)
+
+        result = get_last_run_status(str(tmp_path), "alice")
+        assert result["status"] == "success"  # tv's record is newer
+
+    def test_falls_back_to_heuristic_when_no_explicit_signal_recorded(self, tmp_path):
+        """An install predating #292 (or a run from before it shipped)
+        has no run_status_*.json at all - must fall back to the legacy
+        log-tail heuristic exactly as before, never regress to
+        'unknown'/'never_run' just because the new signal is absent."""
+        _write_log(
+            tmp_path,
+            "recommendations_alice_20260101_030000.log",
+            "Traceback (most recent call last):\nValueError\n",
+        )
+        result = get_last_run_status(str(tmp_path), "alice")
+        assert result["status"] == "failed"
+
+    def test_explicit_signal_still_resolves_log_file_for_view_log_link(self, tmp_path):
+        _write_log(tmp_path, "recommendations_alice_20260101_030000.log", "ok\n")
+        record_run_status(str(tmp_path), "movie", "alice", True)
+        result = get_last_run_status(str(tmp_path), "alice")
+        assert result["log_file"] == "recommendations_alice_20260101_030000.log"
+
+
 class TestListLogFiles:
     """Tests for list_log_files()"""
 
@@ -245,6 +331,58 @@ class TestReadLogTail:
         assert content == ""
         assert reason is not None
         assert "empty" in reason.lower()
+
+
+class TestReadLogFull:
+    """#283: the log viewer only ever showed a fixed-size tail with no
+    way to reach the START of a long run - read_log_full() is the
+    unbounded (up to LOG_VIEW_MAX_BYTES) alternative."""
+
+    def test_reads_entire_file_not_just_last_max_lines(self, tmp_path):
+        content = "\n".join(f"line{i}" for i in range(1000))
+        _write_log(tmp_path, "a.log", content)
+        result, reason, truncated = read_log_full(str(tmp_path), "a.log")
+        assert result.splitlines()[0] == "line0"
+        assert result.splitlines()[-1] == "line999"
+        assert reason is None
+        assert truncated is False
+
+    def test_truncated_true_when_file_exceeds_max_bytes(self, tmp_path):
+        _write_log(tmp_path, "a.log", "x" * 1000)
+        result, _reason, truncated = read_log_full(str(tmp_path), "a.log", max_bytes=100)
+        assert truncated is True
+        assert len(result) <= 100
+
+    def test_not_truncated_when_file_is_under_max_bytes(self, tmp_path):
+        _write_log(tmp_path, "a.log", "small\n")
+        _result, _reason, truncated = read_log_full(str(tmp_path), "a.log", max_bytes=LOG_VIEW_MAX_BYTES)
+        assert truncated is False
+
+    def test_raises_for_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_log_full(str(tmp_path), "missing.log")
+
+    def test_raises_for_path_traversal(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_log_full(str(tmp_path), "../secret.log")
+
+    def test_rejects_non_log_extension(self, tmp_path):
+        (tmp_path / "config.yml").write_text("plex:\n  token: secret\n", encoding="utf-8")
+        with pytest.raises(FileNotFoundError):
+            read_log_full(str(tmp_path), "config.yml")
+
+    def test_redacts_secrets(self, tmp_path):
+        _write_log(tmp_path, "a.log", "token=abcdef123456\n")
+        content, _reason, _truncated = read_log_full(str(tmp_path), "a.log")
+        assert "abcdef123456" not in content
+
+    def test_empty_log_returns_reason(self, tmp_path):
+        _write_log(tmp_path, "a.log", "")
+        content, reason, truncated = read_log_full(str(tmp_path), "a.log")
+        assert content == ""
+        assert reason is not None
+        assert "empty" in reason.lower()
+        assert truncated is False
 
 
 class TestDisplayNameSafeSlug:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -208,6 +208,14 @@ from .radarr import (
     create_radarr_client_from,
 )
 
+# Explicit, structured per-(engine, user) recommender run status (#292 -
+# see module docstring for why this replaces log-tail marker matching)
+from .run_status import (
+    get_latest_run_status_for_user,
+    get_run_status,
+    record_run_status,
+)
+
 # Scheduler utilities (#264)
 from .scheduler import (
     WEEKDAY_NAMES,
@@ -513,6 +521,10 @@ __all__ = [
     # Integration-health signal
     "record_integration_status",
     "get_integration_status",
+    # Per-(engine, user) recommender run status
+    "record_run_status",
+    "get_run_status",
+    "get_latest_run_status_for_user",
     # CLI
     "get_users_from_config",
     "resolve_admin_username",

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.69"
+__version__ = "2.10.70"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/run_status.py
+++ b/utils/run_status.py
@@ -1,0 +1,161 @@
+"""Explicit, structured last-run outcome per (engine, user) - the same
+shape as utils/integration_status.py (see that module's own docstring
+for the original rationale), applied to movie/tv/external recommender
+runs themselves rather than a single downstream integration call.
+
+#292: web/status.py's get_last_run_status() used to infer success/
+failure entirely by grepping the tail of whichever log file
+latest_user_log() happened to pick for English error-ish substrings
+("traceback (most recent call last)", "fatal error", "an error
+occurred"). Two independent, real, confirmed failure modes of that
+approach:
+
+  1. A failure phrased any other way reads as success. Concrete
+     precedent: recommenders/external_sync.py logged
+     "Failed to export <user> to Trakt: Cannot get lists: not
+     authenticated" for months - matching NONE of those markers - and
+     the dashboard reported success the entire time (the reason
+     utils/integration_status.py itself exists, for that one specific
+     integration).
+  2. movie.py and tv.py both write to the identical
+     "recommendations_<user>_<timestamp>.log" naming (see
+     recommenders/movie.py's/tv.py's own process_recommendations() -
+     both pass the literal string "recommendations" to
+     setup_log_file(), not "movie"/"tv"), so latest_user_log()'s
+     newest-by-mtime pick can silently show one engine's outcome while
+     masking a DIFFERENT, older failure from the other engine for the
+     same user.
+
+The recommender itself now records its own real outcome here - one
+JSON file per (engine, user), holding only the LAST attempt, not a
+history - immediately after that (engine, user) pair finishes
+processing (recommenders/movie.py's/tv.py's process_recommendations(),
+recommenders/external.py's per-user loop), success/failure exactly as
+that code itself observed it (did processing for this user raise at
+all - independent of whether utils.cli's own fatal-keyword heuristic
+additionally decided to sys.exit() over it), with no string-matching
+involved on the reading side. get_last_run_status() reads these back
+directly per user, comparing the movie/tv records' own timestamps
+(never file mtime) to resolve which engine's outcome is actually
+newest - solving failure mode 2 above as a side effect of no longer
+needing to guess from a shared filename pattern at all.
+
+Falls back to the pre-existing log-tail heuristic only when neither
+engine has ever recorded a status for a user yet (an install predating
+this feature, or a run from before it shipped) - never removed, since
+every already-written log file on every existing install has no
+recorded status to read.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .redact import redact
+
+logger = logging.getLogger("curatarr")
+
+# Recorded outcomes only ever exist for these - not "full" (that's the
+# `full` engine's own bash-chain construction in web/job_runner.py
+# invoking movie/tv/external as separate subprocesses, each of which
+# records its own status here under its own engine name) and not
+# per-library (a multi-library run still resolves to one "did this
+# user's movie processing raise" outcome per engine, same granularity
+# get_last_run_status()'s existing per-user contract already expects).
+RUN_STATUS_ENGINES = ("movie", "tv", "external")
+
+
+def _status_path(logs_dir: str, engine: str, username: str) -> str:
+    # glob.escape-style safety isn't needed here (this is a fixed path
+    # write/read, never a glob pattern) but the username is still
+    # sanitized enough by os.path.join's own semantics - a username
+    # containing a path separator would need to already be an accepted,
+    # validated Plex username (see utils.config.get_users_from_config)
+    # to reach this code path at all.
+    return os.path.join(logs_dir, f"run_status_{engine}_{username}.json")
+
+
+def record_run_status(logs_dir: str, engine: str, username: str, success: bool, detail: str = "") -> None:
+    """Persist the outcome of the most recent *engine* run for
+    *username* (e.g. engine="movie", username="alice").
+
+    *detail* is redacted (see utils/redact.py) before being written -
+    frequently str(exception), which could in principle echo a token.
+
+    Atomic (temp file + rename), same as record_integration_status - a
+    concurrent reader (the dashboard rendering while a run is
+    mid-write) never sees a half-written file, and a crash mid-write
+    never corrupts the previous, still-valid status.
+
+    Never raises - recording status must never itself fail (or further
+    complicate) a run that's already succeeding/failing; any error here
+    is logged at debug level and swallowed.
+    """
+    try:
+        os.makedirs(logs_dir, exist_ok=True)
+        payload: Dict[str, Any] = {
+            "engine": engine,
+            "user": username,
+            "success": success,
+            "detail": redact(detail),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=logs_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.replace(tmp_path, _status_path(logs_dir, engine, username))
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+    except Exception as e:
+        logger.debug(f"Could not record run status for {engine}/{username}: {e}")
+
+
+def get_run_status(logs_dir: str, engine: str, username: str) -> Optional[Dict[str, Any]]:
+    """Return the last recorded {"engine", "user", "success", "detail",
+    "timestamp"} dict for (engine, username), or None if nothing's been
+    recorded yet, or the file can't be read/parsed.
+
+    Callers must treat None as "no explicit signal recorded" - never as
+    "failed" - see get_last_run_status()'s fallback to the legacy
+    log-tail heuristic for exactly that case.
+    """
+    path = _status_path(logs_dir, engine, username)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "success" not in data or "timestamp" not in data:
+            return None
+        return data
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def get_latest_run_status_for_user(logs_dir: str, username: str) -> Optional[Dict[str, Any]]:
+    """The newest recorded status across every engine for *username*
+    (movie/tv/external), by the record's OWN timestamp - never file
+    mtime, which is what let movie.py's and tv.py's shared
+    "recommendations_<user>_*.log" naming mask one engine's failure
+    behind the other's later success (see this module's own docstring).
+
+    Returns None if no engine has ever recorded a status for this user
+    - the caller's cue to fall back to the legacy log-tail heuristic.
+    """
+    best: Optional[Dict[str, Any]] = None
+    best_ts: Optional[datetime] = None
+    for engine in RUN_STATUS_ENGINES:
+        record = get_run_status(logs_dir, engine, username)
+        if record is None:
+            continue
+        try:
+            ts = datetime.fromisoformat(record["timestamp"])
+        except (KeyError, ValueError):
+            continue
+        if best_ts is None or ts > best_ts:
+            best, best_ts = record, ts
+    return best

--- a/web/app.py
+++ b/web/app.py
@@ -71,7 +71,14 @@ from .config_app import register_config_routes
 from .job_runner import DONE_SENTINEL, JobAlreadyRunningError, JobError, JobManager
 from .scheduler_runner import SchedulerThread
 from .security import redact, register_origin_host_guard, register_token_auth
-from .status import find_user_watchlist, get_last_run_status, list_log_files, read_log_tail
+from .status import (
+    LOG_VIEW_MAX_BYTES,
+    find_user_watchlist,
+    get_last_run_status,
+    list_log_files,
+    read_log_full,
+    read_log_tail,
+)
 from .update_apply import (
     UpdateAlreadyInProgressError,
     UpdateManager,
@@ -612,6 +619,19 @@ def create_app(
                 if last_run
                 else None,
                 "trakt_export": trakt_export,
+                # #292: the last (or in-progress) web-UI-triggered job's
+                # own per-stage breakdown (see web/job_runner.py's
+                # Job.stage_results/external_produced_output, #282/#288) -
+                # None whenever nothing has been triggered from the web
+                # UI at all yet in this process's lifetime. This is a
+                # DIFFERENT signal than last_run above (which is
+                # per-user, spans movie.py AND tv.py, and survives a
+                # server restart via logs/run_status_*.json) - this one
+                # is specifically "what did the most recent Run-page
+                # click do", including which of movie/tv/external ran,
+                # was skipped, or failed, which last_run's single
+                # success/failed/unknown can't express on its own.
+                "last_job": app.job_manager.status(),
             }
         )
 
@@ -835,11 +855,30 @@ def create_app(
 
     @app.get("/results/log/<path:filename>")
     def results_log(filename):
+        # #283: default view is still the last-500-lines tail (cheap,
+        # fine for the common case of "what just happened") - `?view=full`
+        # opts into read_log_full() instead, the only way to reach the
+        # true START of a long run's output (cleanup_old_logs() retains
+        # up to ~20MB per log, so the tail alone can genuinely never
+        # reach it).
+        full = request.args.get("view") == "full"
         try:
-            tail, empty_reason = read_log_tail(logs_dir, filename)
+            if full:
+                content, empty_reason, truncated = read_log_full(logs_dir, filename)
+            else:
+                content, empty_reason = read_log_tail(logs_dir, filename)
+                truncated = False
         except FileNotFoundError:
             abort(404)
-        return render_template("log_view.html", filename=filename, content=tail, empty_reason=empty_reason)
+        return render_template(
+            "log_view.html",
+            filename=filename,
+            content=content,
+            empty_reason=empty_reason,
+            full=full,
+            truncated=truncated,
+            max_bytes=LOG_VIEW_MAX_BYTES,
+        )
 
     return app
 

--- a/web/status.py
+++ b/web/status.py
@@ -10,21 +10,40 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
+from utils import get_latest_run_status_for_user
+
 from .security import redact, safe_join
 
 _TIMESTAMP_RE = re.compile(r"_(\d{8}_\d{6})\.log$")
 
 # Lowercased substrings that indicate a recommender run hit an error.
-# This is a heuristic (per the MVP spec), not a guarantee - a run can
-# print warnings along the way and still succeed overall.
+# #292: this heuristic is ONLY the fallback now, for a user with no
+# utils.run_status record yet (an install predating that fix, or a run
+# from before it shipped) - see get_last_run_status()'s own docstring.
+# Confirmed real failure mode while this WAS the only signal:
+# recommenders/external_sync.py logged "Failed to export <user> to
+# Trakt: Cannot get lists: not authenticated" for months, matching none
+# of these, and the dashboard reported success throughout.
 _FAILURE_MARKERS = (
     "traceback (most recent call last)",
     "fatal error",
     "an error occurred",
 )
 
-# Cap how much of a log file we read for status/display purposes.
+# Cap how much of a log file we read for status/display (the legacy
+# marker-matching fallback above) and for the log viewer's default
+# "tail" view (read_log_tail()) - see read_log_full() for the
+# unbounded (up to LOG_VIEW_MAX_BYTES) alternative the viewer also
+# offers (#283), and cleanup_old_logs() (utils/helpers.py) for why a
+# real log file can legitimately be up to ~20MB before this ever reads
+# it - both deliberately independent of that retention size.
 TAIL_BYTES = 200_000
+
+# Hard ceiling for read_log_full()'s whole-file read (#283). Generous
+# headroom above cleanup_old_logs()'s ~20MB retention target - this is
+# a memory-safety backstop for a misconfigured/legacy-oversized log,
+# not a normal ceiling any real log is expected to hit.
+LOG_VIEW_MAX_BYTES = 50_000_000
 
 
 def _parse_timestamp(filename: str) -> Optional[datetime]:
@@ -101,23 +120,72 @@ def latest_user_log(logs_dir: str, username: str) -> Optional[str]:
 
 
 def get_last_run_status(logs_dir: str, username: str) -> Dict:
-    """Heuristic last-run status for one user, derived from their newest log.
+    """Last-run status for one user.
+
+    #292: prefers the explicit, structured signal recommenders/movie.py's/
+    tv.py's/external.py's own per-user processing records (see
+    utils/run_status.py) - the actual outcome that code itself observed,
+    read back directly with no string-matching involved. Falls back to
+    the legacy log-tail marker-matching heuristic ONLY when neither
+    engine has ever recorded a status for this user (an install
+    predating this fix, or a run from before it shipped) - every
+    already-written log file on every existing install has no recorded
+    status to prefer, so this fallback is never removed.
+
+    The explicit path also fixes a second, independent bug the legacy
+    path had: movie.py and tv.py both write to the identical
+    "recommendations_<user>_<timestamp>.log" naming, so
+    latest_user_log()'s newest-by-mtime pick could show one engine's
+    outcome while masking a different, OLDER failure from the other -
+    the explicit signal instead compares each engine's OWN recorded
+    timestamp (see get_latest_run_status_for_user()), never file mtime.
+
+    latest_user_log() is still used for `log_file` (the "view log" link)
+    in both paths - that's just "which log is relevant to look at", a
+    much lower-stakes question than "did the run succeed", and the
+    explicit signal doesn't currently record its own log filename (see
+    that module's docstring for why: movie.py/tv.py/external.py all
+    resolve it independently in the same process, milliseconds apart,
+    so re-deriving it here is simpler than plumbing an exact filename
+    through record_run_status just for this).
 
     Returns a dict with keys:
       status: 'never_run' | 'success' | 'failed' | 'unknown'
       timestamp: datetime or None
       log_file: basename of the log, or None
-      reason: human-readable explanation, only set (non-None) when
-        status is 'unknown' (#263) - distinguishes a genuinely empty
-        (0-byte, interrupted-run) log from one that exists but couldn't
-        be read at all.
+      reason: human-readable explanation - the failure detail itself
+        for an explicit-signal 'failed' status, or (#263, legacy path
+        only) why status is 'unknown' - None otherwise.
     """
     log_path = latest_user_log(logs_dir, username)
+    log_file = os.path.basename(log_path) if log_path else None
+
+    explicit = get_latest_run_status_for_user(logs_dir, username)
+    if explicit is not None:
+        timestamp: Optional[datetime] = None
+        try:
+            # Stored UTC-aware (see record_run_status) - every other
+            # timestamp this module produces is a naive local datetime
+            # (from _parse_timestamp()/os.path.getmtime() below), same
+            # shape dashboard.html's Jinja formatting and /status.json's
+            # last_run.timestamp comparison already expect.
+            timestamp = datetime.fromisoformat(explicit["timestamp"]).astimezone().replace(tzinfo=None)
+        except (KeyError, ValueError):
+            pass
+        success = bool(explicit.get("success"))
+        return {
+            "status": "success" if success else "failed",
+            "timestamp": timestamp,
+            "log_file": log_file,
+            "reason": None if success else (explicit.get("detail") or None),
+        }
+
+    # Legacy fallback: no explicit signal recorded for this user on
+    # either engine yet - infer from the log tail exactly as before.
     if not log_path:
         return {"status": "never_run", "timestamp": None, "log_file": None, "reason": None}
 
-    basename = os.path.basename(log_path)
-    timestamp = _parse_timestamp(basename)
+    timestamp = _parse_timestamp(log_file or "")
     if timestamp is None:
         try:
             timestamp = datetime.fromtimestamp(os.path.getmtime(log_path))
@@ -137,7 +205,7 @@ def get_last_run_status(logs_dir: str, username: str) -> Dict:
     else:
         status = "success"
 
-    return {"status": status, "timestamp": timestamp, "log_file": basename, "reason": reason}
+    return {"status": status, "timestamp": timestamp, "log_file": log_file, "reason": reason}
 
 
 def list_log_files(logs_dir: str) -> List[Dict]:
@@ -212,3 +280,39 @@ def read_log_tail(logs_dir: str, filename: str, max_lines: int = 500) -> Tuple[s
     content, reason = _read_tail_with_reason(path)
     lines = content.splitlines()[-max_lines:]
     return redact("\n".join(lines)), (reason if not content.strip() else None)
+
+
+def read_log_full(logs_dir: str, filename: str, max_bytes: int = LOG_VIEW_MAX_BYTES) -> Tuple[str, Optional[str], bool]:
+    """Read up to max_bytes of logs_dir/filename in full, not just the
+    last max_lines like read_log_tail() (#283: the log viewer only ever
+    showed a fixed tail, with no way to reach the START of a long run's
+    output). cleanup_old_logs() (utils/helpers.py) retains up to ~20MB
+    per log file, so a real log can legitimately be large enough that
+    reaching the true beginning requires more than the tail view shows.
+
+    Raises FileNotFoundError under the same conditions as
+    read_log_tail() (filename escapes logs_dir, isn't a *.log file, or
+    doesn't resolve to a real file).
+
+    Returns (content, empty_reason, truncated):
+      empty_reason: same meaning as read_log_tail()'s (#263) - None
+        unless content is empty.
+      truncated: True if the file is larger than max_bytes and this is
+        therefore still only its LAST max_bytes, not the genuine
+        beginning - a memory-safety backstop for a misconfigured/
+        unusually large log (LOG_VIEW_MAX_BYTES is well above
+        cleanup_old_logs()'s own retention target), not something any
+        normally-retained log is expected to hit.
+    """
+    if not filename.endswith(".log"):
+        raise FileNotFoundError(filename)
+    path = safe_join(logs_dir, filename)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(filename)
+    try:
+        size = os.path.getsize(path)
+    except OSError as e:
+        return "", f"log file unreadable ({e.strerror or e})", False
+    truncated = size > max_bytes
+    content, reason = _read_tail_with_reason(path, max_bytes=max_bytes)
+    return redact(content), (reason if not content.strip() else None), truncated

--- a/web/templates/log_view.html
+++ b/web/templates/log_view.html
@@ -2,9 +2,23 @@
 {% block title %}{{ filename }} - Curatarr{% endblock %}
 {% block content %}
 <h1>{{ filename }}</h1>
-<p><a href="{{ url_for('results') }}">&larr; back to results</a></p>
+<p>
+  <a href="{{ url_for('results') }}">&larr; back to results</a>
+  &middot;
+  {% if full %}
+  <a href="{{ url_for('results_log', filename=filename) }}">Show last 500 lines</a>
+  {% else %}
+  <a href="{{ url_for('results_log', filename=filename, view='full') }}">Show full log</a>
+  {% endif %}
+</p>
 {% if empty_reason %}
 <p class="banner"><strong>Log is empty:</strong> {{ empty_reason }}</p>
+{% endif %}
+{% if truncated %}
+<p class="banner warn">
+  This log is larger than curatarr will display in full at once - showing the last
+  {{ "%.0f"|format(max_bytes / 1000000) }}MB instead of the true beginning.
+</p>
 {% endif %}
 <pre class="log-output">{{ content }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary

Closes #292, closes #283.

**#292 root cause (independently re-verified, matches your analysis):** `web/status.py`'s `get_last_run_status()` inferred success/failure entirely by grepping the last 200KB of a log for three fixed English substrings (`traceback (most recent call last)`, `fatal error`, `an error occurred`). Two confirmed failure modes:
1. A failure logged any other way reads as success - e.g. `recommenders/external_sync.py`'s `log_error(f"Failed to export {user} to Trakt: {e}")` (no traceback dump) - the exact shape that let a Trakt auth failure report success for six months before `utils/integration_status.py` (v2.10.54) covered that one specific case.
2. `movie.py`/`tv.py` both write to the identical `recommendations_<user>_<timestamp>.log` naming, so the newest-by-mtime pick can show one engine's outcome while masking a different, older failure from the other.

**Fix - stopped inferring status from English prose**, per your ask: new `utils/run_status.py`, same explicit/structured/atomic-write shape as `utils/integration_status.py`. `recommenders/movie.py`'s and `tv.py`'s `process_recommendations()` and `recommenders/external.py`'s per-user loops now record their own real observed outcome (did processing for this user raise at all) immediately after each (engine, user) pair finishes - independent of whether `movie.py`'s own fatal-keyword check additionally decides to `sys.exit()` over it. `get_last_run_status()` reads this back directly, comparing each engine's own recorded timestamp (never file mtime) to resolve which is newest - this also fixes failure mode 2 above as a side effect, so no separate `latest_user_log()` change was needed once the explicit signal exists. Falls back to the legacy log-tail heuristic only when neither engine has ever recorded a status for a user (an install predating this fix, or output from before it shipped) - permanent fallback, not a migration step.

**Per-stage visibility**: `/status.json` now also includes `last_job` - the most recent (or in-progress) web-UI job's full `stage_results`/`external_produced_output` breakdown (#282/#288, your #296 fix) - so a "succeeded" job-level exit code and a "failed" per-user status are both visible together instead of only one or the other.

**#283**: new `read_log_full()` (up to 50MB, a memory-safety backstop well above `cleanup_old_logs()`'s ~20MB retention target) alongside the existing 500-line `read_log_tail()`. `/results/log/<file>?view=full` plus a "Show full log" / "Show last 500 lines" toggle on the log-view page - the same `TAIL_BYTES` constant these two issues share.

## Real-container verification

Triggered a real `external` run whose per-user processing raised inside the actual subprocess pipeline (a message deliberately shaped like the Trakt precedent: `"Cannot get lists: not authenticated"`):
- `/run/status` / `last_job` correctly showed the job itself `succeeded` (exit 0) - reproducing the exact "silently reports success" shape from the original report.
- `/status.json`'s `last_run` and the dashboard correctly showed that user as `failed`, with the real exception message surfaced as the badge's tooltip.
- Confirmed the explicit `run_status_*.json` files were written per (engine, user) for a clean full run too (movie/tv/external all `success: true`).
- Confirmed the log-view `?view=full` / default toggle links work correctly on a real generated log.

## Housekeeping

Checked the CHANGELOG for the duplicate/out-of-order version headings from concurrent lanes colliding (`2.10.64` on both #296/#298, `2.10.67` on both #299/#300) - already clean on current `origin/main`: every rebase in this and my prior PRs re-sequenced the colliding version into the next free number, so there's exactly one heading per version, 2.10.61 through 2.10.69 with no gaps or duplicates. No action needed.

## Test plan

- [x] New `tests/test_web_status.py::TestGetLastRunStatusExplicitSignal` (explicit signal overrides conflicting log content in both directions; cross-engine timestamp comparison; fallback to the legacy heuristic when no explicit signal exists; log_file still resolves for the "view log" link) and `TestReadLogFull` (full read, truncation, redaction, traversal-safety).
- [x] New `tests/test_movie.py`/`test_tv.py`/`test_external.py` coverage: `record_run_status` called with the right engine/user/outcome on success, on a non-fatal error, and (movie.py) even on the fatal `sys.exit()` path; never called when no single user is resolved yet.
- [x] Full suite (2836 passed, 1 skipped), `ruff check .`, `ruff format --check .`, `mypy .` all green.
- [x] Real-container verification above.
