### PR TITLE
Fix migrate_legacy_cache_dir silently destroying user cache data (2.10.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.71] - 2026-07-27
+
+### Fixed
+
+- **`migrate_legacy_cache_dir()` could silently destroy a user's real cache - confirmed data loss, not theoretical.** `recommenders/base.py`'s `BaseRecommender.__init__` unconditionally calls this on every recommender construction. Its `legacy_dir` argument is ALWAYS the real source checkout's own `cache/` directory (computed from `__file__`, never from config or `CURATARR_CONFIG_DIR`), while the destination honors `CURATARR_CONFIG_DIR`. It used `shutil.move()` - any process that set `CURATARR_CONFIG_DIR` to a directory not already holding these cache files (a scratch dir, a test harness, someone experimenting, a misconfigured environment) silently *relocated* - not copied - the real install's cache files there, with only a `log_info()` line (easy to miss, and gated behind whatever logging level happened to be configured) marking it. Deleting that destination afterward destroyed the data permanently, with no backup.
+
+  Now **copies** (`shutil.copy2`, preserving mtime/permissions) instead of moving - the source checkout's `cache/` is never modified by this function, period, regardless of what later happens to the destination. The pre-existing per-file `if os.path.exists(new_path): continue` check (already there to avoid clobbering a destination file) is also what keeps a copy-based migration from repeating itself forever: once copied, a file exists at the destination, so every later call skips it - no separate completion marker needed, and since the source is never deleted, nothing about that check can regress into a delete.
+
+  **Made loud**: switched from `log_info()` to `log_warning()` (visible by default, colored) AND added a direct `print()` - a silent relocation was the core defect, so visibility can't depend on log-level configuration or scrolling back through a log file. The message states exactly what was copied, from where, to where, and how many files.
+
+  Did **not** restructure `BaseRecommender.__init__` to move this out of the constructor in this PR (flagged, not fixed - a constructor mutating the filesystem as a side effect is a separately surprising design worth revisiting, but a bigger change than a copy-not-move data-loss fix should also carry).
+
+  Audited other file-removal/rename call sites in `utils/user_migration.py` (renamed-user cache migration) and `utils/cache_prune.py` (orphaned-cache cleanup) for the same class of bug (a source path resolved one way, a destination resolved a genuinely different way) - neither exhibits it: both operate entirely within one already-consistently-resolved `cache_dir`, never across two independently-resolved directories, and `cache_prune`'s deletion is additionally gated behind an explicit `dry_run: false` opt-in (default `true`).
+
+  **Verified in a real container** (synthetic cache files only - never touched the real repo's own `cache/`, per this fix's own lesson): planted two cache files at the real legacy path (`/app/cache` inside the image), ran the migration against a scratch destination, confirmed both the source and destination held the files afterward, then deleted the scratch destination entirely - the legacy source files remained fully intact with their original content, exactly reproducing (safely) the scenario that previously caused permanent data loss.
+
+  New/updated regression coverage in `tests/test_helpers.py::TestMigrateLegacyCacheDir`: the core assertion (source files still exist after migration, regardless of the destination); idempotency (a second call never re-copies over or clobbers a destination file a real run has since updated); loud logging (both the `log_warning()` message and the direct `print()` mention the filenames and both paths); a copy failure still can't touch the source.
+
 ## [2.10.70] - 2026-07-27
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -524,6 +524,17 @@ class BaseRecommender(ABC):
         legacy_cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cache")
         self.cache_dir = os.path.join(get_project_root(), self.config.get("cache_dir", "cache"))
         os.makedirs(self.cache_dir, exist_ok=True)
+        # #291 (data-loss fix): migrate_legacy_cache_dir() now COPIES,
+        # never moves - see its own docstring for the real incident
+        # that changed this. Runs unconditionally on every construction
+        # of every recommender (a constructor mutating the filesystem
+        # as a side effect is itself a surprising design, flagged but
+        # not restructured out of __init__ in that same fix - a
+        # one-time explicit startup step would be a cleaner home for
+        # it, but that's a bigger change than a copy-not-move fix
+        # should also carry) - safe to call every time regardless,
+        # since its own per-file "already exists at destination" check
+        # makes every call after the first a no-op.
         migrate_legacy_cache_dir(legacy_cache_dir, self.cache_dir)
 
         # Load display options

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -554,11 +554,19 @@ class TestGetProjectRoot:
 
 class TestMigrateLegacyCacheDir:
     """Tests for migrate_legacy_cache_dir() - the best-effort, one-time
-    move of cache files from the pre-2.10.3 __file__-relative cache
-    directory to the get_project_root()-resolved one (see
-    recommenders/base.py's cache_dir setup)."""
+    COPY (never a move - see the function's own docstring for the real
+    data-loss incident this fixes) of cache files from the pre-2.10.3
+    __file__-relative cache directory to the get_project_root()-
+    resolved one (see recommenders/base.py's cache_dir setup)."""
 
-    def test_moves_files_to_new_location(self, tmp_path):
+    def test_copies_files_to_new_location_leaving_originals_in_place(self, tmp_path):
+        """The core regression test: legacy_dir (always the real source
+        checkout's own cache/ in production - see the function's
+        docstring) must still have every file afterward, regardless of
+        what happens to new_dir - this was a shutil.move() before,
+        which silently relocated (not copied) real user data whenever
+        new_dir pointed somewhere temporary, and destroyed it the
+        moment that destination was later removed."""
         legacy_dir = tmp_path / "legacy" / "cache"
         new_dir = tmp_path / "new" / "cache"
         legacy_dir.mkdir(parents=True)
@@ -567,10 +575,35 @@ class TestMigrateLegacyCacheDir:
 
         migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
 
-        assert not (legacy_dir / "all_movies_cache.json").exists()
-        assert not (legacy_dir / "watched_cache_plex_admin.json").exists()
+        # The whole point of this fix: the source is NEVER touched.
+        assert (legacy_dir / "all_movies_cache.json").read_text() == '{"movies": {}}'
+        assert (legacy_dir / "watched_cache_plex_admin.json").exists()
+        # And the destination gets a real copy, not just a reference.
         assert (new_dir / "all_movies_cache.json").read_text() == '{"movies": {}}'
         assert (new_dir / "watched_cache_plex_admin.json").exists()
+
+    def test_second_call_does_not_recopy_once_destination_exists(self, tmp_path):
+        """#291 (data-loss fix): the per-file os.path.exists(new_path)
+        check that already prevents clobbering an existing destination
+        file is also what keeps this from "migrating" forever once a
+        copy has genuinely happened once - no separate completion
+        marker needed, and since the source is never deleted, nothing
+        about this check can regress into losing data on a later run."""
+        legacy_dir = tmp_path / "legacy"
+        new_dir = tmp_path / "new"
+        legacy_dir.mkdir()
+        (legacy_dir / "all_movies_cache.json").write_text('"original"')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+        # Simulate the destination file having since been updated by a
+        # real run (e.g. a fresh cache rebuild) - a second migration
+        # pass must never overwrite that with the stale legacy copy.
+        (new_dir / "all_movies_cache.json").write_text('"updated by a real run"')
+
+        migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
+
+        assert (new_dir / "all_movies_cache.json").read_text() == '"updated by a real run"'
+        assert (legacy_dir / "all_movies_cache.json").read_text() == '"original"'
 
     def test_does_not_overwrite_existing_file_at_new_location(self, tmp_path):
         legacy_dir = tmp_path / "legacy"
@@ -623,21 +656,30 @@ class TestMigrateLegacyCacheDir:
         assert (legacy_dir / "subdir" / "nested.json").exists()
 
     @patch("utils.helpers.log_warning")
-    @patch("utils.helpers.shutil.move")
-    def test_move_failure_logs_warning_and_does_not_raise(self, mock_move, mock_warn, tmp_path):
+    @patch("utils.helpers.shutil.copy2")
+    def test_copy_failure_logs_warning_and_does_not_raise(self, mock_copy, mock_warn, tmp_path):
         legacy_dir = tmp_path / "legacy"
         new_dir = tmp_path / "new"
         legacy_dir.mkdir()
         (legacy_dir / "all_movies_cache.json").write_text('"data"')
-        mock_move.side_effect = OSError("simulated move failure")
+        mock_copy.side_effect = OSError("simulated copy failure")
 
         # Must not raise.
         migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
 
         mock_warn.assert_called_once()
+        # And, since copy2 itself is mocked out to fail, the real
+        # filesystem call that would remove the source never happens
+        # either way - but assert it explicitly since that's the whole
+        # point: a failure here must never touch the source file.
+        assert (legacy_dir / "all_movies_cache.json").read_text() == '"data"'
 
-    @patch("utils.helpers.log_info")
-    def test_logs_migrated_filenames_at_info(self, mock_info, tmp_path):
+    @patch("utils.helpers.log_warning")
+    def test_logs_migrated_filenames_loudly(self, mock_warn, tmp_path, capsys):
+        """#291 (data-loss fix): must log at a visible level (log_warning,
+        not the log_info this used before) AND print directly, so this
+        is never silent regardless of logging configuration - silent
+        relocation of a user's data was the core defect."""
         legacy_dir = tmp_path / "legacy"
         new_dir = tmp_path / "new"
         legacy_dir.mkdir()
@@ -645,8 +687,14 @@ class TestMigrateLegacyCacheDir:
 
         migrate_legacy_cache_dir(str(legacy_dir), str(new_dir))
 
-        mock_info.assert_called_once()
-        assert "all_movies_cache.json" in mock_info.call_args[0][0]
+        mock_warn.assert_called_once()
+        warn_message = mock_warn.call_args[0][0]
+        assert "all_movies_cache.json" in warn_message
+        assert str(legacy_dir) in warn_message
+        assert str(new_dir) in warn_message
+
+        printed = capsys.readouterr().out
+        assert "all_movies_cache.json" in printed
 
 
 class TestNoWindowKwargs:

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.70"
+__version__ = "2.10.71"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 from typing import Dict
 
 from .config import MAX_LOG_FILE_BYTES
-from .display import log_info, log_warning
+from .display import RESET, YELLOW, log_info, log_warning
 
 
 def get_code_root() -> str:
@@ -112,6 +112,21 @@ def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:
     recommenders/base.py's cache_dir setup) to the get_project_root()-
     resolved location.
 
+    legacy_dir is ALWAYS the real, on-disk source checkout's own cache/
+    directory - it's derived from __file__, never from config or
+    CURATARR_CONFIG_DIR. This function runs unconditionally on every
+    BaseRecommender construction (every recommender run), so ANY process
+    that sets CURATARR_CONFIG_DIR to a directory that doesn't already
+    have these cache files reaches here - not just a genuine one-time
+    upgrade. Confirmed: this previously used shutil.move(), and a
+    process pointed at a temporary/later-removed destination (a scratch
+    dir, a test harness, a misconfigured CURATARR_CONFIG_DIR) silently
+    relocated - not copied - a real install's cache files there with no
+    warning; deleting that destination afterward destroyed real user
+    data with nothing left to recover. COPIES instead now, specifically
+    to make that no longer possible: the source repo's cache/ is never
+    touched, regardless of what happens to the destination.
+
     In practice only reachable for a source install run with
     CURATARR_CONFIG_DIR set, where the two locations genuinely differ
     and the old one may still have files on disk:
@@ -126,11 +141,24 @@ def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:
     Callers don't need to special-case any of the above; legacy_dir
     equal to (or empty/missing at) new_dir all just no-op below.
 
-    Only moves files that don't already exist at the new location -
+    Only copies files that don't already exist at the new location -
     never overwrites/clobbers a cache the new location already has.
+    This existing per-file check is also what keeps a copy-based
+    migration from repeating itself forever: once a file has been
+    copied once, it exists at new_path, so every subsequent run's
+    os.path.exists(new_path) check skips it - no separate completion
+    marker needed, and (since the source is never deleted) nothing
+    about that check can ever regress into a delete.
+
     Never raises: any failure is logged as a warning and the run
     continues with whatever ended up on disk - worst case, an
     unmigrated cache simply regenerates rather than blocking a run.
+
+    Logs loudly (both print() and log_warning(), not the log_info() this
+    used before) whenever it actually copies anything - silent
+    relocation of a user's data was the core defect this fixes, so
+    finding out it happened must not depend on log level configuration
+    or on scrolling back through a log file.
     """
     try:
         if not os.path.isdir(legacy_dir):
@@ -138,7 +166,7 @@ def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:
         if os.path.realpath(legacy_dir) == os.path.realpath(new_dir):
             return
 
-        moved = []
+        copied = []
         for filename in os.listdir(legacy_dir):
             legacy_path = os.path.join(legacy_dir, filename)
             if not os.path.isfile(legacy_path):
@@ -146,17 +174,23 @@ def migrate_legacy_cache_dir(legacy_dir: str, new_dir: str) -> None:
             new_path = os.path.join(new_dir, filename)
             if os.path.exists(new_path):
                 # New location already has this cache - don't clobber it,
-                # just leave the stale legacy copy where it is.
+                # just leave the (also untouched) legacy copy where it is.
                 continue
             os.makedirs(new_dir, exist_ok=True)
-            shutil.move(legacy_path, new_path)
-            moved.append(filename)
+            # copy2 (not move/copy): preserves mtime/permissions, and -
+            # the entire point of this fix - leaves legacy_path in place.
+            # The real repo's cache/ is never modified by this function.
+            shutil.copy2(legacy_path, new_path)
+            copied.append(filename)
 
-        if moved:
-            log_info(
-                f"Migrated {len(moved)} cache file(s) from legacy location "
-                f"{legacy_dir} to {new_dir}: {', '.join(sorted(moved))}"
+        if copied:
+            message = (
+                f"Copied {len(copied)} cache file(s) from the legacy location "
+                f"{legacy_dir} to {new_dir} (originals left in place, unmodified): "
+                f"{', '.join(sorted(copied))}"
             )
+            print(f"{YELLOW}{message}{RESET}")
+            log_warning(message)
     except Exception as e:
         log_warning(f"Cache directory migration from {legacy_dir} skipped due to error: {e}")
 


### PR DESCRIPTION
## Summary

Fixes a real, confirmed data-loss bug (not theoretical - destroyed 14 real cache files on the owner's machine).

`recommenders/base.py`'s `BaseRecommender.__init__` unconditionally calls `migrate_legacy_cache_dir(legacy_cache_dir, self.cache_dir)`. `legacy_cache_dir` is computed from `os.path.dirname(os.path.dirname(os.path.abspath(__file__)))` + `"cache"` - ALWAYS the real repo's `cache/`, regardless of config/env. `self.cache_dir` resolves via `get_project_root()` + config, which DOES honor `CURATARR_CONFIG_DIR`. The function used `shutil.move()` - any process that set `CURATARR_CONFIG_DIR` to a directory not already holding these files silently *relocated* the real install's cache there, with only an easy-to-miss `log_info()` line marking it. Deleting that destination afterward destroyed the data with no backup.

## Changes

1. **Copy, not move.** `shutil.copy2` instead of `shutil.move` - the source checkout's `cache/` is never modified by this function, period, regardless of what later happens to the destination.
2. **No endless re-migration, no delete risk.** The pre-existing per-file `if os.path.exists(new_path): continue` check already prevents clobbering an existing destination - it's also exactly what keeps a copy-based migration from repeating itself: once copied, later runs skip it. No new completion-marker mechanism needed, and since the source is never deleted, nothing about this check can regress into a delete.
3. **Made it loud.** Switched `log_info()` → `log_warning()` (visible by default, colored) and added a direct `print()` - visibility can no longer depend on logging configuration. States what was copied, from/to where, and how many files.
4. **Did not restructure the constructor.** Flagged (see the new comment at the call site and the CHANGELOG entry) that a constructor mutating the filesystem as a side effect is a separately surprising design - not fixed here, reported instead per instructions.
5. **Audited other destructive-file-op call sites** (`utils/user_migration.py`'s renamed-user cache migration, `utils/cache_prune.py`'s orphaned-cache cleanup) for the same class of bug (source/destination resolved two genuinely different ways). Neither exhibits it - both operate entirely within one already-consistently-resolved `cache_dir`, and `cache_prune`'s deletion is additionally gated behind an explicit `dry_run: false` opt-in (default `true`).

## Real-container verification

Per the coordinator's own warning, this never touches the real repo's `cache/` - synthetic files only, planted specifically for this test and disposed of with the container:
- Planted two synthetic cache files at the real legacy path (`/app/cache` inside the built image).
- Ran `migrate_legacy_cache_dir` against a scratch destination (`/tmp/scratch-config-dir/cache`).
- Confirmed both the legacy source AND the scratch destination held the files afterward (a genuine copy, not a reference).
- Deleted the scratch destination entirely (`shutil.rmtree`) - simulating exactly the "temp dir gets removed" scenario that destroyed the real data.
- Confirmed the legacy source files remained **fully intact** with their original content.

## Test plan

- [x] `tests/test_helpers.py::TestMigrateLegacyCacheDir`: the core regression assertion (source files still exist after migration, regardless of destination); idempotency (a second call never re-copies over/clobbers a destination a real run has since updated); loud logging (both `log_warning()` and `print()` mention filenames and both paths); a copy failure still can't touch the source.
- [x] Full suite (2837 passed, 1 skipped), `ruff check .`, `ruff format --check .`, `mypy .` all green.
- [x] Real-container verification above.
