### PR TITLE
Stop rewarding items that match on fewer dimensions; bound SSE backlog replay (2.10.85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.85] - 2026-07-28
+
+### Fixed
+
+- **Items matching on FEWER dimensions were scoring HIGHER, inverting the top of every recommendation list.** `_apply_active_weight_redistribution()` moved a dimension's weight onto the dimensions that did score whenever that dimension scored `0` - but `comp_score == 0` conflates two different things: the item has no data for that dimension (not the item's fault, redistribute - the original intent, e.g. a missing language field), and the item HAS that data and it simply scored zero against this user (its keywords aren't ones they watch, or the TF-IDF penalty clamped the component). The second case was being rewarded: the less an item matched, the more weight piled onto whichever dimension did, so a title matching on nothing but generic genres had its genre ratio scaled across the entire weight budget.
+
+  Measured on a real 225-movie profile before the fix: mean final score **0.545** for items scoring on 1 dimension vs **0.384** for 3 and **0.384-0.396** for 3-4 - monotonically backwards. Nine of the top ten recommendations matched on genre alone, each showing a genre component of ~0.19 amplified to a ~0.78 final score (a clean 4x), and **81 of 117** scored items held real keyword data that scored 0 and were rewarded for it. The visible symptom was a Disney Channel TV movie sitting at #3 for an adult profile on four generic genre tokens, with the whole top ten compressed into a 72-80% band because they were all the same kind of near-empty match.
+
+  Redistribution now requires the item to genuinely lack data for that dimension. `calculate_similarity_score()` passes a per-dimension `content_has_data` map; a component absent from that map defaults to "has data", so a future dimension added without updating the map fails closed (no inflation) rather than silently redistributing. Omitting the map entirely preserves the previous behavior, so existing callers are unaffected. **Recommendations will visibly change** - richly-described titles that match on several dimensions imperfectly now outrank sparse or poorly-matching ones, which is the intended ordering.
+
+- **The run page got progressively slower and less responsive the longer a run went.** `Job.try_subscribe()` replayed the entire unbounded `self.lines` backlog into a queue capped at `SUBSCRIBER_QUEUE_MAXSIZE` (2000), while holding `_data_lock`. Since `_safe_queue_put()` evicts oldest-first, replaying 50,000 lines did 50,000 puts to arrive at exactly the same final 2000 - ~96% of the work discarded. `MAX_STREAM_SECONDS` (web/app.py) deliberately ends each SSE response so `EventSource` reconnects, and every reconnect landed back in that replay, so the cost grew with elapsed output on a fixed 2-minute interval. All of it under the lock that `_append_line()` needs for every single line, so the thread pumping the subprocess's stdout stalled behind each replay. Now replays only the last `SUBSCRIBER_QUEUE_MAXSIZE` lines - identical resulting queue contents, constant cost. The replay deliberately stays inside the lock: releasing it between the snapshot and `_subscribers.append(q)` would drop any line emitted in that window.
+
 ## [2.10.84] - 2026-07-28
 
 ### Added

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Reject any commit message carrying a Co-Authored-By trailer.
+#
+# Curatarr does not accept outside contributions (see CLAUDE.md) and its
+# commits are single-author. An AI assistant appending its own
+# "Co-Authored-By:" trailer put a second author on a public commit that
+# then shipped in a signed release, where it cannot be rewritten without
+# invalidating the tag. This hook makes that unrepeatable at the git
+# level rather than relying on anyone - human or agent - remembering.
+#
+# Blocks regardless of casing/spacing, since git's trailer parsing is
+# itself case-insensitive.
+msg_file="$1"
+
+if grep -qiE '^[[:space:]]*co-authored-by[[:space:]]*:' "$msg_file"; then
+    echo "" >&2
+    echo "COMMIT REJECTED: message contains a Co-Authored-By trailer." >&2
+    echo "" >&2
+    grep -inE '^[[:space:]]*co-authored-by[[:space:]]*:' "$msg_file" | sed 's/^/    /' >&2
+    echo "" >&2
+    echo "This repo's commits are single-author. Remove the trailer and commit again." >&2
+    echo "" >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1118,6 +1118,101 @@ class TestApplyActiveWeightRedistribution:
         assert score == pytest.approx(0.5)
 
 
+class TestRedistributionDistinguishesAbsentFromUnmatched:
+    """The fix for the sparse-metadata inflation bug: a dimension that
+    scored 0 only earns its weight back if the ITEM had no data for it.
+    A zero scored against data the item genuinely has is a real signal
+    and must keep costing the item its weight.
+
+    Before this, `comp_score == 0` alone triggered redistribution, so
+    the fewer dimensions an item matched on, the more weight piled onto
+    whichever one did - inverting the ranking. Measured on a real
+    225-movie profile: mean final score 0.545 for items scoring on 1
+    dimension vs 0.384 for 3, with 9 of the top 10 recommendations
+    matching on genre alone.
+    """
+
+    COMPONENT_SCORES = {
+        "genre": 0.2,
+        "director": 0.0,
+        "studio": 0.0,
+        "actor": 0.0,
+        "language": 0.0,
+        "keyword": 0.0,
+    }
+    WEIGHTS = {"genre": 0.25, "director": 0.15, "studio": 0, "actor": 0.20, "language": 0.05, "keyword": 0.45}
+
+    def test_absent_data_still_redistributes(self):
+        """Original intent preserved: an item with no keyword/cast/etc.
+        data isn't penalized for metadata it never had."""
+        has_data = {
+            "genre": True,
+            "director": False,
+            "studio": False,
+            "actor": False,
+            "language": False,
+            "keyword": False,
+        }
+        score = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, has_data)
+        assert score > 0.2
+
+    def test_present_but_unmatched_data_does_not_redistribute(self):
+        """The fix: the item HAS keywords/cast/director, they just don't
+        match this user. That zero is earned and must stick."""
+        has_data = {"genre": True, "director": True, "studio": False, "actor": True, "language": True, "keyword": True}
+        score = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, has_data)
+        assert score == pytest.approx(0.2)
+
+    def test_sparse_item_no_longer_outranks_richly_matching_item(self):
+        """End-to-end shape of the bug: a genre-only match must not beat
+        an item that matches on several dimensions."""
+        sparse_scores = {"genre": 0.2, "director": 0.0, "studio": 0.0, "actor": 0.0, "language": 0.0, "keyword": 0.0}
+        sparse_has_data = {
+            "genre": True,
+            "director": True,
+            "studio": False,
+            "actor": True,
+            "language": True,
+            "keyword": True,
+        }
+        sparse = _apply_active_weight_redistribution(0.2, sparse_scores, self.WEIGHTS, sparse_has_data)
+
+        rich_scores = {"genre": 0.1, "director": 0.05, "studio": 0.0, "actor": 0.08, "language": 0.02, "keyword": 0.15}
+        rich_raw = sum(rich_scores.values())
+        rich_has_data = dict(sparse_has_data)
+        rich = _apply_active_weight_redistribution(rich_raw, rich_scores, self.WEIGHTS, rich_has_data)
+
+        assert rich > sparse, f"richly-matching item ({rich}) must outrank genre-only item ({sparse})"
+
+    def test_partial_absence_redistributes_only_the_absent_share(self):
+        """Mixed case: keyword data absent (redistribute its 0.45), cast
+        data present but unmatched (its 0.20 stays lost)."""
+        has_data = {"genre": True, "director": True, "studio": False, "actor": True, "language": True, "keyword": False}
+        mixed = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, has_data)
+
+        all_absent = {k: (k == "genre") for k in has_data}
+        everything = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, all_absent)
+
+        assert 0.2 < mixed < everything
+
+    def test_omitting_the_map_preserves_legacy_behavior(self):
+        """Existing callers/tests that don't pass content_has_data must
+        be unaffected."""
+        legacy = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS)
+        explicit_absent = _apply_active_weight_redistribution(
+            0.2, self.COMPONENT_SCORES, self.WEIGHTS, {k: False for k in self.COMPONENT_SCORES}
+        )
+        assert legacy == pytest.approx(explicit_absent)
+        assert legacy > 0.2
+
+    def test_unknown_component_defaults_to_having_data(self):
+        """A component missing from the map is treated as 'has data', so
+        a future dimension added without updating the map fails closed
+        (no inflation) rather than silently redistributing."""
+        score = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, {"genre": True})
+        assert score == pytest.approx(0.2)
+
+
 class TestApplyPopularityDampeningHelper:
     """Tests for _apply_popularity_dampening() (see also TestPopularityDampening
     above, which exercises the same behavior through the public function)."""

--- a/utils/config.py
+++ b/utils/config.py
@@ -17,7 +17,18 @@ from .display import log_error, log_info, log_warning
 __version__ = "2.10.85"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
-CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so
+CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's
+# per-item weight-redistribution fix, see CHANGELOG). Cached per-item scores
+# are keyed on profile_hash alone (recommenders/base.py's cache-hit branch in
+# get_recommendations()), which captures the user's watch profile but NOT the
+# scoring code that produced the number. So a scoring fix is a silent no-op on
+# every existing install - every item is a cache hit against a score computed
+# by the OLD algorithm - until that user's profile happens to change. Confirmed
+# empirically while shipping 2.10.85: the fix changed nothing on a real install
+# until this constant moved. Any future change to how scores are CALCULATED
+# needs this bump too, not just changes to what the cache stores.
+#
+# v5: Added rating/vote_count to TV show cache entries so
 # tv: quality_filters (min_rating/min_vote_count) actually apply - they were
 # previously silently a no-op for TV (see CHANGELOG). Bumping this forces a
 # one-time full rebuild of BOTH the movie and show caches on next run (this

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.84"
+__version__ = "2.10.85"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 5  # v5: Added rating/vote_count to TV show cache entries so

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -685,18 +685,48 @@ def _score_keyword_component(
 
 
 def _apply_active_weight_redistribution(
-    score: float, component_scores: Dict[str, float], effective_weights: Dict
+    score: float,
+    component_scores: Dict[str, float],
+    effective_weights: Dict,
+    content_has_data: Optional[Dict[str, bool]] = None,
 ) -> float:
     """
-    Per-item weight redistribution: for dimensions that scored 0 on *this*
-    item, move their weight onto the dimensions that did score (weighted
-    proportionally by each active dimension's own effective weight), so a
-    single item isn't penalized just for not having, say, language data.
+    Per-item weight redistribution: for dimensions this item carries no
+    data for at all, move their weight onto the dimensions that did
+    score (proportionally by each active dimension's own effective
+    weight), so an item isn't penalized just for lacking, say, a
+    language field.
 
     Distinct from _redistribute_weights(), which redistributes at the
     profile level for dimensions the user has no preference data for at
-    all - this operates per-item on whichever dimensions already have a
-    nonzero effective weight but scored 0 for this specific item.
+    all - this operates per-item.
+
+    IMPORTANT - "absent" is not "didn't match". This function used to
+    redistribute on `comp_score == 0` alone, which conflated two very
+    different cases:
+
+      - the item has no data for that dimension (no keywords, no cast
+        listed) - genuinely not the item's fault, redistribute; and
+      - the item HAS that data and it simply scored zero against this
+        user's profile (its keywords aren't ones they watch, or the
+        TF-IDF penalty clamped the component to 0) - a real, meaningful
+        zero.
+
+    Treating the second case as redistributable inverted the ranking:
+    the fewer dimensions an item matched on, the more weight piled onto
+    whichever one did, so an item matching on nothing but generic genres
+    had its genre ratio scaled across the entire weight budget. Measured
+    on a real 225-movie profile before this fix: mean final score 0.545
+    for items with 1 scoring dimension vs 0.384 for items with 3, and 9
+    of the top 10 recommendations matched on genre alone - with 81 of
+    117 items holding keyword data that scored 0 and being rewarded for
+    it. Sparse or poorly-matching items outranked richly-described ones
+    that matched on several dimensions imperfectly.
+
+    `content_has_data` maps component name -> whether this item carries
+    any data for that dimension. Omitted (None) preserves the old
+    score-based behavior, so existing callers/tests that don't supply it
+    are unaffected.
 
     component_scores must be the *rounded* score_breakdown values (e.g.
     score_breakdown["genre_score"]), not the raw per-dimension floats -
@@ -707,11 +737,18 @@ def _apply_active_weight_redistribution(
 
     for comp, comp_score in component_scores.items():
         weight = effective_weights.get(comp, 0)
-        if weight > 0:
-            if comp_score > 0:
-                active_weights[comp] = (weight, comp_score / weight if weight > 0 else 0)
-            else:
-                lost_weight += weight
+        if weight <= 0:
+            continue
+
+        if comp_score > 0:
+            active_weights[comp] = (weight, comp_score / weight)
+            continue
+
+        # Scored zero. Only give its weight away if the item had nothing
+        # to score in the first place; a zero against present data is a
+        # real signal and must keep costing the item its weight.
+        if content_has_data is None or not content_has_data.get(comp, True):
+            lost_weight += weight
 
     if lost_weight > 0 and active_weights:
         total_active_weight = sum(w for w, _ in active_weights.values())
@@ -881,6 +918,7 @@ def calculate_similarity_score(
 
         # --- Director Score (movies only) ---
         director_final = 0.0
+        content_directors: List = []
         if media_type == "movie":
             content_directors = content_info.get("directors", [])
             director_weight = effective_weights.get("director", 0.15)
@@ -894,6 +932,7 @@ def calculate_similarity_score(
         # --- Studio Score (TV only) ---
         studio_final = 0.0
         studio_detail = None
+        content_studio: Any = []
         if media_type == "tv":
             content_studio = content_info.get("studio", content_info.get("studios", []))
             studio_weight = effective_weights.get("studio", 0.15)
@@ -944,7 +983,24 @@ def calculate_similarity_score(
             "language": score_breakdown["language_score"],
             "keyword": score_breakdown["keyword_score"],
         }
-        score = _apply_active_weight_redistribution(score, component_scores, effective_weights)
+        # Whether this item carries any data per dimension, so a zero
+        # scored against data the item HAS keeps costing it its weight -
+        # only genuinely absent data is redistributed. See
+        # _apply_active_weight_redistribution's docstring.
+        #
+        # director/studio are media-type gated above (director is movies
+        # only, studio TV only); the dimension that doesn't apply reports
+        # False here, which is the "absent, redistribute" case and
+        # matches how it was already treated.
+        content_has_data = {
+            "genre": bool(content_genres),
+            "director": bool(content_directors) if media_type == "movie" else False,
+            "studio": bool(content_studio) if media_type == "tv" else False,
+            "actor": bool(content_cast),
+            "language": bool(content_language) and content_language != "N/A",
+            "keyword": bool(content_keywords),
+        }
+        score = _apply_active_weight_redistribution(score, component_scores, effective_weights, content_has_data)
 
         score = min(score, 1.0)
 

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -294,7 +294,28 @@ class Job:
             if self.returncode is None and max_subscribers is not None and len(self._subscribers) >= max_subscribers:
                 return None
             q: "queue.Queue" = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
-            for line in self.lines:
+            # Replay only what this queue can actually hold. `self.lines`
+            # is unbounded (a long run accumulates every line), but `q`
+            # caps at SUBSCRIBER_QUEUE_MAXSIZE and _safe_queue_put()
+            # evicts oldest-first to stay there - so replaying the full
+            # backlog did O(len(self.lines)) work to arrive at exactly
+            # the same final queue contents as replaying the last
+            # SUBSCRIBER_QUEUE_MAXSIZE. Identical result, bounded cost.
+            #
+            # This mattered because MAX_STREAM_SECONDS (web/app.py)
+            # deliberately ends each SSE response so EventSource
+            # reconnects, and every reconnect lands back here. On a long
+            # run that made replay cost grow with elapsed output, on a
+            # fixed interval - and all of it under _data_lock, which
+            # _append_line() needs for every single line, so the thread
+            # pumping the subprocess's stdout stalled behind it. The
+            # slowdown compounded the longer a run went.
+            #
+            # Still inside the lock on purpose: releasing it between the
+            # snapshot and _subscribers.append(q) below would drop any
+            # line emitted in that window. Bounded work under the lock is
+            # the fix, not less locking.
+            for line in self.lines[-SUBSCRIBER_QUEUE_MAXSIZE:]:
                 _safe_queue_put(q, line)
             if self.returncode is not None:
                 _safe_queue_put(q, DONE_SENTINEL)


### PR DESCRIPTION
Two independent bug fixes, both found by profiling a real 225-movie install rather than from reading code.

## 1. Items matching on FEWER dimensions scored HIGHER

`_apply_active_weight_redistribution()` moved a dimension's weight onto whichever dimensions did score whenever that dimension scored `0`. But `comp_score == 0` conflates two different things:

- **the item has no data for that dimension** (no keywords listed, no cast) — not the item's fault, redistribute. This was the original intent, e.g. a missing language field.
- **the item HAS that data and it scored zero against this user** — its keywords aren't ones they watch, or the TF-IDF penalty clamped the component. A real, earned zero.

The second case was being *rewarded*. The less an item matched, the more weight piled onto whichever dimension did, so a title matching on nothing but generic genres had its genre ratio scaled across the entire weight budget.

### Measured on a real profile, before the fix

```
mean final score by number of non-zero scoring dimensions:
   1 live dim:  n=36   mean = 0.545
   2 live dims: n=48   mean = 0.430
   3 live dims: n=22   mean = 0.384
```

Monotonically backwards. Nine of the top ten recommendations matched on genre alone:

```
title                             final  genre    #kw  #cast  kw_score
Powder                            0.800  0.200     12      3     0.000
A Minecraft Movie                 0.788  0.197     21      3     0.000
Invisible Sister                  0.784  0.196      0      3     0.000
The Flash                         0.780  0.195     15      3     0.000
```

Genre component `~0.19` amplified to `~0.78` final — a clean 4x. And **81 of 117** scored items held real keyword data that scored 0 and were rewarded for it. The visible symptom was a Disney Channel TV movie at #3 for an adult profile, with the whole top ten compressed into a 72–80% band because they were all the same kind of near-empty match.

### The fix

Redistribution now requires the item to genuinely lack data for that dimension. `calculate_similarity_score()` passes a per-dimension `content_has_data` map.

- A component **absent from the map defaults to "has data"**, so a future dimension added without updating the map fails closed (no inflation) rather than silently redistributing.
- **Omitting the map entirely preserves the previous behavior**, so existing callers and tests are unaffected.

After the fix, scores spread properly (58.8 → 34.0) instead of compressing into the fake 80–69 band.

**Recommendations will visibly change.** That is intended: richly-described titles matching on several dimensions imperfectly now outrank sparse or poorly-matching ones.

## 2. Scoring changes were a silent no-op on existing installs

Caught only because the fix above appeared to change nothing when re-run on real data.

Per-item cached scores are keyed on `profile_hash` alone (`recommenders/base.py`'s cache-hit branch), which captures the user's watch profile but **not the scoring code that produced the number**. So every item is a cache hit against a score computed by the old algorithm, and any scoring fix stays invisible until that user's profile happens to change.

`CACHE_VERSION` 5 → 6 forces the rebuild. The constant's comment now records that it must move for changes to how scores are *calculated*, not just to what the cache *stores* — the distinction that made this silent.

## 3. Run page got slower the longer a run went

`Job.try_subscribe()` replayed the entire unbounded `self.lines` backlog into a queue capped at `SUBSCRIBER_QUEUE_MAXSIZE` (2000), while holding `_data_lock`. Since `_safe_queue_put()` evicts oldest-first, replaying 50,000 lines did 50,000 puts to arrive at exactly the same final 2000 — ~96% of the work discarded.

`MAX_STREAM_SECONDS` deliberately ends each SSE response so `EventSource` reconnects, and every reconnect landed back in that replay, so cost grew with elapsed output on a fixed 2-minute interval. All under the lock `_append_line()` needs for every line, so the thread pumping the subprocess's stdout stalled behind each replay.

Now replays only the last `SUBSCRIBER_QUEUE_MAXSIZE` lines — identical resulting queue contents, constant cost. The replay deliberately stays inside the lock: releasing it between the snapshot and `_subscribers.append(q)` would drop any line emitted in that window.

## Also

`hooks/commit-msg` rejecting `Co-Authored-By` trailers; this repo's commits are single-author.

## Verification

| Check | Result |
|---|---|
| `pytest tests/` | **2963 passed, 1 skipped** (+6 new regression tests) |
| `ruff check .` | All checks passed |
| `mypy .` | No issues in 136 source files |
| Real-install before/after | Confirmed on a 225-movie profile |
