### PR TITLE
Extend secrets env-var overrides to every integration (2.10.73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.73] - 2026-07-27
+
+### Added
+
+- **Every integration's secrets can now be set via environment variable, the same convenience `PLEX_URL`/`PLEX_TOKEN`/`TMDB_API_KEY` already offered (#289).** New: `TAUTULLI_API_KEY`, `SONARR_API_KEY`, `RADARR_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TRAKT_REFRESH_TOKEN`, `SIMKL_CLIENT_ID`, `SIMKL_ACCESS_TOKEN`, `MDBLIST_API_KEY` - an environment variable always takes precedence over whatever's saved on disk, and config files keep working completely unchanged for anyone who doesn't use this. This is a convenience for operators using Docker secrets or an orchestrator's own secrets management (mounting a value as a file and exporting it, a Kubernetes Secret, etc) - it is **not** a secrets-manager replacement, and Curatarr still doesn't encrypt anything at rest either way.
+
+  `utils.config.ENV_VAR_OVERRIDES` is now the single, shared list every override reads from (`load_config()` to apply them, and the web UI to check them) rather than two independently-hand-written lists that could silently drift apart. That mattered here: the Connections screen's "configured"/"not set" status was computed purely from what's on disk, with no awareness of the environment at all - so an install already using `PLEX_TOKEN`/`TMDB_API_KEY` this way would have shown a misleading "not set" for a field that's actually fully working. Fixed for every secret this PR covers via new `web.config_io.secret_status_with_env`.
+
+  New unit coverage: `tests/test_config.py::TestLoadConfig` (table-driven over every entry in `ENV_VAR_OVERRIDES`, so a future addition is automatically exercised; confirms the env var is logged by name but the value never appears in the log) and `TestGetEnvOverride`; `tests/test_web_config_io.py::TestSecretHelpers` and `tests/test_web_config_connections.py::TestEnvVarSecretStatus` (env-only configuration shows "configured", never the raw value, in both the internal view dict and the rendered page). Documented in every relevant `config/*.example.yml`, `README.md`, and a new `docs/DOCKER.md` section with a `docker-compose.yml` example.
+
+  `mdblist.yml`/`simkl.yml` have a separate, pre-existing, already-documented gap (`web/config_app.py`'s own docstring): `utils.config._load_module_configs()` doesn't merge those two files into the running config at all yet (only `trakt.yml`/`radarr.yml`/`sonarr.yml` are), so `MDBLIST_API_KEY`/`SIMKL_CLIENT_ID`/`SIMKL_ACCESS_TOKEN` only take effect today for an install that embeds an `mdblist:`/`simkl:` section directly in `config.yml` itself. Registering the override doesn't make that pre-existing gap any worse, and closes it automatically whenever that loader gap is fixed - left as-is here rather than bundled into a PR about environment variables, not module loading.
+
 ## [2.10.72] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -296,15 +296,24 @@ users:
 
 ### Environment Variables
 
-For Docker or CI environments, you can use environment variables instead of storing tokens in config.yml:
+For Docker or CI environments, you can use environment variables instead of storing secrets in config.yml/sonarr.yml/radarr.yml/trakt.yml/simkl.yml/mdblist.yml. This is a convenience for operators using Docker secrets or an orchestrator's own secrets management - not a replacement for one; Curatarr itself still doesn't encrypt anything at rest.
 
 | Variable | Overrides |
 |----------|-----------|
 | `PLEX_URL` | `plex.url` |
 | `PLEX_TOKEN` | `plex.token` |
 | `TMDB_API_KEY` | `tmdb.api_key` |
+| `TAUTULLI_API_KEY` | `tautulli.api_key` |
+| `SONARR_API_KEY` | `sonarr.api_key` |
+| `RADARR_API_KEY` | `radarr.api_key` |
+| `TRAKT_CLIENT_SECRET` | `trakt.client_secret` |
+| `TRAKT_ACCESS_TOKEN` | `trakt.access_token` |
+| `TRAKT_REFRESH_TOKEN` | `trakt.refresh_token` |
+| `SIMKL_CLIENT_ID` | `simkl.client_id` |
+| `SIMKL_ACCESS_TOKEN` | `simkl.access_token` |
+| `MDBLIST_API_KEY` | `mdblist.api_key` |
 
-Environment variables take precedence over config file values.
+Environment variables take precedence over config file values, and the web UI's Connections screen correctly shows a field as "configured" when it's set only via the environment (never the value itself - only ever a masked status).
 
 ### Per-User Preferences
 ```yaml

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -4,13 +4,16 @@
 # Plex Server Connection
 plex:
   url: http://YOUR_PLEX_URL:32400  # Or https://YOUR-SERVER.plex.direct:32400
+  # Or set PLEX_URL in the environment (takes precedence)
   token: YOUR_PLEX_TOKEN  # Get from: https://support.plex.tv/articles/204059436
+  # Or set PLEX_TOKEN in the environment (takes precedence)
   movie_library: Movies
   tv_library: TV Shows
 
 # TMDB API (required for metadata)
 tmdb:
   api_key: YOUR_TMDB_API_KEY  # Get free key from: https://www.themoviedb.org/settings/api
+  # Or set TMDB_API_KEY in the environment (takes precedence)
 
 # Users and Preferences
 users:
@@ -159,6 +162,7 @@ tautulli:
   enabled: false
   url: http://YOUR_TAUTULLI_URL:8181  # e.g. http://192.168.1.10:8181
   api_key: YOUR_TAUTULLI_API_KEY  # Settings -> Web Interface -> API Key
+  # Or set TAUTULLI_API_KEY in the environment (takes precedence, #289)
 
 # =============================================================================
 # OPTIONAL MODULE FILES (in this directory)

--- a/config/mdblist.example.yml
+++ b/config/mdblist.example.yml
@@ -5,6 +5,7 @@
 enabled: false
 
 # MDBList API key (get from https://mdblist.com/preferences/)
+# Or set MDBLIST_API_KEY in the environment (takes precedence, #289)
 api_key: YOUR_MDBLIST_API_KEY
 
 # Sync behavior

--- a/config/radarr.example.yml
+++ b/config/radarr.example.yml
@@ -9,7 +9,7 @@
 
 enabled: false
 url: http://localhost:7878
-api_key: YOUR_RADARR_API_KEY
+api_key: YOUR_RADARR_API_KEY  # Or set RADARR_API_KEY in the environment (takes precedence, #289)
 
 # --- SYNC BEHAVIOR ---
 # auto_sync: Run automatically when external recs finish

--- a/config/simkl.example.yml
+++ b/config/simkl.example.yml
@@ -6,9 +6,11 @@ enabled: false
 
 # Simkl API credentials
 # Get your client ID at: https://simkl.com/settings/developer/
+# Or set SIMKL_CLIENT_ID in the environment (takes precedence, #289)
 client_id: YOUR_SIMKL_CLIENT_ID
 
 # Access token (filled automatically by setup wizard after PIN auth)
+# Or set SIMKL_ACCESS_TOKEN in the environment (takes precedence, #289)
 access_token: null
 
 # Import settings - enhance profiles with Simkl watch history

--- a/config/sonarr.example.yml
+++ b/config/sonarr.example.yml
@@ -12,7 +12,7 @@ enabled: false
 
 # Sonarr connection
 url: http://localhost:8989
-api_key: YOUR_SONARR_API_KEY
+api_key: YOUR_SONARR_API_KEY  # Or set SONARR_API_KEY in the environment (takes precedence, #289)
 
 # Sync behavior
 auto_sync: false  # Auto-add on each run (or use external recs manually)

--- a/config/trakt.example.yml
+++ b/config/trakt.example.yml
@@ -5,7 +5,7 @@ enabled: true
 
 # API credentials - get from https://trakt.tv/oauth/applications
 client_id: YOUR_CLIENT_ID
-client_secret: YOUR_CLIENT_SECRET
+client_secret: YOUR_CLIENT_SECRET  # Or set TRAKT_CLIENT_SECRET in the environment (takes precedence, #289)
 
 # OAuth tokens - set automatically after authentication, and kept up
 # to date automatically as they're refreshed (access tokens currently
@@ -16,8 +16,8 @@ client_secret: YOUR_CLIENT_SECRET
 # Run (from the project root, with your virtual environment active if
 # you're using one): python3 -m utils.trakt_auth [--reauth]
 # Docker: docker exec -it curatarr python3 -m utils.trakt_auth [--reauth]
-access_token: null
-refresh_token: null
+access_token: null   # Or set TRAKT_ACCESS_TOKEN in the environment (takes precedence, #289)
+refresh_token: null  # Or set TRAKT_REFRESH_TOKEN in the environment (takes precedence, #289)
 # token_created_at / token_expires_in: also set automatically (used to
 # refresh proactively, before expiry, rather than only reactively on a
 # failed request) - never set these by hand.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -8,6 +8,7 @@ image that runs both the web UI and the recommender, from
 - [Quick start (docker run)](#quick-start-docker-run)
 - [Authentication](#authentication)
 - [Config and cache volumes](#config-and-cache-volumes)
+- [Secrets via environment variables](#secrets-via-environment-variables)
 - [Accessing from another machine](#accessing-from-another-machine)
 - [Scheduling recommendation runs](#scheduling-recommendation-runs)
 - [Updating](#updating)
@@ -139,6 +140,63 @@ container: the web UI's Connections screen creates it for you on first
 save. `docker run curatarr recommend ...` (see
 [Scheduling](#scheduling-recommendation-runs)) does need it to exist
 first, though, since there's no browser involved for that one.
+
+## Secrets via environment variables
+
+Every secret Curatarr stores (Plex token, TMDB API key, Tautulli/
+Sonarr/Radarr API keys, Trakt client secret and tokens, Simkl client
+ID and access token, MDBList API key) can be set as an environment
+variable instead of
+being written to `config.yml`/`sonarr.yml`/`radarr.yml`/`trakt.yml`/
+`simkl.yml`/`mdblist.yml` on disk - useful with Docker secrets, a
+`docker-compose.yml` `env_file:`, or an orchestrator's own secrets
+management (Kubernetes Secrets, etc).
+
+This is a convenience for operators who'd rather inject secrets this
+way than write them to a mounted config file - it is **not** a
+secrets-manager replacement. Curatarr doesn't encrypt anything at
+rest either way; an environment variable just avoids that particular
+value ever touching the config volume at all.
+
+An environment variable always takes precedence over whatever's saved
+in the corresponding config file - the file keeps working unchanged
+for anyone who doesn't use this, and the web UI's Connections screen
+correctly shows a field as "configured" when it's only ever set this
+way (never the value itself, only ever a masked status).
+
+```yaml
+# docker-compose.yml
+services:
+  curatarr:
+    environment:
+      - PLEX_TOKEN=${PLEX_TOKEN}
+      - TMDB_API_KEY=${TMDB_API_KEY}
+      - SONARR_API_KEY=${SONARR_API_KEY}
+      - RADARR_API_KEY=${RADARR_API_KEY}
+      - TRAKT_CLIENT_SECRET=${TRAKT_CLIENT_SECRET}
+    env_file:
+      - .env   # keep the real values out of docker-compose.yml/version control
+```
+
+| Variable | Overrides |
+|----------|-----------|
+| `PLEX_URL` | `plex.url` |
+| `PLEX_TOKEN` | `plex.token` |
+| `TMDB_API_KEY` | `tmdb.api_key` |
+| `TAUTULLI_API_KEY` | `tautulli.api_key` |
+| `SONARR_API_KEY` | `sonarr.api_key` |
+| `RADARR_API_KEY` | `radarr.api_key` |
+| `TRAKT_CLIENT_SECRET` | `trakt.client_secret` |
+| `TRAKT_ACCESS_TOKEN` | `trakt.access_token` |
+| `TRAKT_REFRESH_TOKEN` | `trakt.refresh_token` |
+| `SIMKL_CLIENT_ID` | `simkl.client_id` |
+| `SIMKL_ACCESS_TOKEN` | `simkl.access_token` |
+| `MDBLIST_API_KEY` | `mdblist.api_key` |
+
+Non-secret settings (URLs, `enabled`/`auto_sync` flags, `user_mode`,
+library paths, etc) have no environment-variable override and are
+still only configurable through the config files/web UI - this list
+is deliberately secrets-only.
 
 ## Accessing from another machine
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from utils.config import (
     DEFAULT_NEGATIVE_MULTIPLIERS,
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_RATING_MULTIPLIERS,
+    ENV_VAR_OVERRIDES,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_TV,
     UPDATE_MODES,
@@ -18,6 +19,7 @@ from utils.config import (
     check_cache_version,
     get_config_section,
     get_effective_arr_config,
+    get_env_override,
     get_libraries,
     get_libraries_for_media_type,
     get_negative_multiplier,
@@ -841,6 +843,110 @@ class TestLoadConfig:
             assert result["plex"]["token"] == "file_token"
         finally:
             os.unlink(path)
+
+    def test_every_registered_env_var_override_actually_applies(self):
+        """#289: table-driven over ENV_VAR_OVERRIDES itself (rather than
+        one hardcoded test per integration) so a future addition to that
+        list is automatically covered here too, and any variable that's
+        merely declared but not actually wired through load_config()
+        would fail loudly instead of silently doing nothing."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("plex:\n  url: http://localhost:32400\n")
+            path = f.name
+        try:
+            for env_var, section, key in ENV_VAR_OVERRIDES:
+                os.environ[env_var] = f"env-value-for-{env_var}"
+                try:
+                    result = load_config(path)
+                    assert result[section][key] == f"env-value-for-{env_var}", (
+                        f"{env_var} did not override {section}.{key}"
+                    )
+                finally:
+                    del os.environ[env_var]
+        finally:
+            os.unlink(path)
+
+    def test_sonarr_radarr_trakt_simkl_mdblist_tautulli_env_vars_create_section_if_missing(self):
+        """#289: same create-the-section-if-absent behavior the existing
+        TMDB_API_KEY coverage above already established, extended to
+        every newly-added integration - an operator using ONLY
+        environment variables (no sonarr.yml/radarr.yml/trakt.yml/etc at
+        all) must still end up with a working config."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("plex:\n  url: http://localhost:32400\n")
+            path = f.name
+        env_vars = {
+            "SONARR_API_KEY": ("sonarr", "api_key"),
+            "RADARR_API_KEY": ("radarr", "api_key"),
+            "TRAKT_CLIENT_SECRET": ("trakt", "client_secret"),
+            "TRAKT_ACCESS_TOKEN": ("trakt", "access_token"),
+            "TRAKT_REFRESH_TOKEN": ("trakt", "refresh_token"),
+            "SIMKL_CLIENT_ID": ("simkl", "client_id"),
+            "SIMKL_ACCESS_TOKEN": ("simkl", "access_token"),
+            "MDBLIST_API_KEY": ("mdblist", "api_key"),
+            "TAUTULLI_API_KEY": ("tautulli", "api_key"),
+        }
+        try:
+            for env_var in env_vars:
+                os.environ[env_var] = "env-secret"
+            result = load_config(path)
+            for _env_var, (section, key) in env_vars.items():
+                assert result[section][key] == "env-secret"
+        finally:
+            for env_var in env_vars:
+                if env_var in os.environ:
+                    del os.environ[env_var]
+            os.unlink(path)
+
+    def test_env_var_never_logged(self, caplog):
+        """#289: load_config() must log WHICH env var was used, never the
+        secret VALUE itself."""
+        import logging
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("plex:\n  url: http://localhost:32400\n")
+            path = f.name
+        try:
+            os.environ["TRAKT_CLIENT_SECRET"] = "placeholder-secret-value-should-not-appear"
+            with caplog.at_level(logging.INFO, logger="curatarr"):
+                load_config(path)
+            assert "placeholder-secret-value-should-not-appear" not in caplog.text
+            assert "TRAKT_CLIENT_SECRET" in caplog.text
+        finally:
+            del os.environ["TRAKT_CLIENT_SECRET"]
+            os.unlink(path)
+
+
+class TestGetEnvOverride:
+    """Tests for utils.config.get_env_override - the single lookup web/
+    config_io.py's secret_status_with_env uses to ask "is this
+    (section, key) actively overridden by the environment" without
+    duplicating ENV_VAR_OVERRIDES."""
+
+    def test_returns_none_when_env_var_not_set(self, monkeypatch):
+        monkeypatch.delenv("PLEX_TOKEN", raising=False)
+        assert get_env_override("plex", "token") is None
+
+    def test_returns_value_when_env_var_set(self, monkeypatch):
+        monkeypatch.setenv("PLEX_TOKEN", "env-value")
+        assert get_env_override("plex", "token") == "env-value"
+
+    def test_returns_none_for_unregistered_section_key_pair(self, monkeypatch):
+        """A (section, key) with no entry in ENV_VAR_OVERRIDES at all
+        (e.g. a field that has never had an env var override, like
+        radarr.root_folder) always returns None, never a false positive
+        from some unrelated env var."""
+        assert get_env_override("radarr", "root_folder") is None
+
+    def test_empty_string_env_var_treated_as_unset(self, monkeypatch):
+        monkeypatch.setenv("PLEX_TOKEN", "")
+        assert get_env_override("plex", "token") is None
+
+    def test_covers_every_documented_integration(self):
+        """Belt-and-braces: fails loudly if a future ENV_VAR_OVERRIDES
+        edit forgets one of the sections #289 was actually about."""
+        sections = {section for _env_var, section, _key in ENV_VAR_OVERRIDES}
+        assert sections == {"plex", "tmdb", "tautulli", "sonarr", "radarr", "trakt", "simkl", "mdblist"}
 
 
 class TestModularConfigLoading:

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -65,6 +65,53 @@ class TestGet:
         assert b"configured" in resp.data
 
 
+class TestEnvVarSecretStatus:
+    """#289: an integration configured ONLY via its environment-variable
+    override (nothing at all on disk) must show "configured", not a
+    misleading "not set" - see web/config_io.py's secret_status_with_env.
+    """
+
+    def test_sonarr_api_key_from_env_shows_configured(self, client, monkeypatch):
+        c, app, root = client
+        # No sonarr.yml at all in this fixture root - api_key is
+        # unconfigured on disk, so without the env-var fix this would
+        # show "not set" even though SONARR_API_KEY makes it fully
+        # functional at runtime.
+        monkeypatch.setenv("SONARR_API_KEY", "env-sonarr-key")
+
+        from web.config_connections import _connections_view, _load_connections
+
+        data = _load_connections(root)
+        view = _connections_view(data)
+
+        assert view["sonarr"]["api_key_status"] == "configured"
+        # Never the raw value itself, even in this internal view dict.
+        resp = c.get("/config/connections")
+        assert b"env-sonarr-key" not in resp.data
+
+    def test_trakt_access_token_from_env_shows_configured(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.setenv("TRAKT_ACCESS_TOKEN", "env-trakt-token")
+
+        from web.config_connections import _connections_view, _load_connections
+
+        data = _load_connections(root)
+        view = _connections_view(data)
+
+        assert view["trakt"]["access_token_status"] == "configured"
+
+    def test_no_env_var_set_falls_back_to_disk_not_set(self, client, monkeypatch):
+        c, app, root = client
+        monkeypatch.delenv("SONARR_API_KEY", raising=False)
+
+        from web.config_connections import _connections_view, _load_connections
+
+        data = _load_connections(root)
+        view = _connections_view(data)
+
+        assert view["sonarr"]["api_key_status"] == "not set"
+
+
 class TestTraktReauthHint:
     """The Trakt re-auth instructions shown below the fields must match
     how a user can actually reach this screen in the first place - a

--- a/tests/test_web_config_io.py
+++ b/tests/test_web_config_io.py
@@ -19,6 +19,7 @@ from web.config_io import (
     parse_csv_list,
     save_module,
     secret_status,
+    secret_status_with_env,
     validate_merge,
 )
 
@@ -162,6 +163,26 @@ class TestSecretHelpers:
         assert secret_status("") == "not set"
         assert secret_status(None) == "not set"
         assert secret_status("   ") == "not set"
+
+    def test_secret_status_with_env_falls_back_to_disk_when_unset(self, monkeypatch):
+        monkeypatch.delenv("PLEX_TOKEN", raising=False)
+        assert secret_status_with_env("plex", "token", "a-real-token") == "configured"
+        assert secret_status_with_env("plex", "token", "") == "not set"
+
+    def test_secret_status_with_env_reports_configured_when_only_env_is_set(self, monkeypatch):
+        """#289: an install configured entirely via the environment (no
+        disk value at all) must not show a misleading "not set" - the
+        env var is what's actually active at runtime."""
+        monkeypatch.setenv("PLEX_TOKEN", "env-token")
+        assert secret_status_with_env("plex", "token", "") == "configured"
+        assert secret_status_with_env("plex", "token", None) == "configured"
+
+    def test_secret_status_with_env_ignores_unregistered_section_key(self, monkeypatch):
+        """A (section, key) pair with no registered env var override
+        (e.g. a per-library instance api_key) always falls back to the
+        disk value, never mistaking an unrelated env var for it."""
+        assert secret_status_with_env("radarr", "root_folder", "") == "not set"
+        assert secret_status_with_env("radarr", "root_folder", "/movies") == "configured"
 
 
 class TestCsvHelpers:

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.72"
+__version__ = "2.10.73"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so
@@ -330,6 +330,49 @@ def _auto_migrate_if_needed(config: dict, config_path: str) -> dict:
     return config
 
 
+# #289: single source of truth for every secret's environment-variable
+# override - (ENV_VAR, config-section, config-key). load_config() applies
+# these (env always wins over whatever's on disk); get_env_override()
+# below lets a caller (web/config_io.py's secret-status display, so the
+# web UI shows "configured" - not a stale "not set" - for a value that's
+# only ever set via the environment) ask the identical question without
+# duplicating (and risking drifting from - #261's whole class of bug)
+# this list. This is a convenience for operators using Docker
+# secrets/an orchestrator's own secrets management, not a replacement
+# for one - see config/tuning.example.yml and docs/DOCKER.md for the
+# full list with setup instructions.
+ENV_VAR_OVERRIDES = [
+    ("PLEX_URL", "plex", "url"),
+    ("PLEX_TOKEN", "plex", "token"),
+    ("TMDB_API_KEY", "tmdb", "api_key"),
+    ("TAUTULLI_API_KEY", "tautulli", "api_key"),
+    ("SONARR_API_KEY", "sonarr", "api_key"),
+    ("RADARR_API_KEY", "radarr", "api_key"),
+    ("TRAKT_CLIENT_SECRET", "trakt", "client_secret"),
+    ("TRAKT_ACCESS_TOKEN", "trakt", "access_token"),
+    ("TRAKT_REFRESH_TOKEN", "trakt", "refresh_token"),
+    ("SIMKL_CLIENT_ID", "simkl", "client_id"),
+    ("SIMKL_ACCESS_TOKEN", "simkl", "access_token"),
+    ("MDBLIST_API_KEY", "mdblist", "api_key"),
+]
+
+
+def get_env_override(section: str, key: str) -> Optional[str]:
+    """The environment-variable value that would override config[section]
+    [key] at load_config() time, or None if either no such override is
+    registered in ENV_VAR_OVERRIDES or the env var isn't actually set.
+
+    Exists so a caller other than load_config() itself (currently: web/
+    config_io.py's secret-status display) can ask "is this value coming
+    from the environment" without hand-rolling a second lookup that
+    could silently drift out of sync with the real override list.
+    """
+    for env_var, env_section, env_key in ENV_VAR_OVERRIDES:
+        if env_section == section and env_key == key:
+            return os.environ.get(env_var) or None
+    return None
+
+
 def load_config(config_path: str) -> dict:
     """
     Load YAML configuration with modular config file support.
@@ -340,10 +383,10 @@ def load_config(config_path: str) -> dict:
     - radarr.yml: Radarr integration settings
     - sonarr.yml: Sonarr integration settings
 
-    Environment variables take precedence over all config values:
-        PLEX_URL      -> plex.url
-        PLEX_TOKEN    -> plex.token
-        TMDB_API_KEY  -> tmdb.api_key
+    Environment variables take precedence over all config values - see
+    ENV_VAR_OVERRIDES above for the full, current list (this is a
+    convenience for operators using Docker secrets/an orchestrator, not
+    a secrets-manager replacement - see docs/DOCKER.md).
 
     Args:
         config_path: Path to config.yml file
@@ -380,14 +423,9 @@ def load_config(config_path: str) -> dict:
         # Load and merge modular config files
         config = _load_module_configs(config, config_dir)
 
-        # Override with environment variables (security best practice)
-        env_overrides = [
-            ("PLEX_URL", "plex", "url"),
-            ("PLEX_TOKEN", "plex", "token"),
-            ("TMDB_API_KEY", "tmdb", "api_key"),
-        ]
-
-        for env_var, section, key in env_overrides:
+        # Override with environment variables (security best practice) -
+        # never log the value itself, only which env var was used.
+        for env_var, section, key in ENV_VAR_OVERRIDES:
             value = os.environ.get(env_var)
             if value:
                 if section not in config:

--- a/web/config_connections.py
+++ b/web/config_connections.py
@@ -33,7 +33,7 @@ from .config_io import (
     merge_secret,
     module_path,
     parse_csv_list,
-    secret_status,
+    secret_status_with_env,
 )
 from .config_test_connection import TESTERS
 from .config_validate import validate_choice, validate_required, validate_url
@@ -195,35 +195,43 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
     return {
         "plex": {
             "url": pick("plex", "url", plex.get("url", "")),
-            "token_status": secret_status(
+            "token_status": secret_status_with_env(
+                "plex",
+                "token",
                 merge_secret(plex.get("token"), o.get("plex", {}).get("token_submitted", ""))
                 if "plex" in o
-                else plex.get("token")
+                else plex.get("token"),
             ),
         },
         "tmdb": {
-            "api_key_status": secret_status(
+            "api_key_status": secret_status_with_env(
+                "tmdb",
+                "api_key",
                 merge_secret(tmdb.get("api_key"), o.get("tmdb", {}).get("api_key_submitted", ""))
                 if "tmdb" in o
-                else tmdb.get("api_key")
+                else tmdb.get("api_key"),
             ),
         },
         "tautulli": {
             "enabled": pick("tautulli", "enabled", bool(tautulli.get("enabled", False))),
             "url": pick("tautulli", "url", tautulli.get("url", "")),
-            "api_key_status": secret_status(
+            "api_key_status": secret_status_with_env(
+                "tautulli",
+                "api_key",
                 merge_secret(tautulli.get("api_key"), o.get("tautulli", {}).get("api_key_submitted", ""))
                 if "tautulli" in o
-                else tautulli.get("api_key")
+                else tautulli.get("api_key"),
             ),
         },
         "sonarr": {
             "enabled": pick("sonarr", "enabled", bool(sonarr.get("enabled", False))),
             "url": pick("sonarr", "url", sonarr.get("url", "")),
-            "api_key_status": secret_status(
+            "api_key_status": secret_status_with_env(
+                "sonarr",
+                "api_key",
                 merge_secret(sonarr.get("api_key"), o.get("sonarr", {}).get("api_key_submitted", ""))
                 if "sonarr" in o
-                else sonarr.get("api_key")
+                else sonarr.get("api_key"),
             ),
             "auto_sync": pick("sonarr", "auto_sync", bool(sonarr.get("auto_sync", False))),
             "user_mode": pick("sonarr", "user_mode", sonarr.get("user_mode", "mapping")),
@@ -232,10 +240,12 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
         "radarr": {
             "enabled": pick("radarr", "enabled", bool(radarr.get("enabled", False))),
             "url": pick("radarr", "url", radarr.get("url", "")),
-            "api_key_status": secret_status(
+            "api_key_status": secret_status_with_env(
+                "radarr",
+                "api_key",
                 merge_secret(radarr.get("api_key"), o.get("radarr", {}).get("api_key_submitted", ""))
                 if "radarr" in o
-                else radarr.get("api_key")
+                else radarr.get("api_key"),
             ),
             "auto_sync": pick("radarr", "auto_sync", bool(radarr.get("auto_sync", False))),
             "user_mode": pick("radarr", "user_mode", radarr.get("user_mode", "mapping")),
@@ -244,12 +254,14 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
         "trakt": {
             "enabled": pick("trakt", "enabled", bool(trakt.get("enabled", False))),
             "client_id": pick("trakt", "client_id", trakt.get("client_id", "")),
-            "client_secret_status": secret_status(
+            "client_secret_status": secret_status_with_env(
+                "trakt",
+                "client_secret",
                 merge_secret(trakt.get("client_secret"), o.get("trakt", {}).get("client_secret_submitted", ""))
                 if "trakt" in o
-                else trakt.get("client_secret")
+                else trakt.get("client_secret"),
             ),
-            "access_token_status": secret_status(trakt.get("access_token")),
+            "access_token_status": secret_status_with_env("trakt", "access_token", trakt.get("access_token")),
             "auto_sync": pick("trakt", "auto_sync", bool(trakt_export.get("auto_sync", False))),
             "user_mode": pick("trakt", "user_mode", trakt_export.get("user_mode", "mapping")),
             "plex_users": pick("trakt", "plex_users", format_csv_list(trakt_export.get("plex_users"))),

--- a/web/config_io.py
+++ b/web/config_io.py
@@ -238,6 +238,30 @@ def secret_status(value: Optional[str]) -> str:
     return "configured" if (value or "").strip() else "not set"
 
 
+def secret_status_with_env(section: str, key: str, disk_value: Optional[str]) -> str:
+    """secret_status(), but environment-variable-aware (#289): if an
+    operator has set this field's env var override (see
+    utils.config.ENV_VAR_OVERRIDES - the same list load_config() itself
+    uses, so this can never silently drift out of sync with what's
+    actually active at runtime), that value wins for status purposes
+    too, exactly like it wins for the real value at run time. Without
+    this, an install configured entirely via the environment (Docker
+    secrets, an orchestrator's own secrets management - never written
+    to config.yml/sonarr.yml/etc at all) would show a misleading "not
+    set" here despite working correctly.
+
+    Args:
+        section: Config section (e.g. "plex", "trakt")
+        key: Config key within that section (e.g. "token", "client_secret")
+        disk_value: The value as saved on disk (or merged with a
+            just-submitted form value) - used only when no env override
+            is set.
+    """
+    from utils.config import get_env_override
+
+    return secret_status(get_env_override(section, key) or disk_value)
+
+
 def parse_csv_list(value: Optional[str]) -> list:
     """'a, b, c' -> ['a', 'b', 'c'], dropping blanks. Used for the small
     comma-separated list fields (plex_users, exclude_genres, etc.)."""


### PR DESCRIPTION
Closes #289.

Every integration's secrets now support the same environment-variable
override PLEX_URL/PLEX_TOKEN/TMDB_API_KEY already had:
TAUTULLI_API_KEY, SONARR_API_KEY, RADARR_API_KEY, TRAKT_CLIENT_SECRET,
TRAKT_ACCESS_TOKEN, TRAKT_REFRESH_TOKEN, SIMKL_CLIENT_ID,
SIMKL_ACCESS_TOKEN, MDBLIST_API_KEY.

This is a convenience for operators using Docker secrets or an
orchestrator's own secrets management - not a secrets-manager
replacement. An env var always takes precedence over the config file;
config files keep working unchanged for anyone who doesn't use this.

Also fixes a real gap found while extending the pattern: the
Connections screen's configured/not-set status was computed purely
from disk, with no environment awareness at all, so an install already
using PLEX_TOKEN/TMDB_API_KEY only via the environment would have shown
a misleading not-set. utils.config.ENV_VAR_OVERRIDES is now the single
list both load_config() and the web UI read from.

## Test plan
- [x] Full suite green (pytest)
- [x] ruff check / ruff format --check clean
- [x] mypy clean
- [x] gitleaks clean
- [x] New coverage: table-driven env-var-override test over every
      registered variable, secret-never-logged test, and web UI
      configured/not-set-from-env tests