### PR TITLE
Show progress during "Update now", and report what actually happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.89] - 2026-07-30
+
+### Added
+
+- **"Update now" now shows progress while it works, and says what actually happened when it's done.** Previously it printed one static line ("This can take up to a minute"), went silent for the entire restart, and then simply reloaded the page - never reporting success or failure. You inferred the result from a version number, and a *failed* update looked identical to a successful one, because the worker deliberately relaunches the UI either way. The banner now carries an indeterminate progress bar with a labelled step ("Step 3 of 4: Downloading and verifying the update") and an elapsed-seconds counter, then resolves to `✓ Updated to v2.10.89.` or `✗ <reason>. See logs/update_apply.log.`
+
+  The bar is **indeterminate on purpose - there is no percentage.** The server is dead for almost the whole update (the worker kills it, applies, and starts a fresh one), so nothing is in a position to measure real progress. A percentage would have to be elapsed-time against a guessed duration, which would keep climbing toward 100% while a genuinely hung update sat there - worse than showing no number at all. The step labels are time-based estimates and are presented as steps rather than as measured progress; the *outcome* is not estimated at all.
+
+  The outcome is read from a new `logs/update_status.json` that the worker writes as it goes, exposed by a new `GET /update/status`. It has to be a file rather than in-memory state for the same reason the progress can't be live: the page reconnects to a brand new process with no memory of the update. `begin_update()` resets the file before spawning, since the previous update's verdict is otherwise still sitting on disk and would be read as this one's the moment the page reconnected; the client additionally ignores any status older than its own click. A frozen binary's outcome is deliberately left unknown - its swap and relaunch are performed by an external script that outlives the worker, so the worker genuinely cannot know, and the UI renders that as a neutral reload rather than guessing a verdict.
+
+  On failure the page **does not reload**, since reloading would destroy the only explanation the user ever gets, and the button is re-enabled to retry. On success it reloads after showing the result so the banner clears. Verified by driving the client's own branches - updated / failed / no_update / aborted / stale / unknown - against a stubbed DOM and `fetch`.
+
 ## [2.10.88] - 2026-07-30
 
 ### Fixed

--- a/tests/test_web_update_status.py
+++ b/tests/test_web_update_status.py
@@ -1,0 +1,225 @@
+"""
+Tests for the update progress/outcome reporting added alongside the
+"Update now" progress UI.
+
+The reason any of this is file-based: the server process does NOT survive
+an update. The worker kills it, applies, and starts a fresh one, so the
+page reconnects to a process with no memory of what just happened.
+Anything held in memory dies with the old server; the outcome has to be
+written somewhere both processes can see.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from web.app import create_app
+from web.update_apply import (
+    UPDATE_OUTCOME_ABORTED,
+    UPDATE_OUTCOME_FAILED,
+    UPDATE_OUTCOME_NO_UPDATE,
+    UPDATE_OUTCOME_UPDATED,
+    UPDATE_PHASES,
+    _record_apply_outcome,
+    read_update_status,
+    update_status_path,
+    write_update_status,
+)
+
+
+class TestStatusFileRoundTrip:
+    def test_missing_file_reads_as_empty(self, tmp_path):
+        assert read_update_status(str(tmp_path)) == {}
+
+    def test_write_then_read(self, tmp_path):
+        write_update_status(str(tmp_path), phase="applying", step=3)
+        assert read_update_status(str(tmp_path))["phase"] == "applying"
+
+    def test_writes_merge_rather_than_replace(self, tmp_path):
+        """The worker updates one field at a time as it progresses; an
+        earlier write's `tag` must survive a later `phase` write."""
+        write_update_status(str(tmp_path), tag="v9.9.9", started_at=1.0)
+        write_update_status(str(tmp_path), phase="relaunching")
+        status = read_update_status(str(tmp_path))
+        assert status["tag"] == "v9.9.9"
+        assert status["started_at"] == 1.0
+        assert status["phase"] == "relaunching"
+
+    def test_malformed_file_reads_as_empty_not_raises(self, tmp_path):
+        """Corrupt status means "we don't know" - which the UI renders as
+        neutral. It must never raise into a request handler."""
+        with open(update_status_path(str(tmp_path)), "w", encoding="utf-8") as f:
+            f.write("{not json")
+        assert read_update_status(str(tmp_path)) == {}
+
+    def test_non_dict_json_reads_as_empty(self, tmp_path):
+        with open(update_status_path(str(tmp_path)), "w", encoding="utf-8") as f:
+            json.dump([1, 2, 3], f)
+        assert read_update_status(str(tmp_path)) == {}
+
+    def test_leaves_no_temp_file_behind(self, tmp_path):
+        """Written via a temp file + rename so a concurrent reader in the
+        OTHER process can never see a half-written file."""
+        write_update_status(str(tmp_path), phase="applying")
+        leftovers = [n for n in os.listdir(tmp_path) if n.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_write_never_raises_on_an_unwritable_dir(self, tmp_path):
+        """Best-effort by contract: progress reporting must never be the
+        thing that breaks an otherwise-fine update."""
+        target = tmp_path / "nested"
+        target.write_text("I am a file, not a directory", encoding="utf-8")
+        write_update_status(str(target), phase="applying")  # must not raise
+
+
+class TestApplyOutcomeMapping:
+    """run.sh's --apply-verified-update contract is exactly one of
+    UPDATED:<tag> / NO_UPDATE / FAILED:<reason>."""
+
+    def test_updated_records_tag(self, tmp_path):
+        _record_apply_outcome(str(tmp_path), "UPDATED:v2.10.88")
+        status = read_update_status(str(tmp_path))
+        assert status["outcome"] == UPDATE_OUTCOME_UPDATED
+        assert status["tag"] == "v2.10.88"
+        assert "v2.10.88" in status["detail"]
+        assert status["finished_at"] is not None
+
+    def test_no_update(self, tmp_path):
+        _record_apply_outcome(str(tmp_path), "NO_UPDATE")
+        assert read_update_status(str(tmp_path))["outcome"] == UPDATE_OUTCOME_NO_UPDATE
+
+    def test_failed_carries_the_reason_through(self, tmp_path):
+        _record_apply_outcome(str(tmp_path), "FAILED:Python 3.9.6 is below the 3.10 floor")
+        status = read_update_status(str(tmp_path))
+        assert status["outcome"] == UPDATE_OUTCOME_FAILED
+        assert status["detail"] == "Python 3.9.6 is below the 3.10 floor"
+
+    def test_failed_with_no_reason_still_has_a_message(self, tmp_path):
+        _record_apply_outcome(str(tmp_path), "FAILED:")
+        assert read_update_status(str(tmp_path))["detail"]
+
+    @pytest.mark.parametrize("garbage", ["", "something else entirely", "UPDATED", "ok"])
+    def test_unrecognized_output_is_failure_not_success(self, tmp_path, garbage):
+        """A confident "updated" off an unrecognized string is exactly the
+        false success this reporting exists to prevent."""
+        _record_apply_outcome(str(tmp_path), garbage)
+        assert read_update_status(str(tmp_path))["outcome"] == UPDATE_OUTCOME_FAILED
+
+
+@pytest.fixture
+def web(curatarr_web_root):
+    """Same shape as tests/test_web_routes.py's client fixture."""
+    app = create_app(project_root=curatarr_web_root, code_root=curatarr_web_root)
+    app.testing = True
+    return app.test_client(), app
+
+
+class TestUpdateStatusRoute:
+    def test_returns_empty_shape_when_no_update_has_run(self, web):
+        client, _app = web
+        resp = client.get("/update/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["outcome"] is None
+
+    def test_surfaces_a_recorded_outcome(self, web):
+        client, app = web
+        write_update_status(
+            app.config["LOGS_DIR"],
+            outcome=UPDATE_OUTCOME_UPDATED,
+            tag="v2.10.88",
+            detail="Updated to v2.10.88.",
+            started_at=123.0,
+            finished_at=456.0,
+        )
+        body = client.get("/update/status").get_json()
+        assert body["outcome"] == "updated"
+        assert body["tag"] == "v2.10.88"
+        assert body["started_at"] == 123.0
+
+    def test_surfaces_in_flight_phase(self, web):
+        client, app = web
+        write_update_status(app.config["LOGS_DIR"], phase="applying", step=3, total_steps=4)
+        body = client.get("/update/status").get_json()
+        assert body["phase"] == "applying"
+        assert body["step"] == 3
+        assert body["outcome"] is None
+
+    def test_does_not_leak_extra_fields(self, web):
+        """Deliberately renders only what the UI needs - no paths, no
+        command lines, no stderr."""
+        client, app = web
+        write_update_status(app.config["LOGS_DIR"], phase="applying", secret_path="/home/someone/token")
+        body = client.get("/update/status").get_json()
+        assert "secret_path" not in body
+
+    def test_aborted_outcome_survives_to_the_route(self, web):
+        client, app = web
+        write_update_status(
+            app.config["LOGS_DIR"],
+            outcome=UPDATE_OUTCOME_ABORTED,
+            detail="A recommender run is in progress - nothing was changed.",
+        )
+        assert client.get("/update/status").get_json()["outcome"] == "aborted"
+
+
+class TestProgressMarkupIsRendered:
+    """The script in base.html looks these up by id and silently does
+    nothing useful if they're absent, so a template edit that dropped
+    them would leave the update flow with no visible progress at all -
+    and no test failure anywhere else to catch it."""
+
+    @pytest.fixture
+    def banner_client(self, curatarr_web_root, monkeypatch):
+        import web.app as app_module
+
+        monkeypatch.setattr(app_module, "update_available", lambda **kw: ("99.0.0", "1.0.0", True))
+        monkeypatch.setattr(app_module, "is_dismissed", lambda v: False)
+        app = create_app(project_root=curatarr_web_root, code_root=curatarr_web_root)
+        app.testing = True
+        return app.test_client()
+
+    def test_banner_renders_with_progress_elements(self, banner_client):
+        html = banner_client.get("/").get_data(as_text=True)
+        assert 'id="update-banner"' in html, "no update banner rendered - fixture setup is wrong"
+        for element_id in ("update-progress", "update-progress-bar", "update-progress-step"):
+            assert f'id="{element_id}"' in html, f"progress element #{element_id} missing from base.html"
+
+    def test_progress_starts_hidden(self, banner_client):
+        """It must not be visible until an update is actually running."""
+        html = banner_client.get("/").get_data(as_text=True)
+        progress_div = html[html.index('id="update-progress"') :][:200]
+        assert "hidden" in progress_div
+
+    def test_script_reads_the_status_endpoint(self, banner_client):
+        """The whole point of the change: report the real outcome instead
+        of reloading and leaving the user to infer it."""
+        html = banner_client.get("/").get_data(as_text=True)
+        assert "/update/status" in html
+
+
+class TestBeginUpdateResetsStaleOutcome:
+    def test_previous_outcome_is_cleared_before_spawning(self, tmp_path, monkeypatch):
+        """The status file survives the restart by design, so last time's
+        verdict is still on disk. Left there, the page would read the OLD
+        update's result as this one's the moment it reconnected."""
+        from web.update_apply import UpdateManager
+
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        write_update_status(str(logs_dir), outcome=UPDATE_OUTCOME_FAILED, detail="last time it broke")
+
+        manager = UpdateManager(project_root=str(tmp_path), logs_dir=str(logs_dir))
+        monkeypatch.setattr("web.update_apply.check_verified_update", lambda root: "v9.9.9")
+        monkeypatch.setattr(UpdateManager, "_spawn_worker", lambda self, host, port: None)
+
+        manager.begin_update("127.0.0.1", 8787)
+
+        status = read_update_status(str(logs_dir))
+        assert status["outcome"] is None
+        assert status["tag"] == "v9.9.9"
+        assert status["phase"] == UPDATE_PHASES[0]
+        assert status["started_at"] is not None

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.88"
+__version__ = "2.10.89"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's

--- a/web/app.py
+++ b/web/app.py
@@ -85,6 +85,7 @@ from .update_apply import (
     UpdateAlreadyInProgressError,
     UpdateManager,
     UpdateNotAvailableError,
+    read_update_status,
 )
 
 DEFAULT_PORT = 8787
@@ -494,6 +495,36 @@ def create_app(
         already exposed via /healthz and /status.json - just never
         rendered anywhere a human looks at it directly before this."""
         return {"curatarr_version": __version__}
+
+    @app.get("/update/status")
+    def update_status():
+        """What the last/current update is doing, for base.html's progress UI.
+
+        Exists because the server does NOT survive an update - the worker
+        kills it, applies, and starts a fresh one. The page that reconnects
+        is talking to a process with no memory of the update, so the
+        outcome has to come off disk (logs/update_status.json, written by
+        the worker itself - see web/update_apply.py).
+
+        Unauthenticated for the same reason as /healthz: this app's only
+        boundary is binding 127.0.0.1 plus the origin/host guard, and a
+        phase name and version tag are no more sensitive than the version
+        /healthz already returns. Deliberately returns only what the UI
+        renders - no paths, no command lines, no stderr.
+        """
+        status = read_update_status(app.config["LOGS_DIR"])
+        return jsonify(
+            {
+                "phase": status.get("phase"),
+                "step": status.get("step"),
+                "total_steps": status.get("total_steps"),
+                "tag": status.get("tag"),
+                "outcome": status.get("outcome"),
+                "detail": status.get("detail"),
+                "started_at": status.get("started_at"),
+                "finished_at": status.get("finished_at"),
+            }
+        )
 
     @app.post("/update/dismiss")
     def update_dismiss():

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -343,6 +343,11 @@ button:disabled {
 .banner.running { border-left-color: var(--gold); color: var(--gold-pale); }
 .banner.error { border-left-color: var(--fail); color: var(--fail); }
 .banner.warn { border-left-color: var(--warn); color: var(--warn); }
+/* Used by the update banner when an update finishes successfully - the
+   banner starts as .warn ("update available") and is re-coloured in
+   place rather than replaced, so the result appears exactly where the
+   user was already looking. */
+.banner.ok { border-left-color: var(--ok); color: var(--ok); }
 
 /* --- Per-stage run breakdown (#282/#288 - see run.html/results.html) --- */
 .stage-results { list-style: none; padding: 0; margin: 0 0 12px; }
@@ -355,6 +360,9 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  /* The progress row below is a third flex child and must sit on its own
+     line rather than being squeezed in beside the text and the buttons. */
+  flex-wrap: wrap;
 }
 
 .update-banner a { color: inherit; text-decoration: underline; }
@@ -372,6 +380,59 @@ button:disabled {
   padding: 8px 16px;
   font-size: 0.7rem;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+}
+
+/* --- Update progress (see base.html's "Update now" script) ---
+   Indeterminate on purpose. The server is dead for almost the whole
+   update, so nothing can measure real progress; a percentage here would
+   be invented, and would keep climbing while a hung update sat there. */
+.update-progress {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.update-progress-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.update-progress-bar {
+  height: 100%;
+  width: 100%;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: 0.85;
+}
+
+.update-progress-bar.indeterminate {
+  width: 35%;
+  animation: update-progress-slide 1.4s ease-in-out infinite;
+}
+
+@keyframes update-progress-slide {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(386%); }
+}
+
+/* An indefinitely looping animation is exactly what this setting is for.
+   The step label and the elapsed counter still update, so no information
+   is lost - only the motion is. */
+@media (prefers-reduced-motion: reduce) {
+  .update-progress-bar.indeterminate {
+    width: 100%;
+    animation: none;
+  }
+}
+
+.update-progress-step {
+  font-size: 0.7rem;
+  opacity: 0.85;
 }
 
 .update-banner-dismiss { margin: 0; }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -48,6 +48,16 @@
             <button type="submit" aria-label="Dismiss update notice">&times;</button>
           </form>
         </span>
+        {# Hidden until an update actually starts. The bar is
+           INDETERMINATE on purpose - see the STEPS comment in the script
+           below for why there is no percentage. #}
+        <div class="update-progress" id="update-progress" hidden>
+          <div class="update-progress-track">
+            <div class="update-progress-bar" id="update-progress-bar"></div>
+          </div>
+          <span class="update-progress-step" id="update-progress-step"
+                role="status" aria-live="polite"></span>
+        </div>
       </div>
       <script>
         (function () {
@@ -64,6 +74,7 @@
           if (!btn) { return; }
           var textEl = document.getElementById('update-banner-text');
           var dismissForm = document.getElementById('update-banner-dismiss-form');
+          var banner = document.getElementById('update-banner');
           var POLL_INTERVAL_MS = 2000;
           var POLL_TOTAL_MS = 60000;
           // The worker sleeps this long before touching anything (see
@@ -72,19 +83,111 @@
           // server and short-circuit as "done" before anything happened.
           var INITIAL_DELAY_MS = 2500;
 
+          var progressEl = document.getElementById('update-progress');
+          var barEl = document.getElementById('update-progress-bar');
+          var stepEl = document.getElementById('update-progress-step');
+          var startedAt = 0;
+          var stepTimer = null;
+
+          // Elapsed-time step labels. These mirror UPDATE_PHASES in
+          // web/update_apply.py, but the timings are ESTIMATES and
+          // deliberately presented as such (the bar is indeterminate,
+          // never a percentage). The worker does write a real phase to
+          // logs/update_status.json as it goes - but the server is dead
+          // for almost all of this window, so nothing can be asked for
+          // it until it's over. Showing a fake percentage against an
+          // unknowable duration would be worse than showing none: it
+          // would keep climbing while a hung update sat there.
+          var STEPS = [
+            { at: 0,     label: 'Step 1 of 4: Preparing' },
+            { at: 2000,  label: 'Step 2 of 4: Stopping the current version' },
+            { at: 5000,  label: 'Step 3 of 4: Downloading and verifying the update' },
+            { at: 20000, label: 'Step 4 of 4: Restarting' }
+          ];
+
           function setMessage(msg) {
             textEl.textContent = msg;
           }
 
+          function currentStepLabel(elapsed) {
+            var label = STEPS[0].label;
+            for (var i = 0; i < STEPS.length; i++) {
+              if (elapsed >= STEPS[i].at) { label = STEPS[i].label; }
+            }
+            return label;
+          }
+
+          function startProgress() {
+            startedAt = Date.now();
+            if (progressEl) { progressEl.hidden = false; }
+            if (barEl) { barEl.classList.add('indeterminate'); }
+            stepTimer = setInterval(function () {
+              var elapsed = Date.now() - startedAt;
+              if (stepEl) {
+                stepEl.textContent = currentStepLabel(elapsed) +
+                  '  ·  ' + Math.round(elapsed / 1000) + 's';
+              }
+            }, 500);
+          }
+
+          function stopProgress() {
+            if (stepTimer) { clearInterval(stepTimer); stepTimer = null; }
+            if (barEl) { barEl.classList.remove('indeterminate'); }
+            if (progressEl) { progressEl.hidden = true; }
+          }
+
           function resetToIdle(msg) {
+            stopProgress();
             setMessage(msg);
             btn.disabled = false;
             if (dismissForm) { dismissForm.style.display = ''; }
           }
 
+          // Report what actually happened, from the worker's own record.
+          // Only trusted if it belongs to THIS attempt: the status file
+          // survives the restart by design, so a previous update's
+          // verdict is still on disk until the next one starts.
+          function reportOutcome() {
+            fetch('/update/status', { cache: 'no-store' })
+              .then(function (resp) { return resp.json(); })
+              .then(function (s) {
+                var stale = !s || !s.started_at || (s.started_at * 1000) < (startedAt - 5000);
+                if (stale || !s.outcome) {
+                  // Unknown (frozen hand-off, or an unreadable file) -
+                  // say so plainly and let the reloaded page's version
+                  // speak for itself rather than guessing a verdict.
+                  setMessage('Reconnected - reloading...');
+                  window.location.reload();
+                  return;
+                }
+                if (s.outcome === 'updated') {
+                  banner.classList.remove('warn');
+                  banner.classList.add('ok');
+                  setMessage('✓ ' + (s.detail || 'Updated.') + ' Reloading...');
+                  setTimeout(function () { window.location.reload(); }, 1500);
+                  return;
+                }
+                // no_update / failed / aborted: do NOT reload. Reloading
+                // would wipe the only explanation the user ever gets.
+                banner.classList.remove('warn');
+                banner.classList.add(s.outcome === 'no_update' ? 'ok' : 'error');
+                var mark = s.outcome === 'no_update' ? '✓ ' : '✗ ';
+                var detail = s.detail || 'The update did not complete.';
+                // run.sh's FAILED:<reason> strings aren't guaranteed to be
+                // punctuated, so don't run straight into the next sentence.
+                if (!/[.!?]$/.test(detail)) { detail += '.'; }
+                var suffix = s.outcome === 'failed' ? ' See logs/update_apply.log.' : '';
+                resetToIdle(mark + detail + suffix);
+              })
+              .catch(function () {
+                setMessage('Reconnected - reloading...');
+                window.location.reload();
+              });
+          }
+
           function pollHealthz(deadline) {
             if (Date.now() > deadline) {
-              setMessage('Update is taking longer than expected - check logs/update_apply.log, or restart curatarr manually.');
+              resetToIdle('Update is taking longer than expected - check logs/update_apply.log, or restart curatarr manually.');
               return;
             }
             fetch('/healthz', { cache: 'no-store' })
@@ -93,11 +196,14 @@
                 return resp.json();
               })
               .then(function () {
-                // Something answered again - old code or new, either
-                // way reload and let the page's own banner logic show
-                // whatever's actually true now.
-                setMessage('Reconnected - reloading...');
-                window.location.reload();
+                // Something answered again - old code or new. Which one
+                // it is, and whether the update actually worked, comes
+                // from the worker's own record, not from the mere fact
+                // that a server is listening: the worker relaunches the
+                // UI on failure too, so "it came back" is not success.
+                stopProgress();
+                setMessage('Reconnected - checking result...');
+                reportOutcome();
               })
               .catch(function () {
                 setTimeout(function () { pollHealthz(deadline); }, POLL_INTERVAL_MS);
@@ -120,7 +226,8 @@
                   resetToIdle((result.data && result.data.error) || 'Could not start the update.');
                   return;
                 }
-                setMessage('Updating to ' + result.data.tag + '... the page will reconnect automatically. This can take up to a minute.');
+                setMessage('Updating to ' + result.data.tag + '... the page will reconnect automatically.');
+                startProgress();
                 setTimeout(function () {
                   pollHealthz(Date.now() + POLL_TOTAL_MS);
                 }, INITIAL_DELAY_MS);

--- a/web/update_apply.py
+++ b/web/update_apply.py
@@ -94,6 +94,7 @@ decision directly.
 """
 
 import argparse
+import json
 import logging
 import os
 import signal
@@ -135,6 +136,79 @@ from utils.update_check import update_available
 logger = logging.getLogger("curatarr")
 
 UPDATE_LOG_FILENAME = "update_apply.log"
+
+# Machine-readable sibling of UPDATE_LOG_FILENAME, so the UI can report
+# what actually happened instead of silently reloading and leaving the
+# user to infer it from a version number.
+#
+# A FILE rather than in-memory state, specifically because the server
+# process does not survive an update: the worker kills it, applies, and
+# starts a brand new one. Anything held in memory dies with it. The page
+# reconnects to a process that has no idea an update just happened, so
+# the outcome has to be written somewhere both sides can see.
+UPDATE_STATUS_FILENAME = "update_status.json"
+
+# Phases a source-install worker moves through, in order. The UI shows
+# these as "Step N of 4"; the worker stamps each one into the status
+# file as it starts it.
+#
+# Deliberately coarse. The genuinely slow phase is "applying" (git fetch
+# + signature verify + checkout + a possible dependency reinstall), and
+# nothing inside run.sh --apply-verified-update reports sub-progress, so
+# inventing finer steps would mean inventing their timing too.
+UPDATE_PHASES = ("preparing", "stopping", "applying", "relaunching")
+
+# Terminal values for the status file's "outcome" field. `None` while
+# still running.
+UPDATE_OUTCOME_UPDATED = "updated"
+UPDATE_OUTCOME_NO_UPDATE = "no_update"
+UPDATE_OUTCOME_FAILED = "failed"
+UPDATE_OUTCOME_ABORTED = "aborted"
+
+
+def update_status_path(logs_dir: str) -> str:
+    return os.path.join(logs_dir, UPDATE_STATUS_FILENAME)
+
+
+def write_update_status(logs_dir: str, **fields) -> None:
+    """Merge `fields` into the status file. Never raises.
+
+    Best-effort by design: this is progress reporting for a UI, and a
+    status write failing must never be the thing that breaks an update
+    that would otherwise have succeeded. Every caller is on the worker's
+    critical path.
+
+    Written to a temp file and moved into place so the server - which
+    may poll this concurrently, and which is a *different process* - can
+    never read a half-written file.
+    """
+    try:
+        os.makedirs(logs_dir, exist_ok=True)
+        current = read_update_status(logs_dir)
+        current.update(fields)
+        path = update_status_path(logs_dir)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(current, f)
+        os.replace(tmp, path)
+    except Exception as e:  # pragma: no cover - best-effort by contract
+        logger.debug(f"could not write update status: {e}")
+
+
+def read_update_status(logs_dir: str) -> dict:
+    """Current update status, or {} if there isn't one / it's unreadable.
+
+    Returns {} rather than raising on malformed JSON: a corrupt status
+    file means "we don't know", which the UI renders as a neutral
+    "finished - check the log", never as a false success or failure.
+    """
+    try:
+        with open(update_status_path(logs_dir), "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
 
 # A git fetch against a slow/unreachable remote shouldn't hang the
 # /update/apply request itself - this is just the *precondition check*
@@ -376,6 +450,23 @@ class UpdateManager:
                 tag = check_verified_update(self.project_root)
             if not tag:
                 raise UpdateNotAvailableError("No newer release available to update to.")
+            # Reset before spawning, not after: the file persists across
+            # the restart (that's the point), so a previous run's
+            # terminal `outcome` is still sitting in it. Left in place,
+            # the page would read the OLD update's verdict as this one's
+            # the instant it reconnected. started_at lets the client
+            # ignore anything staler than its own click, too.
+            write_update_status(
+                self.logs_dir,
+                tag=tag,
+                phase=UPDATE_PHASES[0],
+                step=1,
+                total_steps=len(UPDATE_PHASES),
+                started_at=time.time(),
+                outcome=None,
+                detail="",
+                finished_at=None,
+            )
             self._spawn_worker(host, port)
             return tag
         except Exception:
@@ -793,6 +884,48 @@ def _run_frozen_verify_and_handoff(project_root: str, old_pid: int, port: int) -
         print(f"[update-worker] FATAL: could not launch hand-off script: {e}", flush=True)
 
 
+def _record_apply_outcome(logs_dir: str, output: str) -> None:
+    """Translate run.sh's/run.ps1's one-line verdict into the status file.
+
+    That contract is exactly one of `UPDATED:<tag>`, `NO_UPDATE`, or
+    `FAILED:<reason>` (see run.sh's --apply-verified-update). Anything
+    else is treated as unknown rather than guessed at - reporting a
+    confident "updated" off an unrecognized string is precisely the kind
+    of false success this whole file exists to stop.
+    """
+    if output.startswith("UPDATED:"):
+        tag = output.split(":", 1)[1].strip()
+        write_update_status(
+            logs_dir,
+            outcome=UPDATE_OUTCOME_UPDATED,
+            tag=tag,
+            detail=f"Updated to {tag}.",
+            finished_at=time.time(),
+        )
+    elif output == "NO_UPDATE":
+        write_update_status(
+            logs_dir,
+            outcome=UPDATE_OUTCOME_NO_UPDATE,
+            detail="Already up to date - nothing was changed.",
+            finished_at=time.time(),
+        )
+    elif output.startswith("FAILED:"):
+        reason = output.split(":", 1)[1].strip()
+        write_update_status(
+            logs_dir,
+            outcome=UPDATE_OUTCOME_FAILED,
+            detail=reason or "The update could not be applied.",
+            finished_at=time.time(),
+        )
+    else:
+        write_update_status(
+            logs_dir,
+            outcome=UPDATE_OUTCOME_FAILED,
+            detail="The update step returned an unrecognized result - see the log.",
+            finished_at=time.time(),
+        )
+
+
 def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
     """The actual detached sequence - see this module's docstring for
     the why. Plain print()s: stdout/stderr were already redirected to
@@ -824,6 +957,8 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
     the frozen-binary hand-off machinery applies to it.
     """
     print(f"[update-worker] starting, old pid={old_pid}, target={host}:{port}", flush=True)
+    logs_dir = os.path.join(project_root, "logs")
+    write_update_status(logs_dir, phase="preparing", step=1, total_steps=len(UPDATE_PHASES))
 
     try:
         time.sleep(RESPONSE_FLUSH_DELAY_SECONDS)
@@ -843,6 +978,15 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
                 "aborting this update attempt, old server left untouched",
                 flush=True,
             )
+            # The old server is deliberately left alive here, so unlike
+            # every other terminal state the page never loses its
+            # connection - it just needs to be told why nothing happened.
+            write_update_status(
+                logs_dir,
+                outcome=UPDATE_OUTCOME_ABORTED,
+                detail="A recommender run is in progress - nothing was changed. Try again once it finishes.",
+                finished_at=time.time(),
+            )
             return
 
         if getattr(sys, "frozen", False):
@@ -857,10 +1001,25 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
                 # falling through to the source-only relaunch code below
                 # would be wrong for a binary install) - log it and stop.
                 print(f"[update-worker] UNEXPECTED ERROR in frozen apply/hand-off: {e}", flush=True)
+            # No outcome here, deliberately. A frozen binary's swap and
+            # relaunch are done by an EXTERNAL script that outlives this
+            # process entirely (see utils/self_update_handoff.py), so
+            # this worker genuinely cannot know whether it succeeded.
+            # Claiming either verdict would be a guess; the UI treats a
+            # missing outcome as "finished, check the version", which is
+            # the honest rendering.
+            write_update_status(
+                logs_dir,
+                phase="relaunching",
+                step=len(UPDATE_PHASES),
+                detail="Handed off to the installer - the app will restart on its own.",
+                finished_at=time.time(),
+            )
             print("[update-worker] worker exiting (frozen path complete)", flush=True)
             return
 
         print("[update-worker] shutting down old server...", flush=True)
+        write_update_status(logs_dir, phase="stopping", step=2, total_steps=len(UPDATE_PHASES))
         _shut_down_old_server(old_pid, OLD_SERVER_SHUTDOWN_TIMEOUT_SECONDS)
 
         script = _updater_script(project_root)
@@ -877,6 +1036,7 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
             apply_cmd = [_posix_bash_path(), script, "--apply-verified-update"]
 
         print("[update-worker] applying verified update...", flush=True)
+        write_update_status(logs_dir, phase="applying", step=3, total_steps=len(UPDATE_PHASES))
         try:
             result = subprocess.run(
                 apply_cmd,
@@ -890,19 +1050,33 @@ def _run_worker(project_root: str, old_pid: int, host: str, port: int) -> None:
             print(f"[update-worker] apply result: {output!r} (exit {result.returncode})", flush=True)
             if result.stderr:
                 print(f"[update-worker] apply stderr: {result.stderr.strip()}", flush=True)
+            _record_apply_outcome(logs_dir, output)
         except Exception as e:
             # Whatever happened, fall through to relaunching below anyway -
             # an apply step that couldn't even run is exactly the same
             # "stay on the current version" outcome as NO_UPDATE/FAILED.
             print(f"[update-worker] apply step raised: {e}", flush=True)
+            write_update_status(
+                logs_dir,
+                outcome=UPDATE_OUTCOME_FAILED,
+                detail=f"The update step could not run: {e}",
+                finished_at=time.time(),
+            )
     except Exception as e:
         # Last-resort catch-all for the SOURCE path above (the frozen
         # branch already returns before reaching here either way) -
         # nothing above this point may ever skip the unconditional
         # relaunch below.
         print(f"[update-worker] UNEXPECTED ERROR (still relaunching): {e}", flush=True)
+        write_update_status(
+            logs_dir,
+            outcome=UPDATE_OUTCOME_FAILED,
+            detail=f"Unexpected error during update: {e}",
+            finished_at=time.time(),
+        )
 
     print(f"[update-worker] relaunching UI on port {port}...", flush=True)
+    write_update_status(logs_dir, phase="relaunching", step=4, total_steps=len(UPDATE_PHASES))
     try:
         _relaunch_and_verify(project_root, port)
     except Exception as e:


### PR DESCRIPTION
## The problem

"Update now" printed one static line — *"This can take up to a minute"* — went silent for the entire restart, then reloaded the page without ever saying whether it worked.

The result had to be inferred from a version number. And a **failed** update looked identical to a successful one, because the worker deliberately relaunches the UI either way (old code on failure, new code on success). "It came back" was never evidence of success.

## What it does now

While the server is down:

```
Updating to v2.10.89
▓▓▓▓▓▓▓▓░░░░░░░░░░  (indeterminate)
Step 3 of 4: Downloading and verifying the update  ·  24s
```

After it reconnects:

```
✓ Updated to v2.10.89. Reloading...
```
```
✗ Python 3.9.6 is below the 3.10 floor. See logs/update_apply.log.
```

## Why there's no percentage

**The server is dead for almost the whole update.** The worker kills it, applies, and starts a fresh process. Nothing is in a position to measure real progress.

A percentage would have to be elapsed-time against a guessed duration — so it would keep climbing toward 100% while a genuinely hung update sat there. That's worse than no number. The bar is indeterminate, the step labels are time-based estimates presented *as steps*, and the elapsed counter is real.

**The outcome is not estimated at all.**

## How the outcome survives the restart

The worker writes `logs/update_status.json` as it goes; a new `GET /update/status` exposes it. A file rather than in-memory state for the same reason the progress can't be live — the page reconnects to a brand new process with no memory of the update.

Two staleness guards, because the file deliberately outlives the update that wrote it:

- `begin_update()` resets it *before* spawning. Otherwise the previous update's verdict is still on disk and would be read as this one's the instant the page reconnected.
- The client ignores any status whose `started_at` predates its own click.

A frozen binary's outcome is deliberately left **unknown** — its swap and relaunch are done by an external script that outlives the worker, so the worker genuinely cannot know. That renders as a neutral reload rather than a guessed verdict. Same for an unreadable/corrupt file.

## Failure does not reload

This is the crux. Reloading on failure would destroy the only explanation the user ever gets. On failure the message stays put and the button is re-enabled to retry; on success it reloads after showing the result so the banner clears.

## Verification

Client branches driven against a stubbed DOM and `fetch` (via JavaScriptCore), confirming each outcome:

| status | message | reloads? | button |
|---|---|---|---|
| `updated` | ✓ Updated to v2.10.89. | yes | stays disabled |
| `failed` | ✗ …floor. See logs/update_apply.log. | **no** | re-enabled |
| `no_update` | ✓ Already up to date… | no | re-enabled |
| `aborted` | ✗ A recommender run is in progress. | no | re-enabled |
| stale `started_at` | neutral reload | yes | — |
| empty (frozen hand-off) | neutral reload | yes | — |

Plus committed tests for the status file round-trip (including malformed JSON, non-dict JSON, no leftover temp files, and an unwritable dir never raising), the outcome mapping (`UPDATED:` / `NO_UPDATE` / `FAILED:` / unrecognized-is-failure-not-success), the route (including that it doesn't leak extra fields), the stale-outcome reset, and the template markup the script depends on by id.

Full suite: **3020 passed, 1 skipped**. ruff and mypy clean.
