### PR TITLE
Cap per-item weight redistribution; fix the browser-side quadratic on the run page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.10.90] - 2026-07-30
+
+### Fixed
+
+- **An item with no data at all for a heavily-weighted dimension could still take over the top of the list.** 2.10.85 stopped redistributing weight away from dimensions whose data was *present but unmatched*; it left redistribution for *genuinely absent* data unbounded. That correctly pushed the unmatched items down - and thereby floated the one item with truly missing metadata straight to #1.
+
+  Measured on a real 186-candidate library. A title with `tmdb_keywords: []` (one of only 3 such items out of 327) scored against a profile weighting `keyword` at **0.5 - half the entire budget**. That whole 0.5 moved onto genre+language (0.30 active), multiplying its score by `(0.30+0.50)/0.30 = 2.67x`: raw **0.247 -> 0.658**, taking it from a true rank of **#54 to #1**, ahead of every richly-described title that matched on several dimensions. Every other title in the top twelve was being scaled by 1.00-1.07x.
+
+  The flawed assumption was treating "no data" as *"don't penalize it"*. That's right for a missing `language` field worth 0.05; it's wrong for a dimension worth half the budget, where it turns "we know nothing about this item" into "everything we do know counts 2.67x as much".
+
+  Redistribution is now capped by `MAX_REDISTRIBUTION_MULTIPLIER` (1.25): small gaps stay fully forgiven, and past the cap the remaining weight simply stays lost, because an item we know less about genuinely has less evidence of matching. On the same real data this moves the offending title to **#31** and leaves the rest of the top ten identical; the maximum amplification anywhere in the candidate pool is now exactly 1.25x. **`CACHE_VERSION` is bumped to 7** - as with 2.10.85, a scoring change that doesn't move it is a silent no-op on every existing install, since per-item scores are cached against the profile hash and not against the scoring code.
+
+- **The run page still froze on long runs - a second, independent quadratic, this one in the browser.** 2.10.85 fixed the server side (`Job.try_subscribe` replaying an unbounded backlog on every SSE reconnect), which made the page *load* fast while the tab still locked up. The remaining cost was in `web/static/app.js`: `output.textContent += line` per message. Reading `textContent` materializes the whole accumulated log into a fresh string and writing it destroys every child node and rebuilds one, so each line costs O(total so far) - and `scrollTop = scrollHeight` on every line forced a synchronous layout of a steadily growing element on top of that.
+
+  Measured in Chrome, appending N lines the old way vs. the new: 500 -> **1089ms/5ms**, 1000 -> **4333ms/10ms**, 2000 -> **16333ms/21ms**, 4000 -> **66216ms/50ms**. Time quadruples each time N doubles. A real full run emitted **11,505 lines**, which extrapolates to roughly **nine minutes** of blocked main thread.
+
+  Lines are now buffered and written once per animation frame, appending a new text node instead of rewriting the whole element, with the retained tail bounded at 5000 lines (trimmed in one pass every 1000, so the amortized per-line cost stays constant). Auto-scroll only follows the tail if you were already at the bottom, so scrolling up to read something no longer yanks the view back down. A hidden tab - where `requestAnimationFrame` never fires - flushes directly once 1000 lines have piled up rather than buffering without bound.
+
 ## [2.10.89] - 2026-07-30
 
 ### Added

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -7,6 +7,7 @@ from collections import Counter
 
 import pytest
 
+from utils.config import MAX_REDISTRIBUTION_MULTIPLIER
 from utils.scoring import (
     ScoringOptions,
     _apply_active_weight_redistribution,
@@ -1185,15 +1186,27 @@ class TestRedistributionDistinguishesAbsentFromUnmatched:
         assert rich > sparse, f"richly-matching item ({rich}) must outrank genre-only item ({sparse})"
 
     def test_partial_absence_redistributes_only_the_absent_share(self):
-        """Mixed case: keyword data absent (redistribute its 0.45), cast
-        data present but unmatched (its 0.20 stays lost)."""
-        has_data = {"genre": True, "director": True, "studio": False, "actor": True, "language": True, "keyword": False}
-        mixed = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, has_data)
+        """Mixed case: keyword data absent (redistribute its weight), cast
+        data present but unmatched (its weight stays lost).
 
-        all_absent = {k: (k == "genre") for k in has_data}
-        everything = _apply_active_weight_redistribution(0.2, self.COMPONENT_SCORES, self.WEIGHTS, all_absent)
+        Uses deliberately small absent weights so
+        MAX_REDISTRIBUTION_MULTIPLIER doesn't bind. With this class's real
+        WEIGHTS both branches would be clipped to the cap and land on the
+        identical value, hiding the very difference this asserts - that's
+        the cap working as intended, not a regression, and it is covered
+        directly in TestRedistributionIsCapped.
+        """
+        weights = {"genre": 0.90, "actor": 0.05, "keyword": 0.05}
+        scores = {"genre": 0.40, "actor": 0.0, "keyword": 0.0}
 
-        assert 0.2 < mixed < everything
+        mixed = _apply_active_weight_redistribution(
+            0.40, scores, weights, {"genre": True, "actor": True, "keyword": False}
+        )
+        everything = _apply_active_weight_redistribution(
+            0.40, scores, weights, {"genre": True, "actor": False, "keyword": False}
+        )
+
+        assert 0.40 < mixed < everything
 
     def test_omitting_the_map_preserves_legacy_behavior(self):
         """Existing callers/tests that don't pass content_has_data must
@@ -1234,3 +1247,80 @@ class TestApplyPopularityDampeningHelper:
         score, dampening = _apply_popularity_dampening(0.8, {"vote_count": 500000}, options)
         assert score < 0.8
         assert dampening is not None
+
+
+class TestRedistributionIsCapped:
+    """The other half of the sparse-metadata fix.
+
+    Distinguishing "absent" from "didn't match" (see
+    TestRedistributionDistinguishesAbsentFromUnmatched above) correctly
+    pushed down items whose PRESENT data scored zero - and thereby
+    floated the one item with genuinely ABSENT data to the very top,
+    because its redistribution was still unbounded.
+
+    Observed on a real 186-candidate library: a title with no
+    tmdb_keywords at all, scored against a profile weighting keyword at
+    0.5 (half the entire budget), had that whole 0.5 moved onto
+    genre+language (0.30 active) for a 2.67x multiplier - raw 0.247 ->
+    0.658 - taking it from a true rank of #54 to #1. Every other title
+    in the top twelve was being scaled by 1.00-1.07x.
+    """
+
+    def test_a_large_absent_dimension_cannot_take_over_the_score(self):
+        """The real case: keyword weight 0.5 absent, 0.30 active."""
+        component_scores = {"genre": 0.197, "language": 0.05, "keyword": 0.0}
+        weights = {"genre": 0.25, "language": 0.05, "keyword": 0.5}
+        has_data = {"genre": True, "language": True, "keyword": False}
+
+        result = _apply_active_weight_redistribution(0.247, component_scores, weights, has_data)
+
+        # Uncapped this would be 0.247 * (0.30+0.50)/0.30 = 0.659.
+        assert result == pytest.approx(0.247 * MAX_REDISTRIBUTION_MULTIPLIER, rel=1e-6)
+        assert result < 0.35
+
+    def test_a_small_absent_dimension_is_still_fully_forgiven(self):
+        """The original, legitimate intent must survive: a missing
+        language field (0.05) is below the cap and redistributes whole."""
+        component_scores = {"genre": 0.20, "keyword": 0.40, "language": 0.0}
+        weights = {"genre": 0.25, "keyword": 0.5, "language": 0.05}
+        has_data = {"genre": True, "keyword": True, "language": False}
+
+        result = _apply_active_weight_redistribution(0.60, component_scores, weights, has_data)
+
+        uncapped = 0.60 * (0.75 + 0.05) / 0.75
+        assert result == pytest.approx(uncapped, rel=1e-6), "a small gap should not be clipped"
+
+    def test_multiplier_never_exceeds_the_cap(self):
+        """Sweep the absent share; the effective amplification must be
+        monotonic up to the cap and never past it."""
+        for absent in [0.05, 0.1, 0.2, 0.4, 0.6, 0.8]:
+            weights = {"genre": 0.2, "keyword": absent}
+            component_scores = {"genre": 0.2, "keyword": 0.0}
+            has_data = {"genre": True, "keyword": False}
+            result = _apply_active_weight_redistribution(0.2, component_scores, weights, has_data)
+            assert result <= 0.2 * MAX_REDISTRIBUTION_MULTIPLIER + 1e-9, f"cap breached at absent={absent}"
+
+    def test_cap_does_not_affect_items_with_nothing_absent(self):
+        """An item with data everywhere is untouched by any of this."""
+        component_scores = {"genre": 0.2, "keyword": 0.4}
+        weights = {"genre": 0.25, "keyword": 0.5}
+        has_data = {"genre": True, "keyword": True}
+        assert _apply_active_weight_redistribution(0.6, component_scores, weights, has_data) == 0.6
+
+    def test_richly_described_item_outranks_the_sparse_one(self):
+        """The ranking property that actually matters, stated directly."""
+        weights = {"genre": 0.25, "actor": 0.2, "keyword": 0.5, "language": 0.05}
+
+        sparse = _apply_active_weight_redistribution(
+            0.247,
+            {"genre": 0.197, "language": 0.05, "actor": 0.0, "keyword": 0.0},
+            weights,
+            {"genre": True, "language": True, "actor": True, "keyword": False},
+        )
+        rich = _apply_active_weight_redistribution(
+            0.40,
+            {"genre": 0.15, "actor": 0.05, "keyword": 0.20, "language": 0.0},
+            weights,
+            {"genre": True, "actor": True, "keyword": True, "language": False},
+        )
+        assert rich > sparse, "an item matching on three dimensions must beat one matching on genre alone"

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,10 +14,15 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.89"
+__version__ = "2.10.90"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
-CACHE_VERSION = 6  # v6: NOT a format change - a SCORING change (2.10.85's
+CACHE_VERSION = 7  # v7: another SCORING change, not a format one - the
+# MAX_REDISTRIBUTION_MULTIPLIER cap below (2.10.90). Same reasoning as v6
+# immediately after this: a scoring change that doesn't move this constant
+# is invisible on every existing install.
+#
+# v6: NOT a format change - a SCORING change (2.10.85's
 # per-item weight-redistribution fix, see CHANGELOG). Cached per-item scores
 # are keyed on profile_hash alone (recommenders/base.py's cache-hit branch in
 # get_recommendations()), which captures the user's watch profile but NOT the
@@ -78,6 +83,25 @@ TFIDF_GENRE_PENALTY = 0.3  # Max 30% penalty per rare genre
 TFIDF_KEYWORD_PENALTY = 0.15  # Max 15% penalty per rare keyword
 UNSEEN_GENRE_PENALTY = 0.1  # Penalty for genres user has never watched
 UNSEEN_KEYWORD_PENALTY = 0.02  # Penalty for keywords user has never seen
+
+# Ceiling on per-item weight redistribution (utils/scoring.py's
+# _apply_active_weight_redistribution). When an item carries no data at
+# all for a dimension, that dimension's weight moves onto the ones that
+# did score - which is right for a small dimension (a missing language
+# field, weight 0.05) and badly wrong for a large one.
+#
+# Measured on a real library: a title with no tmdb_keywords, against a
+# profile weighting keyword at 0.5 - half the whole budget - had its
+# score multiplied by 2.67x and jumped from a true rank of #54 to #1,
+# ahead of every title that actually matched on several dimensions.
+# Everything else was being scaled by 1.00-1.07x.
+#
+# 1.25 keeps small gaps forgiven while refusing to let an absent
+# dimension take over the score: past this point the remaining weight
+# stays lost, because an item we know less about genuinely has less
+# evidence of matching. Raising this re-opens that failure; lowering it
+# toward 1.0 approaches "absent scores zero".
+MAX_REDISTRIBUTION_MULTIPLIER = 1.25
 
 # Popularity dampening for very popular content (prevents blockbusters dominating)
 POPULARITY_DAMPENING_FACTOR = 0.03  # ~3% penalty per order of magnitude above threshold

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
 
 from .config import (
+    MAX_REDISTRIBUTION_MULTIPLIER,
     POPULARITY_DAMPENING_CAP,
     POPULARITY_DAMPENING_FACTOR,
     TFIDF_GENRE_PENALTY,
@@ -753,6 +754,35 @@ def _apply_active_weight_redistribution(
     if lost_weight > 0 and active_weights:
         total_active_weight = sum(w for w, _ in active_weights.values())
         if total_active_weight > 0:
+            # Cap how far redistribution may amplify a score.
+            #
+            # Forgiving a missing dimension is right when the dimension is
+            # SMALL - an item with no language field (weight 0.05) should
+            # not be marked down for it. It is wrong when the dimension is
+            # large, because then "we know nothing about this item" turns
+            # into "everything we do know counts several times over".
+            #
+            # Measured on a real 186-candidate library: one title had no
+            # tmdb_keywords at all, and keyword weight was 0.5 - half the
+            # entire budget. Its whole 0.5 moved onto genre+language
+            # (0.30 active), multiplying its score by (0.30+0.50)/0.30 =
+            # 2.67x, from a raw 0.247 to 0.658. That took it from a true
+            # rank of #54 to #1, ahead of every richly-described title
+            # that matched on several dimensions. Every other item in the
+            # top twelve was being scaled by 1.00-1.07x.
+            #
+            # This is the other half of the fix in 2.10.85, which stopped
+            # rewarding items whose PRESENT data scored zero. That
+            # correctly pushed those items down - and thereby floated the
+            # one item with genuinely ABSENT data to the top, since its
+            # redistribution was left untouched.
+            multiplier = (total_active_weight + lost_weight) / total_active_weight
+            if multiplier > MAX_REDISTRIBUTION_MULTIPLIER:
+                # Keep only as much lost weight as the cap allows, and
+                # let the remainder stay lost: an item we know less about
+                # genuinely has less evidence of matching.
+                lost_weight = (MAX_REDISTRIBUTION_MULTIPLIER - 1.0) * total_active_weight
+
             for _comp, (weight, ratio) in active_weights.items():
                 extra_weight = lost_weight * (weight / total_active_weight)
                 extra_score = extra_weight * ratio

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -53,22 +53,89 @@
   // finished job's own subscribe() replays its backlog and closes
   // immediately (see web/app.py's run_stream()), so the only thing
   // that bug added was one more pointless connection.
+  // Live-output rendering. `output.textContent += line` looks harmless
+  // and is quadratic: READING textContent materializes the entire
+  // accumulated log into a fresh string, and WRITING it destroys every
+  // child node and rebuilds one - so each line costs O(total so far).
+  // Setting scrollTop=scrollHeight on every line then forces a synchronous
+  // layout of a steadily growing element on top of that.
+  //
+  // Measured in Chrome, appending N lines this way vs. the buffered
+  // approach below: 500 -> 1089ms/5ms, 1000 -> 4333ms/10ms,
+  // 2000 -> 16333ms/21ms, 4000 -> 66216ms/50ms. Time quadruples each
+  // time N doubles. A real full run emitted 11505 lines, which
+  // extrapolates to ~9 MINUTES of blocked main thread - the run page
+  // "going unresponsive" partway through a long run.
+  //
+  // (This is a SECOND, independent quadratic from the server-side
+  // backlog replay fixed in 2.10.85 - that one was in Job.try_subscribe,
+  // this one is in the browser. Fixing the server made the page load
+  // fast while the tab still locked up.)
+  //
+  // So: buffer incoming lines and write them once per animation frame,
+  // appending a NEW text node instead of rewriting the whole thing.
+  var MAX_LINES = 5000; // keep a bounded tail - a long run can emit far more
+  var TRIM_TO = 4000;
+  var pending = [];
+  var flushScheduled = false;
+  var lineCount = 0;
+
+  function nearBottom() {
+    // Checked BEFORE appending, since appending changes scrollHeight.
+    return output.scrollHeight - output.scrollTop - output.clientHeight < 40;
+  }
+
+  function flushLines() {
+    flushScheduled = false;
+    if (!pending.length) { return; }
+    // Don't yank the view back down if the user has scrolled up to read
+    // something - only keep following the tail if they were already there.
+    var stick = nearBottom();
+    output.appendChild(document.createTextNode(pending.join('\n') + '\n'));
+    lineCount += pending.length;
+    pending.length = 0;
+    if (lineCount > MAX_LINES) {
+      // O(n), but only once every (MAX_LINES - TRIM_TO) lines, so the
+      // amortized cost per line stays constant.
+      var kept = output.textContent.split('\n').slice(-TRIM_TO);
+      output.textContent = kept.join('\n');
+      lineCount = kept.length;
+    }
+    if (stick) { output.scrollTop = output.scrollHeight; }
+  }
+
+  function appendLine(text) {
+    pending.push(text);
+    // requestAnimationFrame doesn't fire in a background tab, so a
+    // hidden page would otherwise buffer without bound - flush directly
+    // once enough has piled up.
+    if (pending.length >= 1000) { flushLines(); return; }
+    if (!flushScheduled) {
+      flushScheduled = true;
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(flushLines);
+      } else {
+        setTimeout(flushLines, 16);
+      }
+    }
+  }
+
   if (output && window.CURATARR_JOB_RUNNING) {
     var source = new EventSource('/run/stream');
 
     source.onmessage = function (event) {
-      output.textContent += event.data + '\n';
-      output.scrollTop = output.scrollHeight;
+      appendLine(event.data);
     };
 
     source.addEventListener('done', function (event) {
+      flushLines(); // don't leave the last few lines sitting in the buffer
       markDone(event.data);
       source.close();
     });
 
     source.addEventListener('busy', function (event) {
-      output.textContent += event.data + '\n';
-      output.scrollTop = output.scrollHeight;
+      appendLine(event.data);
+      flushLines(); // terminal message - show it now, don't wait for a frame
       source.close();
       pollStatus();
     });


### PR DESCRIPTION
Two follow-ups to 2.10.85, both found on real data *after* that release shipped.

## 1. A sparse item could still take over the top of the list

2.10.85 stopped redistributing weight away from dimensions whose data was **present but unmatched**. It left redistribution for **genuinely absent** data unbounded. That correctly pushed the unmatched items down — and thereby floated the one item with truly missing metadata straight to #1.

Measured on a real 186-candidate library. A title with `tmdb_keywords: []` (one of only **3 out of 327**) scored against a profile weighting `keyword` at **0.5 — half the entire budget**:

```
raw components:  genre 0.197 + language 0.05  = 0.247
active weight:   0.25 + 0.05 = 0.30
absent weight:   0.50  (keywords)
multiplier:      (0.30 + 0.50) / 0.30 = 2.67x
final:           0.247 x 2.67 = 0.658   -> #1
```

Its raw score ranks it **#54**. The boost alone made it **#1**, ahead of every richly-described title that matched on several dimensions. Every other title in the top twelve was scaled by **1.00–1.07x**.

**The flawed assumption** was treating "no data" as *"don't penalize it"*. That's right for a missing `language` field worth 0.05. It's wrong for a dimension worth half the budget, where it converts *"we know nothing about this item"* into *"everything we do know counts 2.67x as much"*.

`MAX_REDISTRIBUTION_MULTIPLIER` (1.25) now bounds it. Small gaps stay fully forgiven; past the cap the remaining weight simply stays lost, because an item we know less about genuinely has less evidence of matching.

Verified against the same real data — the rest of the list is untouched:

| | before | after |
|---|---|---|
| the sparse title | **#1** (0.658) | **#31** (0.308) |
| top 10 | — | identical |
| max amplification anywhere | 2.67x | **1.25x** |

**`CACHE_VERSION` -> 7.** As with 2.10.85, a scoring change that doesn't move it is a silent no-op on every existing install: per-item scores are cached against the profile hash, not against the scoring code.

## 2. The run page still froze — a second, independent quadratic

2.10.85 fixed the **server** side (`Job.try_subscribe` replaying an unbounded backlog on every SSE reconnect). That made the page *load* fast while the tab still locked up, because the remaining cost was in the **browser**.

`web/static/app.js` did `output.textContent += line` per message. Reading `textContent` materializes the entire accumulated log into a fresh string; writing it destroys every child node and rebuilds one. So each line costs O(total so far) — and `scrollTop = scrollHeight` on every line forced a synchronous layout of a steadily growing element on top of that.

Measured in Chrome, old vs. new:

| lines | current | fixed |
|---|---|---|
| 500 | 1,089 ms | 5 ms |
| 1,000 | 4,333 ms | 10 ms |
| 2,000 | 16,333 ms | 21 ms |
| 4,000 | 66,216 ms | 50 ms |

Time quadruples each time N doubles. A real full run emitted **11,505 lines**, extrapolating to roughly **nine minutes** of blocked main thread.

Now buffered and written once per animation frame, appending a new text node instead of rewriting the element, with the retained tail bounded at 5000 lines (trimmed in one pass every 1000, so amortized per-line cost stays constant). Auto-scroll only follows the tail if you were already at the bottom. A hidden tab — where `requestAnimationFrame` never fires — flushes directly once 1000 lines pile up rather than buffering without bound.

## One existing test changed, not deleted

`test_partial_absence_redistributes_only_the_absent_share` asserted that *more* absent weight yields a *higher* score. The cap deliberately stops that being true past the ceiling, so both branches now clip to the same value. It's re-expressed with weights below the cap, so it still tests the property it was written for — that present-but-unmatched weight stays lost — and the cap itself is covered directly in `TestRedistributionIsCapped`.

Full suite: **3025 passed, 1 skipped**. ruff and mypy clean.
