### PR TITLE
fix: close two test-isolation gaps (logs/cache leak, socket guard false guarantee)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.80] - 2026-07-28
+
+### Fixed
+
+- **Two test-isolation gaps in `tests/conftest.py`'s suite-wide safety nets, found while investigating how test-fixture usernames (`alice`/`bob`) leaked into a real Plex library.**
+
+  **Real repo `logs/` writes during a normal pytest run.** `_isolated_recommender_cache_dir` patched `recommenders.base.get_project_root` and `recommenders.external.get_project_root` but not `recommenders.movie.get_project_root`/`recommenders.tv.get_project_root` - a separate name binding each of those two modules holds from their own `from utils import get_project_root`, used by `process_recommendations()`'s `log_dir = os.path.join(get_project_root(), "logs")` (feeding `setup_log_file()`/`teardown_log_file()`/`record_run_status()`). `tests/test_movie.py`'s and `tests/test_tv.py`'s `TestProcessRecommendationsLibraryParam` classes mocked `setup_log_file`/`teardown_log_file`/the recommender class but not `record_run_status`, so a plain test run wrote real `logs/run_status_movie_alice.json` / `run_status_tv_alice.json` into the owner's own repo - confirmed reproduced and cleaned up. Fixed by extending `_isolated_recommender_cache_dir` to also patch `recommenders.movie`/`recommenders.tv`'s `get_project_root`, and by additionally patching `record_run_status` directly in both test classes (same belt-and-suspenders convention already used for `setup_log_file`/`teardown_log_file` there).
+
+  Added a new session-scoped, autouse `_fail_if_real_logs_or_cache_written` guard: snapshots the real repo's `logs/` and `cache/` directories (path -> mtime) once at session start and once at session end, and fails the whole run with every changed path named if either directory was touched - this class of leak was previously only ever noticed by someone spotting an unexpected file in `git status`/`ls -la` afterward. Verified it actually fires (a throwaway test that wrote directly into the real `logs/` dir was correctly caught and failed the session, confirmed before removing that throwaway test).
+
+  **The socket guard's own loopback allowance was a false guarantee.** `_block_non_loopback_sockets` (added to stop tests from making real outbound network calls) allowed any `127.0.0.1`/`::1`/`localhost` connection through unconditionally. Plex's own `plex.direct` hostnames - standard, expected Plex behavior, not exotic - resolve straight to a loopback IP (confirmed directly against this project's own `config/config.yml`, which has a real `https://127-0-0-1.<hash>.plex.direct:32400` URL); by the time a real HTTP client's `socket.connect()` fires, that hostname is already resolved to plain `127.0.0.1`, indistinguishable from this suite's own local test-server binds. A test that ended up using a real config would sail straight through the loopback check and connect to a real, live Plex Media Server running on the same machine - no current test does this, but the guard's docstring claimed a guarantee it didn't actually provide.
+
+  Fixed by additionally blocking loopback connections to Plex's well-known default port (32400) specifically, regardless of host - nothing in this suite's legitimate loopback socket use (`test_web_routes.py`'s `TestWaitForListening`/`TestBindRetry`, which always bind an OS-assigned ephemeral port) ever targets that port. Chose this over blocking by original hostname (not reliably visible at the `.connect()` layer at all - `requests`/`urllib3`/`socket.create_connection()` all resolve via `getaddrinfo()` before `.connect()` ever fires) or requiring an explicit per-test opt-in marker (a much bigger, more invasive change to every existing legitimate local-bind test for a gap with no currently-affected test).
+
+  New coverage in `tests/test_conftest_guards.py`: `test_blocks_genuine_external_host` (unchanged original behavior), `test_allows_loopback_on_an_ordinary_port` (the legitimate local-test-server case still works), and `test_blocks_loopback_resolving_plex_direct_style_address` (proves the guard now blocks the exact plex.direct-resolves-to-loopback case this closes).
+
 ## [2.10.79] - 2026-07-28
 
 ### Fixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,28 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-def _is_loopback_address(address) -> bool:
-    """True if a socket.connect() address targets only this machine.
+# Plex Media Server's well-known default port. plex.direct hostnames -
+# the ones Plex itself issues for every real server, e.g. this project's
+# own config/config.yml has "https://127-0-0-1.<hash>.plex.direct:32400"
+# - are standard, expected Plex behavior (not exotic), and they resolve
+# straight to a loopback IP (the dash-encoded address in the hostname
+# itself). By the time a real HTTP client (requests/urllib3/plexapi)
+# calls socket.connect(), that hostname has already been resolved via
+# getaddrinfo() to a plain IP, so a plex.direct name that resolves to
+# 127.0.0.1 arrives here indistinguishable from this suite's own local
+# test-server binds - a loopback-only check alone would silently ALLOW a
+# test with a real config accidentally connecting to a real, live PMS
+# instance running on this same machine, defeating the whole point of
+# this guard. Blocking this port specifically (regardless of how the
+# host got resolved) is what actually closes that gap: nothing in this
+# suite's own legitimate loopback socket use (test_web_routes.py's
+# TestWaitForListening/TestBindRetry, which always bind to an
+# OS-assigned ephemeral port via ("127.0.0.1", 0)) ever targets it.
+_PLEX_DEFAULT_PORT = 32400
+
+
+def _is_allowed_test_socket_address(address) -> bool:
+    """True if a socket.connect() address is safe to allow during a test run.
 
     address is whatever was passed to socket.socket.connect() - for
     AF_INET it's (host, port), for AF_INET6 it's (host, port, flowinfo,
@@ -21,6 +41,9 @@ def _is_loopback_address(address) -> bool:
     reaches .connect(), the host is normally already a resolved IP
     (requests/urllib3 resolve via getaddrinfo first), but 'localhost' is
     allowed too for anything that connects before resolving.
+
+    Loopback alone is NOT sufficient - see _PLEX_DEFAULT_PORT above for
+    why a loopback address on Plex's default port is also blocked.
     """
     if not isinstance(address, tuple) or not address:
         return True
@@ -28,7 +51,13 @@ def _is_loopback_address(address) -> bool:
     if isinstance(host, bytes):
         host = host.decode("ascii", "ignore")
     host = str(host)
-    return host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
+    is_loopback_host = host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
+    if not is_loopback_host:
+        return False
+    port = address[1] if len(address) > 1 else None
+    if port == _PLEX_DEFAULT_PORT:
+        return False
+    return True
 
 
 @pytest.fixture(autouse=True)
@@ -52,24 +81,30 @@ def _block_non_loopback_sockets(monkeypatch):
     therefore urllib3/requests - eventually goes through) to allow
     127.0.0.1/::1/localhost (loopback - e.g. tests/test_web_routes.py's
     TestWaitForListening/TestBindRetry classes, which bind a real local
-    server socket and poll it) and raise immediately, with the offending
-    host in the message, for anything else. A loud, instant,
-    self-diagnosing failure instead of a silent leak or a multi-minute
-    hang - any test that legitimately needs to reach a real non-loopback
-    host must mock the call instead (mirroring the rest of this suite's
-    existing convention of mocking requests.get/MyPlexAccount/etc. rather
-    than hitting the network for real).
+    server socket and poll it) EXCEPT on Plex's own default port (see
+    _PLEX_DEFAULT_PORT/_is_allowed_test_socket_address above - a
+    loopback-only check would have been a false guarantee: plex.direct
+    hostnames are standard Plex behavior that resolve straight to
+    loopback, so a test running against a real config would sail
+    straight through a check that only looked at the host), and raise
+    immediately, with the offending address in the message, for
+    anything else. A loud, instant, self-diagnosing failure instead of a
+    silent leak or a multi-minute hang - any test that legitimately
+    needs to reach a real non-loopback host (or the real Plex port) must
+    mock the call instead (mirroring the rest of this suite's existing
+    convention of mocking requests.get/MyPlexAccount/etc. rather than
+    hitting the network for real).
     """
     real_connect = _socket_module.socket.connect
 
     def _guarded_connect(self, address, *args, **kwargs):
-        if not _is_loopback_address(address):
+        if not _is_allowed_test_socket_address(address):
             raise AssertionError(
                 f"Blocked outbound network connect attempt to {address!r} during "
                 "test run - tests must mock all real network calls (Plex, TMDB, "
                 "GitHub, etc.) rather than reach the network. If this is a "
                 "legitimate local-server test, it must connect to "
-                "127.0.0.1/::1/localhost only."
+                "127.0.0.1/::1/localhost on a non-Plex port only."
             )
         return real_connect(self, address, *args, **kwargs)
 
@@ -205,6 +240,26 @@ def _isolated_recommender_cache_dir(tmp_path_factory, monkeypatch):
     tests/test_base.py already mocks this itself in every test that
     needs to (its own @patch layers on top of this, same convention as
     every other fixture here).
+
+    ALSO patches recommenders.movie.get_project_root and
+    recommenders.tv.get_project_root - a second, separate name binding
+    from recommenders.base.get_project_root above (movie.py/tv.py each
+    hold their own `from utils import get_project_root`), used by
+    process_recommendations()'s own log_dir = os.path.join(
+    get_project_root(), "logs") (feeding both setup_log_file()/
+    teardown_log_file() and record_run_status()). Left unpatched, any
+    test that calls process_recommendations() without ALSO separately
+    mocking those two - or the setup_log_file/teardown_log_file/
+    record_run_status calls it makes - resolves log_dir to the REAL
+    repo's logs/ directory and writes a real run_status_movie_<user>.json
+    / run_status_tv_<user>.json into it. Confirmed: tests/test_movie.py's
+    and tests/test_tv.py's TestProcessRecommendationsLibraryParam classes
+    did exactly this (mocked setup_log_file/teardown_log_file/the
+    recommender class, but not record_run_status) before this fixture
+    covered these two modules - the same class of leak
+    _isolated_metrics_dir/_isolated_update_dismissal_dir/
+    _no_real_update_check_network above each exist to close for their
+    own module.
     """
     fallback_root = str(tmp_path_factory.mktemp("recommender_cache"))
 
@@ -217,6 +272,8 @@ def _isolated_recommender_cache_dir(tmp_path_factory, monkeypatch):
 
     monkeypatch.setattr("recommenders.base.get_project_root", _fake_get_project_root)
     monkeypatch.setattr("recommenders.external.get_project_root", _fake_get_project_root)
+    monkeypatch.setattr("recommenders.movie.get_project_root", _fake_get_project_root)
+    monkeypatch.setattr("recommenders.tv.get_project_root", _fake_get_project_root)
     monkeypatch.setattr("recommenders.base.migrate_legacy_cache_dir", lambda legacy_dir, new_dir: None)
 
 
@@ -311,3 +368,75 @@ def curatarr_web_root(tmp_path):
     (root / "run.sh").write_text(_FAKE_RUN_SH, encoding="utf-8")
     (root / "run.ps1").write_text(_FAKE_RUN_PS1, encoding="utf-8")
     return str(root)
+
+
+def _snapshot_dir_mtimes(directory: str) -> dict:
+    """path -> mtime for every file under *directory* (empty dict if it
+    doesn't exist). Helper for _fail_if_real_logs_or_cache_written below."""
+    if not os.path.isdir(directory):
+        return {}
+    snapshot = {}
+    for root, _dirs, files in os.walk(directory):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                snapshot[path] = os.path.getmtime(path)
+            except OSError:
+                # Deleted between os.walk() yielding it and getmtime() -
+                # nothing to snapshot, and not a leak this guard cares about.
+                continue
+    return snapshot
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _fail_if_real_logs_or_cache_written():
+    """Hard gate: this project has a repeat history of test-isolation
+    leaks writing real files into the checked-out repo's own logs/ and
+    cache/ directories (see _isolated_recommender_cache_dir's docstring
+    above for the fullest account, and utils/metrics.py's/utils/
+    update_dismissal.py's own equivalents) - every prior instance was
+    only ever noticed by someone spotting an unexpected file in `git
+    status`/`ls -la` afterward, not by the suite itself. This snapshots
+    the real repo's logs/ and cache/ directories (by path -> mtime) once
+    at session start and once at session end; if anything was created,
+    deleted, or modified in either, the session fails loudly naming
+    every changed path, rather than staying green while quietly
+    corrupting the owner's real generated data.
+
+    Deliberately session-scoped (one check for the whole run, not
+    per-test) - walking both directories after each of ~2900 tests would
+    be wasteful, and the fixtures this guards against are themselves
+    autouse-for-the-whole-suite, so there's no per-test granularity to
+    preserve here anyway.
+    """
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    logs_dir = os.path.join(repo_root, "logs")
+    cache_dir = os.path.join(repo_root, "cache")
+
+    before_logs = _snapshot_dir_mtimes(logs_dir)
+    before_cache = _snapshot_dir_mtimes(cache_dir)
+
+    yield
+
+    after_logs = _snapshot_dir_mtimes(logs_dir)
+    after_cache = _snapshot_dir_mtimes(cache_dir)
+
+    changed = []
+    for label, before, after in (("logs", before_logs, after_logs), ("cache", before_cache, after_cache)):
+        for path in sorted(set(after) - set(before)):
+            changed.append(f"created ({label}): {path}")
+        for path in sorted(set(before) - set(after)):
+            changed.append(f"deleted ({label}): {path}")
+        for path in sorted(set(after) & set(before)):
+            if after[path] != before[path]:
+                changed.append(f"modified ({label}): {path}")
+
+    if changed:
+        raise AssertionError(
+            "Test suite wrote to the real repo's logs/ and/or cache/ directory "
+            "- every test must isolate these via tmp_path/tmp_path_factory (see "
+            "_isolated_recommender_cache_dir, _isolated_metrics_dir, and "
+            "_isolated_update_dismissal_dir above) rather than letting a "
+            "module's real get_project_root() resolve during a test run. "
+            "Changed paths:\n  " + "\n  ".join(changed)
+        )

--- a/tests/test_conftest_guards.py
+++ b/tests/test_conftest_guards.py
@@ -1,0 +1,65 @@
+"""Direct tests for tests/conftest.py's own suite-wide safety-net
+fixtures - specifically _block_non_loopback_sockets/
+_is_allowed_test_socket_address, which every other test file relies on
+implicitly (autouse) but nothing exercised directly until now."""
+
+import socket
+
+import pytest
+
+
+class TestBlockNonLoopbackSockets:
+    """Tests for the autouse _block_non_loopback_sockets fixture (see
+    tests/conftest.py for the full rationale)."""
+
+    def test_blocks_genuine_external_host(self):
+        """A real, unambiguous non-loopback host must still be blocked -
+        this is the guard's original, always-worked case."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(AssertionError, match="Blocked outbound"):
+                sock.connect(("93.184.216.34", 443))
+        finally:
+            sock.close()
+
+    def test_allows_loopback_on_an_ordinary_port(self):
+        """This suite's own local test-server binds (test_web_routes.py's
+        TestWaitForListening/TestBindRetry) connect to 127.0.0.1 on an
+        OS-assigned ephemeral port - never Plex's default port - and
+        must keep working unchanged."""
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            client.settimeout(2)
+            client.connect(("127.0.0.1", port))  # must not raise
+        finally:
+            client.close()
+            server.close()
+
+    def test_blocks_loopback_resolving_plex_direct_style_address(self):
+        """The real bug this closes: plex.direct hostnames (Plex's own
+        DNS names for every real server - e.g. this project's own
+        config/config.yml has a real 'https://127-0-0-1.<hash>.
+        plex.direct:32400' URL) resolve straight to a loopback IP, which
+        is standard, expected Plex behavior, not something exotic. A
+        loopback-only check would silently ALLOW a test that ends up
+        using a real config to connect straight through to a real, live
+        Plex Media Server instance on this same machine - defeating the
+        whole point of this guard. By the time a real HTTP client's
+        socket.connect() fires, the hostname is already resolved to
+        plain 127.0.0.1 (that's simulated directly here, rather than
+        performing a real DNS lookup of a fake plex.direct name, which
+        wouldn't resolve and would make this test network-dependent for
+        no benefit - the address shape below is exactly what a real
+        resolved connect() call receives either way). This must now be
+        blocked specifically because of the Plex-default port, even
+        though the host alone is loopback."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(AssertionError, match="32400"):
+                sock.connect(("127.0.0.1", 32400))
+        finally:
+            sock.close()

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -525,12 +525,23 @@ class TestFormatMovieOutput:
 class TestProcessRecommendationsLibraryParam:
     """Tests for process_recommendations library forwarding (#157 Phase 3)."""
 
+    @patch("recommenders.movie.record_run_status")
     @patch("recommenders.movie.PlexMovieRecommender")
     @patch("recommenders.movie.teardown_log_file")
     @patch("recommenders.movie.setup_log_file")
-    def test_forwards_library_to_recommender(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+    def test_forwards_library_to_recommender(
+        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
+    ):
         """process_recommendations passes library through to
-        PlexMovieRecommender's constructor unchanged."""
+        PlexMovieRecommender's constructor unchanged.
+
+        record_run_status is mocked here for the same reason
+        setup_log_file/teardown_log_file already are - this test only
+        cares about library forwarding, and conftest.py's
+        _isolated_recommender_cache_dir already isolates
+        recommenders.movie.get_project_root (log_dir) from the real repo
+        as a suite-wide safety net; this adds an explicit, test-local
+        guarantee independent of that fixture."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
         mock_instance.config = {"general": {}}
@@ -543,10 +554,13 @@ class TestProcessRecommendationsLibraryParam:
             "/path/to/config.yml", single_user="alice", library=library, library_items_cache=None
         )
 
+    @patch("recommenders.movie.record_run_status")
     @patch("recommenders.movie.PlexMovieRecommender")
     @patch("recommenders.movie.teardown_log_file")
     @patch("recommenders.movie.setup_log_file")
-    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+    def test_defaults_library_to_none(
+        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
+    ):
         """process_recommendations defaults library=None (legacy callers)."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -558,9 +558,7 @@ class TestProcessRecommendationsLibraryParam:
     @patch("recommenders.movie.PlexMovieRecommender")
     @patch("recommenders.movie.teardown_log_file")
     @patch("recommenders.movie.setup_log_file")
-    def test_defaults_library_to_none(
-        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
-    ):
+    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status):
         """process_recommendations defaults library=None (legacy callers)."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1267,9 +1267,7 @@ class TestProcessRecommendationsLibraryParam:
     @patch("recommenders.tv.PlexTVRecommender")
     @patch("recommenders.tv.teardown_log_file")
     @patch("recommenders.tv.setup_log_file")
-    def test_defaults_library_to_none(
-        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
-    ):
+    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status):
         """process_recommendations defaults library=None (legacy callers)."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1234,12 +1234,23 @@ class TestExtractGenresFromShow:
 class TestProcessRecommendationsLibraryParam:
     """Tests for process_recommendations library forwarding (#157 Phase 3)."""
 
+    @patch("recommenders.tv.record_run_status")
     @patch("recommenders.tv.PlexTVRecommender")
     @patch("recommenders.tv.teardown_log_file")
     @patch("recommenders.tv.setup_log_file")
-    def test_forwards_library_to_recommender(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+    def test_forwards_library_to_recommender(
+        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
+    ):
         """process_recommendations passes library through to
-        PlexTVRecommender's constructor unchanged."""
+        PlexTVRecommender's constructor unchanged.
+
+        record_run_status is mocked here for the same reason
+        setup_log_file/teardown_log_file already are - this test only
+        cares about library forwarding, and conftest.py's
+        _isolated_recommender_cache_dir already isolates
+        recommenders.tv.get_project_root (log_dir) from the real repo as
+        a suite-wide safety net; this adds an explicit, test-local
+        guarantee independent of that fixture."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}
         mock_instance.config = {"general": {}}
@@ -1252,10 +1263,13 @@ class TestProcessRecommendationsLibraryParam:
             "/path/to/config.yml", "alice", library=library, library_items_cache=None
         )
 
+    @patch("recommenders.tv.record_run_status")
     @patch("recommenders.tv.PlexTVRecommender")
     @patch("recommenders.tv.teardown_log_file")
     @patch("recommenders.tv.setup_log_file")
-    def test_defaults_library_to_none(self, mock_setup_log, mock_teardown, mock_recommender_cls):
+    def test_defaults_library_to_none(
+        self, mock_setup_log, mock_teardown, mock_recommender_cls, mock_record_status
+    ):
         """process_recommendations defaults library=None (legacy callers)."""
         mock_instance = Mock()
         mock_instance.get_recommendations.return_value = {"plex_recommendations": []}

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.79"
+__version__ = "2.10.80"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary
- tests/conftest.py's _isolated_recommender_cache_dir patched recommenders.base/recommenders.external's get_project_root but not recommenders.movie/recommenders.tv's own separate binding of the same name - process_recommendations()'s log_dir resolution (feeding record_run_status) fell through to the REAL repo. Confirmed reproduced: a plain pytest run wrote real logs/run_status_movie_alice.json / run_status_tv_alice.json into the repo (cleaned up as part of this PR). Fixed by extending that fixture to cover both modules, patching record_run_status directly in the two affected test classes too, and adding a new session-scoped autouse guard that fails the suite if the real logs/ or cache/ directory is touched at all.
- The socket guard's loopback allowance (_block_non_loopback_sockets) was a false guarantee: Plex's own plex.direct hostnames are standard Plex behavior that resolve straight to loopback (confirmed against this project's own config/config.yml, which has a real plex.direct URL) - a test using a real config would sail straight through the loopback check to a real, live PMS instance. Fixed by also blocking loopback connections to Plex's default port (32400) specifically, since nothing in this suite's legitimate loopback socket use ever targets that port. Chose this over blocking by hostname (not reliably visible at the .connect() layer - resolution already happened) or an opt-in marker (much more invasive for a gap with no currently-affected test).

## Test plan
- [x] tests/test_movie.py::TestProcessRecommendationsLibraryParam / tests/test_tv.py's equivalent now also patch record_run_status
- [x] New _fail_if_real_logs_or_cache_written session guard - verified it actually fires (throwaway leak test caught and failed the session, removed after confirming)
- [x] tests/test_conftest_guards.py: test_blocks_genuine_external_host, test_allows_loopback_on_an_ordinary_port, test_blocks_loopback_resolving_plex_direct_style_address
- [x] Full suite (2941 passed, 1 skipped), ruff check, mypy all green
- [x] No stray files left in logs/ or cache/ after this PR's own test runs