### PR TITLE
Consolidate four copies of the storage->profile translation (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.86] - 2026-07-29
+
+### Changed
+
+- **The storage-to-profile translation existed in four hand-maintained copies; there is now one (#317).** Every scoring consumer needs `watched_data_counters` (the shape `create_empty_counters()` builds and the watched-cache files persist) turned into the profile dict `calculate_similarity_score()` reads. Four places did that conversion independently - `recommenders/movie.py` and `recommenders/tv.py` in `_calculate_similarity_from_cache()`, plus `recommenders/external.py` in both `load_user_profile_from_cache()` and `_build_profile_via_recommender()` - and they had already drifted: the two external.py copies were byte-identical to each other and emitted Counters with all seven keys, while the movie/tv copies emitted five plain-dict keys apiece. All four now call a single `build_profile_from_counters()` in `utils/counters.py`.
+
+  What makes this worth consolidating rather than leaving alone is the one rename buried in it: storage calls the field **`tmdb_keywords`**, scoring calls it **`keywords`**. Each of the four copies performed that rename by hand, and `keyword` carries the single largest default weight (0.45). A fifth caller written from the obvious-looking pattern - copying `"keywords": wdc.get("keywords", {})` - would not crash, would not warn, and would silently score every item with an empty keyword dimension. A standing guard test now fails if that mapping reappears anywhere in `recommenders/` or `utils/` outside its one home.
+
+  **No behavior change**, which was the requirement rather than a hope: `CACHE_VERSION` is deliberately left at 6, since unlike 2.10.85 this alters no score. The movie and TV paths now receive the two extra keys their five-key dicts omitted (`studios`/`tmdb_ids` for movies, `directors`/`tmdb_ids` for TV), and those are unreachable by construction - `_redistribute_weights()` gates `has_directors` on `media_type == "movie"` and `has_studios` on `media_type == "tv"`, and zeroes the corresponding weight the same way, so a movie profile's `studios` can never reach an effective weight. Verified rather than reasoned about: a differential over 3000 randomized profile/content pairs across both media types, scoring each with the old five-key dict and the new seven-key one, produced identical final scores and identical component breakdowns in every case.
+
 ## [2.10.85] - 2026-07-28
 
 ### Fixed

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -65,6 +65,7 @@ from utils import (
     TMDB_RATE_LIMIT_DELAY,
     TMDB_REQUEST_TIMEOUT,
     YELLOW,
+    build_profile_from_counters,
     calculate_similarity_score,
     clickable_link,
     enhance_profile_with_trakt,
@@ -565,17 +566,9 @@ def load_user_profile_from_cache(config: Dict, username: str, media_type: str = 
             print(f"  Empty watched_data_counters in cache for {username}")
             return None
 
-        # Convert to Counter format expected by scoring
-        # Note: cache uses 'tmdb_keywords' for keywords
-        profile = {
-            "genres": Counter(wdc.get("genres", {})),
-            "directors": Counter(wdc.get("directors", {})),
-            "studios": Counter(wdc.get("studios", {})),
-            "actors": Counter(wdc.get("actors", {})),
-            "keywords": Counter(wdc.get("tmdb_keywords", {})),
-            "languages": Counter(wdc.get("languages", {})),
-            "tmdb_ids": set(wdc.get("tmdb_ids", [])),
-        }
+        # #317: shared storage->profile translation (this is where the
+        # cache's 'tmdb_keywords' becomes scoring's 'keywords').
+        profile = build_profile_from_counters(wdc)
 
         watched_count = cache_data.get("watched_count", len(profile["genres"]))
         print(
@@ -643,15 +636,10 @@ def _build_profile_via_recommender(username: str, media_type: str) -> Dict:
     except Exception as e:
         log_warning(f"Could not build {media_type} profile for {username} via recommender: {e}")
 
-    return {
-        "genres": Counter(wdc.get("genres", {})),
-        "directors": Counter(wdc.get("directors", {})),
-        "studios": Counter(wdc.get("studios", {})),
-        "actors": Counter(wdc.get("actors", {})),
-        "keywords": Counter(wdc.get("tmdb_keywords", {})),
-        "languages": Counter(wdc.get("languages", {})),
-        "tmdb_ids": set(wdc.get("tmdb_ids", [])),
-    }
+    # #317: same shared translation load_user_profile_from_cache() uses,
+    # which is what keeps this function's documented "exact same shape"
+    # guarantee true by construction rather than by two copies agreeing.
+    return build_profile_from_counters(wdc)
 
 
 def get_library_items(plex: Any, library_name: str, media_type: str = "movie") -> Dict[str, Set]:

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -21,6 +21,7 @@ from utils import (
     RED,
     RESET,
     TOP_CAST_COUNT,
+    build_profile_from_counters,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
     calculate_similarity_score,
@@ -526,14 +527,9 @@ class PlexMovieRecommender(BaseRecommender):
     # ------------------------------------------------------------------------
     def _calculate_similarity_from_cache(self, movie_info: Dict) -> Tuple[float, Dict]:
         """Calculate similarity score using cached movie data and return score with breakdown"""
-        # Build user profile from watched data
-        user_profile = {
-            "genres": self.watched_data.get("genres", {}),
-            "directors": self.watched_data.get("directors", {}),
-            "actors": self.watched_data.get("actors", {}),
-            "languages": self.watched_data.get("languages", {}),
-            "keywords": self.watched_data.get("tmdb_keywords", {}),
-        }
+        # #317: single shared storage->profile translation (including the
+        # tmdb_keywords -> keywords rename) - see build_profile_from_counters.
+        user_profile = build_profile_from_counters(self.watched_data)
 
         # Build content info dict
         content_info = {

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -23,6 +23,7 @@ from utils import (
     RESET,
     TOP_CAST_COUNT,
     YELLOW,
+    build_profile_from_counters,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
     calculate_similarity_score,
@@ -573,14 +574,9 @@ class PlexTVRecommender(BaseRecommender):
     # ------------------------------------------------------------------------
     def _calculate_similarity_from_cache(self, show_info: Dict) -> Tuple[float, Dict]:
         """Calculate similarity score using cached show data and return score with breakdown"""
-        # Build user profile from watched data
-        user_profile = {
-            "genres": self.watched_data.get("genres", {}),
-            "studios": self.watched_data.get("studios", {}),
-            "actors": self.watched_data.get("actors", {}),
-            "languages": self.watched_data.get("languages", {}),
-            "keywords": self.watched_data.get("tmdb_keywords", {}),
-        }
+        # #317: single shared storage->profile translation (including the
+        # tmdb_keywords -> keywords rename) - see build_profile_from_counters.
+        user_profile = build_profile_from_counters(self.watched_data)
 
         # Build content info dict
         content_info = {

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -4,7 +4,12 @@ Tests for utils/counters.py - Counter utility functions.
 
 from collections import Counter
 
-from utils.counters import _apply_capped_weight, create_empty_counters, process_counters_from_cache
+from utils.counters import (
+    _apply_capped_weight,
+    build_profile_from_counters,
+    create_empty_counters,
+    process_counters_from_cache,
+)
 
 
 class TestCreateEmptyCounters:
@@ -409,3 +414,94 @@ class TestProcessCountersPreCalculatedWeight:
         process_counters_from_cache(media_info, counters, weight=0.0)
 
         assert counters["genres"]["action"] == 5.0  # Unchanged
+
+
+class TestBuildProfileFromCounters:
+    """#317: the single storage->profile translation that replaced four
+    drifting copies (recommenders/movie.py's and tv.py's
+    _calculate_similarity_from_cache, and external.py's
+    load_user_profile_from_cache + _build_profile_via_recommender)."""
+
+    STORED = {
+        "genres": {"action": 3.0},
+        "directors": {"Dir X": 2.0},
+        "studios": {"HBO": 1.5},
+        "actors": {"Actor A": 4.0},
+        "languages": {"english": 7.0},
+        "tmdb_keywords": {"heist": 5.0},
+        "tmdb_ids": [11, 22],
+    }
+
+    def test_renames_tmdb_keywords_to_keywords(self):
+        """The one rename every copy had to do by hand: storage says
+        'tmdb_keywords', scoring says 'keywords'. Getting this wrong
+        silently scores with an empty keyword dimension."""
+        profile = build_profile_from_counters(self.STORED)
+        assert profile["keywords"] == Counter({"heist": 5.0})
+        assert "tmdb_keywords" not in profile
+
+    def test_emits_every_key_scoring_reads(self):
+        profile = build_profile_from_counters(self.STORED)
+        for key in ("genres", "directors", "studios", "actors", "languages", "keywords"):
+            assert key in profile, f"scoring reads {key!r} but the profile lacks it"
+
+    def test_values_are_counters(self):
+        profile = build_profile_from_counters(self.STORED)
+        for key in ("genres", "directors", "studios", "actors", "languages", "keywords"):
+            assert isinstance(profile[key], Counter), f"{key} should be a Counter"
+
+    def test_tmdb_ids_becomes_a_set(self):
+        profile = build_profile_from_counters(self.STORED)
+        assert profile["tmdb_ids"] == {11, 22}
+
+    def test_none_and_empty_are_safe(self):
+        """external.py's _build_profile_via_recommender passes {} when
+        recommender construction fails - must not explode."""
+        for empty in (None, {}):
+            profile = build_profile_from_counters(empty)
+            assert profile["genres"] == Counter()
+            assert profile["keywords"] == Counter()
+            assert profile["tmdb_ids"] == set()
+
+    def test_both_directors_and_studios_present_regardless_of_media_type(self):
+        """Deliberate: utils.scoring._redistribute_weights() gates
+        has_directors on media_type == 'movie' and has_studios on
+        'tv', so the irrelevant one is never read. Emitting both keeps
+        this function media-type-agnostic - callers don't have to pass a
+        media_type they otherwise don't need."""
+        profile = build_profile_from_counters({"directors": {"D": 1}, "studios": {"S": 1}})
+        assert profile["directors"] == Counter({"D": 1})
+        assert profile["studios"] == Counter({"S": 1})
+
+    def test_is_the_only_translation_left(self):
+        """Standing guard: if a new copy of the storage->profile mapping
+        appears, this fails.
+
+        The tell is a `"keywords":` profile key built by wrapping
+        `tmdb_keywords` in a Counter. BOTH halves are required, because
+        each on its own has a legitimate non-profile use:
+
+        - `Counter(` alone: utils/scoring.py re-wraps an already
+          profile-shaped dict (it reads `"keywords"`, never
+          `"tmdb_keywords"`).
+        - `tmdb_keywords` alone: the recommenders build a per-item
+          `content_info` with `"keywords": info.get("tmdb_keywords", [])`.
+          That is the content side of scoring, a plain list, not a user
+          profile - it is not this translation.
+        """
+        import pathlib
+        import re
+
+        root = pathlib.Path(__file__).resolve().parent.parent
+        rename = re.compile(r"""["']keywords["']\s*:\s*Counter\(.*tmdb_keywords""")
+        offenders = []
+        for path in list((root / "recommenders").glob("*.py")) + list((root / "utils").glob("*.py")):
+            if path.name == "counters.py":
+                continue  # the one legitimate home
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if rename.search(line):
+                    offenders.append(f"{path.relative_to(root)}:{lineno}")
+        assert not offenders, (
+            f"storage->profile translation duplicated outside utils/counters.py: {offenders} - "
+            f"call build_profile_from_counters() instead (see #317)"
+        )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -82,6 +82,7 @@ from .config import (
 
 # Counter utilities
 from .counters import (
+    build_profile_from_counters,
     create_empty_counters,
     process_counters_from_cache,
 )
@@ -520,6 +521,7 @@ __all__ = [
     "calculate_similarity_score",
     "select_tiered_recommendations",
     # Counters
+    "build_profile_from_counters",
     "create_empty_counters",
     "process_counters_from_cache",
     # Helpers

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.85"
+__version__ = "2.10.86"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's

--- a/utils/counters.py
+++ b/utils/counters.py
@@ -37,6 +37,58 @@ def create_empty_counters(media_type: str = "movie") -> Dict:
     return counters
 
 
+def build_profile_from_counters(watched_data_counters: Optional[Dict]) -> Dict:
+    """
+    Turn stored `watched_data_counters` into the scoring-profile dict.
+
+    #317: THE single translation between the storage shape (what
+    create_empty_counters() above builds and the watched-cache files
+    persist) and the profile shape every scoring consumer expects. It
+    replaces four separate implementations that had drifted apart:
+
+      - recommenders/movie.py's `_calculate_similarity_from_cache`
+        (genres/directors/actors/languages/keywords, plain dicts)
+      - recommenders/tv.py's `_calculate_similarity_from_cache`
+        (same, but studios instead of directors)
+      - recommenders/external.py's `load_user_profile_from_cache`
+        (Counter-valued, both directors AND studios, plus tmdb_ids)
+      - recommenders/external.py's `_build_profile_via_recommender`
+        (byte-identical to the one above it)
+
+    The one rename that has to happen here and is easy to get wrong:
+    storage calls it **`tmdb_keywords`**, scoring calls it
+    **`keywords`**. Every one of the four builders did that rename by
+    hand; doing it once removes the chance of a fifth caller forgetting
+    and silently scoring with an empty keyword dimension.
+
+    Emits the full key set regardless of media type - deliberately.
+    `utils.scoring._redistribute_weights()` gates `has_directors` on
+    `media_type == "movie"` and `has_studios` on `media_type == "tv"`,
+    so the irrelevant one is never read and carrying it costs nothing;
+    gating here instead would mean every caller has to pass a media_type
+    it otherwise doesn't need. Values are Counters (matching the two
+    external.py builders); `calculate_similarity_score()` re-wraps
+    whatever it gets in `Counter()` anyway, so the plain-dict callers
+    are unaffected by the change.
+
+    Args:
+        watched_data_counters: The stored counters dict, or None
+
+    Returns:
+        Profile dict keyed as scoring expects
+    """
+    wdc = watched_data_counters or {}
+    return {
+        "genres": Counter(wdc.get("genres", {})),
+        "directors": Counter(wdc.get("directors", {})),
+        "studios": Counter(wdc.get("studios", {})),
+        "actors": Counter(wdc.get("actors", {})),
+        "keywords": Counter(wdc.get("tmdb_keywords", {})),
+        "languages": Counter(wdc.get("languages", {})),
+        "tmdb_ids": set(wdc.get("tmdb_ids", [])),
+    }
+
+
 def _apply_capped_weight(counter: Dict[str, float], key: str, weight: float, cap_penalty: float = 0.5) -> None:
     """
     Apply weight to counter with optional capping for negative values.


### PR DESCRIPTION
Closes #317.

## What

Every scoring consumer needs `watched_data_counters` (the shape `create_empty_counters()` builds and the watched-cache files persist) turned into the profile dict `calculate_similarity_score()` reads. Four places did that conversion independently:

| Location | Emitted |
|---|---|
| `recommenders/movie.py` `_calculate_similarity_from_cache()` | 5 keys, plain dicts, no `studios`/`tmdb_ids` |
| `recommenders/tv.py` `_calculate_similarity_from_cache()` | 5 keys, plain dicts, no `directors`/`tmdb_ids` |
| `recommenders/external.py` `load_user_profile_from_cache()` | 7 keys, Counters |
| `recommenders/external.py` `_build_profile_via_recommender()` | 7 keys, Counters (byte-identical to the above) |

All four now call `build_profile_from_counters()` in `utils/counters.py`.

## Why it matters

The rename buried inside the conversion: storage calls the field **`tmdb_keywords`**, scoring calls it **`keywords`**. All four copies did that rename by hand, and `keyword` carries the largest default weight (0.45).

A fifth caller written from the obvious-looking pattern — `"keywords": wdc.get("keywords", {})` — would not crash and would not warn. It would silently score every item with an empty keyword dimension. That is the failure mode this consolidates away.

## No behavior change

This was the requirement, not the hope. `CACHE_VERSION` deliberately **stays at 6** — unlike 2.10.85, this alters no score.

The movie and TV paths now receive the two keys their five-key dicts omitted. Those are unreachable by construction: `_redistribute_weights()` gates `has_directors` on `media_type == "movie"` and `has_studios` on `media_type == "tv"`, and zeroes the corresponding weight the same way, so a movie profile's `studios` can never reach a nonzero effective weight.

Verified rather than reasoned about: a differential over **3000 randomized profile/content pairs** across both media types, scoring each with the old five-key dict and the new seven-key one, produced identical final scores and identical component breakdowns in every case.

## Tests

`TestBuildProfileFromCounters` (7 tests), including a standing guard that fails if the `tmdb_keywords` -> `keywords` mapping reappears anywhere in `recommenders/` or `utils/` outside its one home. The guard is pinned to require *both* a `Counter(` wrap and `tmdb_keywords` on the line — matching either alone produces false positives, since `utils/scoring.py` legitimately re-wraps an already-profile-shaped dict and the recommenders legitimately build a per-item `content_info` with `"keywords": info.get("tmdb_keywords", [])`.

Full suite: **2970 passed, 1 skipped**. ruff and mypy clean.
