### PR TITLE
Remove dead per-user watchlist HTML preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.81] - 2026-07-28
+
+### Removed
+
+- **Dead per-user watchlist HTML preference in `web/status.py`'s `find_user_watchlist()`, and six stale, seven-month-old files it was checking for.** The dashboard's per-user "watchlist" link resolved a per-user `<display_name>_watchlist.html` file first, falling back to the combined, all-users `watchlist.html` only if that per-user file didn't exist. `recommenders/external_render.py` has never written that per-user HTML file anywhere in this repo's tracked history (only the per-user markdown via `generate_markdown()` and the combined HTML via `generate_combined_html()`) - the only files ever matching that pattern on disk (`recommendations/external/{user}_watchlist.html`) were dated January 2026, predating this repo's tracked history (a filter-repo truncation), and were never regenerated since. Every install was therefore already silently falling through to the combined-file branch - removing the per-user preference changes nothing anyone sees. Deleted the six stale files (`eric_`, `home_`, `jason_`, `lynn_`, `nadia_`, `natasha_watchlist.html`); the per-user `.md` files and the live, daily-regenerating combined `watchlist.html` are untouched.
+
 ## [2.10.80] - 2026-07-28
 
 ### Fixed

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -137,14 +137,33 @@ class TestDashboard:
         resp = c.get("/")
         assert b"success" in resp.data
 
-    def test_links_to_per_user_watchlist_when_generated(self, client):
+    def test_dashboard_link_ignores_stray_per_user_watchlist_file(self, client):
+        """find_user_watchlist()'s per-user "<slug>_watchlist.html"
+        preference was removed - recommenders/external_render.py has
+        never written that file in this repo's tracked history, only
+        stragglers predating it ever existed on disk (since deleted).
+        A stray file matching that naming must not be linked to, even
+        when it's the only file present.
+        """
         c, app, root = client
         ext_dir = os.path.join(root, "recommendations", "external")
         with open(os.path.join(ext_dir, "alice_a_watchlist.html"), "w") as f:
             f.write("<html>alice list</html>")
         resp = c.get("/")
         assert resp.status_code == 200
-        assert b"alice_a_watchlist.html" in resp.data
+        assert b"alice_a_watchlist.html" not in resp.data
+
+    def test_dashboard_links_to_combined_watchlist_regardless_of_stray_per_user_file(self, client):
+        c, app, root = client
+        ext_dir = os.path.join(root, "recommendations", "external")
+        with open(os.path.join(ext_dir, "alice_a_watchlist.html"), "w") as f:
+            f.write("<html>alice list</html>")
+        with open(os.path.join(ext_dir, "watchlist.html"), "w") as f:
+            f.write("<html>combined</html>")
+        resp = c.get("/")
+        assert resp.status_code == 200
+        assert b"watchlist.html" in resp.data
+        assert b"alice_a_watchlist.html" not in resp.data
 
     def test_dashboard_watchlist_link_absent_when_nothing_generated(self, client):
         c, app, root = client

--- a/tests/test_web_status.py
+++ b/tests/test_web_status.py
@@ -13,7 +13,6 @@ from utils.run_status import record_run_status
 from web.status import (
     LOG_VIEW_MAX_BYTES,
     TAIL_BYTES,
-    display_name_safe_slug,
     find_user_watchlist,
     get_last_run_status,
     list_log_files,
@@ -385,33 +384,30 @@ class TestReadLogFull:
         assert truncated is False
 
 
-class TestDisplayNameSafeSlug:
-    """Tests for display_name_safe_slug()"""
-
-    def test_uses_display_name_when_configured(self):
-        config = {"users": {"preferences": {"alice": {"display_name": "Alice A"}}}}
-        assert display_name_safe_slug(config, "alice") == "alice_a"
-
-    def test_falls_back_to_username_when_no_display_name(self):
-        config = {"users": {"preferences": {}}}
-        assert display_name_safe_slug(config, "bob") == "bob"
-
-    def test_handles_none_config(self):
-        assert display_name_safe_slug(None, "bob") == "bob"
-
-
 class TestFindUserWatchlist:
     """Tests for find_user_watchlist()"""
 
-    def test_prefers_per_user_file(self, tmp_path):
+    def test_ignores_stray_per_user_html_file(self, tmp_path):
+        """The per-user "<slug>_watchlist.html" preference was removed
+        (recommenders/external_render.py has never written that file in
+        this repo's tracked history - only six-month-old stragglers
+        predating it ever existed on disk, since deleted). Even if one
+        is somehow present, this must still resolve to the combined
+        file, not the per-user one.
+        """
         config = {"users": {"preferences": {"alice": {"display_name": "Alice A"}}}}
         (tmp_path / "alice_a_watchlist.html").write_text("<html></html>")
         (tmp_path / "watchlist.html").write_text("<html></html>")
         result = find_user_watchlist(str(tmp_path), config, "alice")
-        assert result == "alice_a_watchlist.html"
+        assert result == "watchlist.html"
 
-    def test_falls_back_to_combined_file(self, tmp_path):
+    def test_falls_back_to_combined_file_with_user_markdown_present(self, tmp_path):
+        """The realistic case: this user's own per-user markdown
+        (which does regenerate every run - generate_markdown()) exists
+        alongside the combined HTML. Resolves to the combined file.
+        """
         config = {"users": {"preferences": {"alice": {"display_name": "Alice A"}}}}
+        (tmp_path / "alice_a_watchlist.md").write_text("# Alice A")
         (tmp_path / "watchlist.html").write_text("<html></html>")
         result = find_user_watchlist(str(tmp_path), config, "alice")
         assert result == "watchlist.html"

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.80"
+__version__ = "2.10.81"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/web/status.py
+++ b/web/status.py
@@ -231,29 +231,27 @@ def list_log_files(logs_dir: str) -> List[Dict]:
     return entries
 
 
-def display_name_safe_slug(config: Dict, username: str) -> str:
-    """Mirror recommenders/external_render.py's filename derivation:
-    display_name (falling back to the username itself), lowercased,
-    spaces replaced with underscores.
-    """
-    prefs = (config or {}).get("users", {}).get("preferences", {}) or {}
-    display_name = (prefs.get(username) or {}).get("display_name", username)
-    return str(display_name).lower().replace(" ", "_")
-
-
 def find_user_watchlist(external_dir: str, config: Dict, username: str) -> Optional[str]:
     """Return the basename of this user's generated watchlist, if any.
 
-    Prefers the per-user "<display_name>_watchlist.html" file that
-    recommenders/external_render.py writes; falls back to the combined
-    (all-users, tabbed) "watchlist.html" if that's all that exists yet.
-    Returns None if neither has been generated.
-    """
-    slug = display_name_safe_slug(config, username)
-    per_user = f"{slug}_watchlist.html"
-    if os.path.isfile(os.path.join(external_dir, per_user)):
-        return per_user
+    Returns the combined (all-users, tabbed) "watchlist.html" if it's
+    been generated, else None.
 
+    Used to prefer a per-user "<display_name>_watchlist.html"
+    file first. recommenders/external_render.py has never written that
+    file in this repo's tracked history (only the per-user markdown and
+    the combined HTML - see generate_markdown()/generate_combined_html()
+    there); the only files matching that pattern on disk were six-month-old
+    stragglers from before this repo's history was truncated (a
+    filter-repo at root commit dbd2054), never regenerated, and are now
+    deleted. Every caller (web/app.py's dashboard()) was therefore
+    already silently falling through to this same combined-file return
+    on every real install - removing the dead branch changes nothing
+    users see. config/username are still accepted (rather than
+    narrowing this function's signature) so this stays a drop-in
+    replacement for that one caller; neither is used internally
+    anymore.
+    """
     combined = "watchlist.html"
     if os.path.isfile(os.path.join(external_dir, combined)):
         return combined


### PR DESCRIPTION
## Summary
- find_user_watchlist() preferred a per-user `<display_name>_watchlist.html` file that recommenders/external_render.py has never written anywhere in this repo's tracked history (only per-user markdown and the combined watchlist.html) - the six files matching that pattern on disk were dated January 2026, predating this repo's tracked history (a filter-repo truncation), and were never regenerated since.
- Confirmed the removal is a no-op for users: the only caller (web/app.py's dashboard()) was already silently falling through to the combined-file branch on every real install, since the per-user file never existed.
- Removed the dead per-user branch and the now-unused display_name_safe_slug() helper (its only purpose was deriving that per-user filename).
- Deleted the six stale per-user HTML files from recommendations/external/ (per-user .md files and the live combined watchlist.html are untouched).
- Updated tests to cover the removed branch (a stray per-user file is ignored) and the surviving fallback (resolves to the combined file, with or without a user's own .md present; returns None when nothing exists).

## Test plan
- [x] pytest tests/ (2939 passed, 1 skipped)
- [x] ruff check .
- [x] mypy .