### PR TITLE
Default profile_accuracy.enabled to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.82] - 2026-07-28
+
+### Changed
+
+- **`profile_accuracy.enabled` now defaults to `true` (was `false`). Recommendations WILL change for every non-admin user on the next run.** This flag (added, default-off, by the #273 PR1 fix documented further down this file) gates a defect fix, not a preference: every user's recommendation profile was being built from the SERVER ADMIN's own Plex watch history, ratings, and view counts instead of their own. `utils/cli.py`'s `update_config_for_user` swaps the configured username between runs but never swaps the Plex TOKEN, and `BaseRecommender._get_all_library_items()` caches one library snapshot shared across every user processed in a run - so `viewCount`/`userRating`, both per-account Plex state, could only ever reflect the admin's own account, regardless of whose profile was supposedly being built. Separately, movie rating weighting was dead code entirely: Plex's watch-history API (`/status/sessions/history/all`) never returns `userRating` at all (verified against 2,475 real history entries across 6 real accounts), so every movie fell back to the unrated multiplier and a genuinely disliked movie could never produce a negative signal.
+
+  Per-user recommendations are this product's core function - a user named Nadia should get Nadia's recommendations, not the admin's. Shipping the #273 PR1 fix default-off meant every existing install kept the admin-contaminated behavior until someone found the flag; that's backwards for a defect this fundamental, so the default flips here.
+
+  **What to expect after upgrading:** every configured non-admin user's watched-data profile is rebuilt from their OWN Plex account (via `switchUser`) instead of the shared admin snapshot, and movie ratings are read from the Plex library item instead of the (never-populated) history API. The very next run does a full profile rescore - `compute_profile_hash` changes because the underlying profile data changes - not an incremental one; a deliberate one-time cost, not a bug. Measured on a real 6-user library: per-user top-10 recommendation overlap between the old (admin-contaminated) and new (per-user) output was 8/10, 8/10, 7/10, 6/10, 3/10, and 1/10 - the thinnest watch-history profiles changed the most, exactly as expected since they were the most diluted by admin data under the old behavior.
+
+  **To keep the old (admin-contaminated) output unchanged for a release**, set `profile_accuracy.enabled: false` in `config/tuning.yml`. The flag is not being removed - anyone who has tuned expectations around the current output can opt back out at any time.
+
 ## [2.10.81] - 2026-07-28
 
 ### Removed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -192,25 +192,30 @@ negative_signals:
 # =============================================================================
 # PROFILE ACCURACY (#273)
 # =============================================================================
-# Advanced - off by default. When enabled, movie/tv preference profiles
-# are built from MORE ACCURATE Plex data than the legacy default:
+# On by default since v2.10.82 - this is a defect fix, not a preference.
+# When enabled, movie/tv preference profiles are built from MORE
+# ACCURATE Plex data than the legacy (enabled: false) behavior:
 #   - Movie ratings are read from the Plex LIBRARY item (matches how TV
 #     profiles already work) instead of Plex's watch-history API, which
-#     never actually carries a user's star rating - so today, a movie
-#     you've disliked NEVER produces a negative signal.
+#     never actually carries a user's star rating - so with this off, a
+#     movie you've disliked NEVER produces a negative signal.
 #   - Each configured user's own view count/rating is fetched through
 #     THEIR OWN Plex account (switchUser) instead of always reading the
-#     shared admin account's view - today, every user's rewatch/rating
-#     weighting is silently computed from the ADMIN's own Plex state,
-#     not their own.
-# Off by default because enabling this changes existing users' actual
+#     shared admin account's view - with this off, every user's
+#     rewatch/rating weighting is silently computed from the ADMIN's own
+#     Plex state, not their own.
+# Enabling/upgrading into this default changes existing users' actual
 # recommendations (previously-invisible dislikes can now suppress
-# similar content) and forces a one-time full profile rescore on the
-# next run after you enable it (the profile hash changes) - a
-# deliberate one-time cost, not a bug. See CHANGELOG for the full
-# rationale and the real-library findings that motivated this.
+# similar content, and non-admin users stop getting the admin's own
+# profile) and forces a one-time full profile rescore on the next run
+# after the flag flips (the profile hash changes) - a deliberate
+# one-time cost, not a bug. Set enabled: false to keep the old
+# (admin-contaminated) output unchanged for a release. See CHANGELOG
+# for the full rationale and the real-library findings that motivated
+# this, including measured top-10 recommendation overlap between old and
+# new output.
 profile_accuracy:
-  enabled: false
+  enabled: true
 
 # =============================================================================
 # USER PREFERENCES

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1620,10 +1620,11 @@ class BaseRecommender(ABC):
         every builder read this state through one shared admin snapshot.
 
         Only used behind the profile_accuracy.enabled config flag (see
-        movie.py's/tv.py's watched-data builders) - the legacy path keeps
-        reading _get_all_library_items()'s shared admin snapshot
-        unchanged, so this method has zero effect on any install that
-        hasn't opted in.
+        movie.py's/tv.py's watched-data builders) - default ON since
+        v2.10.82; the legacy path (_get_all_library_items()'s shared
+        admin snapshot) is still available by explicitly setting
+        profile_accuracy.enabled: false, so this method has zero effect
+        on any install that has opted back out.
 
         Cached in the same shared _library_items_cache dict as
         _get_all_library_items(), under a per-user key so it's never

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -297,10 +297,11 @@ class PlexMovieRecommender(BaseRecommender):
             # across 6 real accounts, zero with the attribute present - so
             # this branch is dead in practice and user_ratings stays empty
             # via this path alone. Left exactly as-is (not removed) so
-            # profile_accuracy.enabled: false (the default) stays
+            # profile_accuracy.enabled: false (the opt-out) stays
             # byte-for-byte identical to pre-#273 behavior; see the
             # profile_accuracy.enabled branch below for the actual
-            # (library-sourced, per-user) fix.
+            # (library-sourced, per-user) fix, which is ON by default
+            # since v2.10.82.
             if hasattr(item, "userRating") and item.userRating:
                 user_rating = float(item.userRating)
                 if movie_id not in user_ratings or user_rating > user_ratings[movie_id]:
@@ -311,27 +312,29 @@ class PlexMovieRecommender(BaseRecommender):
         # all, and (per the verified finding above) never reliably
         # provides userRating either.
         #
-        # profile_accuracy.enabled (config flag, default OFF - see
-        # config/tuning.example.yml): fetches EACH user's own Plex-token
-        # library snapshot (_get_all_library_items_for_user, #273)
-        # instead of the one shared admin-token snapshot every builder
-        # used before - viewCount/userRating are per-account Plex state,
-        # so the admin's token can only ever see the admin's OWN values
-        # for them, never another configured user's (verified against a
-        # real library - see CHANGELOG). Also reads userRating straight
-        # off the library item, mirroring what recommenders/tv.py's own
-        # builder already does correctly (tv.py was never affected by
-        # the dead-history-userRating issue above). Per-user max-merge
-        # (view_count and rating both) mirrors this same function's own
-        # existing history-derived user_ratings merge convention just
-        # above, for when users_to_match has more than one entry.
+        # profile_accuracy.enabled (config flag, default ON since
+        # v2.10.82 - see config/tuning.example.yml): fetches EACH user's
+        # own Plex-token library snapshot (_get_all_library_items_for_user,
+        # #273) instead of the one shared admin-token snapshot every
+        # builder used before - viewCount/userRating are per-account Plex
+        # state, so the admin's token can only ever see the admin's OWN
+        # values for them, never another configured user's (verified
+        # against a real library - see CHANGELOG). Also reads userRating
+        # straight off the library item, mirroring what
+        # recommenders/tv.py's own builder already does correctly (tv.py
+        # was never affected by the dead-history-userRating issue above).
+        # Per-user max-merge (view_count and rating both) mirrors this
+        # same function's own existing history-derived user_ratings merge
+        # convention just above, for when users_to_match has more than
+        # one entry.
         #
-        # Disabled (default): unchanged legacy behavior - the shared
-        # admin-token snapshot's view counts only, no library-sourced
-        # ratings at all (the history-sourced attempt above already
-        # covers - and, per the verified finding, never actually
-        # populates - user_ratings for the default path).
-        if self.config.get("profile_accuracy", {}).get("enabled", False):
+        # Disabled (enabled: false - opt-out for anyone who wants the
+        # pre-v2.10.82 output unchanged for a release): legacy behavior -
+        # the shared admin-token snapshot's view counts only, no
+        # library-sourced ratings at all (the history-sourced attempt
+        # above already covers - and, per the verified finding, never
+        # actually populates - user_ratings for the disabled path).
+        if self.config.get("profile_accuracy", {}).get("enabled", True):
             for username in users_to_match:
                 try:
                     for movie in self._get_all_library_items_for_user(username):

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -372,21 +372,23 @@ class PlexTVRecommender(BaseRecommender):
                 if show_id not in user_ratings or user_rating > user_ratings[show_id]:
                     user_ratings[show_id] = user_rating
 
-        # profile_accuracy.enabled (config flag, default OFF - see
-        # config/tuning.example.yml, #273): fetches EACH user's own
-        # Plex-token library snapshot (_get_all_library_items_for_user)
-        # instead of the one shared admin-token snapshot every builder
-        # used before - viewCount/userRating are per-account Plex state,
-        # so the admin's token can only ever see the admin's OWN values
-        # for them, never another configured user's (verified against a
+        # profile_accuracy.enabled (config flag, default ON since
+        # v2.10.82 - see config/tuning.example.yml, #273): fetches EACH
+        # user's own Plex-token library snapshot
+        # (_get_all_library_items_for_user) instead of the one shared
+        # admin-token snapshot every builder used before -
+        # viewCount/userRating are per-account Plex state, so the
+        # admin's token can only ever see the admin's OWN values for
+        # them, never another configured user's (verified against a
         # real library - see CHANGELOG). Per-user max-merge (rewatch
         # count and rating both) for when more than one user is
-        # configured. Disabled (default): unchanged legacy behavior -
-        # one shared admin-token snapshot for every user, reused from
-        # this run instead of a fresh section.all() (#233 audit
-        # remediation batch D / PR1(a)).
+        # configured. Disabled (enabled: false - opt-out for anyone who
+        # wants the pre-v2.10.82 output unchanged for a release): legacy
+        # behavior - one shared admin-token snapshot for every user,
+        # reused from this run instead of a fresh section.all() (#233
+        # audit remediation batch D / PR1(a)).
         try:
-            if self.config.get("profile_accuracy", {}).get("enabled", False):
+            if self.config.get("profile_accuracy", {}).get("enabled", True):
                 users_to_match = [self.single_user] if self.single_user else self.users["plex_users"]
                 for username in users_to_match:
                     for show in self._get_all_library_items_for_user(username):

--- a/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
+++ b/tests/fixtures/profile_builder_harness/profile_builder_snapshot.json
@@ -1,34 +1,34 @@
 {
   "external_load_cache_movie_alice": {
     "actors": {
-      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
-      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
-      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Alex Monroe": "0x1.8394855edf9d8p-2",
+      "Casey Rhodes": "0x1.4623e187d5601p-2",
+      "Jordan Vance": "0x1.12f0ae54a22cep-2",
       "Robin Alvarez": "0x1.eb851eb851eb8p-4",
-      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.47ae147ae1478p-7",
       "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
     },
     "directors": {
       "Marcus Webb": "0x1.eb851eb851eb8p-4",
       "Nora Lin": "0x1.eb851eb851eb8p-5",
       "Priya Anand": "0x1.eb851eb851eb8p-5",
-      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+      "Ridley Stone": "0x1.ab0014fb2fdeep-3"
     },
     "genres": {
-      "action": "0x1.eb851eb851eb8p-3",
-      "sci-fi": "0x1.70a3d70a3d70ap-3"
+      "action": "0x1.5061522bac6a5p-2",
+      "sci-fi": "0x1.8394855edf9d8p-2"
     },
     "keywords": {
-      "heist": "0x1.eb851eb851eb8p-4",
-      "revenge": "0x1.eb851eb851eb8p-5",
+      "heist": "0x1.4623e187d5601p-2",
+      "revenge": "-0x1.999999999999ap-5",
       "road-trip": "0x1.eb851eb851eb8p-5",
-      "space-station": "0x1.70a3d70a3d70ap-3",
-      "survival": "0x1.eb851eb851eb8p-4",
+      "space-station": "0x1.8394855edf9d8p-2",
+      "survival": "0x1.47ae147ae1478p-7",
       "time-travel": "0x1.eb851eb851eb8p-5",
       "undercover": "0x1.eb851eb851eb8p-4"
     },
     "languages": {
-      "english": "0x1.70a3d70a3d70ap-2"
+      "english": "0x1.cb4299d9c0e53p-2"
     },
     "studios": {},
     "tmdb_ids": [
@@ -45,26 +45,26 @@
       "Alex Monroe": "0x1.eb851eb851eb8p-5",
       "Casey Rhodes": "0x1.eb851eb851eb8p-5",
       "Jordan Vance": "0x1.eb851eb851eb8p-5",
-      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.3333333333334p-3",
       "Sam Kestrel": "0x1.eb851eb851eb8p-4",
-      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+      "Taylor Nguyen": "0x1.ae147ae147ae2p-3"
     },
     "directors": {
       "Marcus Webb": "0x1.eb851eb851eb8p-5",
-      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.ae147ae147ae2p-3",
       "Priya Anand": "0x1.eb851eb851eb8p-5"
     },
     "genres": {
-      "comedy": "0x1.70a3d70a3d70ap-3",
-      "romance": "0x1.eb851eb851eb8p-4"
+      "comedy": "0x1.147ae147ae148p-2",
+      "romance": "0x1.ae147ae147ae2p-3"
     },
     "keywords": {
       "coming-of-age": "0x1.eb851eb851eb8p-4",
-      "road-trip": "0x1.eb851eb851eb8p-5",
-      "wedding": "0x1.eb851eb851eb8p-4"
+      "road-trip": "0x1.3333333333334p-3",
+      "wedding": "0x1.ae147ae147ae2p-3"
     },
     "languages": {
-      "english": "0x1.eb851eb851eb8p-3"
+      "english": "0x1.51eb851eb851fp-2"
     },
     "studios": {},
     "tmdb_ids": [
@@ -76,33 +76,33 @@
   },
   "external_load_cache_tv_alice": {
     "actors": {
-      "Derek Cho": "0x1.eb851eb851eb8p-4",
-      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Derek Cho": "0x1.0a3d70a3d70a4p-2",
+      "Elena Frost": "-0x1.47ae147ae147cp-4",
       "Lucas Wren": "0x1.eb851eb851eb8p-5",
-      "Mira Solano": "0x1.eb851eb851eb8p-4",
+      "Mira Solano": "0x1.0a3d70a3d70a4p-2",
       "Nadia Okafor": "0x1.eb851eb851eb8p-5",
-      "Theo Baptiste": "0x1.eb851eb851eb8p-5"
+      "Theo Baptiste": "-0x1.47ae147ae147cp-4"
     },
     "directors": {},
     "genres": {
-      "crime": "0x1.eb851eb851eb8p-4",
-      "sci-fi": "0x1.eb851eb851eb8p-4"
+      "crime": "-0x1.47ae147ae1480p-6",
+      "sci-fi": "0x1.0a3d70a3d70a4p-2"
     },
     "keywords": {
-      "exploration": "0x1.eb851eb851eb8p-4",
-      "first-contact": "0x1.eb851eb851eb8p-5",
+      "exploration": "0x1.0a3d70a3d70a4p-2",
+      "first-contact": "0x1.999999999999ap-3",
       "heist": "0x1.eb851eb851eb8p-5",
-      "investigation": "0x1.eb851eb851eb8p-4",
-      "noir": "0x1.eb851eb851eb8p-5",
+      "investigation": "-0x1.47ae147ae1480p-6",
+      "noir": "-0x1.47ae147ae147cp-4",
       "survival": "0x1.eb851eb851eb8p-5"
     },
     "languages": {
       "english": "0x1.eb851eb851eb8p-3"
     },
     "studios": {
-      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "bluecrest media": "-0x1.47ae147ae147cp-4",
       "ferrous pictures": "0x1.eb851eb851eb8p-5",
-      "northgate studios": "0x1.eb851eb851eb8p-4"
+      "northgate studios": "0x1.0a3d70a3d70a4p-2"
     },
     "tmdb_ids": [
       "201",
@@ -113,26 +113,26 @@
   },
   "external_load_cache_tv_bob": {
     "actors": {
-      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Elena Frost": "0x1.8d0cdc8930b3fp-3",
       "Lucas Wren": "0x1.eb851eb851eb8p-5",
       "Mira Solano": "0x1.eb851eb851eb8p-5",
       "Nadia Okafor": "0x1.eb851eb851eb8p-5",
-      "Theo Baptiste": "0x1.eb851eb851eb8p-4"
+      "Theo Baptiste": "0x1.03f7121ba2976p-2"
     },
     "directors": {},
     "genres": {
-      "comedy": "0x1.70a3d70a3d70ap-3"
+      "comedy": "0x1.4167b5f2acd4dp-2"
     },
     "keywords": {
-      "roommates": "0x1.eb851eb851eb8p-4",
-      "workplace": "0x1.eb851eb851eb8p-4"
+      "roommates": "0x1.03f7121ba2976p-2",
+      "workplace": "0x1.03f7121ba2976p-2"
     },
     "languages": {
-      "english": "0x1.70a3d70a3d70ap-3"
+      "english": "0x1.4167b5f2acd4dp-2"
     },
     "studios": {
       "bluecrest media": "0x1.eb851eb851eb8p-5",
-      "lumen works": "0x1.eb851eb851eb8p-4"
+      "lumen works": "0x1.03f7121ba2976p-2"
     },
     "tmdb_ids": [
       "205",
@@ -142,34 +142,34 @@
   },
   "external_profile_via_recommender_movie_alice": {
     "actors": {
-      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
-      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
-      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Alex Monroe": "0x1.8394855edf9d8p-2",
+      "Casey Rhodes": "0x1.4623e187d5601p-2",
+      "Jordan Vance": "0x1.12f0ae54a22cep-2",
       "Robin Alvarez": "0x1.eb851eb851eb8p-4",
-      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.47ae147ae1478p-7",
       "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
     },
     "directors": {
       "Marcus Webb": "0x1.eb851eb851eb8p-4",
       "Nora Lin": "0x1.eb851eb851eb8p-5",
       "Priya Anand": "0x1.eb851eb851eb8p-5",
-      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+      "Ridley Stone": "0x1.ab0014fb2fdeep-3"
     },
     "genres": {
-      "action": "0x1.eb851eb851eb8p-3",
-      "sci-fi": "0x1.70a3d70a3d70ap-3"
+      "action": "0x1.5061522bac6a5p-2",
+      "sci-fi": "0x1.8394855edf9d8p-2"
     },
     "keywords": {
-      "heist": "0x1.eb851eb851eb8p-4",
-      "revenge": "0x1.eb851eb851eb8p-5",
+      "heist": "0x1.4623e187d5601p-2",
+      "revenge": "-0x1.999999999999ap-5",
       "road-trip": "0x1.eb851eb851eb8p-5",
-      "space-station": "0x1.70a3d70a3d70ap-3",
-      "survival": "0x1.eb851eb851eb8p-4",
+      "space-station": "0x1.8394855edf9d8p-2",
+      "survival": "0x1.47ae147ae1478p-7",
       "time-travel": "0x1.eb851eb851eb8p-5",
       "undercover": "0x1.eb851eb851eb8p-4"
     },
     "languages": {
-      "english": "0x1.70a3d70a3d70ap-2"
+      "english": "0x1.cb4299d9c0e53p-2"
     },
     "studios": {},
     "tmdb_ids": [
@@ -186,26 +186,26 @@
       "Alex Monroe": "0x1.eb851eb851eb8p-5",
       "Casey Rhodes": "0x1.eb851eb851eb8p-5",
       "Jordan Vance": "0x1.eb851eb851eb8p-5",
-      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.3333333333334p-3",
       "Sam Kestrel": "0x1.eb851eb851eb8p-4",
-      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+      "Taylor Nguyen": "0x1.ae147ae147ae2p-3"
     },
     "directors": {
       "Marcus Webb": "0x1.eb851eb851eb8p-5",
-      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.ae147ae147ae2p-3",
       "Priya Anand": "0x1.eb851eb851eb8p-5"
     },
     "genres": {
-      "comedy": "0x1.70a3d70a3d70ap-3",
-      "romance": "0x1.eb851eb851eb8p-4"
+      "comedy": "0x1.147ae147ae148p-2",
+      "romance": "0x1.ae147ae147ae2p-3"
     },
     "keywords": {
       "coming-of-age": "0x1.eb851eb851eb8p-4",
-      "road-trip": "0x1.eb851eb851eb8p-5",
-      "wedding": "0x1.eb851eb851eb8p-4"
+      "road-trip": "0x1.3333333333334p-3",
+      "wedding": "0x1.ae147ae147ae2p-3"
     },
     "languages": {
-      "english": "0x1.eb851eb851eb8p-3"
+      "english": "0x1.51eb851eb851fp-2"
     },
     "studios": {},
     "tmdb_ids": [
@@ -266,11 +266,11 @@
   },
   "movie_plex_watched_alice": {
     "actors": {
-      "Alex Monroe": "0x1.70a3d70a3d70ap-3",
-      "Casey Rhodes": "0x1.eb851eb851eb8p-4",
-      "Jordan Vance": "0x1.70a3d70a3d70ap-3",
+      "Alex Monroe": "0x1.8394855edf9d8p-2",
+      "Casey Rhodes": "0x1.4623e187d5601p-2",
+      "Jordan Vance": "0x1.12f0ae54a22cep-2",
       "Robin Alvarez": "0x1.eb851eb851eb8p-4",
-      "Sam Kestrel": "0x1.eb851eb851eb8p-4",
+      "Sam Kestrel": "0x1.47ae147ae1478p-7",
       "Taylor Nguyen": "0x1.eb851eb851eb8p-5"
     },
     "collections": {},
@@ -278,14 +278,14 @@
       "Marcus Webb": "0x1.eb851eb851eb8p-4",
       "Nora Lin": "0x1.eb851eb851eb8p-5",
       "Priya Anand": "0x1.eb851eb851eb8p-5",
-      "Ridley Stone": "0x1.eb851eb851eb8p-4"
+      "Ridley Stone": "0x1.ab0014fb2fdeep-3"
     },
     "genres": {
-      "action": "0x1.eb851eb851eb8p-3",
-      "sci-fi": "0x1.70a3d70a3d70ap-3"
+      "action": "0x1.5061522bac6a5p-2",
+      "sci-fi": "0x1.8394855edf9d8p-2"
     },
     "languages": {
-      "english": "0x1.70a3d70a3d70ap-2"
+      "english": "0x1.cb4299d9c0e53p-2"
     },
     "tmdb_ids": [
       "101",
@@ -296,11 +296,11 @@
       "106"
     ],
     "tmdb_keywords": {
-      "heist": "0x1.eb851eb851eb8p-4",
-      "revenge": "0x1.eb851eb851eb8p-5",
+      "heist": "0x1.4623e187d5601p-2",
+      "revenge": "-0x1.999999999999ap-5",
       "road-trip": "0x1.eb851eb851eb8p-5",
-      "space-station": "0x1.70a3d70a3d70ap-3",
-      "survival": "0x1.eb851eb851eb8p-4",
+      "space-station": "0x1.8394855edf9d8p-2",
+      "survival": "0x1.47ae147ae1478p-7",
       "time-travel": "0x1.eb851eb851eb8p-5",
       "undercover": "0x1.eb851eb851eb8p-4"
     }
@@ -310,22 +310,22 @@
       "Alex Monroe": "0x1.eb851eb851eb8p-5",
       "Casey Rhodes": "0x1.eb851eb851eb8p-5",
       "Jordan Vance": "0x1.eb851eb851eb8p-5",
-      "Robin Alvarez": "0x1.eb851eb851eb8p-5",
+      "Robin Alvarez": "0x1.3333333333334p-3",
       "Sam Kestrel": "0x1.eb851eb851eb8p-4",
-      "Taylor Nguyen": "0x1.eb851eb851eb8p-4"
+      "Taylor Nguyen": "0x1.ae147ae147ae2p-3"
     },
     "collections": {},
     "directors": {
       "Marcus Webb": "0x1.eb851eb851eb8p-5",
-      "Nora Lin": "0x1.eb851eb851eb8p-4",
+      "Nora Lin": "0x1.ae147ae147ae2p-3",
       "Priya Anand": "0x1.eb851eb851eb8p-5"
     },
     "genres": {
-      "comedy": "0x1.70a3d70a3d70ap-3",
-      "romance": "0x1.eb851eb851eb8p-4"
+      "comedy": "0x1.147ae147ae148p-2",
+      "romance": "0x1.ae147ae147ae2p-3"
     },
     "languages": {
-      "english": "0x1.eb851eb851eb8p-3"
+      "english": "0x1.51eb851eb851fp-2"
     },
     "tmdb_ids": [
       "107",
@@ -335,8 +335,8 @@
     ],
     "tmdb_keywords": {
       "coming-of-age": "0x1.eb851eb851eb8p-4",
-      "road-trip": "0x1.eb851eb851eb8p-5",
-      "wedding": "0x1.eb851eb851eb8p-4"
+      "road-trip": "0x1.3333333333334p-3",
+      "wedding": "0x1.ae147ae147ae2p-3"
     }
   },
   "tv_managed_users": {
@@ -384,25 +384,25 @@
   },
   "tv_plex_watched_alice": {
     "actors": {
-      "Derek Cho": "0x1.eb851eb851eb8p-4",
-      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Derek Cho": "0x1.0a3d70a3d70a4p-2",
+      "Elena Frost": "-0x1.47ae147ae147cp-4",
       "Lucas Wren": "0x1.eb851eb851eb8p-5",
-      "Mira Solano": "0x1.eb851eb851eb8p-4",
+      "Mira Solano": "0x1.0a3d70a3d70a4p-2",
       "Nadia Okafor": "0x1.eb851eb851eb8p-5",
-      "Theo Baptiste": "0x1.eb851eb851eb8p-5"
+      "Theo Baptiste": "-0x1.47ae147ae147cp-4"
     },
     "genres": {
-      "crime": "0x1.eb851eb851eb8p-4",
-      "sci-fi": "0x1.eb851eb851eb8p-4"
+      "crime": "-0x1.47ae147ae1480p-6",
+      "sci-fi": "0x1.0a3d70a3d70a4p-2"
     },
     "languages": {
       "english": "0x1.eb851eb851eb8p-3"
     },
     "production_companies": {},
     "studios": {
-      "bluecrest media": "0x1.eb851eb851eb8p-5",
+      "bluecrest media": "-0x1.47ae147ae147cp-4",
       "ferrous pictures": "0x1.eb851eb851eb8p-5",
-      "northgate studios": "0x1.eb851eb851eb8p-4"
+      "northgate studios": "0x1.0a3d70a3d70a4p-2"
     },
     "tmdb_ids": [
       "201",
@@ -411,32 +411,32 @@
       "204"
     ],
     "tmdb_keywords": {
-      "exploration": "0x1.eb851eb851eb8p-4",
-      "first-contact": "0x1.eb851eb851eb8p-5",
+      "exploration": "0x1.0a3d70a3d70a4p-2",
+      "first-contact": "0x1.999999999999ap-3",
       "heist": "0x1.eb851eb851eb8p-5",
-      "investigation": "0x1.eb851eb851eb8p-4",
-      "noir": "0x1.eb851eb851eb8p-5",
+      "investigation": "-0x1.47ae147ae1480p-6",
+      "noir": "-0x1.47ae147ae147cp-4",
       "survival": "0x1.eb851eb851eb8p-5"
     }
   },
   "tv_plex_watched_bob": {
     "actors": {
-      "Elena Frost": "0x1.eb851eb851eb8p-5",
+      "Elena Frost": "0x1.8d0cdc8930b3fp-3",
       "Lucas Wren": "0x1.eb851eb851eb8p-5",
       "Mira Solano": "0x1.eb851eb851eb8p-5",
       "Nadia Okafor": "0x1.eb851eb851eb8p-5",
-      "Theo Baptiste": "0x1.eb851eb851eb8p-4"
+      "Theo Baptiste": "0x1.03f7121ba2976p-2"
     },
     "genres": {
-      "comedy": "0x1.70a3d70a3d70ap-3"
+      "comedy": "0x1.4167b5f2acd4dp-2"
     },
     "languages": {
-      "english": "0x1.70a3d70a3d70ap-3"
+      "english": "0x1.4167b5f2acd4dp-2"
     },
     "production_companies": {},
     "studios": {
       "bluecrest media": "0x1.eb851eb851eb8p-5",
-      "lumen works": "0x1.eb851eb851eb8p-4"
+      "lumen works": "0x1.03f7121ba2976p-2"
     },
     "tmdb_ids": [
       "205",
@@ -444,8 +444,8 @@
       "207"
     ],
     "tmdb_keywords": {
-      "roommates": "0x1.eb851eb851eb8p-4",
-      "workplace": "0x1.eb851eb851eb8p-4"
+      "roommates": "0x1.03f7121ba2976p-2",
+      "workplace": "0x1.03f7121ba2976p-2"
     }
   }
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -649,13 +649,14 @@ class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
     def test_profile_accuracy_defaults_match(self):
         """#273: recommenders/movie.py's _get_plex_watched_data() and
         recommenders/tv.py's _get_plex_watched_shows_data() both read
-        this with this exact fallback default (False) - see also
+        this with this exact fallback default (True, since v2.10.82 -
+        was False before that; see CHANGELOG) - see also
         tests/test_config.py's own note in this class's docstring about
         why this guardrail exists: a documented example value drifting
         from the real code default (#261) is exactly the class of bug
         this class exists to catch."""
         tuning = self._load_example_tuning()
-        assert tuning["profile_accuracy"]["enabled"] is False
+        assert tuning["profile_accuracy"]["enabled"] is True
 
     def test_recommend_for_no_history_defaults_match(self):
         """#291: BaseRecommender.get_recommendations() reads

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1331,14 +1331,19 @@ class TestGetPlexWatchedDataMovie:
 
 
 class TestGetPlexWatchedDataMovieAccurateMode:
-    """Tests for the profile_accuracy.enabled=True path (#273) in
+    """Tests for the profile_accuracy.enabled path (#273) in
     PlexMovieRecommender._get_plex_watched_data - per-user library-
     sourced ratings/view counts instead of the legacy shared admin-token
     snapshot's view counts and Plex-history-sourced (verified: never
-    actually populated in practice) ratings. Default (flag absent/False)
-    behavior is covered by TestGetPlexWatchedDataMovie above and must
-    stay byte-identical - see this class's own
-    test_default_never_calls_per_user_fetch.
+    actually populated in practice) ratings.
+
+    Default flipped False -> True in v2.10.82 (a defect fix, not a
+    preference - see CHANGELOG): a config that has never touched this
+    key now gets accurate mode, proven by this class's own
+    test_absent_config_key_defaults_to_accurate_mode. The explicit
+    opt-out (enabled: false) that keeps the pre-v2.10.82 legacy
+    behavior byte-identical (covered by TestGetPlexWatchedDataMovie
+    above) is proven by test_explicit_disabled_never_calls_per_user_fetch.
     """
 
     @patch("os.path.exists", return_value=False)
@@ -1439,7 +1444,7 @@ class TestGetPlexWatchedDataMovieAccurateMode:
     @patch("recommenders.movie.fetch_plex_watch_history_movies")
     @patch("recommenders.movie.get_plex_account_ids")
     @patch("recommenders.movie.get_watched_movie_count", return_value=1)
-    def test_default_never_calls_per_user_fetch(
+    def test_absent_config_key_defaults_to_accurate_mode(
         self,
         mock_count,
         mock_account_ids,
@@ -1450,15 +1455,56 @@ class TestGetPlexWatchedDataMovieAccurateMode:
         mock_per_user_items,
         mock_exists,
     ):
-        """profile_accuracy absent from config entirely (real-world
-        default for every existing install) - _get_all_library_items_for_user
-        must never even be called, proving zero behavior change."""
+        """profile_accuracy genuinely absent from config (an install
+        that has never touched this setting) now defaults to accurate
+        mode (v2.10.82) - _get_all_library_items_for_user IS called,
+        proving the flipped default actually takes effect for a real
+        config that never sets the key at all."""
+        mock_account_ids.return_value = ["acct1"]
+        history_item = Mock(ratingKey=42, viewedAt=None, userRating=None)
+        mock_history.return_value = ([history_item], {})
+        mock_per_user_items.return_value = []
+
+        config = copy.deepcopy(MOVIE_TEST_CONFIG)
+        assert "profile_accuracy" not in config
+        _make_movie_recommender(
+            config=config,
+            users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"},
+            movie_cache_data={"42": {"title": "Movie", "genres": ["action"], "tmdb_id": 999}},
+        )
+
+        mock_per_user_items.assert_called_once_with("alice")
+
+    @patch("os.path.exists", return_value=False)
+    @patch("recommenders.base.BaseRecommender._get_all_library_items_for_user")
+    @patch("recommenders.movie.process_counters_from_cache")
+    @patch("recommenders.movie.calculate_rewatch_multiplier", return_value=1.0)
+    @patch("recommenders.movie.calculate_recency_multiplier", return_value=1.0)
+    @patch("recommenders.movie.fetch_plex_watch_history_movies")
+    @patch("recommenders.movie.get_plex_account_ids")
+    @patch("recommenders.movie.get_watched_movie_count", return_value=1)
+    def test_explicit_disabled_never_calls_per_user_fetch(
+        self,
+        mock_count,
+        mock_account_ids,
+        mock_history,
+        mock_recency,
+        mock_rewatch,
+        mock_process_counters,
+        mock_per_user_items,
+        mock_exists,
+    ):
+        """profile_accuracy explicitly set to enabled: false (the
+        opt-out for anyone who wants the pre-v2.10.82 output unchanged
+        for a release) - _get_all_library_items_for_user must never
+        even be called, proving the legacy path stays byte-identical
+        for anyone who opts back out."""
         mock_account_ids.return_value = ["acct1"]
         history_item = Mock(ratingKey=42, viewedAt=None, userRating=None)
         mock_history.return_value = ([history_item], {})
 
         config = copy.deepcopy(MOVIE_TEST_CONFIG)
-        assert "profile_accuracy" not in config
+        config["profile_accuracy"] = {"enabled": False}
         _make_movie_recommender(
             config=config,
             users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"},

--- a/tests/test_profile_builder_harness.py
+++ b/tests/test_profile_builder_harness.py
@@ -107,36 +107,39 @@ class TestProfileBuilderHarnessCatchesTheFourBugs:
             "make this pinned-bug assertion stale."
         )
 
-    def test_bug2_movie_watched_data_shows_no_rewatch_or_rating_signal_today(self):
-        """Bug #2: alice's and bob's fixture overrides give them
-        genuinely different, nonzero view_counts/ratings on the movies
-        they've each watched (see MOVIE_PER_USER_LIBRARY_STATE) - but
-        movie.py's _get_plex_watched_data() only ever reads that state
-        through the shared ADMIN-token library snapshot
-        (_get_all_library_items()), which reports 0/None for every item
-        regardless of user. The only per-movie unit weight in play
-        today is therefore RATING_MULTIPLIER_UNRATED (unrated) times
-        whatever recency bucket this fixture's watch timestamps fall
-        into (tests/e2e_plex_fixture.py's history timestamps are fixed
-        at ~2023-11-14 - already >365 days in the past and only growing
-        more so, always the oldest/smallest decay bucket) times
-        rewatch_multiplier(1) (view_count is never seen at all on this
-        legacy path) - every genre-counter value for BOTH users should
-        be a plain integer multiple of that one unit."""
+    def test_bug2_movie_watched_data_now_applies_per_user_weighting_by_default(self):
+        """Bug #2 - FIXED BY DEFAULT (#273 PR1, profile_accuracy.enabled
+        flipped on by default in v2.10.82): alice's and bob's fixture
+        overrides give them genuinely different, nonzero
+        view_counts/ratings on the movies they've each watched (see
+        MOVIE_PER_USER_LIBRARY_STATE) - movie.py's
+        _get_plex_watched_data() now reads that state through EACH
+        user's own Plex-token library snapshot
+        (_get_all_library_items_for_user), not the shared ADMIN-token
+        snapshot that always reported 0/None regardless of user. Not
+        every genre-counter value for both users is still a plain
+        integer multiple of the legacy unrated/oldest-recency-bucket
+        unit weight anymore - this is the golden-fixture-diff PR0's own
+        docstring predicted (see test_bug4's own note below): a #273 PR
+        intentionally changing one of the builders regenerates the
+        snapshot and updates this test to assert the FIXED shape
+        instead of the bug, same as test_bug4 already did."""
         live = run_profile_builders()
         unit = RATING_MULTIPLIER_UNRATED * calculate_recency_multiplier(0, {}) * calculate_rewatch_multiplier(1)
+        any_non_multiple = False
         for username in ("alice", "bob"):
             genres = live[f"movie_plex_watched_{username}"]["genres"]
             assert genres, f"expected at least one genre counted for {username}'s movie profile"
             for value_hex in genres.values():
                 value = float.fromhex(value_hex)
                 multiple = value / unit
-                assert abs(multiple - round(multiple)) < 1e-9, (
-                    f"{username}'s genre weight {value} is not a plain multiple of the "
-                    f"unrated/oldest-recency-bucket unit weight ({unit}) - per-user "
-                    "rewatch/rating weighting may already be wired up correctly (#273 "
-                    "PR1), which would make this pinned-bug assertion stale."
-                )
+                if abs(multiple - round(multiple)) >= 1e-9:
+                    any_non_multiple = True
+        assert any_non_multiple, (
+            "every genre weight for both users is still a plain multiple of the legacy "
+            "unrated/oldest-recency-bucket unit weight - the profile_accuracy "
+            "default-on fix (#273 PR1) may have regressed."
+        )
 
     def test_bug4_managed_users_builder_now_applies_real_weighting(self):
         """Bug #4 - FIXED (#273 PR2): base.py's _get_managed_users_watched_data()

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1498,13 +1498,18 @@ class TestGetPlexWatchedShowsData:
 
 
 class TestGetPlexWatchedShowsDataAccurateMode:
-    """Tests for the profile_accuracy.enabled=True path (#273) in
+    """Tests for the profile_accuracy.enabled path (#273) in
     PlexTVRecommender._get_plex_watched_shows_data - per-user
     library-sourced rewatch counts/ratings instead of the legacy shared
-    admin-token snapshot every builder used before. Default
-    (flag absent/False) behavior is covered by
-    TestGetPlexWatchedShowsData above and must stay byte-identical - see
-    this class's own test_default_never_calls_per_user_fetch.
+    admin-token snapshot every builder used before.
+
+    Default flipped False -> True in v2.10.82 (a defect fix, not a
+    preference - see CHANGELOG): a config that has never touched this
+    key now gets accurate mode, proven by this class's own
+    test_absent_config_key_defaults_to_accurate_mode. The explicit
+    opt-out (enabled: false) that keeps the pre-v2.10.82 legacy
+    behavior byte-identical (covered by TestGetPlexWatchedShowsData
+    above) is proven by test_explicit_disabled_never_calls_per_user_fetch.
     """
 
     @patch("os.path.exists", return_value=False)
@@ -1598,7 +1603,7 @@ class TestGetPlexWatchedShowsDataAccurateMode:
     @patch("recommenders.tv.fetch_plex_watch_history_shows")
     @patch("recommenders.tv.get_plex_account_ids")
     @patch("recommenders.tv.get_watched_show_count", return_value=1)
-    def test_default_never_calls_per_user_fetch(
+    def test_absent_config_key_defaults_to_accurate_mode(
         self,
         mock_count,
         mock_account_ids,
@@ -1609,15 +1614,56 @@ class TestGetPlexWatchedShowsDataAccurateMode:
         mock_per_user_items,
         mock_exists,
     ):
-        """profile_accuracy absent from config entirely (real-world
-        default for every existing install) - _get_all_library_items_for_user
-        must never even be called, proving zero behavior change."""
+        """profile_accuracy genuinely absent from config (an install
+        that has never touched this setting) now defaults to accurate
+        mode (v2.10.82) - _get_all_library_items_for_user IS called,
+        proving the flipped default actually takes effect for a real
+        config that never sets the key at all."""
+        mock_account_ids.return_value = ["acct1"]
+        mock_history.return_value = ({99}, {99: 1700000000})
+        mock_per_user_items.return_value = []
+
+        config = copy.deepcopy(TV_TEST_CONFIG)
+        config["negative_signals"] = {"dropped_shows": {"enabled": False}}
+        assert "profile_accuracy" not in config
+        _make_tv_recommender(
+            config=config,
+            users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"},
+            show_cache_data={"99": {"title": "Show", "genres": ["drama"], "tmdb_id": 888}},
+        )
+
+        mock_per_user_items.assert_called_once_with("alice")
+
+    @patch("os.path.exists", return_value=False)
+    @patch("recommenders.base.BaseRecommender._get_all_library_items_for_user")
+    @patch("recommenders.tv.process_counters_from_cache")
+    @patch("recommenders.tv.calculate_rewatch_multiplier", return_value=1.0)
+    @patch("recommenders.tv.calculate_recency_multiplier", return_value=1.0)
+    @patch("recommenders.tv.fetch_plex_watch_history_shows")
+    @patch("recommenders.tv.get_plex_account_ids")
+    @patch("recommenders.tv.get_watched_show_count", return_value=1)
+    def test_explicit_disabled_never_calls_per_user_fetch(
+        self,
+        mock_count,
+        mock_account_ids,
+        mock_history,
+        mock_recency,
+        mock_rewatch,
+        mock_process_counters,
+        mock_per_user_items,
+        mock_exists,
+    ):
+        """profile_accuracy explicitly set to enabled: false (the
+        opt-out for anyone who wants the pre-v2.10.82 output unchanged
+        for a release) - _get_all_library_items_for_user must never
+        even be called, proving the legacy path stays byte-identical
+        for anyone who opts back out."""
         mock_account_ids.return_value = ["acct1"]
         mock_history.return_value = ({99}, {99: 1700000000})
 
         config = copy.deepcopy(TV_TEST_CONFIG)
         config["negative_signals"] = {"dropped_shows": {"enabled": False}}
-        assert "profile_accuracy" not in config
+        config["profile_accuracy"] = {"enabled": False}
         _make_tv_recommender(
             config=config,
             users={"plex_users": ["alice"], "managed_users": [], "admin_user": "admin"},

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,7 +13,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.81"
+__version__ = "2.10.82"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so


### PR DESCRIPTION
## Summary
- profile_accuracy.enabled (added by #273 PR1, previously default false) now defaults to true. Gates a defect fix, not a preference: every non-admin user's recommendation profile was built from the admin's own Plex watch history/ratings/view counts instead of their own (utils/cli.py's update_config_for_user swaps username but never the Plex token; BaseRecommender._get_all_library_items() caches one shared admin-token snapshot across every user in a run). Movie rating weighting was also dead code - Plex's history API never returns userRating (verified against 2,475 real history entries across 6 real accounts), so a disliked movie could never produce a negative signal.
- config/tuning.example.yml default flipped to match, with an honest, prominent CHANGELOG entry: recommendations WILL change for every non-admin user, the next run forces a full profile rescore (compute_profile_hash changes), and how to set enabled: false to opt back out for a release.
- Kept the flag - not removed. Verified the guardrail test (tests/test_config.py's test_profile_accuracy_defaults_match) enforces code/example-config parity.
- Updated tests/test_movie.py's and tests/test_tv.py's TestGetPlexWatchedData(Movie|ShowsData)AccurateMode classes: split the old single default test into two, covering BOTH states - absent config key now defaults to accurate mode (per-user fetch called), and an explicit enabled: false still fully disables it (legacy path byte-identical).
- Regenerated tests/fixtures/profile_builder_harness/profile_builder_snapshot.json (its config never set this flag, so it's now exercising the new default) and updated the one now-stale pinned-bug test (test_bug2) to assert the FIXED shape, matching the same convention test_bug4 already used for a bug fixed unconditionally in an earlier PR.

## Findings while searching for other assumptions of the old default (requirement to report, not fix)
- tests/test_e2e_pipeline.py's e2e fixture patches utils.plex.MyPlexAccount but not recommenders.base.MyPlexAccount, so its per-user profile_accuracy path now hits an unmocked MyPlexAccount call that the suite's socket guard blocks, silently swallowed by movie.py's/tv.py's own broad except around that block (degrades to no signal for that path). Not a coverage regression: that test's own docstring already declares rating/rewatch weighting out of scope, covered elsewhere by test_movie.py/test_tv.py/test_profile_builder_harness.py - left as-is rather than expanding that file's mocked surface beyond its stated scope.
- tests/test_migrate_config.py's TestCoreSectionsIncludesProfileAccuracy docstring narrates the original off-by-default bug finding; its assertions don't depend on default direction so no change needed.

## Test plan
- [x] pytest tests/ (2941 passed, 1 skipped)
- [x] ruff check .
- [x] mypy .