### PR TITLE
Surface collection naming templates in Settings UI (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.76] - 2026-07-27
+
+### Added
+
+- **Collection naming templates (#274) surfaced in the web UI's Settings screen (#286).** `collections.movie_name_template`/`collections.tv_name_template` were only ever editable by hand-editing `config/tuning.yml` since #274 shipped them - the only remaining item on the original web-UI-parity queue.
+
+  The existing default renders byte-identical to today's output for anyone who never touches this screen - the two new fields fall back to the exact same `utils.labels.DEFAULT_MOVIE_NAME_TEMPLATE`/`DEFAULT_TV_NAME_TEMPLATE` constants the recommender itself uses, not a re-typed copy of them (same #261-class guardrail as this project's other config defaults). Leaving a field blank on save means "use the default" - it's written back as that exact default constant rather than a literal empty-string template, matching `config/tuning.example.yml`'s own documented way to reset this (deleting the line).
+
+  New `web/config_validate.py::validate_collection_template()` rejects an invalid template (unknown placeholder, malformed braces) outright with a visible inline field error, rather than mirroring `utils.labels.render_collection_name()`'s own runtime behavior (silently falls back to the default and logs a warning - by design, so a bad hand-edited `tuning.yml` can never crash a run). Same deliberate divergence this screen's `validate_weights_sum` already establishes: a UI-driven typo shouldn't be silently accepted only to fall back at every actual run with nothing but a log line to explain why.
+
+  The screen also explains that the multi-library disambiguation suffix (e.g. " (Movies 4K)") is always appended after the template renders, so a user doesn't try to add it themselves.
+
+  Field-scoped the same way every other section on this screen already is (#290): only `movie_name_template`/`tv_name_template` are read/written here - `collections.add_label`/`label_name`/`append_usernames`/`rename_on_template_change`/`private_collections` (same YAML section, but not owned by this screen) are left untouched. Audited `web/config_connections.py` and every other config screen first - none currently render an editable `collections.*` field, so there was no #290-class duplicate-field clobber risk to begin with here.
+
+  New coverage: `tests/test_web_config_validate.py::TestValidateCollectionTemplate` (valid/invalid templates for both media types); `tests/test_web_config_settings.py::TestCollectionNaming` (default rendering matches the real constants byte-for-byte, custom templates persist, blank/omitted fields save the real default rather than an empty string, an invalid template is rejected with a visible error and never corrupts the existing file, and saving this screen never touches the other `collections.*` keys it doesn't own).
+
 ## [2.10.75] - 2026-07-27
 
 ### Fixed

--- a/tests/test_web_config_settings.py
+++ b/tests/test_web_config_settings.py
@@ -20,6 +20,7 @@ import pytest
 import yaml
 
 from utils.config import get_update_mode
+from utils.labels import DEFAULT_MOVIE_NAME_TEMPLATE, DEFAULT_TV_NAME_TEMPLATE
 from web.app import create_app
 from web.config_io import module_path
 
@@ -301,6 +302,122 @@ class TestSaveNeverTouchesSyncSafety:
                 assert f'name="{svc}_{field}"' not in text
         # Still shows the current (Connections-owned) value read-only.
         assert "combined" in text  # sonarr_user_mode from CONNECTIONS_FORM above
+
+
+class TestCollectionNaming:
+    """#286: surfaces collections.movie_name_template/tv_name_template
+    (#267/PR#274) on this screen. The existing default must render
+    byte-identical to today's output for anyone who never touches this
+    - see utils.labels.DEFAULT_MOVIE_NAME_TEMPLATE/DEFAULT_TV_NAME_TEMPLATE,
+    which this screen falls back to and this test class imports rather
+    than re-typing (avoids the class of bug #261 already covers:
+    hand-copied defaults drifting out of sync with the real ones)."""
+
+    def test_get_shows_the_real_default_when_unset(self, client):
+        c, app, root = client
+        resp = c.get("/config/settings")
+        text = resp.data.decode()
+        assert f'value="{DEFAULT_MOVIE_NAME_TEMPLATE}"' in text
+        assert f'value="{DEFAULT_TV_NAME_TEMPLATE}"' in text
+
+    def test_saves_custom_templates_to_tuning_yml(self, client):
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form["collections_movie_name_template"] = "Movie picks for {user}"
+        form["collections_tv_name_template"] = "{media_type} picks for {user}"
+        resp = c.post("/config/settings", data=form)
+        assert resp.status_code == 303
+
+        tuning = _read_yaml(root, "tuning")
+        assert tuning["collections"]["movie_name_template"] == "Movie picks for {user}"
+        assert tuning["collections"]["tv_name_template"] == "{media_type} picks for {user}"
+
+    def test_blank_field_saves_the_real_default_rather_than_empty_string(self, client):
+        """Leaving the field blank means "use the default" (matches
+        config/tuning.example.yml's own documented way to do this by
+        deleting the line) - not a literal empty-string template."""
+        c, app, root = client
+        form = dict(VALID_FORM)
+        form["collections_movie_name_template"] = "   "
+        form["collections_tv_name_template"] = ""
+        c.post("/config/settings", data=form)
+
+        tuning = _read_yaml(root, "tuning")
+        assert tuning["collections"]["movie_name_template"] == DEFAULT_MOVIE_NAME_TEMPLATE
+        assert tuning["collections"]["tv_name_template"] == DEFAULT_TV_NAME_TEMPLATE
+
+    def test_omitted_fields_also_default(self, client):
+        """VALID_FORM itself never sets either field - the baseline
+        save path (every other test in this file using VALID_FORM
+        as-is) must not blow up or write a blank template."""
+        c, app, root = client
+        assert "collections_movie_name_template" not in VALID_FORM
+        c.post("/config/settings", data=VALID_FORM)
+
+        tuning = _read_yaml(root, "tuning")
+        assert tuning["collections"]["movie_name_template"] == DEFAULT_MOVIE_NAME_TEMPLATE
+        assert tuning["collections"]["tv_name_template"] == DEFAULT_TV_NAME_TEMPLATE
+
+    def test_invalid_movie_template_rejected_with_visible_error(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad["collections_movie_name_template"] = "Oops {typo}"
+        resp = c.post("/config/settings", data=bad)
+        assert resp.status_code == 400
+        assert b"Invalid template" in resp.data
+
+    def test_invalid_tv_template_rejected_with_visible_error(self, client):
+        c, app, root = client
+        bad = dict(VALID_FORM)
+        bad["collections_tv_name_template"] = "Oops {"
+        resp = c.post("/config/settings", data=bad)
+        assert resp.status_code == 400
+        assert b"Invalid template" in resp.data
+
+    def test_invalid_template_does_not_corrupt_existing_tuning_file(self, client):
+        c, app, root = client
+        c.post("/config/settings", data=VALID_FORM)  # establish a valid baseline
+        before = _read_yaml(root, "tuning")
+
+        bad = dict(VALID_FORM)
+        bad["collections_movie_name_template"] = "Oops {typo}"
+        c.post("/config/settings", data=bad)
+
+        after = _read_yaml(root, "tuning")
+        assert after == before
+
+    def test_save_does_not_touch_other_collections_keys(self, client):
+        """add_label/label_name/append_usernames/rename_on_template_change/
+        private_collections all live under the same collections: section
+        but are config-file-only (not owned by this screen) - saving the
+        two template fields here must not clobber them, same field-
+        scoping guarantee #290 already established for other sections."""
+        c, app, root = client
+        tuning_path = module_path(root, "tuning")
+        with open(tuning_path, "w", encoding="utf-8") as f:
+            f.write(
+                "collections:\n"
+                "  add_label: false\n"
+                "  label_name: CustomLabel\n"
+                "  append_usernames: false\n"
+                "  private_collections: false\n"
+            )
+
+        form = dict(VALID_FORM)
+        form["collections_movie_name_template"] = "Movie picks for {user}"
+        c.post("/config/settings", data=form)
+
+        tuning = _read_yaml(root, "tuning")
+        assert tuning["collections"]["movie_name_template"] == "Movie picks for {user}"
+        assert tuning["collections"]["add_label"] is False
+        assert tuning["collections"]["label_name"] == "CustomLabel"
+        assert tuning["collections"]["append_usernames"] is False
+        assert tuning["collections"]["private_collections"] is False
+
+    def test_explains_multi_library_suffix_is_appended_separately(self, client):
+        c, app, root = client
+        resp = c.get("/config/settings")
+        assert b"disambiguation suffix" in resp.data
 
 
 class TestValidation:

--- a/tests/test_web_config_validate.py
+++ b/tests/test_web_config_validate.py
@@ -6,8 +6,10 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from utils.labels import DEFAULT_MOVIE_NAME_TEMPLATE
 from web.config_validate import (
     validate_choice,
+    validate_collection_template,
     validate_float,
     validate_int,
     validate_required,
@@ -128,3 +130,49 @@ class TestValidateWeightsSum:
         errors = {}
         validate_weights_sum({"a": 0.3333333, "b": 0.3333333, "c": 0.3333334}, "weights", errors)
         assert errors == {}
+
+
+class TestValidateCollectionTemplate:
+    """#286: same reject-outright convention as validate_weights_sum
+    above, rather than mirroring utils.labels.render_collection_name's
+    own runtime fallback-with-a-logged-warning behavior - see that
+    function's docstring/#267 for why the runtime path is deliberately
+    lenient; a UI submission doesn't need to be."""
+
+    def test_default_template_passes(self):
+        errors = {}
+        validate_collection_template(DEFAULT_MOVIE_NAME_TEMPLATE, "f", errors, "movie")
+        assert errors == {}
+
+    def test_both_placeholders_pass_for_either_media_type(self):
+        errors = {}
+        validate_collection_template("{media_type} picks for {user}", "f", errors, "tv")
+        assert errors == {}
+
+    def test_no_placeholders_at_all_passes(self):
+        """A template with neither placeholder is unusual but not
+        malformed - str.format() with extra unused kwargs never raises."""
+        errors = {}
+        validate_collection_template("Recommended", "f", errors, "movie")
+        assert errors == {}
+
+    def test_unknown_placeholder_fails(self):
+        errors = {}
+        validate_collection_template("Oops {usr}", "f", errors, "movie")
+        assert "f" in errors
+        assert "Invalid template" in errors["f"]
+
+    def test_malformed_braces_fail(self):
+        errors = {}
+        validate_collection_template("Oops {", "f", errors, "movie")
+        assert "f" in errors
+
+    def test_movie_and_tv_render_media_type_label_correctly(self):
+        """{media_type} alone must not itself be treated as an unknown
+        placeholder for either media_type argument."""
+        errors_movie: dict = {}
+        errors_tv: dict = {}
+        validate_collection_template("{media_type}", "f", errors_movie, "movie")
+        validate_collection_template("{media_type}", "f", errors_tv, "tv")
+        assert errors_movie == {}
+        assert errors_tv == {}

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.75"
+__version__ = "2.10.76"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/config_settings.py
+++ b/web/config_settings.py
@@ -1,6 +1,7 @@
 """Settings / Tuning screen: scoring weights, quality filters, recency
 decay, rating multipliers, negative signals, external-recommendations
-tuning, and general/logging options.
+tuning, collection naming templates (#286), and general/logging
+options.
 
 #290: the sync-safety fields (Sonarr/Radarr/Trakt auto_sync/user_mode/
 plex_users) used to ALSO be a fully editable, separately-submitted copy
@@ -30,6 +31,7 @@ from flask import redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
 
 from utils.config import UPDATE_MODES, get_update_mode
+from utils.labels import DEFAULT_MOVIE_NAME_TEMPLATE, DEFAULT_TV_NAME_TEMPLATE
 from utils.scheduler import WEEKDAY_NAMES, describe_next_run, parse_schedule_config
 
 from .config_io import (
@@ -39,7 +41,13 @@ from .config_io import (
     load_module,
     module_path,
 )
-from .config_validate import validate_choice, validate_float, validate_int, validate_weights_sum
+from .config_validate import (
+    validate_choice,
+    validate_collection_template,
+    validate_float,
+    validate_int,
+    validate_weights_sum,
+)
 
 LOG_LEVEL_CHOICES = ("DEBUG", "INFO", "WARNING", "ERROR")
 
@@ -163,6 +171,7 @@ def _settings_view(
     bad_ratings = negsig.get("bad_ratings") or {}
     dropped_shows = negsig.get("dropped_shows") or {}
     external = tuning.get("external_recommendations") or {}
+    collections = tuning.get("collections") or {}
     general = core.get("general") or {}
     logging_cfg = core.get("logging") or {}
     schedule_cfg = core.get("schedule") or {}
@@ -224,6 +233,14 @@ def _settings_view(
             "max_iterations": external.get("max_iterations", 8),
             "language": external.get("language") or "",
             "auto_open_html": bool(external.get("auto_open_html", False)),
+        },
+        # #286: only the two name-template fields (#274) are surfaced
+        # here - collections.add_label/label_name/append_usernames/
+        # rename_on_template_change/private_collections are config-file-
+        # only for now, out of scope for this screen.
+        "collections": {
+            "movie_name_template": collections.get("movie_name_template") or DEFAULT_MOVIE_NAME_TEMPLATE,
+            "tv_name_template": collections.get("tv_name_template") or DEFAULT_TV_NAME_TEMPLATE,
         },
         "general": {
             # get_update_mode() resolves the effective mode, falling back
@@ -343,6 +360,22 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
         "language": form.get("ext_language", "").strip(),
         "auto_open_html": flag("ext_auto_open_html"),
     }
+    # #286: blank (or whitespace-only) means "use the default" - same
+    # as leaving collections.movie_name_template/tv_name_template unset
+    # in a hand-edited tuning.yml (config/tuning.example.yml's own
+    # documented way to do this) - rather than saving a literal empty
+    # string template. Written as the actual default constant (not
+    # omitted) so what's on disk always matches what's rendered; see
+    # config/tuning.example.yml's own byte-identical default.
+    movie_name_template = form.get("collections_movie_name_template", "").strip() or DEFAULT_MOVIE_NAME_TEMPLATE
+    tv_name_template = form.get("collections_tv_name_template", "").strip() or DEFAULT_TV_NAME_TEMPLATE
+    validate_collection_template(movie_name_template, "collections_movie_name_template", errors, "movie")
+    validate_collection_template(tv_name_template, "collections_tv_name_template", errors, "tv")
+    collections = {
+        "movie_name_template": movie_name_template,
+        "tv_name_template": tv_name_template,
+    }
+
     update_mode = form.get("general_update_mode", "notify")
     validate_choice(update_mode, "general_update_mode", errors, UPDATE_MODES)
     general = {
@@ -380,6 +413,7 @@ def _parse_settings_form(form, errors: Dict[str, str]) -> Dict:
         "rating_multipliers": rating_multipliers,
         "negative_signals": negative_signals,
         "external": external,
+        "collections": collections,
         "general": general,
         "logging": {"level": logging_level},
         "schedule": schedule,
@@ -444,6 +478,14 @@ def _apply_settings(
     ext_section["max_iterations"] = ext["max_iterations"]
     ext_section["language"] = ext["language"] or None
     ext_section["auto_open_html"] = ext["auto_open_html"]
+
+    # #286: only writes the two name-template keys - add_label/
+    # label_name/append_usernames/rename_on_template_change/
+    # private_collections (also under collections:) are untouched,
+    # same field-scoping guarantee as every other section here (#290).
+    collections_section = ensure_section(tuning, "collections")
+    collections_section["movie_name_template"] = parsed["collections"]["movie_name_template"]
+    collections_section["tv_name_template"] = parsed["collections"]["tv_name_template"]
 
     ensure_section(core, "general").update(parsed["general"])
     ensure_section(core, "logging")["level"] = parsed["logging"]["level"]

--- a/web/config_validate.py
+++ b/web/config_validate.py
@@ -104,3 +104,25 @@ def validate_weights_sum(weights: Dict[str, float], field: str, errors: Dict[str
     total = sum(float(v) for v in weights.values())
     if abs(total - 1.0) > WEIGHT_SUM_TOLERANCE:
         errors[field] = f"Weights must sum to 1.0 (currently {total:.4f})"
+
+
+def validate_collection_template(value: str, field: str, errors: Dict[str, str], media_type: str) -> None:
+    """Validates a collections.movie_name_template/tv_name_template
+    value (#267/#286) against the exact rules utils.labels.
+    render_collection_name applies at run time: str.format() with only
+    {user}/{media_type} available.
+
+    render_collection_name() itself never raises - an invalid template
+    there falls back to the matching DEFAULT_*_NAME_TEMPLATE and logs a
+    warning, so a bad tuning.yml edit can never crash a recommender run.
+    This validator deliberately does NOT reuse that lenient behavior:
+    same as validate_weights_sum above, a UI-driven typo/malformed
+    template is rejected outright here rather than silently accepted
+    only to fall back at every actual run with nothing but a log line
+    to explain why.
+    """
+    media_type_label = "Movie" if media_type == "movie" else "TV"
+    try:
+        value.format(user="Test User", media_type=media_type_label)
+    except (KeyError, IndexError, ValueError) as e:
+        errors[field] = f"Invalid template ({e}) - only {{user}} and {{media_type}} placeholders are supported"

--- a/web/templates/config_settings.html
+++ b/web/templates/config_settings.html
@@ -135,6 +135,31 @@
   </fieldset>
 
   <fieldset>
+    <legend>Collection naming (#286)</legend>
+    <p class="muted">
+      Controls the name curatarr gives each user's recommendation collection in Plex. Leave blank to keep the
+      default shown here. Placeholders: <code>{user}</code> (the collection's resolved display name) and
+      <code>{media_type}</code> (renders as "Movie"/"TV"). An invalid template - an unknown placeholder or
+      malformed braces - is rejected below rather than silently accepted; at run time (e.g. from a hand-edited
+      tuning.yml) the same invalid template instead falls back to the default and logs a warning, so a bad value
+      there can never crash a run.
+    </p>
+    <p class="muted">
+      The multi-library disambiguation suffix (e.g. " (Movies 4K)") is always appended after this template
+      renders, for every install with more than one library of the same media type - do not add it to the
+      template yourself.
+    </p>
+    <label>Movie collection name
+      <input type="text" name="collections_movie_name_template" value="{{ collections.movie_name_template }}">
+    </label>
+    {{ field_error(errors, 'collections_movie_name_template') }}
+    <label>TV collection name
+      <input type="text" name="collections_tv_name_template" value="{{ collections.tv_name_template }}">
+    </label>
+    {{ field_error(errors, 'collections_tv_name_template') }}
+  </fieldset>
+
+  <fieldset>
     <legend>General</legend>
     <label>Updates
       <select name="general_update_mode">


### PR DESCRIPTION
## Summary
- Adds collections.movie_name_template/tv_name_template (#274) to the web UI Settings screen - closes #286, the last item on the web-UI-parity queue.
- Default renders byte-identical to today's output (falls back to the real DEFAULT_MOVIE_NAME_TEMPLATE/DEFAULT_TV_NAME_TEMPLATE constants, not a re-typed copy).
- An invalid template is rejected outright with a visible inline error rather than silently accepted (deliberately stricter than the runtime fallback-with-a-logged-warning behavior, same convention as this screen's existing validate_weights_sum).
- Explains the multi-library disambiguation suffix is appended separately.
- Field-scoped: only movie_name_template/tv_name_template are read/written - confirmed no other config screen already renders an editable collections.* field, so this can't reintroduce #290.

## Test plan
- [x] tests/test_web_config_validate.py::TestValidateCollectionTemplate
- [x] tests/test_web_config_settings.py::TestCollectionNaming - default rendering, persistence, blank/omitted-field defaulting, invalid-template rejection + no file corruption, and no clobber of sibling collections.* keys
- [x] Full suite (2930 passed), ruff check/format, mypy - all green