### PR TITLE
fix: TV omitted language weight no longer defaults to a nonzero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.78] - 2026-07-28
+
+### Fixed
+
+- **Nightly TV runs logged "Warning: Weights sum to 1.05, expected 1.0" every run whenever tv:/weights: in config/tuning.yml provided the 4 documented keys (genre/studio/actor/keyword, already summing to 1.0 on their own per config/tuning.example.yml) without an explicit language key.** recommenders/tv.py's PlexTVRecommender._load_weights() defaulted an omitted language weight to 0.05 unconditionally, silently reintroducing a 5th scoring dimension the config never asked for on top of an already-complete 4-key block - both the spurious warning and a real, uninvited language-matching contribution to every score.
+
+  PlexMovieRecommender._load_weights() already got this right for movies (language defaults to 0.0 there, always) - TV was the sole outlier. Fixed by making the language default conditional on whether the caller supplied any explicit weights at all: a genuinely empty/absent tv:/weights: block (no config/tuning.yml, or tv: with no weights: sub-key) still gets curatarr's own baked-in default profile unchanged, which deliberately blends in a small 0.05 language weight as part of a 5-value set already designed to sum to 1.0 - but once any explicit weights are supplied, an omitted language key now defaults to 0, matching the movie engine's behavior. Every other key (genre/studio/actor/keyword) keeps its existing per-field default regardless, unchanged - those four are the documented core set config/tuning.example.yml expects users to tune as a unit; language is the one dimension deliberately left out of that documented block.
+
+  Audited every other optional weight key in both engines for the same gap: none exists. genre/actor/director-or-studio/keyword are always part of the documented example weights: block for both movies: and tv: (the one set config/tuning.example.yml shows as "must sum to 1.0"); language is the only key either engine treats as an implicit bonus dimension excluded from that documented block, and it's now consistently zero-defaulted (movies always; TV whenever any explicit weights are given) in both.
+
+  New coverage in `tests/test_tv.py::TestPlexTVRecommenderWeights`: `test_fully_default_weights_with_no_config_still_sum_to_one` (regression guard - a zero-config TV install must keep summing to 1.0 exactly as before), `test_omitted_language_in_explicit_config_defaults_to_zero` (reproduces the real 1.05 case and asserts it now sums to 1.0 with no warning), and `test_explicit_language_weight_in_partial_config_still_honored` (an explicitly-set language weight is never overridden).
+
 ## [2.10.77] - 2026-07-27
 
 ### Fixed

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -116,12 +116,41 @@ class PlexTVRecommender(BaseRecommender):
 
     def _load_weights(self, weights_config: Dict) -> Dict:
         """Load TV-specific scoring weights from config."""
+        # language is deliberately not part of tv:/weights: in
+        # config/tuning.example.yml - it is an opt-in bonus dimension,
+        # not one of the 4 keys (genre/studio/actor/keyword) the docs
+        # and web-UI validator require to sum to 1.0 on their own, and
+        # that example 4-key block already sums to 1.0 without it.
+        #
+        # A genuinely empty/absent weights_config (no config/tuning.yml
+        # at all, or tv: present with no weights: sub-key) gets
+        # curatarr's own baked-in default PROFILE below, which
+        # deliberately blends in a small language weight (0.05) as a
+        # real 5th dimension - that whole 5-value set is designed
+        # together and already sums to 1.0.
+        #
+        # But once a user supplies ANY explicit tv:/weights: override -
+        # even a complete-looking 4-key block that simply omits
+        # language, as the documented example itself does - an omitted
+        # language key must default to 0, not to that 0.05 constant:
+        # silently reintroducing a 5th scoring dimension on top of
+        # weights the user chose is what made an already-1.0 4-key
+        # block sum to 1.05 (the recurring nightly warning) while also
+        # applying language matching at a weight nobody asked for.
+        # Every other key here keeps defaulting per-field regardless -
+        # genre/studio/actor/keyword are the documented core set users
+        # are expected to tune as a unit, unlike language.
+        #
+        # Mirrors PlexMovieRecommender._load_weights(), whose own
+        # baked-in default profile never included language at all
+        # (already 0.0 unconditionally - no such split needed there).
+        language_default = 0.0 if weights_config else 0.05
         return {
             "genre": weights_config.get("genre", weights_config.get("genre_weight", 0.20)),
             "actor": weights_config.get("actor", weights_config.get("actor_weight", 0.15)),
             "studio": weights_config.get("studio", weights_config.get("studio_weight", 0.15)),
             "keyword": weights_config.get("keyword", weights_config.get("keyword_weight", 0.45)),
-            "language": weights_config.get("language", weights_config.get("language_weight", 0.05)),
+            "language": weights_config.get("language", weights_config.get("language_weight", language_default)),
         }
 
     def __init__(

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -420,6 +420,113 @@ class TestPlexTVRecommenderWeights:
         assert "studio" in recommender.weights
         assert "actor" in recommender.weights
 
+    @patch("recommenders.base.log_warning")
+    @patch("recommenders.tv.ShowCache")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_fully_default_weights_with_no_config_still_sum_to_one(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_warn
+    ):
+        """Regression guard: an install with NO tv:/weights: override at all
+        (weights_config == {}) must keep getting curatarr's own baked-in
+        5-dimension default profile - genre/actor/studio/keyword/language -
+        which is designed as a whole to already sum to 1.0. This must NOT
+        change when the omitted-language-in-a-partial-config fix (below)
+        ships, or every zero-config TV install would start warning too."""
+        mock_load.return_value = {"plex": {"url": "http://localhost", "token": "abc"}, "general": {}, "weights": {}}
+        mock_users.return_value = {"plex_users": ["user1"], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_section = Mock()
+        mock_section.all.return_value = []
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+        mock_cache.return_value = Mock(cache={"shows": {}})
+
+        recommender = PlexTVRecommender("/path/to/config.yml")
+
+        assert recommender.weights["language"] == 0.05
+        assert sum(recommender.weights.values()) == pytest.approx(1.0)
+        mock_warn.assert_not_called()
+
+    @patch("recommenders.base.log_warning")
+    @patch("recommenders.tv.ShowCache")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_omitted_language_in_explicit_config_defaults_to_zero(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_warn
+    ):
+        """Reproduces the real bug: an owner's tv:/weights: block matching
+        config/tuning.example.yml's own documented 4-key template
+        (genre/studio/actor/keyword, no language key at all) already sums
+        to 1.0 on its own. Before this fix, the missing language key
+        silently defaulted to 0.05, making the total 1.05 and applying a
+        scoring dimension the user never configured. It must now default
+        to 0 and the total must be exactly 1.0, with no warning logged."""
+        mock_load.return_value = {
+            "plex": {"url": "http://localhost", "token": "abc"},
+            "general": {},
+            "weights": {"genre": 0.25, "studio": 0.10, "actor": 0.20, "keyword": 0.45},
+        }
+        mock_users.return_value = {"plex_users": ["user1"], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_section = Mock()
+        mock_section.all.return_value = []
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+        mock_cache.return_value = Mock(cache={"shows": {}})
+
+        recommender = PlexTVRecommender("/path/to/config.yml")
+
+        assert recommender.weights["language"] == 0.0
+        assert recommender.weights["genre"] == 0.25
+        assert recommender.weights["studio"] == 0.10
+        assert recommender.weights["actor"] == 0.20
+        assert recommender.weights["keyword"] == 0.45
+        assert sum(recommender.weights.values()) == pytest.approx(1.0)
+        mock_warn.assert_not_called()
+
+    @patch("recommenders.base.log_warning")
+    @patch("recommenders.tv.ShowCache")
+    @patch("recommenders.base.init_plex")
+    @patch("recommenders.base.get_configured_users")
+    @patch("recommenders.base.get_tmdb_config")
+    @patch("recommenders.base.load_config")
+    @patch("os.makedirs")
+    def test_explicit_language_weight_in_partial_config_still_honored(
+        self, mock_makedirs, mock_load, mock_tmdb, mock_users, mock_plex, mock_cache, mock_warn
+    ):
+        """An explicit language weight, even alongside a partial
+        override of the other 4 keys, must be used exactly as given -
+        this fix only changes the default applied when the key is
+        absent, never a value the user actually set."""
+        mock_load.return_value = {
+            "plex": {"url": "http://localhost", "token": "abc"},
+            "general": {},
+            "weights": {"genre": 0.20, "studio": 0.10, "actor": 0.20, "keyword": 0.40, "language": 0.10},
+        }
+        mock_users.return_value = {"plex_users": ["user1"], "managed_users": [], "admin_user": "admin"}
+        mock_tmdb.return_value = {"use_keywords": True, "api_key": "key"}
+        mock_section = Mock()
+        mock_section.all.return_value = []
+        mock_plex_inst = Mock()
+        mock_plex_inst.library.section.return_value = mock_section
+        mock_plex.return_value = mock_plex_inst
+        mock_cache.return_value = Mock(cache={"shows": {}})
+
+        recommender = PlexTVRecommender("/path/to/config.yml")
+
+        assert recommender.weights["language"] == 0.10
+        assert sum(recommender.weights.values()) == pytest.approx(1.0)
+        mock_warn.assert_not_called()
+
 
 class TestPlexTVRecommenderLibraryMethods:
     """Tests for PlexTVRecommender library methods."""

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.77"
+__version__ = "2.10.78"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary
- `recommenders/tv.py`'s `PlexTVRecommender._load_weights()` defaulted an omitted `language` weight to 0.05 unconditionally - the owner's `tv:/weights:` block (genre/studio/actor/keyword, no `language` key, matching `config/tuning.example.yml`'s own documented 4-key template which already sums to 1.0) silently got a 5th scoring dimension it never asked for, producing the recurring nightly "Weights sum to 1.05, expected 1.0" warning.
- `PlexMovieRecommender._load_weights()` already defaulted omitted `language` to 0.0 - TV was the sole outlier. Fixed TV to match, but conditionally: a genuinely empty/absent weights block (no `config/tuning.yml`, or `tv:` with no `weights:` sub-key at all) still gets curatarr's own baked-in 5-dimension default profile unchanged (that whole set is designed together and already sums to 1.0 including a deliberate 0.05 language contribution) - only once a user supplies **any** explicit weights does an omitted `language` key now default to 0. This avoids introducing a new warning/behavior change for zero-config installs.
- Audited every other optional weight key in both engines: no other gap exists. genre/actor/director-or-studio/keyword are always part of both engines' documented example weights block; `language` is the only key excluded from that documented block in either engine, and it's now consistently zero-defaulted whenever explicit weights are given.

## Test plan
- [x] `tests/test_tv.py::TestPlexTVRecommenderWeights::test_fully_default_weights_with_no_config_still_sum_to_one` - regression guard, zero-config TV install unchanged
- [x] `tests/test_tv.py::TestPlexTVRecommenderWeights::test_omitted_language_in_explicit_config_defaults_to_zero` - reproduces the real 1.05 case, asserts fixed
- [x] `tests/test_tv.py::TestPlexTVRecommenderWeights::test_explicit_language_weight_in_partial_config_still_honored` - explicit value never overridden
- [x] Full suite (2934 passed, 1 skipped), `ruff check`, `mypy` all green