### PR TITLE
Use a project-local virtualenv in run.sh/run-ui.sh instead of PATH's python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.87] - 2026-07-30
+
+### Fixed
+
+- **`run.sh` and `run-ui.sh` ignored a project-local virtualenv, so a checkout with a working `./.venv` refused to start on any machine whose system Python was older than the floor.** Both scripts called bare `python3`/`pip3` and took whatever `PATH` handed them. On macOS, `python3` is the Command Line Tools' 3.9.6, so `./run-ui.sh` in a checkout with a perfectly good 3.12 `.venv` two directories away died on `Python 3.9.6 found, but curatarr's web UI requires Python 3.10+` - naming an interpreter the user hadn't chosen and wasn't using. A new shared `scripts/lib/python-env.sh` resolves the interpreter once, preferring an already-activated venv (`$VIRTUAL_ENV`), then `./.venv`, then `./venv`, then `python3`; `CURATARR_NO_VENV=1` opts out. This is the bash side catching up to `run.ps1`, which has always resolved `$pythonCmd` once and invoked `& $pythonCmd -m pip`.
+
+  The reason this is more than a `PATH` prepend: **a `uv venv` contains no pip at all** (nor does `python -m venv --without-pip`). Putting `.venv/bin` first on `PATH` therefore redirects `python3` into the venv while leaving `pip3` resolving to the *system* pip - so dependencies install into the system interpreter, the venv still can't import them, and each launch's `if ! python3 -c "import flask"` guard reinstalls them forever. That silent split is a worse bug than the one being fixed, so pip is now always addressed as `$CURATARR_PYTHON -m pip` (`curatarr_pip`, which bootstraps via `ensurepip` when the venv has no pip yet), and `run.sh`'s `command -v pip3` probe - which would have found the system pip and reported success - now asks the resolved interpreter instead.
+
+  Adopting a venv also *prepends* its `bin/` to `PATH` exactly as `activate` does, so the remaining plain `python3 ...` invocations (the YAML one-liners, `python3 recommenders/movie.py`, `trakt_sync.py`) run under it without every call site having to spell it out. A venv is used even when it turns out to be below the floor - silently ignoring one the user deliberately created would be the more surprising of the two behaviors - but the floor message now names the venv path and the `CURATARR_NO_VENV=1` escape hatch, so a stale venv produces an obvious diagnosis instead of a baffling one. Verified end to end on a machine whose system `python3` is 3.9.6: `run-ui.sh` now reports `Using virtualenv: .../.venv`, starts, serves HTTP 200, and the listening process is `.venv/bin/python3 -m web.app`.
+
 ## [2.10.86] - 2026-07-29
 
 ### Changed

--- a/run-ui.sh
+++ b/run-ui.sh
@@ -7,13 +7,24 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Prefer a project-local virtualenv (./.venv, ./venv) or an already
+# activated one over whatever `python3` PATH happens to point at - also
+# used by run.sh. Must be sourced BEFORE pip-install.sh, whose
+# curatarr_pip_install goes through the interpreter this resolves.
+source "$SCRIPT_DIR/scripts/lib/python-env.sh"
+curatarr_resolve_python "$SCRIPT_DIR"
+
 # Shared "hash-verified lockfile, fall back to plain requirements" pip
 # install helper - also used by run.sh.
 source "$SCRIPT_DIR/scripts/lib/pip-install.sh"
 
-if ! command -v python3 &> /dev/null; then
+if ! command -v "$CURATARR_PYTHON" &> /dev/null; then
     echo "Python 3 not found. Install Python 3.10+ first." >&2
     exit 1
+fi
+
+if [ -n "$CURATARR_VENV" ]; then
+    echo "Using virtualenv: $CURATARR_VENV"
 fi
 
 # Python floor gate - same rationale as run.sh's check_and_install_dependencies:
@@ -29,16 +40,22 @@ fi
 # ~20 third-party-backed submodule imports) isn't safe on a fresh
 # checkout, and REQUIRED_PYTHON is a 2-component "X.Y" string that
 # parse_version's exactly-3-component anchoring would reject anyway.
-PYTHON_VERSION="$(python3 --version | awk '{print $2}')"
+PYTHON_VERSION="$("$CURATARR_PYTHON" --version | awk '{print $2}')"
 if [ -f "requirements.lock" ]; then
     REQUIRED_PYTHON="$(grep -oE -- '--python-version [0-9]+\.[0-9]+' requirements.lock | head -1 | awk '{print $2}')"
-    if [ -n "$REQUIRED_PYTHON" ] && ! python3 -c "
+    if [ -n "$REQUIRED_PYTHON" ] && ! "$CURATARR_PYTHON" -c "
 import sys
 def parse(v):
     return tuple(int(p) for p in v.strip().split('.'))
 sys.exit(0 if parse(sys.argv[1]) >= parse(sys.argv[2]) else 1)
 " "$PYTHON_VERSION" "$REQUIRED_PYTHON" 2>/dev/null; then
         echo "Python $PYTHON_VERSION found, but curatarr's web UI requires Python $REQUIRED_PYTHON+." >&2
+        # Name the interpreter when it came from a venv - otherwise "Python
+        # 3.9.6 found" is baffling on a machine whose `python3` is 3.12.
+        if [ -n "$CURATARR_VENV" ]; then
+            echo "That interpreter is the virtualenv at $CURATARR_VENV ($CURATARR_PYTHON)." >&2
+            echo "Recreate it with a newer Python, or set CURATARR_NO_VENV=1 to ignore it." >&2
+        fi
         echo "Upgrade Python, or use a standalone curatarr binary instead (bundles its own" >&2
         echo "Python + UI deps): https://github.com/OrchestratedChaos/curatarr/releases" >&2
         exit 1
@@ -49,8 +66,10 @@ fi
 # UI's own deps (flask/ruamel.yaml - requirements-ui.txt). Prefer the
 # hashed locks when present, same rationale as run.sh; fall back to the
 # plain pinned files (still reproducible, just unverified) otherwise.
-# The actual pip3 invocation/fallback is shared with run.sh - see
-# scripts/lib/pip-install.sh (curatarr_pip_install).
+# The actual pip invocation/fallback is shared with run.sh - see
+# scripts/lib/pip-install.sh (curatarr_pip_install), which installs via
+# $CURATARR_PYTHON -m pip so the deps land in the same interpreter the
+# import check below and the exec at the end of this file use.
 _run_ui_on_hash_fail() {
     echo "Hash-verified install failed (hash/platform mismatch?) - falling back to a" >&2
     echo "normal pinned install (no hash verification) for this run." >&2
@@ -60,11 +79,11 @@ install_deps() {
     curatarr_pip_install "requirements.lock requirements-ui.lock" "requirements.txt requirements-ui.txt" _run_ui_on_hash_fail
 }
 
-if ! python3 -c "import flask, ruamel.yaml" &> /dev/null; then
+if ! "$CURATARR_PYTHON" -c "import flask, ruamel.yaml" &> /dev/null; then
     echo "Installing web UI dependencies..."
     install_deps
 fi
 
 export CURATARR_UI_PORT="${CURATARR_UI_PORT:-8787}"
 echo "Starting Curatarr web UI on http://127.0.0.1:${CURATARR_UI_PORT} (Ctrl+C to stop) ..."
-exec python3 -m web.app
+exec "$CURATARR_PYTHON" -m web.app

--- a/run.sh
+++ b/run.sh
@@ -34,6 +34,21 @@ cd "$SCRIPT_DIR"
 # keeps its own copy - see scripts/lib/colors.sh's docstring for why).
 source "$SCRIPT_DIR/scripts/lib/colors.sh"
 
+# Prefer a project-local virtualenv (./.venv, ./venv) or an already
+# activated one over whatever `python3` PATH happens to point at - also
+# used by run-ui.sh. Must be sourced BEFORE pip-install.sh, whose
+# curatarr_pip_install goes through the interpreter this resolves.
+source "$SCRIPT_DIR/scripts/lib/python-env.sh"
+curatarr_resolve_python "$SCRIPT_DIR"
+# When a venv is adopted this also prepends its bin/ to PATH, the same way
+# `activate` does - so the plain `python3 ...` invocations further down
+# (the yaml one-liners, `python3 recommenders/movie.py`, trakt_sync.py)
+# run under it too, without each call site having to spell it out. The
+# places that must NOT rely on PATH - anything invoking pip, and the
+# version floor gate - use "$CURATARR_PYTHON" explicitly instead, because
+# a venv can lack its own pip binary while still being the interpreter
+# that has to import the result. See scripts/lib/python-env.sh.
+
 # Shared "hash-verified lockfile, fall back to plain requirements" pip
 # install helper - also used by run-ui.sh.
 source "$SCRIPT_DIR/scripts/lib/pip-install.sh"
@@ -52,7 +67,7 @@ check_and_install_dependencies() {
     echo ""
 
     # Check Python 3
-    if ! command -v python3 &> /dev/null; then
+    if ! command -v "$CURATARR_PYTHON" &> /dev/null; then
         echo -e "${RED}❌ Python 3 not found${NC}"
         echo ""
         echo "Please install Python 3.10+ from:"
@@ -62,8 +77,12 @@ check_and_install_dependencies() {
         exit 1
     fi
 
-    PYTHON_VERSION=$(python3 --version | awk '{print $2}')
-    echo -e "${GREEN}✓ Python $PYTHON_VERSION found${NC}"
+    PYTHON_VERSION=$("$CURATARR_PYTHON" --version | awk '{print $2}')
+    if [ -n "$CURATARR_VENV" ]; then
+        echo -e "${GREEN}✓ Python $PYTHON_VERSION found${NC} ${CYAN}(virtualenv: $CURATARR_VENV)${NC}"
+    else
+        echo -e "${GREEN}✓ Python $PYTHON_VERSION found${NC}"
+    fi
 
     # Python floor gate. requirements.lock's own header declares the
     # actual floor via the `--python-version X.Y` in its regenerate
@@ -76,6 +95,15 @@ check_and_install_dependencies() {
         if [ -n "$REQUIRED_PYTHON" ] && ! version_ge "$PYTHON_VERSION" "$REQUIRED_PYTHON"; then
             echo -e "${RED}❌ Python $PYTHON_VERSION found, but curatarr requires Python $REQUIRED_PYTHON+${NC}"
             echo ""
+            # Name the interpreter when it came from a venv - otherwise
+            # "Python 3.9.6 found" is baffling on a machine whose own
+            # `python3` is new enough.
+            if [ -n "$CURATARR_VENV" ]; then
+                echo "That interpreter is the virtualenv at $CURATARR_VENV"
+                echo "($CURATARR_PYTHON), not your system python3. Recreate it with a"
+                echo "newer Python, or set CURATARR_NO_VENV=1 to ignore it."
+                echo ""
+            fi
             echo "Nothing has been changed - your existing setup is untouched."
             echo "To proceed, either:"
             echo "  - Upgrade Python to $REQUIRED_PYTHON+ (https://www.python.org/downloads/ or"
@@ -88,18 +116,22 @@ check_and_install_dependencies() {
         fi
     fi
 
-    # Check pip3
-    if ! command -v pip3 &> /dev/null; then
-        echo -e "${YELLOW}pip3 not found, attempting to install...${NC}"
-        python3 -m ensurepip --upgrade || {
-            echo -e "${RED}❌ Failed to install pip3${NC}"
-            echo "Please install pip3 manually:"
-            echo "  - macOS: python3 -m ensurepip --upgrade"
+    # Check pip. Asks the RESOLVED interpreter whether it has pip, rather
+    # than asking PATH whether a `pip3` binary exists anywhere: a uv-created
+    # venv has no pip of its own, so `command -v pip3` would happily find
+    # the SYSTEM pip and every install would land outside the venv. See
+    # scripts/lib/python-env.sh (curatarr_pip) for the full rationale.
+    if ! "$CURATARR_PYTHON" -m pip --version &> /dev/null; then
+        echo -e "${YELLOW}pip not found for $CURATARR_PYTHON, attempting to install...${NC}"
+        "$CURATARR_PYTHON" -m ensurepip --upgrade || {
+            echo -e "${RED}❌ Failed to install pip${NC}"
+            echo "Please install pip manually:"
+            echo "  - $CURATARR_PYTHON -m ensurepip --upgrade"
             echo "  - Linux: sudo apt install python3-pip"
             exit 1
         }
     fi
-    echo -e "${GREEN}✓ pip3 found${NC}"
+    echo -e "${GREEN}✓ pip found${NC}"
 
     # Install Python dependencies - prefer the fully-hashed lock file
     # (requirements.lock, generated from requirements.txt - see the
@@ -148,7 +180,7 @@ check_and_install_dependencies() {
         fi
     else
         echo -e "${RED}❌ Failed to install Python dependencies${NC}"
-        echo "Try running manually: pip3 install -r requirements.txt"
+        echo "Try running manually: $CURATARR_PYTHON -m pip install -r requirements.txt"
         exit 1
     fi
 

--- a/scripts/lib/pip-install.sh
+++ b/scripts/lib/pip-install.sh
@@ -5,7 +5,13 @@
 # independently (their own comments cross-referenced each other's
 # copy - see the 2.10.18 audit-remediation pass).
 #
-# Only the pip3 invocation + fallback decision is shared here - each
+# Requires scripts/lib/python-env.sh to have been sourced first, and
+# curatarr_resolve_python to have run: the actual pip invocation goes
+# through curatarr_pip (i.e. `$CURATARR_PYTHON -m pip`), never a bare
+# `pip3`, so a project-local venv without its own pip can't end up
+# installing into the system interpreter. See that file for why.
+#
+# Only the pip invocation + fallback decision is shared here - each
 # caller keeps its own success/failure messaging (run.sh wants colored
 # checkmark/warning output and a hard `exit 1` on total failure;
 # run-ui.sh is quieter and relies on `set -e`) via optional callback
@@ -56,7 +62,7 @@ curatarr_pip_install() {
             lock_args="$lock_args -r $f"
         done
         # shellcheck disable=SC2086  # intentional word-splitting of -r flags
-        if pip3 install --require-hashes $lock_args --quiet; then
+        if curatarr_pip install --require-hashes $lock_args --quiet; then
             CURATARR_PIP_INSTALL_MODE="hash-verified"
             return 0
         fi
@@ -76,7 +82,7 @@ curatarr_pip_install() {
     [ "$any_req_exists" -eq 1 ] || return 1
 
     # shellcheck disable=SC2086
-    if pip3 install $req_args --quiet; then
+    if curatarr_pip install $req_args --quiet; then
         CURATARR_PIP_INSTALL_MODE="fallback"
         return 0
     fi

--- a/scripts/lib/python-env.sh
+++ b/scripts/lib/python-env.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Shared "which Python interpreter should this run use" resolver, sourced
+# by run.sh and run-ui.sh.
+#
+# Both scripts used to call bare `python3` and `pip3` and take whatever
+# PATH happened to hand them, which broke the extremely common case of a
+# project-local virtualenv: a checkout with a working ./.venv (3.12) on a
+# machine whose system `python3` is older (macOS ships 3.9.6 via the
+# Command Line Tools) would fail the Python floor gate and refuse to
+# start, while the interpreter that satisfied the floor sat unused two
+# directories away. run.ps1 has always done this properly - it resolves
+# $pythonCmd once and invokes `& $pythonCmd -m pip` - so this is the bash
+# side catching up to the PowerShell side, not a new contract.
+#
+# curatarr_resolve_python PROJECT_ROOT
+#
+#   Sets (and exports):
+#     CURATARR_PYTHON - the interpreter every python/pip invocation
+#                       should go through. An absolute path when a venv
+#                       is in play, otherwise plain `python3`.
+#     CURATARR_VENV   - the venv that was adopted, or "" if none. Callers
+#                       use this for messaging only.
+#     VIRTUAL_ENV / PATH - set the way `activate` sets them when a venv
+#                       is adopted, so bare `python3` in this script, in
+#                       anything it execs, and in any child process
+#                       resolves to the same interpreter.
+#
+#   Always returns 0 - "no venv anywhere" is the normal case, not an
+#   error, and these scripts run under `set -e`.
+#
+# Resolution order:
+#   1. CURATARR_NO_VENV=1        - explicit opt-out, use PATH's python3.
+#   2. An already-activated venv - $VIRTUAL_ENV wins. Someone who ran
+#      `source .venv/bin/activate` (or is inside tox/CI) has stated their
+#      intent more directly than a directory listing can.
+#   3. PROJECT_ROOT/.venv, then PROJECT_ROOT/venv - the two conventional
+#      names, checked in that order.
+#   4. python3 from PATH - the historical behavior, unchanged.
+#
+# Note that an adopted venv is used even if it turns out to be older than
+# requirements.lock's floor. Silently ignoring a venv the user explicitly
+# created would be the more surprising behavior of the two; instead the
+# floor gate in the caller reports which interpreter it rejected (see the
+# CURATARR_VENV mention in run.sh's and run-ui.sh's floor messages), so a
+# stale venv produces an obvious diagnosis rather than a confusing one.
+curatarr_resolve_python() {
+    local project_root="$1"
+    local candidate
+
+    CURATARR_VENV=""
+
+    if [ -n "${CURATARR_NO_VENV:-}" ]; then
+        CURATARR_PYTHON="python3"
+        export CURATARR_PYTHON CURATARR_VENV
+        return 0
+    fi
+
+    if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/python3" ]; then
+        CURATARR_VENV="$VIRTUAL_ENV"
+        CURATARR_PYTHON="${VIRTUAL_ENV}/bin/python3"
+        _curatarr_prepend_path "${VIRTUAL_ENV}/bin"
+        export CURATARR_PYTHON CURATARR_VENV
+        return 0
+    fi
+
+    for candidate in "${project_root}/.venv" "${project_root}/venv"; do
+        if [ -x "${candidate}/bin/python3" ]; then
+            CURATARR_VENV="$candidate"
+            CURATARR_PYTHON="${candidate}/bin/python3"
+            VIRTUAL_ENV="$candidate"
+            export VIRTUAL_ENV
+            # PYTHONHOME would override the venv's own prefix and is what
+            # `activate` unsets for exactly this reason.
+            unset PYTHONHOME
+            _curatarr_prepend_path "${candidate}/bin"
+            export CURATARR_PYTHON CURATARR_VENV
+            return 0
+        fi
+    done
+
+    CURATARR_PYTHON="python3"
+    export CURATARR_PYTHON CURATARR_VENV
+    return 0
+}
+
+# Put $1 at the front of PATH, without duplicating it if it's already
+# there (re-running this shouldn't grow PATH without bound).
+_curatarr_prepend_path() {
+    local dir="$1"
+    case ":${PATH}:" in
+        *":${dir}:"*) ;;
+        *) PATH="${dir}:${PATH}"; export PATH ;;
+    esac
+}
+
+# Run pip for the resolved interpreter.
+#
+# ALWAYS `$CURATARR_PYTHON -m pip`, never a bare `pip3`, and this is the
+# whole reason the resolver exists rather than just prepending to PATH.
+# A `uv venv` (and `python -m venv --without-pip`) creates a venv with NO
+# pip in it at all. Prepending .venv/bin to PATH therefore redirects
+# `python3` into the venv while leaving `pip3` resolving to the SYSTEM
+# pip - so dependencies get installed into the system interpreter, the
+# venv still can't import them, and the caller's `if ! python3 -c "import
+# flask"` guard re-runs the install on every single launch. That silent
+# split is strictly worse than the bug this file fixes, so pip is always
+# addressed through the interpreter that will actually import the result.
+#
+# If that interpreter has no pip module, bootstrap it with ensurepip
+# (present and functional in uv-created venvs) before giving up.
+curatarr_pip() {
+    if ! "$CURATARR_PYTHON" -m pip --version > /dev/null 2>&1; then
+        "$CURATARR_PYTHON" -m ensurepip --upgrade > /dev/null 2>&1 || return 1
+    fi
+    "$CURATARR_PYTHON" -m pip "$@"
+}

--- a/tests/test_python_env_sh.py
+++ b/tests/test_python_env_sh.py
@@ -1,0 +1,224 @@
+"""
+Tests for scripts/lib/python-env.sh - the shared "which Python interpreter
+should this run use" resolver that run.sh and run-ui.sh both source.
+
+These drive the real shell function through `bash` against throwaway
+project roots containing fake venvs, rather than testing a Python
+re-implementation of it, because the bug being guarded here was
+specifically about shell-level resolution order (PATH vs $VIRTUAL_ENV vs
+./.venv) and about which binary a bare `pip3` resolves to.
+"""
+
+import pathlib
+import re
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYTHON_ENV_SH = REPO_ROOT / "scripts" / "lib" / "python-env.sh"
+PIP_INSTALL_SH = REPO_ROOT / "scripts" / "lib" / "pip-install.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+
+
+def make_fake_venv(root: pathlib.Path, name: str = ".venv", version: str = "3.12.13") -> pathlib.Path:
+    """A directory that looks enough like a venv for the resolver: an
+    executable bin/python3 that reports a version."""
+    venv = root / name
+    bindir = venv / "bin"
+    bindir.mkdir(parents=True)
+    python3 = bindir / "python3"
+    python3.write_text(f'#!/bin/bash\necho "Python {version}"\n', encoding="utf-8")
+    python3.chmod(0o755)
+    return venv
+
+
+def resolve(project_root: pathlib.Path, env_prefix: str = "") -> dict:
+    """Source the resolver, run it, and report what it decided."""
+    script = f"""
+    set -u
+    {env_prefix}
+    source '{PYTHON_ENV_SH}'
+    curatarr_resolve_python '{project_root}'
+    echo "PYTHON=$CURATARR_PYTHON"
+    echo "VENV=$CURATARR_VENV"
+    echo "PATH=$PATH"
+    """
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"resolver failed: {proc.stderr}"
+    out = {}
+    for line in proc.stdout.splitlines():
+        key, _, value = line.partition("=")
+        out[key] = value
+    return out
+
+
+class TestResolvePython:
+    def test_adopts_project_dot_venv(self, tmp_path):
+        venv = make_fake_venv(tmp_path)
+        result = resolve(tmp_path)
+        assert result["PYTHON"] == str(venv / "bin" / "python3")
+        assert result["VENV"] == str(venv)
+
+    def test_prepends_venv_bin_to_path(self, tmp_path):
+        venv = make_fake_venv(tmp_path)
+        result = resolve(tmp_path)
+        assert result["PATH"].split(":")[0] == str(venv / "bin")
+
+    def test_does_not_duplicate_path_entry_when_run_twice(self, tmp_path):
+        venv = make_fake_venv(tmp_path)
+        script = f"""
+        set -u
+        source '{PYTHON_ENV_SH}'
+        curatarr_resolve_python '{tmp_path}'
+        curatarr_resolve_python '{tmp_path}'
+        echo "$PATH"
+        """
+        proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip().split(":").count(str(venv / "bin")) == 1
+
+    def test_falls_back_to_plain_python3_with_no_venv(self, tmp_path):
+        result = resolve(tmp_path)
+        assert result["PYTHON"] == "python3"
+        assert result["VENV"] == ""
+
+    def test_dot_venv_wins_over_venv(self, tmp_path):
+        """Both names present - .venv is checked first."""
+        dot_venv = make_fake_venv(tmp_path, ".venv")
+        make_fake_venv(tmp_path, "venv")
+        assert resolve(tmp_path)["VENV"] == str(dot_venv)
+
+    def test_accepts_undotted_venv_directory(self, tmp_path):
+        venv = make_fake_venv(tmp_path, "venv")
+        assert resolve(tmp_path)["VENV"] == str(venv)
+
+    def test_curatarr_no_venv_opts_out(self, tmp_path):
+        make_fake_venv(tmp_path)
+        result = resolve(tmp_path, env_prefix="export CURATARR_NO_VENV=1")
+        assert result["PYTHON"] == "python3"
+        assert result["VENV"] == ""
+
+    def test_already_activated_virtualenv_wins_over_project_dir(self, tmp_path):
+        """Someone who ran `source activate` stated their intent more
+        directly than a directory listing did."""
+        project = tmp_path / "project"
+        project.mkdir()
+        make_fake_venv(project)
+        active = make_fake_venv(tmp_path, "activated")
+        result = resolve(project, env_prefix=f"export VIRTUAL_ENV='{active}'")
+        assert result["VENV"] == str(active)
+        assert result["PYTHON"] == str(active / "bin" / "python3")
+
+    def test_ignores_virtualenv_pointing_at_nothing(self, tmp_path):
+        """A stale exported VIRTUAL_ENV (deleted venv) must not win over a
+        real ./.venv sitting right there."""
+        venv = make_fake_venv(tmp_path)
+        result = resolve(tmp_path, env_prefix=f"export VIRTUAL_ENV='{tmp_path}/gone'")
+        assert result["VENV"] == str(venv)
+
+    def test_ignores_venv_directory_without_executable_python(self, tmp_path):
+        """A bin/python3 that isn't executable isn't a usable venv."""
+        bindir = tmp_path / ".venv" / "bin"
+        bindir.mkdir(parents=True)
+        (bindir / "python3").write_text("not executable", encoding="utf-8")
+        (bindir / "python3").chmod(0o644)
+        assert resolve(tmp_path)["PYTHON"] == "python3"
+
+
+class TestPipGoesThroughTheResolvedInterpreter:
+    """The regression that motivated all of this.
+
+    A `uv venv` (and `python -m venv --without-pip`) has NO pip inside it.
+    So prepending .venv/bin to PATH sends `python3` into the venv while a
+    bare `pip3` still resolves to the SYSTEM pip - dependencies install
+    into the system interpreter, the venv can't import them, and the
+    callers' `if ! python3 -c "import flask"` guard reinstalls on every
+    launch forever. Pip must always be addressed as
+    `$CURATARR_PYTHON -m pip`.
+    """
+
+    def test_shared_pip_helper_never_invokes_a_bare_pip3(self):
+        bare = re.compile(r"(?<![\w$/-])pip3\s+install")
+        offenders = [
+            f"{PIP_INSTALL_SH.name}:{n}"
+            for n, line in enumerate(PIP_INSTALL_SH.read_text(encoding="utf-8").splitlines(), 1)
+            if bare.search(line) and not line.lstrip().startswith("#")
+        ]
+        assert not offenders, (
+            f"bare `pip3 install` in {offenders} - use curatarr_pip (i.e. "
+            f"$CURATARR_PYTHON -m pip) so deps land in the interpreter that imports them"
+        )
+
+    def test_shared_pip_helper_calls_curatarr_pip(self):
+        body = PIP_INSTALL_SH.read_text(encoding="utf-8")
+        assert body.count("curatarr_pip install") == 2, (
+            "expected both the hash-verified and the fallback install to go through curatarr_pip"
+        )
+
+    def test_run_scripts_check_pip_via_the_interpreter_not_via_path(self):
+        """`command -v pip3` would find the system pip even when the venv
+        has none - the check has to ask the resolved interpreter.
+
+        Scans code lines only: the comment explaining precisely why
+        `command -v pip3` is wrong sits directly above the fixed check, and
+        matching the whole file would flag that prose as the defect.
+        """
+        run_sh = (REPO_ROOT / "run.sh").read_text(encoding="utf-8")
+        offenders = [
+            f"run.sh:{n}"
+            for n, line in enumerate(run_sh.splitlines(), 1)
+            if "command -v pip3" in line and not line.lstrip().startswith("#")
+        ]
+        assert not offenders, f"PATH-based pip check at {offenders} - ask $CURATARR_PYTHON instead"
+        assert '"$CURATARR_PYTHON" -m pip --version' in run_sh
+
+    def test_curatarr_pip_bootstraps_pip_when_the_venv_has_none(self, tmp_path):
+        """Given an interpreter whose `-m pip` fails, curatarr_pip must try
+        ensurepip before giving up (uv venvs ship ensurepip but not pip)."""
+        fake = tmp_path / "python3"
+        marker = tmp_path / "ensurepip_called"
+        fake.write_text(
+            "#!/bin/bash\n"
+            'if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then\n'
+            f'  if [ -f "{marker}" ]; then echo "pip 25.0"; exit 0; fi\n'
+            "  exit 1\n"
+            "fi\n"
+            'if [ "$1" = "-m" ] && [ "$2" = "ensurepip" ]; then\n'
+            f'  touch "{marker}"; exit 0\n'
+            "fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        script = f"""
+        set -u
+        source '{PYTHON_ENV_SH}'
+        CURATARR_PYTHON='{fake}'
+        curatarr_pip --version
+        """
+        proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0, f"curatarr_pip did not recover via ensurepip: {proc.stderr}"
+        assert marker.exists(), "ensurepip was never attempted"
+
+
+class TestRunScriptsSourceTheResolver:
+    """Both entry points must resolve before they install or exec, and
+    pip-install.sh depends on the resolver having run."""
+
+    @pytest.mark.parametrize("script_name", ["run.sh", "run-ui.sh"])
+    def test_sources_python_env_before_pip_install(self, script_name):
+        body = (REPO_ROOT / script_name).read_text(encoding="utf-8")
+        env_at = body.find("scripts/lib/python-env.sh")
+        pip_at = body.find("scripts/lib/pip-install.sh")
+        assert env_at != -1, f"{script_name} does not source python-env.sh"
+        assert pip_at != -1, f"{script_name} does not source pip-install.sh"
+        assert env_at < pip_at, f"{script_name} must source python-env.sh before pip-install.sh"
+        assert "curatarr_resolve_python" in body, f"{script_name} sources the lib but never calls the resolver"
+
+    def test_run_ui_execs_the_resolved_interpreter(self):
+        """The whole point: the server must run under the venv, not PATH's python3."""
+        body = (REPO_ROOT / "run-ui.sh").read_text(encoding="utf-8")
+        assert 'exec "$CURATARR_PYTHON" -m web.app' in body

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.86"
+__version__ = "2.10.87"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's


### PR DESCRIPTION
## The bug

`run.sh` and `run-ui.sh` called bare `python3`/`pip3` and took whatever `PATH` handed them, so a checkout with a working `./.venv` refused to start on any machine whose *system* Python was below the floor.

On macOS `python3` is the Command Line Tools' 3.9.6. So `./run-ui.sh`, in a checkout with a perfectly good 3.12 `.venv` two directories away, died on:

```
Python 3.9.6 found, but curatarr's web UI requires Python 3.10+.
```

naming an interpreter the user hadn't chosen and wasn't using.

## The fix

New shared `scripts/lib/python-env.sh` resolves the interpreter once:

1. `CURATARR_NO_VENV=1` — explicit opt-out
2. an already-activated `$VIRTUAL_ENV`
3. `./.venv`, then `./venv`
4. `python3` from `PATH` (unchanged historical behavior)

This is the bash side catching up to `run.ps1`, which has always resolved `$pythonCmd` once and invoked `& $pythonCmd -m pip`.

## Why this isn't just a PATH prepend

**A `uv venv` contains no pip at all** (nor does `python -m venv --without-pip`).

Putting `.venv/bin` first on `PATH` redirects `python3` into the venv but leaves `pip3` resolving to the **system** pip. Dependencies then install into the system interpreter, the venv still can't import them, and each launch's `if ! python3 -c "import flask"` guard reinstalls them — forever. That silent split is a *worse* bug than the one being fixed.

So pip is always addressed as `$CURATARR_PYTHON -m pip` (`curatarr_pip`, which bootstraps via `ensurepip` when the venv has none yet), and `run.sh`'s `command -v pip3` probe — which would have found the system pip and cheerfully reported success — now asks the resolved interpreter instead.

Adopting a venv also prepends its `bin/` to `PATH` exactly as `activate` does, so the remaining plain `python3 ...` calls (YAML one-liners, `recommenders/movie.py`, `trakt_sync.py`) run under it without every call site spelling it out.

## Deliberate call

A venv is adopted **even if it's below the floor**. Silently ignoring a venv the user deliberately created would be the more surprising of the two behaviors. Instead the floor message now names the venv path and the `CURATARR_NO_VENV=1` escape hatch, so a stale venv gives an obvious diagnosis rather than a baffling one.

## Verification

On a machine whose system `python3` is 3.9.6 (i.e. the reported failure reproduced exactly — `CURATARR_NO_VENV=1` reproduces the old behavior for a same-script before/after):

- `run-ui.sh` reports `Using virtualenv: .../.venv`, starts, serves **HTTP 200**, and the listening process is `.venv/bin/python3 -m web.app`
- `run.sh`'s dependency check reports `Python 3.12.13 (virtualenv: ...)` and completes a **hash-verified** install
- `curatarr_pip` bootstrapped pip *into the venv* (`.venv/lib/python3.12/site-packages/pip`), not the system

## Tests

17 new tests in `tests/test_python_env_sh.py` drive the real shell function through `bash` against throwaway project roots (rather than testing a Python re-implementation, since the bug was specifically about shell-level resolution order). Covers each resolution branch, PATH prepend without duplication, a stale `$VIRTUAL_ENV` losing to a real `./.venv`, ensurepip bootstrap, and a standing guard that fails on any bare `pip3 install` reappearing in the shared helper.

Full suite: **2987 passed, 1 skipped**. ruff and mypy clean.
