### PR TITLE
Load mdblist.yml/simkl.yml module configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.75] - 2026-07-27
+
+### Fixed
+
+- **`mdblist.yml`/`simkl.yml` were shipped as example configs but never actually loaded - a real config bug, same class as #261.** `utils/config.py::_load_module_configs()` looped over exactly `["trakt", "radarr", "sonarr"]`, so a user who copied `config/mdblist.example.yml`/`config/simkl.example.yml`, filled in a real API key/client ID, and set `enabled: true` was silently ignored - `recommenders/external_sync.py`'s `export_to_mdblist()`/`export_to_simkl()` always saw `config.get("mdblist", {})`/`config.get("simkl", {})` come back empty, then logged "check config/mdblist.yml"/"check config/simkl.yml" - telling the user to check the exact file they'd just filled in.
+
+  Fixed by adding `mdblist`/`simkl` to the same module-file loop `trakt`/`radarr`/`sonarr` already go through, with the identical deep-merge precedence (a module file's keys win; sibling keys it doesn't mention survive). Both shipped examples default `enabled: false`, so this is a behavior change only for an install that already has one of these files with `enabled: true` sitting in `config/` - for whom the change is "the integration I explicitly configured starts working," not a surprise. Verified no such file exists on this install before merging.
+
+  Also closes a documented half of #289: `MDBLIST_API_KEY`/`SIMKL_CLIENT_ID`/`SIMKL_ACCESS_TOKEN` previously only took effect for an install that embedded an `mdblist:`/`simkl:` section directly in `config.yml` itself (env-var override application was already unconditional, but had nothing to override on top of when the module file was never read). Now verified to win over a value the module file itself sets, same as every other integration.
+
+  `_load_module_configs()` now also logs one summary line at load time ("Module configs merged: ..." or "No optional module config files found") so which module files were actually found and merged is visible, not just inferred from individual per-file lines.
+
+  Removed `web/config_app.py`'s docstring note describing this as a deliberate, deferred gap, since it no longer exists. Left `mdblist`/`simkl` unexposed on a Settings/Connections screen for now (UI work, out of scope for this config-loading fix) - both are still config-file-only, same as before.
+
+  New coverage in `tests/test_config.py::TestModularConfigLoading`: both files load and merge; both deep-merge into a pre-existing same-named section instead of replacing it outright; the three env-var overrides apply and win even when the corresponding module file also sets that key.
+
 ## [2.10.74] - 2026-07-27
 
 ### Added

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1032,6 +1032,50 @@ class TestModularConfigLoading:
         finally:
             shutil.rmtree(config_dir)
 
+    def test_loads_mdblist_yml_when_present(self):
+        """Regression: _load_module_configs previously looped over only
+        ["trakt", "radarr", "sonarr"], so mdblist.yml shipped an example
+        but was never actually read at run time - a user who copied
+        config/mdblist.example.yml, filled in a real api_key, and set
+        enabled: true would silently stay disabled."""
+        import shutil
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            mdblist_path = os.path.join(config_dir, "mdblist.yml")
+            with open(mdblist_path, "w") as f:
+                f.write("enabled: true\napi_key: mdblist-key1\n")
+
+            result = load_config(config_path)
+            assert result["mdblist"]["enabled"] is True
+            assert result["mdblist"]["api_key"] == "mdblist-key1"
+        finally:
+            shutil.rmtree(config_dir)
+
+    def test_loads_simkl_yml_when_present(self):
+        """Same regression as mdblist.yml above, for simkl.yml."""
+        import shutil
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            simkl_path = os.path.join(config_dir, "simkl.yml")
+            with open(simkl_path, "w") as f:
+                f.write("enabled: true\nclient_id: real-simkl-client-id\n")
+
+            result = load_config(config_path)
+            assert result["simkl"]["enabled"] is True
+            assert result["simkl"]["client_id"] == "real-simkl-client-id"
+        finally:
+            shutil.rmtree(config_dir)
+
     def test_works_without_module_files(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
             f.write("plex:\n  url: http://localhost:32400\n")
@@ -1221,6 +1265,110 @@ class TestModularConfigLoading:
             assert result["trakt"]["enabled"] is True
             # Pre-existing client_id, not mentioned by trakt.yml, survives.
             assert result["trakt"]["client_id"] == "legacy_id"
+        finally:
+            import shutil
+
+            shutil.rmtree(config_dir)
+
+    def test_mdblist_module_deep_merges_into_existing_same_named_section(self):
+        """Same deep-merge guarantee as the trakt/radarr/sonarr test
+        above, for mdblist.yml - added alongside trakt/radarr/sonarr in
+        the loader loop, so it must behave identically."""
+        from utils.config import _load_module_configs
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            mdblist_path = os.path.join(config_dir, "mdblist.yml")
+            with open(mdblist_path, "w") as f:
+                f.write("enabled: true\n")
+
+            config = {
+                "plex": {"url": "http://localhost:32400"},
+                "mdblist": {"enabled": False, "list_prefix": "Curatarr"},
+            }
+            result = _load_module_configs(config, config_dir)
+
+            # mdblist.yml's explicit override wins.
+            assert result["mdblist"]["enabled"] is True
+            # Pre-existing list_prefix, not mentioned by mdblist.yml, survives.
+            assert result["mdblist"]["list_prefix"] == "Curatarr"
+        finally:
+            import shutil
+
+            shutil.rmtree(config_dir)
+
+    def test_simkl_module_deep_merges_into_existing_same_named_section(self):
+        """Same deep-merge guarantee as the trakt/radarr/sonarr test
+        above, for simkl.yml - added alongside trakt/radarr/sonarr in
+        the loader loop, so it must behave identically."""
+        from utils.config import _load_module_configs
+
+        config_dir = tempfile.mkdtemp()
+        try:
+            simkl_path = os.path.join(config_dir, "simkl.yml")
+            with open(simkl_path, "w") as f:
+                f.write("enabled: true\n")
+
+            config = {
+                "plex": {"url": "http://localhost:32400"},
+                "simkl": {"enabled": False, "client_id": "legacy_id"},
+            }
+            result = _load_module_configs(config, config_dir)
+
+            # simkl.yml's explicit override wins.
+            assert result["simkl"]["enabled"] is True
+            # Pre-existing client_id, not mentioned by simkl.yml, survives.
+            assert result["simkl"]["client_id"] == "legacy_id"
+        finally:
+            import shutil
+
+            shutil.rmtree(config_dir)
+
+    def test_env_var_overrides_mdblist_api_key_when_mdblist_yml_also_present(self, monkeypatch):
+        """Closes the gap CHANGELOG 2.10.74 noted: MDBLIST_API_KEY
+        previously only took effect for an install embedding an
+        `mdblist:` section directly in config.yml, because
+        _load_module_configs never loaded mdblist.yml at all. Now that
+        it does, the env var must still win over whatever mdblist.yml
+        itself says (env always wins, #289)."""
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            mdblist_path = os.path.join(config_dir, "mdblist.yml")
+            with open(mdblist_path, "w") as f:
+                f.write("enabled: true\napi_key: file-key\n")
+
+            monkeypatch.setenv("MDBLIST_API_KEY", "env-key")
+            result = load_config(config_path)
+            assert result["mdblist"]["api_key"] == "env-key"
+            # File-only key (enabled) is untouched by the env override.
+            assert result["mdblist"]["enabled"] is True
+        finally:
+            import shutil
+
+            shutil.rmtree(config_dir)
+
+    def test_env_var_overrides_simkl_client_id_when_simkl_yml_also_present(self, monkeypatch):
+        """Same gap-closing guarantee as the MDBList test above, for
+        SIMKL_CLIENT_ID/simkl.yml."""
+        config_dir = tempfile.mkdtemp()
+        try:
+            config_path = os.path.join(config_dir, "config.yml")
+            with open(config_path, "w") as f:
+                f.write("plex:\n  url: http://localhost:32400\n")
+
+            simkl_path = os.path.join(config_dir, "simkl.yml")
+            with open(simkl_path, "w") as f:
+                f.write("enabled: true\nclient_id: file-client-id\n")
+
+            monkeypatch.setenv("SIMKL_CLIENT_ID", "env-client-id")
+            result = load_config(config_path)
+            assert result["simkl"]["client_id"] == "env-client-id"
+            # File-only key (enabled) is untouched by the env override.
+            assert result["simkl"]["enabled"] is True
         finally:
             import shutil
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.74"
+__version__ = "2.10.75"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so
@@ -265,7 +265,8 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
     """
     Load and merge modular config files into the main config.
 
-    Loads tuning.yml, trakt.yml, radarr.yml, sonarr.yml if they exist.
+    Loads tuning.yml, trakt.yml, radarr.yml, sonarr.yml, mdblist.yml,
+    simkl.yml if they exist.
 
     Precedence: for any top-level key a module file defines, that module
     file wins. Dict-valued keys are deep-merged (see `_deep_merge_dicts`),
@@ -275,6 +276,8 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
     specifies are overridden. Non-dict values (including lists) are
     replaced outright, never merged.
     """
+    loaded_modules = []
+
     # Tuning modules merge their sections into root
     tuning_path = os.path.join(config_dir, "tuning.yml")
     if os.path.exists(tuning_path):
@@ -284,13 +287,17 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
                 if tuning:
                     config = _deep_merge_dicts(config, tuning)
                     log_info("Loaded tuning.yml")
+                    loaded_modules.append("tuning.yml")
         except Exception as e:
             log_warning(f"Could not load tuning.yml: {e}")
 
     # Feature modules go under their key, but still deep-merge in case
     # config.yml already carries a same-named section (e.g. pre-migration
     # leftovers) - same precedence rule as above applies within that key.
-    for module in ["trakt", "radarr", "sonarr"]:
+    # mdblist/simkl added here alongside trakt/radarr/sonarr (previously
+    # missing, which meant a user's mdblist.yml/simkl.yml was silently
+    # never read at all).
+    for module in ["trakt", "radarr", "sonarr", "mdblist", "simkl"]:
         module_path = os.path.join(config_dir, f"{module}.yml")
         if os.path.exists(module_path):
             try:
@@ -303,8 +310,18 @@ def _load_module_configs(config: dict, config_dir: str) -> dict:
                         else:
                             config[module] = module_config
                         log_info(f"Loaded {module}.yml")
+                        loaded_modules.append(f"{module}.yml")
             except Exception as e:
                 log_warning(f"Could not load {module}.yml: {e}")
+
+    # Make it visible at load time which optional module files were
+    # actually found and merged, rather than only ever seeing per-file
+    # lines scroll by (or, for a file that doesn't exist, no signal at
+    # all) - one summary line an operator can grep for.
+    if loaded_modules:
+        log_info(f"Module configs merged: {', '.join(loaded_modules)}")
+    else:
+        log_info("No optional module config files found (config.yml only)")
 
     return config
 
@@ -382,6 +399,8 @@ def load_config(config_path: str) -> dict:
     - trakt.yml: Trakt integration settings
     - radarr.yml: Radarr integration settings
     - sonarr.yml: Sonarr integration settings
+    - mdblist.yml: MDBList integration settings
+    - simkl.yml: Simkl integration settings
 
     Environment variables take precedence over all config values - see
     ENV_VAR_OVERRIDES above for the full, current list (this is a

--- a/web/config_app.py
+++ b/web/config_app.py
@@ -12,6 +12,9 @@ run time:
                        recency_decay, rating_multipliers, negative_signals,
                        external_recommendations
     sonarr.yml / radarr.yml / trakt.yml - one file per integration
+    mdblist.yml / simkl.yml - loaded and merged by _load_module_configs
+                       same as the above, but not yet exposed on a
+                       Settings/Connections screen here
 
 Package layout (audit remediation batch F/I, PR1(a) - this module used
 to hold all four screens' view/parse/apply CRUD logic directly; it's now
@@ -33,13 +36,6 @@ This module is purely additive: register_config_routes() is called once
 from web.app.create_app() and only adds new routes. It never touches
 the dashboard/run/results routes or the recommenders themselves.
 
-mdblist.yml/simkl.yml are deliberately NOT exposed here - see the "mdblist
-/simkl gap" note in the PR description. utils.config._load_module_configs
-never loads those two files into the merged config, so an mdblist.yml or
-simkl.yml a user hand-writes today is silently ignored at run time. Fixing
-that loader gap is a behavior change for anyone who already has one of
-those files sitting in config/ (it would suddenly start exporting), so
-it's left as a follow-up rather than bundled into this UI-only PR.
 """
 
 from .config_connections import register_connections_routes


### PR DESCRIPTION
## Summary
- _load_module_configs() looped over only trakt/radarr/sonarr, so mdblist.yml/simkl.yml shipped as examples were never actually read at run time.
- Adds mdblist/simkl to the same module-file loop with identical deep-merge precedence, closes the corresponding half of the MDBLIST_API_KEY/SIMKL_CLIENT_ID/SIMKL_ACCESS_TOKEN env-var override gap, adds a load-time summary log line, and removes the now-stale gap note from web/config_app.py.
- Both shipped examples default enabled: false, so this only changes behavior for an install that already set enabled: true in one of these files - verified no such file exists on this install.

## Test plan
- [x] tests/test_config.py::TestModularConfigLoading - both files load/merge, deep-merge into a pre-existing same-named section, env overrides apply and win over the file
- [x] Full suite (pytest tests/ --cov, 2915 passed), ruff check/format, mypy - all green