### PR TITLE
Fix "Update now" on source installs: worker could not import, and one failure wedged the button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.88] - 2026-07-30
+
+### Fixed
+
+- **The web UI's "Update now" button never worked on a source install, and one click permanently disabled it.** Two separate defects, found together on a real install where an update attempt had left `logs/update_apply.log` holding nothing but a traceback and every subsequent click returning `409 CONFLICT` for a day afterwards.
+
+  **1. The detached worker couldn't import its own dependencies.** `UpdateManager._spawn_worker` launches it as a plain script - `sys.executable os.path.abspath(__file__)` - which puts `web/` at `sys.path[0]`, not the project root. Its module-level `from utils import self_update, self_update_handoff` therefore raised `ModuleNotFoundError: No module named 'utils'` and the worker died before doing any work at all. The spawner does pass `cwd=project_root`, which makes it look like it should resolve, but cwd is not on `sys.path` for a script invocation - only the script's own directory is. `web/update_apply.py` now puts the project root on `sys.path` before those imports, guarded on `__package__` so it stays a no-op when imported normally or run via `-m`.
+
+  Nothing surfaced any of this: the route had already returned `202 started`, the traceback went to a log file, and the page just polled `/healthz` until it timed out with "Update is taking longer than expected".
+
+  **2. A dead worker wedged the button forever.** `subprocess.Popen()` succeeds the instant the child is spawned, so a worker that dies a millisecond later still counts as a successful spawn. `_in_progress` was set to `True` with nothing alive to ever clear it - and it lives in memory in a server process that (because the update failed) never restarted. Every later "Update now" hit `UpdateAlreadyInProgressError` -> 409. A single transient worker failure permanently disabled updates until the process was manually restarted. `is_in_progress()` now cross-checks the flag against the worker actually being alive via `poll()`, so a worker that exits without restarting the server no longer blocks anything. The normal success path is unaffected - a real update ends with this server process killed, so nothing is left to observe the worker's exit.
+
+  Both are covered by regression tests that fail against the previous code: the worker is spawned as a script from two different working directories and asserted not to raise `ModuleNotFoundError`, and the stuck-flag path is driven through `begin_update()` to prove a crashed predecessor no longer blocks a retry while a genuinely concurrent update still does.
+
 ## [2.10.87] - 2026-07-30
 
 ### Fixed

--- a/tests/test_web_update_worker_bootstrap.py
+++ b/tests/test_web_update_worker_bootstrap.py
@@ -1,0 +1,158 @@
+"""
+Regression tests for the two defects that made the web UI's "Update now"
+button fail permanently on a source install.
+
+1. The detached worker is spawned as a PLAIN SCRIPT
+   (`sys.executable os.path.abspath(web/update_apply.py)`), which puts
+   web/ on sys.path rather than the project root, so its module-level
+   `from utils import ...` raised ModuleNotFoundError and the worker died
+   before doing anything. Nothing surfaced it: the route had already
+   returned 202, and the traceback went to logs/update_apply.log.
+
+2. Because subprocess.Popen() succeeds the moment the child is spawned,
+   that instantly-dead worker left UpdateManager._in_progress True with
+   nothing alive to clear it - so every subsequent click returned 409
+   CONFLICT until the server process was restarted. One transient
+   failure permanently disabled updates.
+
+Observed together on a real install: an update attempt logged
+ModuleNotFoundError, and every "Update now" for the next day returned
+409.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from web.update_apply import UpdateManager
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKER = REPO_ROOT / "web" / "update_apply.py"
+
+
+class TestWorkerIsImportableAsAScript:
+    """The exact invocation UpdateManager._spawn_worker uses."""
+
+    def test_running_worker_as_a_script_does_not_fail_to_import(self):
+        # No args, so argparse rejects it and exits 2 - but only AFTER the
+        # module body (and its `from utils import ...`) has executed. An
+        # import error would instead surface as a traceback on stderr.
+        proc = subprocess.run(
+            [sys.executable, str(WORKER)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        assert "ModuleNotFoundError" not in proc.stderr, (
+            f"worker cannot import its own dependencies when spawned as a script:\n{proc.stderr}"
+        )
+        assert "usage:" in proc.stderr, f"expected argparse usage, got:\n{proc.stderr}"
+
+    def test_worker_imports_from_an_unrelated_cwd(self, tmp_path):
+        """cwd is not what makes the import work - the sys.path bootstrap is.
+
+        The spawner does pass cwd=project_root, which makes it tempting to
+        assume that's sufficient; it isn't, because cwd is not on sys.path
+        for a script invocation. Running from elsewhere proves the fix
+        doesn't secretly depend on it.
+        """
+        proc = subprocess.run(
+            [sys.executable, str(WORKER)],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            timeout=60,
+        )
+        assert "ModuleNotFoundError" not in proc.stderr, proc.stderr
+        assert "usage:" in proc.stderr
+
+    def test_bootstrap_is_a_noop_when_imported_as_a_module(self):
+        """`from web import update_apply` must not shove a duplicate entry
+        onto sys.path - the guard is on __package__ for that reason."""
+        code = (
+            "import sys; before = list(sys.path);"
+            "import web.update_apply;"
+            "print('DUPLICATE' if len(sys.path) != len(before) else 'CLEAN')"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        assert "CLEAN" in proc.stdout, f"sys.path mutated on normal import: {proc.stdout} {proc.stderr}"
+
+
+class FakeProc:
+    """Stands in for subprocess.Popen - poll() is all UpdateManager uses."""
+
+    def __init__(self, exit_code=None, pid=4242):
+        self._exit_code = exit_code
+        self.pid = pid
+        self.returncode = exit_code
+
+    def poll(self):
+        return self._exit_code
+
+
+class TestDeadWorkerDoesNotWedgeTheButton:
+    @pytest.fixture
+    def manager(self, tmp_path):
+        return UpdateManager(project_root=str(tmp_path), logs_dir=str(tmp_path / "logs"))
+
+    def test_reports_in_progress_while_the_worker_is_alive(self, manager):
+        manager._in_progress = True
+        manager._worker = FakeProc(exit_code=None)  # still running
+        assert manager.is_in_progress() is True
+
+    def test_clears_in_progress_when_the_worker_has_exited(self, manager):
+        """The actual bug: worker died, server lived, flag stuck forever."""
+        manager._in_progress = True
+        manager._worker = FakeProc(exit_code=1)  # crashed, e.g. ModuleNotFoundError
+        assert manager.is_in_progress() is False
+        assert manager._in_progress is False
+
+    def test_clears_in_progress_even_on_a_zero_exit(self, manager):
+        """A worker that exits 0 without restarting the server is equally
+        stuck - success is the server going away, not a zero exit code."""
+        manager._in_progress = True
+        manager._worker = FakeProc(exit_code=0)
+        assert manager.is_in_progress() is False
+
+    def test_a_crashed_worker_does_not_block_the_next_attempt(self, manager, monkeypatch):
+        """End to end: begin_update must not raise UpdateAlreadyInProgress
+        just because a previous worker died."""
+        manager._in_progress = True
+        manager._worker = FakeProc(exit_code=1)
+
+        monkeypatch.setattr("web.update_apply.check_verified_update", lambda root: "v9.9.9")
+        spawned = {}
+        monkeypatch.setattr(
+            UpdateManager, "_spawn_worker", lambda self, host, port: spawned.update(host=host, port=port)
+        )
+
+        tag = manager.begin_update("127.0.0.1", 8787)
+        assert tag == "v9.9.9"
+        assert spawned == {"host": "127.0.0.1", "port": 8787}
+
+    def test_still_rejects_a_genuinely_concurrent_update(self, manager, monkeypatch):
+        """The guard must not be so permissive that two real updates overlap."""
+        manager._in_progress = True
+        manager._worker = FakeProc(exit_code=None)  # alive
+
+        monkeypatch.setattr("web.update_apply.check_verified_update", lambda root: "v9.9.9")
+        from web.update_apply import UpdateAlreadyInProgressError
+
+        with pytest.raises(UpdateAlreadyInProgressError):
+            manager.begin_update("127.0.0.1", 8787)
+
+    def test_no_worker_handle_yet_is_still_in_progress(self, manager):
+        """Between setting the flag and Popen returning there's no handle -
+        that window must not read as 'not running'."""
+        manager._in_progress = True
+        manager._worker = None
+        assert manager.is_in_progress() is True

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.87"
+__version__ = "2.10.88"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's

--- a/web/update_apply.py
+++ b/web/update_apply.py
@@ -105,6 +105,29 @@ import threading
 import time
 from typing import Optional
 
+# A source install spawns this module as a PLAIN SCRIPT - `sys.executable
+# os.path.abspath(__file__)`, see UpdateManager._spawn_worker - which puts
+# THIS file's own directory (web/) at sys.path[0], not the project root.
+# The `from utils import ...` below therefore could not resolve, and the
+# detached worker died with `ModuleNotFoundError: No module named 'utils'`
+# before doing anything at all. `cwd` IS set to the project root by the
+# spawner, but cwd is not on sys.path for a script invocation - only the
+# script's own directory is - so that didn't help.
+#
+# The failure was invisible from the UI: the worker's traceback goes to
+# logs/update_apply.log, the server had already returned 202 "started",
+# and the page just polled /healthz until it timed out. Worse, the
+# server's own in-memory `_in_progress` flag stayed True forever, so
+# every later click returned 409 CONFLICT until the process was
+# restarted - i.e. one failed update permanently disabled the button.
+#
+# Guarded on __package__ so it applies ONLY to that script invocation:
+# imported normally (`from web import update_apply`) or run as
+# `-m web.update_apply`, the project root is already on the path and
+# this is a no-op rather than a duplicate entry.
+if __package__ in (None, ""):  # pragma: no cover - only true for the spawned-as-script worker
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from utils import self_update, self_update_handoff
 from utils.helpers import no_window_kwargs, resolve_system_executable
 from utils.update_check import update_available
@@ -257,9 +280,48 @@ class UpdateManager:
         self.logs_dir = logs_dir
         self._lock = threading.Lock()
         self._in_progress = False
+        self._worker: Optional[subprocess.Popen] = None
+
+    def _in_progress_locked(self) -> bool:
+        """Whether an update is genuinely still running. CALL WITH _lock HELD.
+
+        `_in_progress` alone is not enough. subprocess.Popen() succeeds as
+        soon as the child is spawned, so a worker that dies immediately
+        afterwards - which is exactly what happened when it couldn't
+        import `utils` (see the sys.path note at the top of this module) -
+        left this flag True with nothing alive to ever clear it. The
+        server survived, every later "Update now" got 409 CONFLICT, and
+        the only cure was restarting the process: a single transient
+        worker failure permanently disabled the button.
+
+        So the flag is now cross-checked against the worker actually
+        being alive. poll() works here because start_new_session only
+        detaches the session/process group - the worker is still this
+        process's child, so it's still reapable.
+
+        Note the normal, successful path never reaches the False branch:
+        the worker's whole job is to kill THIS process, so a live update
+        ends with the server gone rather than with anything observing the
+        worker exit. This only fires when the worker died without taking
+        the server with it - i.e. precisely the stuck case.
+        """
+        if not self._in_progress:
+            return False
+        worker = self._worker
+        if worker is not None and worker.poll() is not None:
+            logger.warning(
+                f"Update worker (pid {worker.pid}) exited with code {worker.returncode} "
+                f"without restarting the server - clearing the in-progress flag. "
+                f"See {os.path.join(self.logs_dir, UPDATE_LOG_FILENAME)}."
+            )
+            self._in_progress = False
+            self._worker = None
+            return False
+        return True
 
     def is_in_progress(self) -> bool:
-        return self._in_progress
+        with self._lock:
+            return self._in_progress_locked()
 
     def begin_update(self, host: str, port: int) -> str:
         """
@@ -296,9 +358,10 @@ class UpdateManager:
         Returns the (advisory, for a frozen binary) tag being applied.
         """
         with self._lock:
-            if self._in_progress:
+            if self._in_progress_locked():
                 raise UpdateAlreadyInProgressError("An update is already being applied.")
             self._in_progress = True
+            self._worker = None
 
         try:
             if os.environ.get("RUNNING_IN_DOCKER") == "true":
@@ -421,8 +484,12 @@ class UpdateManager:
         else:
             popen_kwargs["start_new_session"] = True
 
-        subprocess.Popen(cmd, **popen_kwargs)  # type: ignore[call-overload]  # mypy can't resolve Popen's overloads against a dynamically-built **dict splat
-        logger.info(f"Update worker started for {host}:{port} (log: {log_path})")
+        # Keep the handle: _in_progress_locked() polls it so a worker that
+        # dies without restarting the server can't wedge the button.
+        proc = subprocess.Popen(cmd, **popen_kwargs)  # type: ignore[call-overload]  # mypy can't resolve Popen's overloads against a dynamically-built **dict splat
+        with self._lock:
+            self._worker = proc
+        logger.info(f"Update worker started for {host}:{port} (log: {log_path}, pid: {proc.pid})")
 
 
 # =============================================================================


### PR DESCRIPTION
The web UI's **"Update now" button never worked on a source install** — and a single click permanently disabled it.

Found together on a real install: an update attempt left `logs/update_apply.log` holding nothing but a traceback, and every subsequent click returned `409 CONFLICT` for a day afterwards.

## 1. The worker couldn't import its own dependencies

`UpdateManager._spawn_worker` launches it as a plain script:

```python
cmd = [sys.executable, os.path.abspath(__file__), ...]
```

That puts **`web/`** at `sys.path[0]`, not the project root. So the module-level import on line 108 —

```python
from utils import self_update, self_update_handoff
```

— raised `ModuleNotFoundError: No module named 'utils'`, and the worker died before doing any work at all.

The spawner *does* pass `cwd=project_root`, which makes this look like it should resolve. It doesn't: **cwd is not on `sys.path` for a script invocation** — only the script's own directory is.

Nothing surfaced it. The route had already returned `202 started`, the traceback went to a log file, and the page polled `/healthz` until it timed out with "Update is taking longer than expected".

Fixed by putting the project root on `sys.path` before those imports, guarded on `__package__` so it's a no-op when imported normally or run via `-m`.

## 2. A dead worker wedged the button forever

`subprocess.Popen()` succeeds the instant the child is spawned — a worker that dies a millisecond later still counts as a successful spawn. So `_in_progress` was set `True` with nothing alive to ever clear it, in a server process that (because the update failed) never restarted.

Every later click then hit `UpdateAlreadyInProgressError` → 409. **One transient worker failure permanently disabled updates** until the process was manually restarted.

`is_in_progress()` now cross-checks the flag against the worker actually being alive via `poll()`. `poll()` is valid here because `start_new_session` only detaches the session/process group — the worker is still this process's child.

The success path is unaffected: a real update ends with this server process killed, so nothing is ever left to observe the worker's exit. The False branch only fires when the worker died *without* taking the server with it — precisely the stuck case.

## Verification

Both defects are covered by tests that **fail against the previous code** (confirmed by running the pre-fix file from git at the same path — it reproduces the exact `ModuleNotFoundError` the test asserts on):

- worker spawned as a script from the project root **and** from an unrelated cwd, asserted not to raise `ModuleNotFoundError` (the second proves the fix doesn't secretly depend on cwd)
- the `__package__` guard asserted to leave `sys.path` unmutated on a normal import
- the stuck-flag path driven through `begin_update()` to prove a crashed predecessor no longer blocks a retry, **while a genuinely concurrent update still does**

Full suite: **2996 passed, 1 skipped**. ruff and mypy clean.
