### PR TITLE
Route Plex watch-history errors through the logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.77] - 2026-07-27
+
+### Fixed
+
+- **A Plex watch-history fetch failure was the one integration NOT governed by the `logging.verbosity` (off/quiet/verbose) setting #306 added.** `utils/plex.py`'s `fetch_plex_watch_history_movies()` per-account except clause was a bare `print(f" {RED}ERROR: {e}{RESET}")` - no `log_error()` call at all, unlike every other choke point #306 already routed through the level-gated logging module (Plex connection init, TMDB, Trakt, Simkl, the shared Sonarr/Radarr/Tautulli/MDBList client), and unlike this exact module's own sibling functions - `fetch_plex_watch_history_shows()` and `fetch_show_completion_data()` - which already called `log_error()`/`log_warning()` correctly for the identical class of failure.
+
+  Fixed by replacing that `print()` with `log_error(f"Error fetching watch history for account {account_id}: {e}")`, naming the failing account (the sibling functions' messages don't - this one now does, for easier triage across multiple users). Stays visible at the default `quiet` level (and even at `off`, which maps to ERROR-only, not full silence) - a failure to fetch a user's watch history is exactly the kind of thing an operator must see, and it's the class of silent failure that hid a real six-month Trakt outage. No bare `print()` reintroduced.
+
+  New regression coverage in `tests/test_plex.py::TestFetchPlexWatchHistoryMovies::test_per_account_fetch_error_routed_through_log_error_not_bare_print` - asserts `log_error` is called with the failing account ID, and that one account's failure doesn't abort the fetch for the rest.
+
 ## [2.10.76] - 2026-07-27
 
 ### Added

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1427,6 +1427,44 @@ class TestFetchPlexWatchHistoryMovies:
         # Should return empty since no matching accounts
         assert history == []
 
+    @patch("utils.plex.MyPlexAccount")
+    @patch("utils.plex.requests.get")
+    @patch("utils.plex.log_error")
+    def test_per_account_fetch_error_routed_through_log_error_not_bare_print(
+        self, mock_log, mock_get, mock_account_class
+    ):
+        """Regression: the per-account fetch's except clause used to be
+        a bare print() with no log_error call at all - the one choke
+        point in this module NOT routed through the level-gated logging
+        module #306 added (every sibling function -
+        fetch_plex_watch_history_shows, fetch_show_completion_data -
+        already called log_error/log_warning here). A per-account
+        failure must be logged (so logging.verbosity actually governs
+        it, and it's visible in a real log file, not just a
+        console-only print), and must not raise - one account's
+        failure should not abort every other account's fetch."""
+        from utils.plex import fetch_plex_watch_history_movies
+
+        mock_user = Mock()
+        mock_user.id = 123
+        mock_account = Mock()
+        mock_account.users.return_value = [mock_user]
+        mock_account_class.return_value = mock_account
+
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        mock_section = Mock()
+        mock_section.key = 1
+
+        config = {"plex": {"url": "http://localhost", "token": "test"}}
+        history, dates = fetch_plex_watch_history_movies(config, ["123"], mock_section)
+
+        assert history == []
+        assert dates == {}
+        mock_log.assert_called_once()
+        logged_message = mock_log.call_args[0][0]
+        assert "123" in logged_message
+
 
 class TestFetchWatchHistoryWithTmdb:
     """Tests for fetch_watch_history_with_tmdb() function."""

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.76"
+__version__ = "2.10.77"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -25,7 +25,7 @@ import urllib3
 from plexapi.myplex import MyPlexAccount
 
 from .config import PLEX_LONG_REQUEST_TIMEOUT, PLEX_REQUEST_TIMEOUT
-from .display import GREEN, RED, RESET, YELLOW, log_error, log_warning
+from .display import GREEN, RESET, YELLOW, log_error, log_warning
 from .helpers import normalize_title, read_response_capped
 from .labels import remove_labels_from_items
 from .metrics import record_api_call
@@ -363,7 +363,21 @@ def fetch_plex_watch_history_movies(
                     print(f" {YELLOW}SKIP (account not found in managed users){RESET}")
 
             except (requests.RequestException, ET.ParseError) as e:
-                print(f" {RED}ERROR: {e}{RESET}")
+                # Routed through the level-gated logging module (#306) -
+                # this is the one choke point that was still a bare
+                # print(), so logging.verbosity's off/quiet/verbose
+                # setting didn't govern it like every other integration
+                # (Plex connection init, TMDB, Trakt, Simkl, the shared
+                # Sonarr/Radarr/Tautulli/MDBList client, and this same
+                # module's fetch_plex_watch_history_shows/
+                # fetch_show_completion_data siblings just below, which
+                # already did this correctly). A failure to fetch one
+                # user's watch history is exactly the kind of thing an
+                # operator must see - the same class of silent failure
+                # that hid a real six-month Trakt outage - so this stays
+                # visible at the default 'quiet' level (log_error maps
+                # to logging.ERROR, at or above every non-off tier).
+                log_error(f"Error fetching watch history for account {account_id}: {e}")
 
         return all_history_items, watched_movie_dates
 


### PR DESCRIPTION
## Summary
- fetch_plex_watch_history_movies()'s per-account except clause was a bare print() with no log_error() call - the one choke point in utils/plex.py NOT routed through the level-gated logging module #306 added.
- Its own sibling functions (fetch_plex_watch_history_shows, fetch_show_completion_data) already called log_error()/log_warning() correctly for the identical class of failure.
- Replaced with log_error(f"Error fetching watch history for account {account_id}: {e}") - stays visible at the default quiet level (and even off, which maps to ERROR-only). No bare print() reintroduced.

## Test plan
- [x] tests/test_plex.py::TestFetchPlexWatchHistoryMovies::test_per_account_fetch_error_routed_through_log_error_not_bare_print
- [x] Full suite (2931 passed), ruff check/format, mypy - all green