### PR TITLE
fix: validate --username against configured users before touching live Plex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.79] - 2026-07-28
+
+### Fixed
+
+- **The optional positional `username` CLI argument (e.g. `python3 recommenders/movie.py alice`) accepted any string with zero validation and could mint real collections/labels on live Plex for a user that was never configured.** `utils/cli.py`'s `run_recommender_main()` took `args.username` straight from argparse and used it verbatim as the sole entry in `all_users` - nothing checked it against the configured user list (or a real Plex account) before it reached `recommenders/base.py`'s collection (`Recommended_<user>`) and label (`PrivateCollection_<user>`) creation. Reproduced: `python3 recommenders/movie.py alice` for a username absent from every configured location (`users.list`/`plex_users.users`/`plex.managed_users`) created a real "Alice - Recommendation" collection, applied `Recommended_alice` labels to real library items, and wrote per-user cache/log files - for a user that doesn't exist.
+
+  `run_recommender_main()` now validates that positional argument (case-insensitively) against the actually-configured user list before it can reach any of that, and exits with a clear error naming the valid usernames if it isn't one of them. `Admin`/`Administrator` remain always accepted regardless of the configured list, unchanged - `resolve_admin_username()` already resolves either to the real Plex account username downstream, independent of what's in config.
+
+  Deliberately a hard failure with no override flag. A `--force`-style escape hatch would be exactly what the next throwaway/manual-test invocation reaches for, reproducing this same live-Plex-mutation-for-a-typo'd-username bug; testing against a genuinely new user is one `config.yml` edit away.
+
+  New coverage in `tests/test_cli.py::TestRunRecommenderMain`: `test_single_user_mode_rejects_unconfigured_username` (exits 1, creates nothing, error names the configured users), `test_single_user_mode_unconfigured_username_creates_nothing` (same, with zero users configured at all), `test_single_user_mode_accepts_configured_username_case_insensitively`, and `test_single_user_mode_accepts_admin_keyword_even_if_unconfigured`.
+
 ## [2.10.78] - 2026-07-28
 
 ### Fixed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -481,6 +481,164 @@ class TestRunRecommenderMain:
 
         assert mock_process.call_count == 1
 
+    @patch("utils.cli.log_error")
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_single_user_mode_rejects_unconfigured_username(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        mock_error,
+    ):
+        """A username not in the configured user list must be rejected
+        before it can reach collection/label creation on live Plex - see
+        utils/cli.py's own comment on this check for the incident this
+        covers (`python3 recommenders/movie.py alice` for a nonexistent
+        user creating real collections/labels)."""
+        mock_parse_args.return_value = Mock(username="alice", debug=False, library_id=None)
+        mock_root.return_value = "/fake/root"
+        mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "bob, charlie"}}
+        mock_migrate.return_value = {}
+
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_recommender_main("Movie", "Test", mock_process)
+
+        assert exc_info.value.code == 1
+        mock_process.assert_not_called()
+        error_message = mock_error.call_args[0][0]
+        assert "alice" in error_message
+        assert "bob" in error_message
+        assert "charlie" in error_message
+
+    @patch("utils.cli.log_error")
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_single_user_mode_accepts_configured_username_case_insensitively(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        mock_error,
+    ):
+        """A configured username still works unchanged, including when
+        the casing typed on the command line doesn't match config.yml's
+        casing exactly."""
+        mock_parse_args.return_value = Mock(username="BOB", debug=False, library_id=None)
+        mock_root.return_value = "/fake/root"
+        mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "bob, charlie"}}
+        mock_migrate.return_value = {}
+
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main("Movie", "Test", mock_process)
+
+        assert mock_process.call_count == 1
+        mock_error.assert_not_called()
+
+    @patch("utils.cli.log_error")
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_single_user_mode_accepts_admin_keyword_even_if_unconfigured(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        mock_error,
+    ):
+        """'Admin'/'Administrator' are always accepted regardless of the
+        configured user list - resolve_admin_username() resolves either
+        to the real Plex account username downstream."""
+        mock_parse_args.return_value = Mock(username="Admin", debug=False, library_id=None)
+        mock_root.return_value = "/fake/root"
+        mock_yaml.return_value = {"plex": {"token": "abc"}, "users": {"list": "bob, charlie"}}
+        mock_migrate.return_value = {}
+
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+        mock_resolve.side_effect = lambda u, t: u
+
+        run_recommender_main("Movie", "Test", mock_process)
+
+        assert mock_process.call_count == 1
+        mock_error.assert_not_called()
+
+    @patch("utils.cli.log_error")
+    @patch("utils.cli.migrate_renamed_plex_users")
+    @patch("utils.cli.print_runtime")
+    @patch("utils.cli.resolve_admin_username")
+    @patch("utils.cli.setup_logging")
+    @patch("utils.cli.yaml.safe_load")
+    @patch("builtins.open", create=True)
+    @patch("utils.cli.get_project_root")
+    @patch("utils.cli.argparse.ArgumentParser.parse_args")
+    def test_single_user_mode_unconfigured_username_creates_nothing(
+        self,
+        mock_parse_args,
+        mock_root,
+        mock_open,
+        mock_yaml,
+        mock_setup_log,
+        mock_resolve,
+        mock_print,
+        mock_migrate,
+        mock_error,
+    ):
+        """No users configured at all (not even the requested one) still
+        rejects a --username value cleanly instead of falling through to
+        a single-element all_users list built straight from the raw arg."""
+        mock_parse_args.return_value = Mock(username="alice", debug=False, library_id=None)
+        mock_root.return_value = "/fake/root"
+        mock_yaml.return_value = {"plex": {"token": "abc"}}  # No users configured at all
+        mock_migrate.return_value = {}
+
+        mock_process = Mock()
+        mock_setup_log.return_value = Mock()
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_recommender_main("Movie", "Test", mock_process)
+
+        assert exc_info.value.code == 1
+        mock_process.assert_not_called()
+
     @patch("utils.cli.migrate_renamed_plex_users")
     @patch("utils.cli.print_runtime")
     @patch("utils.cli.resolve_admin_username")

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -358,14 +358,38 @@ def run_recommender_main(
         # for why this (not run.sh/run.ps1) is what binary users see.
         print_update_notice(get_update_mode(root_config))
 
-        # Handle single user mode
-        single_user = args.username
-        if single_user:
-            log_warning(f"Single user mode: {single_user}")
-
         # Get users to process
         all_users = get_users_from_config(root_config)
+
+        # Handle single user mode. Validated against the configured user
+        # list (case-insensitively) before it can reach anything that
+        # touches live Plex - a real incident: `python3 recommenders/
+        # movie.py alice` for a username that was never configured
+        # anywhere still created a real "Alice - Recommendation"
+        # collection, applied Recommended_alice labels to real library
+        # items, and wrote per-user cache/log files, all for a user that
+        # does not exist. "Admin"/"Administrator" are always accepted
+        # here (unchanged) since resolve_admin_username() below resolves
+        # either to the real Plex account username regardless of what's
+        # in the configured user list.
+        #
+        # Hard failure, no override flag: a deliberate escape hatch here
+        # is exactly what the next throwaway/manual-test invocation would
+        # reach for, reproducing the same live-Plex-mutation-for-a-typo'd
+        # username this exists to prevent. Genuinely testing against a
+        # new user is one config.yml edit away.
+        single_user = args.username
         if single_user:
+            valid_usernames = {u.lower() for u in all_users} | {"admin", "administrator"}
+            if single_user.lower() not in valid_usernames:
+                configured_list = ", ".join(all_users) if all_users else "(none configured)"
+                log_error(
+                    f"Unknown user '{single_user}' - not in the configured user list. "
+                    f"Configured users: {configured_list}. Add this user to config.yml "
+                    "(users.list / plex_users.users / plex.managed_users) before running against it."
+                )
+                sys.exit(1)
+            log_warning(f"Single user mode: {single_user}")
             all_users = [single_user]
 
         if not all_users:

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.78"
+__version__ = "2.10.79"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary
- utils/cli.py's run_recommender_main() took the optional positional username argument straight from argparse with zero validation and used it verbatim as the sole entry in all_users, with no check against the configured user list or a real Plex account before it reached recommenders/base.py's collection (Recommended_<user>) and label (PrivateCollection_<user>) creation.
- Reproduced: python3 recommenders/movie.py alice for a username absent from every configured location (users.list/plex_users.users/plex.managed_users) created a real collection, applied labels to real library items, and wrote per-user cache/log files - for a user that does not exist.
- Fixed by validating the username (case-insensitively) against the configured user list before it can reach anything downstream, exiting with a clear error naming the valid usernames if it isn't one of them. Admin/Administrator remain always accepted regardless of the configured list (resolve_admin_username() already resolves either to the real account downstream).
- Deliberately a hard failure, no override/force flag: an escape hatch here is exactly what the next throwaway/manual-test invocation would reach for, reproducing the same bug. Testing against a genuinely new user is one config.yml edit away.

## Test plan
- [x] test_single_user_mode_rejects_unconfigured_username - exits 1, creates nothing, error names configured users
- [x] test_single_user_mode_unconfigured_username_creates_nothing - same with zero users configured at all
- [x] test_single_user_mode_accepts_configured_username_case_insensitively - unchanged behavior for real users
- [x] test_single_user_mode_accepts_admin_keyword_even_if_unconfigured - Admin/Administrator special-case preserved
- [x] Full suite (2938 passed, 1 skipped), ruff check, mypy all green