### PR TITLE
Recommendation quality: calibration, score floor, corpus IDF, ignored-rec feedback, supply health (2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.11.0] - 2026-07-31
+
+### Added
+
+- **Calibrated recommendations - the collection's genre mix now matches your actual viewing, instead of the leftovers in your library.** Reported as "why is my Recommended collection full of children's movies?" on a profile that is **3.8% family/animation**. Last night's collection was **38%**.
+
+  The scorer was not at fault. Measured against the real candidate pool: family/animation was **37.8%** of the 127 eligible candidates and **38.0%** of the delivered top 50 - a selection bias of **1.01x**, i.e. none. Ranking by score faithfully reproduced the composition of what was left. The user had watched **233 of 334** movies, and what survives fifteen years of watching everything else is disproportionately the titles bought for the kids.
+
+  This is the failure mode Harald Steck describes in *Calibrated Recommendations* (Netflix, RecSys 2018): greedy top-N does not preserve a user's taste distribution. Steck's example runs the other way - 70% action / 30% romance yields a 100% action list, the minority interest erased - but it is the same defect, the list's distribution drifting from the profile's, and the same fix works in both directions. New `movies:`/`tv:` `calibration_strength` (default `0.0` = off) greedily maximizes `(1 - s) * sum(similarity) - s * SCALE * KL(profile || collection)`.
+
+  On the reported profile it moves kid-genre mass **18.0% -> 12.5%** at `0.10`/`0.5`, and **-> 6.7%** with no score floor, while pulling every major genre toward its profile share (thriller 6.8% -> 11.7%, action 3.6% -> 12.4%). It is explicitly **not** a genre exclusion: a genre you genuinely watch still appears, at the rate you watch it, represented by its best-scoring titles - which is what a blunt `exclude_genres: family` could never do.
+
+  `calibration_strength` is a plain 0.0-1.0 dial rather than Steck's raw lambda. A marginal KL change is ~1e-3 against a ~1e-1 marginal similarity change, so unscaled, similarity dominates until lambda is within 0.01 of 1.0 (Steck's own experiments use 0.99). `CALIBRATION_DIVERGENCE_SCALE` maps that useful range back onto 0.0-1.0 so 0.25/0.5/0.75 are all meaningfully different.
+
+  Note calibration matches genre **mass**, not title count. A six-genre action/adventure/comedy/sci-fi/family title contributes ~1/6 of its weight to `family`, because it is mostly the action film it also is. A collection calibrated to a 2.5% family profile can still hold a visible number of titles that carry a family tag among several others.
+
+- **A minimum-similarity floor for library collections, which may now come in under `limit_results` rather than pad itself.** The library path had no quality gate at all - it filled to `limit_results` regardless of score, so the reported collection ran down to **12.2% similarity** and presented it as a recommendation. The external path has always had `external_recommendations.min_relevance_score`; this is its library-side counterpart. New `movies:`/`tv:` `min_similarity` (default `0.0` = off, preserving existing behavior). A short collection is a truthful report that the library is exhausted for that profile, and it now says so instead of quietly padding.
+
+  **These two interact, and the interaction is worth knowing before tuning either.** Calibration works by choosing; the floor shrinks what there is to choose from. On the reported library: floor `0.00` leaves 132 candidates, `0.15` leaves 71, `0.20` leaves 52 - and past ~52, with a 50-slot collection, calibration has nothing left to select between and silently becomes a no-op. `0.10` + `0.5` is the recommended starting pair.
+
+- **Corpus-level IDF - the missing half of what the scorer called "TF-IDF".** Every rarity penalty in `utils/scoring.py` was computed against the *user's own profile*: a term rare **for you** was penalized. Nothing ever asked how common the term is across the library, which is what the IDF in TF-IDF actually means (inverse *document* frequency).
+
+  So structural, non-discriminative metadata read as taste. On the reference library `sequel` appears in **28%** of titles and `aftercreditsstinger` in 14%, yet both outranked `survival` (2%) and `nasa` (1%) in the user's profile - because they are frequent everywhere, which is precisely why they say nothing. The observable effect: **22 of the top 50 were sequels** against a 28% library baseline.
+
+  Matches are now scaled by `log(N / (1 + df)) / log(N)`, bounded to `[0.05, 1.0]`. On the real library this discounts `sequel` to **0.216** and `aftercreditsstinger` to **0.337** while `nasa` keeps **0.761**. A term absent from the corpus takes the full 1.0 - the library holding nothing else with it makes it *more* distinctive, not less - and the floor is 0.05 rather than 0 so an item whose metadata is entirely common terms degrades instead of silently losing a whole dimension. **`CACHE_VERSION` is bumped to 8**; as with 2.10.85 and 2.10.90, a scoring change that does not move it is a silent no-op on every existing install.
+
+- **Negative feedback from recommendations that were shown and never watched.** The strongest signal a recommender gets is not what you watched - it is what it put in front of you that you declined. Curatarr already had both halves and never connected them: `label_dates` has always recorded when each item entered a collection, and `utils/scoring.py` has always had `elif genre_count < 0` / `elif count < 0` branches for negative preference. **Nothing ever wrote one.** An item you passed over every night was re-recommended with an identical score every night, forever.
+
+  A title labeled for `min_days_shown` (default 21) and still unwatched now decrements its genres and keywords. The penalty is split across the terms an item carries, so a seven-genre title does not deliver seven times the punishment of a two-genre one for the same single act of being ignored; and no term may fall below 25% of the profile's largest positive count, so a long run of ignores cannot bury a genre so deep the profile could never recover if taste swung back. Applied **before** `compute_profile_hash()` - the hash is what invalidates cached scores, so applying it after would have left the feedback inert. Configured under `negative_signals.ignored_recommendations`.
+
+- **Library supply health, and acquisition that targets the gap instead of deepening it.** Every change above improves how candidates are *chosen*; none creates candidates. With 132 candidates for a 50-slot collection (2.6:1), selection has almost no discretion left - a large catalog is nearer 1000:1, which is why ranking is the binding constraint there and supply is the binding constraint here.
+
+  Runs now report the ratio, flag a depleted pool, and list under-supplied genres - those the profile wants more of than the unwatched pool can offer. On the reported profile: science fiction **13.8% wanted / 3.8% available**, thriller 14.0% / 7.3%, action 12.3% / 6.6%.
+
+  That list is also now wired into external discovery, which is the part that actually fixes anything. `discover_candidates_by_profile()` searched a profile's **top** genres - fetching more of whatever the library is already thickest in, the exact opposite of what an exhausted library needs. Gap genres now lead the search order, so acquisition fills the hole. With no gaps (a healthy library) the order is unchanged from before.
+
+  Depletion is deliberately **not** reported for a user with no watch history: a zero-history user facing a small library has not "watched most of it", and saying so would be false. Cold start remains the `recommend_for_no_history` path's job.
+
+### Notes
+
+- Every new setting defaults to off or to its pre-existing behavior, so upgrading changes nothing until you opt in - except `CACHE_VERSION`, which forces a one-time cache rebuild on first run.
+
 ## [2.10.90] - 2026-07-30
 
 ### Fixed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -10,6 +10,40 @@ movies:
   # count (see general.limit_plex_results in config.example.yml for the
   # internal candidate-scoring buffer this feeds).
   limit_results: 50
+
+  # Minimum similarity score (0.0-1.0) an item must reach to enter the
+  # collection. The collection is allowed to come in UNDER limit_results
+  # rather than pad itself with weak matches - if only 31 movies clear
+  # the bar, you get 31 and a warning telling you the library is running
+  # short of unwatched content matching that profile.
+  #
+  # Default 0.0 (disabled) preserves the historical behavior of always
+  # filling to limit_results regardless of score. 0.20 is a reasonable
+  # starting point; raise it until the tail of the collection stops
+  # looking like filler. This is the library-side counterpart to
+  # external_recommendations.min_relevance_score.
+  min_similarity: 0.0
+
+  # Calibrated recommendations (Steck, "Calibrated Recommendations",
+  # RecSys 2018) - see utils/calibration.py.
+  #
+  # Ranking purely by score does not preserve your taste distribution:
+  # whatever is abundant among the remaining unwatched candidates comes
+  # to dominate the collection, however little of your actual viewing it
+  # represents. A profile that is 4% family can easily produce a
+  # collection that is 38% family once you have watched most of the
+  # non-family library.
+  #
+  # Calibration instead matches the collection's genre mix to your watch
+  # history's genre mix. It is NOT a genre exclusion: a genre you
+  # genuinely watch still appears, at the rate you actually watch it and
+  # represented by its highest-scoring titles.
+  #
+  # 0.0 = disabled (plain top-N by score, the historical behavior)
+  # 0.5 = weight relevance and calibration equally (suggested start)
+  # 1.0 = match the distribution as closely as possible, ignoring score
+  calibration_strength: 0.0
+
   randomize_recommendations: false  # Randomize from top pool
 
   # Display options for recommendations output
@@ -54,6 +88,8 @@ movies:
 # =============================================================================
 tv:
   limit_results: 20  # Max recommendations per user
+  min_similarity: 0.0  # See movies.min_similarity above
+  calibration_strength: 0.0  # See movies.calibration_strength above
   randomize_recommendations: false
   normalize_counters: true  # Normalize across different show lengths
 
@@ -188,6 +224,23 @@ negative_signals:
     min_episodes_watched: 2  # Must watch N episodes to count
     max_completion_percent: 25  # Consider dropped if < 25% watched
     penalty_multiplier: -0.4
+
+  # Recommendations that were shown and never watched.
+  #
+  # The strongest signal a recommender gets is not what you watched - it
+  # is what it put in front of you that you declined. A title that sat in
+  # your collection for weeks unplayed is a far more direct "not for me"
+  # than the mere absence of a play, which is ambiguous (never offered?
+  # never noticed?). Without this, an item you keep passing over is
+  # re-recommended with an identical score every single night.
+  #
+  # Penalties are split across an item's genres/keywords and floored, so
+  # one skipped title barely registers but a consistent pattern does, and
+  # no genre can be buried so deep the profile cannot recover from it.
+  ignored_recommendations:
+    enabled: true
+    min_days_shown: 21  # Days on display before it counts as declined
+    penalty: 0.5  # Total negative weight per ignored title
 
 # =============================================================================
 # PROFILE ACCURACY (#273)

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -30,6 +30,8 @@ from utils import (
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_TV_NAME_TEMPLATE,
     GREEN,
+    IGNORED_REC_MIN_DAYS_SHOWN,
+    IGNORED_REC_PENALTY,
     RATING_MULTIPLIER_2_STAR,
     RATING_MULTIPLIER_3_STAR,
     RATING_MULTIPLIER_4_STAR,
@@ -48,18 +50,28 @@ from utils import (
     WEIGHT_SUM_TOLERANCE,
     YELLOW,
     add_labels_to_items,
+    apply_ignored_penalties,
     apply_user_label_restrictions,
+    assess_pool_health,
+    build_corpus_idf,
     build_label_name,
+    build_target_distribution,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
+    calibrate_recommendations,
+    calibration_report,
     categorize_labeled_items,
     check_cache_version,
     cleanup_legacy_unnamed_collection,
     cleanup_old_collections,
     create_empty_counters,
+    describe_least_informative,
     enhance_profile_with_trakt,
     extract_ids_from_guids,
     fetch_tmdb_with_retry,
+    find_ignored_recommendations,
+    find_supply_gaps,
+    format_health_report,
     get_configured_users,
     get_excluded_genres_for_user,
     get_full_language_name,
@@ -67,6 +79,7 @@ from utils import (
     get_library_imdb_ids_from_items,
     get_max_rating_for_user,
     get_negative_multiplier,
+    get_negative_signals_config,
     get_project_root,
     get_tmdb_config,
     get_tmdb_id_for_item,
@@ -563,6 +576,13 @@ class BaseRecommender(ABC):
         # existing documented/tested behavior for installs that already set it.
         default_limit = self.limit_results * CANDIDATE_BUFFER_MULTIPLIER
         self.limit_plex_results = general_config.get("limit_plex_results", default_limit)
+        # Quality gate + calibration (config/tuning.yml movies:/tv:), both
+        # resolved by resolve_media_type_overrides() and both defaulting to
+        # 0.0 = off, so an install that sets neither is bit-for-bit
+        # unchanged. See utils/calibration.py for what calibration does.
+        self.min_similarity = self.config["min_similarity"]
+        self.calibration_strength = self.config["calibration_strength"]
+
         self.randomize_recommendations = self.config["randomize_recommendations"]
         self.normalize_counters = self.config["normalize_counters"]
         self.show_summary = self.config["show_summary"]
@@ -947,6 +967,18 @@ class BaseRecommender(ABC):
                 f"(rating: {min_rating}+, votes: {min_vote_count}+)"
             )
 
+        # Corpus IDF over the whole library, built once per run (see
+        # utils/corpus_idf.py). Scoring falls back to its previous
+        # behavior wherever these come back empty.
+        self.genre_idf = build_corpus_idf(all_items.values(), "genres")
+        self.keyword_idf = build_corpus_idf(all_items.values(), "tmdb_keywords")
+        if self.keyword_idf and logger.isEnabledFor(logging.DEBUG):
+            discounted = describe_least_informative(self.keyword_idf)
+            summary = ", ".join(f"{t} ({w:.2f})" for t, w in discounted)
+            logger.debug(f"Least informative keywords (discounted by corpus IDF): {summary}")
+
+        self._report_library_health(unwatched_items)
+
         if not unwatched_items:
             log_warning(f"No unwatched {self.media_key} found matching your criteria.")
             plex_recs = []
@@ -1001,6 +1033,20 @@ class BaseRecommender(ABC):
                 key=lambda x: (x["similarity_score"], x.get("rating") or 0.0, x.get("vote_count") or 0),
                 reverse=True,
             )
+
+            # Quality gate. Applied here as well as in _update_labels_by_rank
+            # so the printed recommendation list never advertises items the
+            # collection would refuse - previously this list ran all the way
+            # down the candidate buffer regardless of score.
+            if self.min_similarity > 0:
+                above_floor = [x for x in scored_items if x["similarity_score"] >= self.min_similarity]
+                dropped = len(scored_items) - len(above_floor)
+                if dropped:
+                    logger.debug(
+                        f"Score floor dropped {dropped} of {len(scored_items)} scored candidates "
+                        f"below min_similarity {self.min_similarity:.2f}"
+                    )
+                scored_items = above_floor
 
             if self.randomize_recommendations:
                 plex_recs = select_tiered_recommendations(
@@ -1154,6 +1200,158 @@ class BaseRecommender(ABC):
 
         return filtered
 
+    def _collection_label_name(self) -> str:
+        """
+        This user's collection label - the same value manage_plex_labels()
+        builds, factored out so the ignored-recommendation feedback can
+        key into label_dates before any collection work runs.
+        """
+        base_label = self.config.get("collections", {}).get("label_name", "Recommended")
+        base_label = f"{base_label}{self._library_suffix_for_label()}"
+        # Same derivation manage_plex_labels() uses - self.users is the
+        # dict from get_configured_users(); build_label_name() wants the
+        # flat username LIST off it, not the dict. Getting this wrong
+        # would silently produce a label that matches nothing in
+        # label_dates, and the feedback would quietly never fire.
+        users = self.users["plex_users"] or self.users["managed_users"]
+        append_usernames = self.config.get("collections", {}).get("append_usernames", True)
+        return build_label_name(base_label, users, self.single_user, append_usernames)
+
+    def _apply_ignored_recommendation_feedback(self) -> None:
+        """
+        Fold declined recommendations into the profile as negative signal
+        (utils/ignored_recs.py).
+
+        Must run BEFORE compute_profile_hash(): the penalties change the
+        profile, and the hash is what invalidates cached item scores.
+        Applying them after would leave every score cached against the
+        pre-penalty profile and the feedback would have no effect until
+        something else happened to change the profile.
+        """
+        signals = get_negative_signals_config(self.config)
+        if not signals.get("enabled", True):
+            return
+        ignored_config = signals.get("ignored_recommendations", {})
+        if not ignored_config.get("enabled", True):
+            return
+
+        label_dates = getattr(self, "label_dates", None)
+        if not label_dates:
+            return
+
+        try:
+            ignored = find_ignored_recommendations(
+                label_dates,
+                self._collection_label_name(),
+                self.watched_ids,
+                min_days_shown=ignored_config.get("min_days_shown", IGNORED_REC_MIN_DAYS_SHOWN),
+            )
+            if not ignored:
+                return
+
+            media_items = self._get_media_cache().cache.get(self.media_key, {})
+            ignored_items = [media_items[str(rk)] for rk, _days in ignored if str(rk) in media_items]
+            if not ignored_items:
+                return
+
+            applied = apply_ignored_penalties(
+                self.watched_data_counters,
+                ignored_items,
+                penalty=ignored_config.get("penalty", IGNORED_REC_PENALTY),
+            )
+            print(
+                f"{YELLOW}Negative feedback: {len(ignored_items)} recommendation(s) shown "
+                f"but never watched are now counted against this profile{RESET}"
+            )
+            logger.debug(f"Ignored-recommendation penalties applied: {applied}")
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            logger.debug(f"Ignored-recommendation feedback skipped: {e}")
+
+    def _report_library_health(self, unwatched_items: List[Dict]) -> None:
+        """
+        Measure and report candidate supply (utils/library_health.py).
+
+        Also stashes the resulting supply gaps on the instance so the
+        external/Radarr discovery path can aim acquisition at the genres
+        this profile wants and the library cannot serve, instead of at
+        the genres it already holds most of.
+        """
+        self.supply_gaps = []
+        try:
+            genre_counter = (self.watched_data_counters or {}).get("genres") or {}
+            target_distribution = build_target_distribution(genre_counter)
+
+            # Depletion is a statement about a user having consumed their
+            # library, which is meaningless without watch history: a
+            # zero-history user facing a small library has not "watched
+            # most of it", and telling them so would be simply false.
+            # Cold start is handled by the recommend_for_no_history path,
+            # not by this report.
+            if not target_distribution:
+                logger.debug("Skipping library health report: no watch history to assess supply against")
+                return
+
+            health = assess_pool_health(len(unwatched_items), self.limit_results)
+            self.supply_gaps = find_supply_gaps(
+                target_distribution,
+                [[g.lower() for g in (i.get("genres") or [])] for i in unwatched_items],
+            )
+
+            for line in format_health_report(health, self.supply_gaps, self.media_key):
+                if health.depleted:
+                    log_warning(line)
+                else:
+                    print(line)
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            # Reporting must never take down a run that would otherwise
+            # produce a collection.
+            logger.debug(f"Library health report skipped: {e}")
+
+    def _select_calibrated(self, sorted_candidates: List, media_items: Dict, target_count: int) -> List:
+        """
+        Pick the final `target_count` items from score-sorted candidates.
+
+        With calibration disabled (the default) this is the historical
+        plain truncation. With it enabled, the selection instead matches
+        the collection's genre mix to the user's actual watch-history mix
+        - see utils/calibration.py.
+
+        Returns the selected (item_id, (plex_item, score)) entries.
+        """
+        if self.calibration_strength <= 0:
+            return sorted_candidates[:target_count]
+
+        genre_counter = (self.watched_data_counters or {}).get("genres") or {}
+        target_distribution = build_target_distribution(genre_counter)
+        if not target_distribution:
+            # Cold start: no profile to calibrate against, so score order
+            # (which _rank_key already falls back to rating/votes for) is
+            # the only meaningful signal.
+            return sorted_candidates[:target_count]
+
+        def _genres(entry):
+            item_id, _ = entry
+            item_info = media_items.get(str(item_id)) or {}
+            return [g.lower() for g in (item_info.get("genres") or [])]
+
+        selected = calibrate_recommendations(
+            sorted_candidates,
+            target_count,
+            get_genres=_genres,
+            get_score=lambda entry: entry[1][1],
+            target_distribution=target_distribution,
+            calibration_strength=self.calibration_strength,
+        )
+
+        if selected:
+            print(
+                f"{GREEN}Calibrated collection to profile genre mix (strength {self.calibration_strength:.2f}){RESET}"
+            )
+            for genre, target, actual in calibration_report(target_distribution, [_genres(e) for e in selected]):
+                print(f"  {genre:<20} profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
+
+        return selected
+
     def _update_labels_by_rank(
         self, all_candidates: Dict, unwatched_labeled: List, label_name: str, target_count: int
     ) -> List:
@@ -1173,7 +1371,30 @@ class BaseRecommender(ABC):
             return (score, item_info.get("rating") or 0.0, item_info.get("vote_count") or 0)
 
         sorted_candidates = sorted(all_candidates.items(), key=_rank_key, reverse=True)
-        top_candidates = sorted_candidates[:target_count]
+
+        # Quality gate before size. A collection short of target_count is a
+        # truthful report that the library is exhausted for this user;
+        # padding it to target_count with sub-threshold items is not.
+        if self.min_similarity > 0:
+            eligible = [c for c in sorted_candidates if c[1][1] >= self.min_similarity]
+            dropped = len(sorted_candidates) - len(eligible)
+            if dropped:
+                log_warning(
+                    f"{dropped} of {len(sorted_candidates)} candidates scored below "
+                    f"min_similarity {self.min_similarity:.2f} and were excluded"
+                )
+            sorted_candidates = eligible
+
+        top_candidates = self._select_calibrated(sorted_candidates, media_items, target_count)
+
+        if len(top_candidates) < target_count:
+            log_warning(
+                f"Collection is {target_count - len(top_candidates)} short of the configured "
+                f"{target_count}: only {len(top_candidates)} candidates qualified. The library "
+                f"is running out of unwatched {self.media_key} matching this profile - consider "
+                f"adding new content rather than lowering the bar."
+            )
+
         top_ids = {item_id for item_id, _ in top_candidates}
 
         current_ids = {int(m.ratingKey) for m in unwatched_labeled}

--- a/recommenders/external.py
+++ b/recommenders/external.py
@@ -236,6 +236,7 @@ def discover_candidates_by_profile(
     exclude_ids: Optional[Set[int]] = None,
     top_scored_items: Optional[List[Dict]] = None,
     language_filter: Optional[str] = None,
+    priority_genres: Optional[List[str]] = None,
 ) -> Dict[int, Dict]:
     """
     Discover candidates using TMDB Discover API based on user profile.
@@ -277,7 +278,21 @@ def discover_candidates_by_profile(
     genres_counter = user_profile.get("genres")
     if not isinstance(genres_counter, Counter):
         genres_counter = Counter(genres_counter or {})
-    all_genres = list(genres_counter.most_common(20))
+    # Ordering matters more than it looks. Searching a profile's TOP
+    # genres fetches more of whatever the library is already thickest in
+    # - which is precisely the wrong move for the case external
+    # recommendations exist to solve, a user who has exhausted their
+    # library. `priority_genres` (from utils/library_health.py's supply
+    # gap analysis) leads with the genres this profile wants and the
+    # shelf can no longer supply, so acquisition fills the hole instead
+    # of deepening it. Absent that, this is the previous top-genre order.
+    if priority_genres:
+        ranked = [(g, genres_counter.get(g, 0)) for g in priority_genres]
+        seen_genres = {g for g, _ in ranked}
+        ranked += [(g, c) for g, c in genres_counter.most_common(20) if g not in seen_genres]
+        all_genres = ranked[:20]
+    else:
+        all_genres = list(genres_counter.most_common(20))
     top_genres = all_genres[genre_start:genre_end]
     genre_id_map = TMDB_MOVIE_GENRE_IDS if media_type == "movie" else TMDB_TV_GENRE_IDS
 

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -223,6 +223,10 @@ class PlexMovieRecommender(BaseRecommender):
         # Enhance profile with Trakt watch history (if enabled)
         self._enhance_profile_with_trakt()
 
+        # Fold declined recommendations into the profile BEFORE hashing -
+        # the hash is what invalidates cached scores (utils/ignored_recs.py).
+        self._apply_ignored_recommendation_feedback()
+
         # Compute profile hash for score caching
         self.profile_hash = compute_profile_hash(self.watched_data_counters)
 
@@ -550,6 +554,8 @@ class PlexMovieRecommender(BaseRecommender):
             weights=self.weights,
             normalize_counters=self.normalize_counters,
             use_fuzzy_keywords=self.use_tmdb_keywords,
+            genre_idf=getattr(self, "genre_idf", None),
+            keyword_idf=getattr(self, "keyword_idf", None),
         )
 
         # Apply collection bonus for sequels/prequels

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -250,6 +250,10 @@ class PlexTVRecommender(BaseRecommender):
         self._enhance_profile_with_trakt()
 
         # Compute profile hash for score caching
+        # Fold declined recommendations into the profile BEFORE hashing -
+        # the hash is what invalidates cached scores (utils/ignored_recs.py).
+        self._apply_ignored_recommendation_feedback()
+
         self.profile_hash = compute_profile_hash(self.watched_data_counters)
 
         print("Fetching library metadata (for existing Shows checks)...")
@@ -596,6 +600,8 @@ class PlexTVRecommender(BaseRecommender):
             weights=self.weights,
             normalize_counters=self.normalize_counters,
             use_fuzzy_keywords=self.use_tmdb_keywords,
+            genre_idf=getattr(self, "genre_idf", None),
+            keyword_idf=getattr(self, "keyword_idf", None),
         )
 
         # Apply franchise/spinoff bonus based on shared production companies

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2457,6 +2457,173 @@ class TestUpdateLabelsByRank:
         assert [int(i.ratingKey) for i in result] == [2, 1]
 
 
+class TestMinSimilarityFloor:
+    """
+    config/tuning.yml movies:/tv: min_similarity - the library path's
+    quality gate.
+
+    Before this existed the collection was always padded to
+    limit_results no matter how weak the remaining candidates were, so a
+    user who had watched most of their library got sub-15%-similarity
+    items presented as recommendations.
+    """
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_disabled_by_default_pads_to_target(self, mock_remove, mock_add):
+        """Default 0.0 must reproduce the historical fill-to-target behavior."""
+        recommender = _make_recommender()
+        assert recommender.min_similarity == 0.0
+        candidates = {1: (Mock(ratingKey=1), 0.9), 2: (Mock(ratingKey=2), 0.01)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=2)
+
+        assert len(result) == 2
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_excludes_candidates_below_floor(self, mock_remove, mock_add):
+        recommender = _make_recommender()
+        recommender.min_similarity = 0.2
+        candidates = {1: (Mock(ratingKey=1), 0.9), 2: (Mock(ratingKey=2), 0.05)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=2)
+
+        assert [int(i.ratingKey) for i in result] == [1]
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_collection_comes_in_short_rather_than_padding(self, mock_remove, mock_add):
+        """
+        A collection under target_count is a truthful report that the
+        library is exhausted for this profile. Padding it with
+        sub-threshold items is what produced the original complaint.
+        """
+        recommender = _make_recommender()
+        recommender.min_similarity = 0.5
+        candidates = {i: (Mock(ratingKey=i), 0.1) for i in range(1, 11)}
+        candidates[1] = (Mock(ratingKey=1), 0.8)
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=10)
+
+        assert len(result) == 1
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_score_exactly_at_floor_is_kept(self, mock_remove, mock_add):
+        """The gate is >=, not > - a score landing exactly on the
+        configured threshold qualifies."""
+        recommender = _make_recommender()
+        recommender.min_similarity = 0.25
+        candidates = {1: (Mock(ratingKey=1), 0.25)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=5)
+
+        assert [int(i.ratingKey) for i in result] == [1]
+
+
+class TestLibraryHealthReport:
+    """BaseRecommender._report_library_health (utils/library_health.py)."""
+
+    @patch("recommenders.base.log_warning")
+    def test_no_watch_history_reports_nothing(self, mock_warn):
+        """
+        Depletion means "this user consumed their library" - which is
+        meaningless without watch history. A zero-history user facing a
+        small library has NOT watched most of it, and saying so would be
+        false. Cold start is the recommend_for_no_history path's job.
+        """
+        recommender = _make_recommender()
+        recommender.watched_data_counters = {}
+        recommender._report_library_health([{"genres": ["action"]}])
+        mock_warn.assert_not_called()
+        assert recommender.supply_gaps == []
+
+    @patch("recommenders.base.log_warning")
+    def test_depleted_pool_warns_for_a_user_with_history(self, mock_warn):
+        recommender = _make_recommender()
+        recommender.watched_data_counters = {"genres": {"thriller": 50.0}}
+        recommender.limit_results = 50
+        recommender._report_library_health([{"genres": ["comedy"]}])
+        assert mock_warn.called
+
+    @patch("recommenders.base.log_warning")
+    def test_supply_gaps_are_recorded_for_discovery(self, mock_warn):
+        """The gap list is what redirects external acquisition."""
+        recommender = _make_recommender()
+        recommender.watched_data_counters = {"genres": {"thriller": 90.0, "comedy": 10.0}}
+        recommender.limit_results = 2
+        recommender._report_library_health([{"genres": ["comedy"]}, {"genres": ["comedy"]}])
+        assert any(g.genre == "thriller" for g in recommender.supply_gaps)
+
+    @patch("recommenders.base.log_warning")
+    def test_reporting_failure_never_breaks_a_run(self, mock_warn):
+        recommender = _make_recommender()
+        recommender.watched_data_counters = {"genres": {"thriller": 50.0}}
+        recommender._report_library_health([{"genres": None}, "not-a-dict"])
+        assert recommender.supply_gaps == []
+
+
+class TestSelectCalibrated:
+    """
+    config/tuning.yml movies:/tv: calibration_strength - see
+    utils/calibration.py.
+    """
+
+    @staticmethod
+    def _recommender_with_genres(genre_map, profile_genres, strength):
+        recommender = _make_recommender()
+        recommender.calibration_strength = strength
+        recommender.watched_data_counters = {"genres": profile_genres}
+        media_cache = Mock()
+        media_cache.cache = {"movies": {str(k): {"genres": v} for k, v in genre_map.items()}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        return recommender
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_disabled_by_default_keeps_pure_score_order(self, mock_remove, mock_add):
+        recommender = _make_recommender()
+        assert recommender.calibration_strength == 0.0
+        candidates = {1: (Mock(ratingKey=1), 0.5), 2: (Mock(ratingKey=2), 0.9)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=2)
+
+        assert [int(i.ratingKey) for i in result] == [2, 1]
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_pulls_overrepresented_genre_back_toward_profile(self, mock_remove, mock_add):
+        """
+        The reported defect, end to end: a thriller-dominated profile
+        whose remaining unwatched pool is mostly family (because the
+        thrillers are already watched) must not yield an all-family
+        collection.
+        """
+        genre_map = {i: ["family"] for i in range(1, 11)}
+        genre_map.update({i: ["thriller"] for i in range(11, 21)})
+        recommender = self._recommender_with_genres(genre_map, {"thriller": 95.0, "family": 5.0}, strength=0.5)
+        # Family scores higher across the board - score order alone would
+        # return nothing but family.
+        candidates = {i: (Mock(ratingKey=i), 0.6 if i <= 10 else 0.5) for i in range(1, 21)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=10)
+
+        family_kept = sum(1 for i in result if genre_map[int(i.ratingKey)] == ["family"])
+        assert family_kept < 10, "calibration failed to pull the overrepresented genre down"
+
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_cold_start_profile_falls_back_to_score_order(self, mock_remove, mock_add):
+        """No watch history means no distribution to calibrate against."""
+        recommender = self._recommender_with_genres({1: ["family"], 2: ["thriller"]}, {}, strength=0.5)
+        candidates = {1: (Mock(ratingKey=1), 0.5), 2: (Mock(ratingKey=2), 0.9)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=2)
+
+        assert [int(i.ratingKey) for i in result] == [2, 1]
+
+
 class TestSyncPlexCollectionEmpty:
     """Tests for BaseRecommender._sync_plex_collection with no items."""
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,270 @@
+"""
+Tests for utils/calibration.py - calibrated recommendation re-ranking
+(Steck, "Calibrated Recommendations", RecSys 2018).
+"""
+
+import math
+
+import pytest
+
+from utils.calibration import (
+    build_target_distribution,
+    calibrate_recommendations,
+    calibration_report,
+    item_genre_distribution,
+    kl_divergence,
+    list_distribution,
+)
+from utils.config import CALIBRATION_SMOOTHING_ALPHA
+
+
+def _item(title, genres, score):
+    return {"title": title, "genres": genres, "score": score}
+
+
+def _calibrate(items, limit, target, strength):
+    return calibrate_recommendations(
+        items,
+        limit,
+        get_genres=lambda i: i["genres"],
+        get_score=lambda i: i["score"],
+        target_distribution=target,
+        calibration_strength=strength,
+    )
+
+
+class TestBuildTargetDistribution:
+    """build_target_distribution() - profile counter -> p(g|u)."""
+
+    def test_normalizes_to_one(self):
+        dist = build_target_distribution({"action": 30.0, "drama": 10.0})
+        assert dist["action"] == pytest.approx(0.75)
+        assert dist["drama"] == pytest.approx(0.25)
+        assert sum(dist.values()) == pytest.approx(1.0)
+
+    def test_preserves_weighting_not_just_presence(self):
+        """
+        The counter values are recency/rating-weighted, so a heavily
+        watched genre must carry proportionally more target mass - not
+        be flattened to "genres the user has seen".
+        """
+        dist = build_target_distribution({"thriller": 38.45, "family": 6.91})
+        assert dist["thriller"] > 5 * dist["family"]
+
+    def test_empty_profile_returns_empty(self):
+        assert build_target_distribution({}) == {}
+
+    def test_zero_mass_profile_returns_empty(self):
+        """A counter of all zeros has no distribution to speak of."""
+        assert build_target_distribution({"action": 0.0}) == {}
+
+    def test_negative_counts_excluded(self):
+        """Negative counters are explicit dislike signals, not target mass."""
+        dist = build_target_distribution({"action": 10.0, "horror": -5.0})
+        assert "horror" not in dist
+        assert dist["action"] == pytest.approx(1.0)
+
+
+class TestItemGenreDistribution:
+    """item_genre_distribution() - p(g|i)."""
+
+    def test_splits_mass_evenly(self):
+        dist = item_genre_distribution(["action", "comedy", "family"])
+        assert all(v == pytest.approx(1 / 3) for v in dist.values())
+        assert sum(dist.values()) == pytest.approx(1.0)
+
+    def test_broadly_tagged_item_contributes_less_per_genre(self):
+        """
+        The library's kid titles carry ~5.2 genre tags against ~3.3 for
+        everything else. Splitting rather than counting each tag at full
+        weight is what stops that breadth from inflating their
+        contribution to the list distribution.
+        """
+        narrow = item_genre_distribution(["thriller", "drama"])
+        broad = item_genre_distribution(["comedy", "family", "animation", "adventure", "fantasy", "music", "musical"])
+        assert narrow["thriller"] > broad["family"]
+
+    def test_empty_genres_returns_empty(self):
+        assert item_genre_distribution([]) == {}
+
+
+class TestListDistribution:
+    """list_distribution() - q(g)."""
+
+    def test_averages_item_distributions(self):
+        dist = list_distribution([["action"], ["drama"]])
+        assert dist["action"] == pytest.approx(0.5)
+        assert dist["drama"] == pytest.approx(0.5)
+
+    def test_sums_to_one(self):
+        dist = list_distribution([["a", "b"], ["b", "c"], ["a"]])
+        assert sum(dist.values()) == pytest.approx(1.0)
+
+    def test_empty_list_returns_empty(self):
+        assert list_distribution([]) == {}
+
+
+class TestKlDivergence:
+    """kl_divergence() with Steck's smoothing."""
+
+    def test_identical_distributions_are_zero(self):
+        p = {"action": 0.5, "drama": 0.5}
+        assert kl_divergence(p, p) == pytest.approx(0.0, abs=1e-9)
+
+    def test_is_non_negative(self):
+        p = {"action": 0.7, "drama": 0.3}
+        q = {"action": 0.2, "drama": 0.8}
+        assert kl_divergence(p, q) >= 0
+
+    def test_missing_genre_is_finite_not_infinite(self):
+        """
+        The case that matters most: a genre the user watches that the
+        list omits entirely. Without smoothing this is log(p/0) = inf,
+        which would make every incomplete list equally (in)comparable.
+        """
+        divergence = kl_divergence({"action": 0.5, "drama": 0.5}, {"action": 1.0})
+        assert math.isfinite(divergence)
+        assert divergence > 0
+
+    def test_larger_mismatch_diverges_more(self):
+        p = {"action": 0.9, "family": 0.1}
+        close = kl_divergence(p, {"action": 0.8, "family": 0.2})
+        far = kl_divergence(p, {"action": 0.2, "family": 0.8})
+        assert far > close
+
+    def test_smoothing_alpha_is_applied(self):
+        """alpha interpolates the actual distribution toward the target."""
+        p = {"action": 1.0}
+        unsmoothed_q = {"action": 0.0}
+        divergence = kl_divergence(p, unsmoothed_q, alpha=CALIBRATION_SMOOTHING_ALPHA)
+        assert divergence == pytest.approx(-math.log(CALIBRATION_SMOOTHING_ALPHA))
+
+
+class TestCalibrateRecommendations:
+    """calibrate_recommendations() - the greedy selection."""
+
+    def test_disabled_strength_preserves_score_order(self):
+        items = [_item("a", ["action"], 0.9), _item("b", ["drama"], 0.5)]
+        result = _calibrate(items, 2, {"action": 0.5, "drama": 0.5}, 0.0)
+        assert [i["title"] for i in result] == ["a", "b"]
+
+    def test_empty_target_falls_back_to_score_order(self):
+        """Cold start: no profile means nothing to calibrate against."""
+        items = [_item("a", ["action"], 0.9), _item("b", ["drama"], 0.5)]
+        result = _calibrate(items, 2, {}, 0.5)
+        assert [i["title"] for i in result] == ["a", "b"]
+
+    def test_candidates_fitting_within_limit_are_untouched(self):
+        """Nothing to trade off when everything is selected anyway."""
+        items = [_item("a", ["action"], 0.9), _item("b", ["family"], 0.8)]
+        result = _calibrate(items, 5, {"action": 0.99, "family": 0.01}, 1.0)
+        assert len(result) == 2
+
+    def test_respects_limit(self):
+        items = [_item(str(i), ["action"], 0.5) for i in range(20)]
+        assert len(_calibrate(items, 7, {"action": 1.0}, 0.5)) == 7
+
+    def test_zero_limit_returns_empty(self):
+        items = [_item("a", ["action"], 0.9)]
+        assert _calibrate(items, 0, {"action": 1.0}, 0.5) == []
+
+    def test_empty_candidates_returns_empty(self):
+        assert _calibrate([], 10, {"action": 1.0}, 0.5) == []
+
+    def test_suppresses_genre_overrepresented_relative_to_profile(self):
+        """
+        The reported defect: a profile that is mostly thriller, and a
+        candidate pool that is mostly family because the user has
+        already watched the thrillers, previously yielded a
+        mostly-family collection. Calibration must pull the family
+        share back down toward the profile's.
+        """
+        target = {"thriller": 0.95, "family": 0.05}
+        items = [_item(f"fam{i}", ["family"], 0.60) for i in range(20)]
+        items += [_item(f"thr{i}", ["thriller"], 0.55) for i in range(20)]
+
+        uncalibrated = _calibrate(items, 10, target, 0.0)
+        calibrated = _calibrate(items, 10, target, 0.5)
+
+        def family_count(sel):
+            return sum(1 for i in sel if "family" in i["genres"])
+
+        # Score order alone hands back an all-family list.
+        assert family_count(uncalibrated) == 10
+        assert family_count(calibrated) < family_count(uncalibrated)
+
+    def test_does_not_eliminate_a_genre_the_user_actually_watches(self):
+        """
+        Calibration is not exclusion - this is the whole reason to
+        prefer it. A genre with real profile mass must still appear,
+        just at its proper rate.
+        """
+        target = {"thriller": 0.8, "family": 0.2}
+        items = [_item(f"fam{i}", ["family"], 0.30) for i in range(20)]
+        items += [_item(f"thr{i}", ["thriller"], 0.90) for i in range(20)]
+
+        calibrated = _calibrate(items, 10, target, 0.5)
+        family = [i for i in calibrated if "family" in i["genres"]]
+        assert len(family) > 0, "calibration eliminated a genre the profile contains"
+
+    def test_keeps_the_best_examples_of_a_downweighted_genre(self):
+        """
+        When calibration trims a genre it should keep that genre's
+        highest-scoring titles - "the right ones", not an arbitrary
+        slice.
+        """
+        target = {"thriller": 0.9, "family": 0.1}
+        items = [_item("good-family", ["family"], 0.90)]
+        items += [_item(f"weak-family{i}", ["family"], 0.20) for i in range(10)]
+        items += [_item(f"thr{i}", ["thriller"], 0.50) for i in range(10)]
+
+        calibrated = _calibrate(items, 6, target, 0.5)
+        family = [i["title"] for i in calibrated if "family" in i["genres"]]
+        assert "good-family" in family
+
+    def test_higher_strength_calibrates_more_closely(self):
+        target = {"thriller": 0.9, "family": 0.1}
+        items = [_item(f"fam{i}", ["family"], 0.80) for i in range(20)]
+        items += [_item(f"thr{i}", ["thriller"], 0.50) for i in range(20)]
+
+        def divergence_at(strength):
+            sel = _calibrate(items, 10, target, strength)
+            return kl_divergence(target, list_distribution([i["genres"] for i in sel]))
+
+        assert divergence_at(0.5) < divergence_at(0.0)
+
+    def test_returns_only_original_candidate_objects(self):
+        """No copying/wrapping - callers rely on identity downstream."""
+        items = [_item("a", ["action"], 0.9), _item("b", ["family"], 0.8)]
+        result = _calibrate(items, 1, {"action": 0.9, "family": 0.1}, 0.5)
+        assert result[0] is items[0] or result[0] is items[1]
+
+    def test_no_duplicate_selections(self):
+        items = [_item(str(i), ["action", "drama"], 0.5) for i in range(10)]
+        result = _calibrate(items, 5, {"action": 0.5, "drama": 0.5}, 0.5)
+        assert len({id(i) for i in result}) == 5
+
+
+class TestCalibrationReport:
+    """calibration_report() - the logging comparison."""
+
+    def test_reports_worst_divergence_first(self):
+        target = {"action": 0.5, "drama": 0.4, "family": 0.1}
+        rows = calibration_report(target, [["family"], ["family"]], top_n=3)
+        assert rows[0][0] == "family"
+
+    def test_returns_target_and_actual_shares(self):
+        rows = calibration_report({"action": 1.0}, [["action"]], top_n=1)
+        genre, target_share, actual_share = rows[0]
+        assert genre == "action"
+        assert target_share == pytest.approx(1.0)
+        assert actual_share == pytest.approx(1.0)
+
+    def test_respects_top_n(self):
+        target = {"a": 0.25, "b": 0.25, "c": 0.25, "d": 0.25}
+        assert len(calibration_report(target, [["a"]], top_n=2)) == 2
+
+    def test_includes_genres_absent_from_the_list(self):
+        """A genre the collection omits entirely is exactly what to surface."""
+        rows = calibration_report({"action": 0.5, "drama": 0.5}, [["action"]], top_n=5)
+        assert "drama" in {r[0] for r in rows}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -463,6 +463,8 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         result = resolve_media_type_overrides({"movies": movies}, MEDIA_TYPE_MOVIE)
 
         assert result["limit_results"] == movies["limit_results"]
+        assert result["min_similarity"] == movies["min_similarity"]
+        assert result["calibration_strength"] == movies["calibration_strength"]
         assert result["randomize_recommendations"] == movies["randomize_recommendations"]
         assert result["show_summary"] == movies["show_summary"]
         assert result["show_cast"] == movies["show_cast"]
@@ -486,6 +488,8 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         result = resolve_media_type_overrides({"tv": tv}, MEDIA_TYPE_TV)
 
         assert result["limit_results"] == tv["limit_results"]
+        assert result["min_similarity"] == tv["min_similarity"]
+        assert result["calibration_strength"] == tv["calibration_strength"]
         assert result["randomize_recommendations"] == tv["randomize_recommendations"]
         assert result["normalize_counters"] == tv["normalize_counters"]
         assert result["show_summary"] == tv["show_summary"]
@@ -505,6 +509,8 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         tuning = self._load_example_tuning()
         covered_movie_keys = {
             "limit_results",
+            "min_similarity",
+            "calibration_strength",
             "randomize_recommendations",
             "show_summary",
             "show_cast",
@@ -519,6 +525,8 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         }
         covered_tv_keys = {
             "limit_results",
+            "min_similarity",
+            "calibration_strength",
             "randomize_recommendations",
             "normalize_counters",
             "show_summary",

--- a/tests/test_corpus_idf.py
+++ b/tests/test_corpus_idf.py
@@ -1,0 +1,165 @@
+"""
+Tests for utils/corpus_idf.py - corpus-level inverse document frequency.
+"""
+
+import pytest
+
+from utils.config import IDF_MIN_CORPUS_SIZE, IDF_MIN_WEIGHT
+from utils.corpus_idf import (
+    build_corpus_idf,
+    build_document_frequency,
+    describe_least_informative,
+    idf_weight,
+)
+
+
+def _corpus(size, common_term="sequel", rare_term="nasa"):
+    """A corpus where `common_term` is everywhere and `rare_term` is in one item."""
+    items = [{"tmdb_keywords": [common_term]} for _ in range(size)]
+    items[0]["tmdb_keywords"] = [common_term, rare_term]
+    return items
+
+
+class TestBuildDocumentFrequency:
+    def test_counts_items_containing_each_term(self):
+        items = [{"genres": ["Action", "Drama"]}, {"genres": ["Action"]}]
+        assert build_document_frequency(items, "genres") == {"action": 2, "drama": 1}
+
+    def test_lowercases_terms(self):
+        items = [{"genres": ["ACTION"]}, {"genres": ["action"]}]
+        assert build_document_frequency(items, "genres") == {"action": 2}
+
+    def test_duplicate_term_in_one_item_counts_once(self):
+        """Document frequency, not term frequency."""
+        items = [{"genres": ["action", "Action", "ACTION"]}]
+        assert build_document_frequency(items, "genres") == {"action": 1}
+
+    def test_missing_field_is_skipped(self):
+        items = [{"genres": ["action"]}, {}, {"genres": None}]
+        assert build_document_frequency(items, "genres") == {"action": 1}
+
+    def test_non_string_terms_ignored(self):
+        items = [{"genres": ["action", None, 7]}]
+        assert build_document_frequency(items, "genres") == {"action": 1}
+
+
+class TestBuildCorpusIdf:
+    def test_ubiquitous_term_scores_lower_than_rare_term(self):
+        """The whole point: a term in every item carries no information."""
+        weights = build_corpus_idf(_corpus(100), "tmdb_keywords")
+        assert weights["sequel"] < weights["nasa"]
+
+    def test_weights_are_bounded(self):
+        weights = build_corpus_idf(_corpus(100), "tmdb_keywords")
+        assert all(IDF_MIN_WEIGHT <= w <= 1.0 for w in weights.values())
+
+    def test_ubiquitous_term_hits_the_floor_not_zero(self):
+        """
+        Zeroing a term outright would silently erase the dimension for an
+        item whose metadata is entirely common terms - degrade, don't
+        drop (CLAUDE.md).
+        """
+        weights = build_corpus_idf(_corpus(200), "tmdb_keywords")
+        assert weights["sequel"] == pytest.approx(IDF_MIN_WEIGHT)
+
+    def test_small_corpus_returns_empty(self):
+        """Below the minimum, document frequency is too noisy to trust."""
+        assert build_corpus_idf(_corpus(IDF_MIN_CORPUS_SIZE - 1), "tmdb_keywords") == {}
+
+    def test_at_minimum_corpus_size_produces_weights(self):
+        assert build_corpus_idf(_corpus(IDF_MIN_CORPUS_SIZE), "tmdb_keywords") != {}
+
+    def test_empty_corpus_returns_empty(self):
+        assert build_corpus_idf([], "tmdb_keywords") == {}
+
+    def test_corpus_with_no_terms_returns_empty(self):
+        assert build_corpus_idf([{} for _ in range(50)], "tmdb_keywords") == {}
+
+    def test_ordering_matches_real_library_shape(self):
+        """
+        Reproduces the observed defect: 'sequel' (28% of the library)
+        must be discounted well below 'survival' (2%), despite carrying
+        MORE weight in the user's profile.
+        """
+        items = []
+        for i in range(100):
+            kws = []
+            if i < 28:
+                kws.append("sequel")
+            if i < 14:
+                kws.append("aftercreditsstinger")
+            if i < 2:
+                kws.append("survival")
+            items.append({"tmdb_keywords": kws or ["filler"]})
+        weights = build_corpus_idf(items, "tmdb_keywords")
+        assert weights["survival"] > weights["aftercreditsstinger"] > weights["sequel"]
+
+
+class TestIdfWeight:
+    def test_no_corpus_is_neutral(self):
+        """This is what keeps pre-existing callers bit-for-bit unchanged."""
+        assert idf_weight("anything", None) == 1.0
+        assert idf_weight("anything", {}) == 1.0
+
+    def test_looks_up_case_insensitively(self):
+        assert idf_weight("Sequel", {"sequel": 0.2}) == 0.2
+
+    def test_unknown_term_is_treated_as_maximally_distinctive(self):
+        """
+        A term the library holds nothing else for is MORE distinctive
+        than any term in it, so it takes 1.0 rather than the floor.
+        """
+        assert idf_weight("obscure", {"sequel": 0.2}) == 1.0
+
+
+class TestDescribeLeastInformative:
+    def test_returns_lowest_weighted_first(self):
+        weights = {"sequel": 0.05, "survival": 0.9, "stinger": 0.2}
+        assert [t for t, _ in describe_least_informative(weights, top_n=2)] == ["sequel", "stinger"]
+
+    def test_respects_top_n(self):
+        assert len(describe_least_informative({"a": 0.1, "b": 0.2, "c": 0.3}, top_n=2)) == 2
+
+
+class TestScoringIntegration:
+    """The IDF must actually change a similarity score, not just exist."""
+
+    def test_ubiquitous_keyword_match_scores_below_rare_one(self):
+        from utils.scoring import calculate_similarity_score
+
+        corpus = []
+        for i in range(100):
+            kws = ["sequel"] if i < 90 else []
+            if i < 3:
+                kws.append("nasa")
+            corpus.append({"tmdb_keywords": kws or ["filler"]})
+        keyword_idf = build_corpus_idf(corpus, "tmdb_keywords")
+
+        profile = {"genres": {}, "actors": {}, "directors": {}, "keywords": {"sequel": 10, "nasa": 10}}
+        weights = {"genre": 0.0, "director": 0.0, "actor": 0.0, "keyword": 1.0}
+
+        # NB: the corpus is built from the cache's storage field name
+        # ("tmdb_keywords"), but scoring reads content_info["keywords"] -
+        # the recommenders translate between the two. The IDF map is
+        # keyed on the keyword strings themselves, so it spans both.
+        common, _ = calculate_similarity_score(
+            {"keywords": ["sequel"]}, dict(profile), "movie", weights, keyword_idf=keyword_idf
+        )
+        rare, _ = calculate_similarity_score(
+            {"keywords": ["nasa"]}, dict(profile), "movie", weights, keyword_idf=keyword_idf
+        )
+        assert rare > common, "corpus IDF did not discount the ubiquitous keyword"
+
+    def test_absent_corpus_leaves_scoring_unchanged(self):
+        """Backwards compatibility for every existing caller."""
+        from utils.scoring import calculate_similarity_score
+
+        profile = {"genres": {}, "actors": {}, "directors": {}, "keywords": {"sequel": 10}}
+        weights = {"genre": 0.0, "director": 0.0, "actor": 0.0, "keyword": 1.0}
+        content = {"keywords": ["sequel"]}
+
+        without, _ = calculate_similarity_score(content, dict(profile), "movie", weights)
+        explicit_none, _ = calculate_similarity_score(
+            content, dict(profile), "movie", weights, keyword_idf=None, genre_idf=None
+        )
+        assert without == explicit_none

--- a/tests/test_ignored_recs.py
+++ b/tests/test_ignored_recs.py
@@ -1,0 +1,137 @@
+"""
+Tests for utils/ignored_recs.py - negative feedback from recommendations
+that were shown and never watched.
+"""
+
+from datetime import datetime, timedelta
+
+from utils.config import IGNORED_REC_MAX_PROFILE_FRACTION, IGNORED_REC_MIN_DAYS_SHOWN
+from utils.ignored_recs import apply_ignored_penalties, find_ignored_recommendations
+
+NOW = datetime(2026, 7, 31, 12, 0, 0)
+LABEL = "Recommended_alice"
+
+
+def _days_ago(n):
+    return (NOW - timedelta(days=n)).isoformat()
+
+
+class TestFindIgnoredRecommendations:
+    def test_finds_item_shown_long_enough_and_unwatched(self):
+        dates = {f"1_{LABEL}": _days_ago(IGNORED_REC_MIN_DAYS_SHOWN + 1)}
+        assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == [(1, IGNORED_REC_MIN_DAYS_SHOWN + 1)]
+
+    def test_ignores_item_not_shown_long_enough(self):
+        dates = {f"1_{LABEL}": _days_ago(IGNORED_REC_MIN_DAYS_SHOWN - 1)}
+        assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == []
+
+    def test_boundary_day_counts_as_ignored(self):
+        dates = {f"1_{LABEL}": _days_ago(IGNORED_REC_MIN_DAYS_SHOWN)}
+        assert len(find_ignored_recommendations(dates, LABEL, set(), now=NOW)) == 1
+
+    def test_watched_item_is_not_ignored(self):
+        """Watching it is the opposite signal - the recommendation worked."""
+        dates = {f"1_{LABEL}": _days_ago(90)}
+        assert find_ignored_recommendations(dates, LABEL, {1}, now=NOW) == []
+
+    def test_other_users_labels_are_not_counted(self):
+        """
+        label_dates is shared across users; charging one profile for
+        another's untouched recommendations would be flatly wrong.
+        """
+        dates = {"1_Recommended_bob": _days_ago(90)}
+        assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == []
+
+    def test_malformed_timestamp_is_skipped_not_guessed(self):
+        dates = {f"1_{LABEL}": "not-a-date"}
+        assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == []
+
+    def test_non_numeric_rating_key_is_skipped(self):
+        dates = {f"abc_{LABEL}": _days_ago(90)}
+        assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == []
+
+    def test_sorted_longest_shown_first(self):
+        dates = {
+            f"1_{LABEL}": _days_ago(30),
+            f"2_{LABEL}": _days_ago(90),
+            f"3_{LABEL}": _days_ago(60),
+        }
+        assert [rk for rk, _ in find_ignored_recommendations(dates, LABEL, set(), now=NOW)] == [2, 3, 1]
+
+    def test_empty_label_dates(self):
+        assert find_ignored_recommendations({}, LABEL, set(), now=NOW) == []
+
+    def test_custom_min_days_is_respected(self):
+        dates = {f"1_{LABEL}": _days_ago(5)}
+        assert len(find_ignored_recommendations(dates, LABEL, set(), now=NOW, min_days_shown=3)) == 1
+
+
+class TestApplyIgnoredPenalties:
+    def test_drives_genre_counter_downward(self):
+        counters = {"genres": {"family": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(counters, [{"genres": ["family"]}], penalty=0.5)
+        assert counters["genres"]["family"] < 10.0
+
+    def test_can_push_an_unseen_genre_negative(self):
+        """
+        Negative counts are what utils/scoring.py's existing
+        `genre_count < 0` branch consumes - the branch that had no
+        producer before this module.
+        """
+        counters = {"genres": {"action": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(counters, [{"genres": ["polka"]}] * 5, penalty=0.5)
+        assert counters["genres"]["polka"] < 0
+
+    def test_penalty_is_split_across_an_items_terms(self):
+        """
+        A 7-genre title must not deliver 7x the punishment of a 2-genre
+        one for the same single act of being ignored.
+        """
+        narrow = {"genres": {"a": 10.0, "b": 10.0}, "tmdb_keywords": {}}
+        broad = {"genres": {"a": 10.0, "b": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(narrow, [{"genres": ["a", "b"]}], penalty=1.0)
+        apply_ignored_penalties(broad, [{"genres": ["a", "b", "c", "d", "e", "f", "g"]}], penalty=1.0)
+        assert narrow["genres"]["a"] < broad["genres"]["a"]
+
+    def test_floor_prevents_unrecoverable_burial(self):
+        """
+        Without a floor, a long run of ignored recommendations could bury
+        a genre so deep the profile could never recover if taste swung
+        back.
+        """
+        counters = {"genres": {"action": 100.0, "family": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(counters, [{"genres": ["family"]}] * 500, penalty=1.0)
+        floor = -(100.0 * IGNORED_REC_MAX_PROFILE_FRACTION)
+        assert counters["genres"]["family"] >= floor
+
+    def test_penalizes_keywords_too(self):
+        counters = {"genres": {}, "tmdb_keywords": {"sequel": 5.0}}
+        apply_ignored_penalties(counters, [{"tmdb_keywords": ["sequel"]}], penalty=0.5)
+        assert counters["tmdb_keywords"]["sequel"] < 5.0
+
+    def test_reports_how_many_terms_were_penalized(self):
+        counters = {"genres": {"a": 1.0}, "tmdb_keywords": {}}
+        applied = apply_ignored_penalties(counters, [{"genres": ["x", "y"]}], penalty=0.5)
+        assert applied["genres"] == 2
+
+    def test_no_ignored_items_is_a_noop(self):
+        counters = {"genres": {"action": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(counters, [], penalty=0.5)
+        assert counters["genres"]["action"] == 10.0
+
+    def test_item_with_no_terms_is_skipped(self):
+        counters = {"genres": {"action": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(counters, [{"genres": []}], penalty=0.5)
+        assert counters["genres"]["action"] == 10.0
+
+    def test_missing_dimension_does_not_raise(self):
+        counters = {"genres": {"action": 10.0}}
+        apply_ignored_penalties(counters, [{"tmdb_keywords": ["x"]}], penalty=0.5)
+        assert counters["genres"]["action"] == 10.0
+
+    def test_repeated_ignores_of_same_genre_compound(self):
+        once = {"genres": {"family": 10.0}, "tmdb_keywords": {}}
+        many = {"genres": {"family": 10.0}, "tmdb_keywords": {}}
+        apply_ignored_penalties(once, [{"genres": ["family"]}], penalty=0.5)
+        apply_ignored_penalties(many, [{"genres": ["family"]}] * 5, penalty=0.5)
+        assert many["genres"]["family"] < once["genres"]["family"]

--- a/tests/test_library_health.py
+++ b/tests/test_library_health.py
@@ -1,0 +1,139 @@
+"""
+Tests for utils/library_health.py - candidate supply measurement.
+"""
+
+import pytest
+
+from utils.config import POOL_DEPLETION_RATIO
+from utils.library_health import (
+    assess_pool_health,
+    find_supply_gaps,
+    format_health_report,
+    gaps_to_dict,
+    prioritize_discovery_genres,
+)
+
+
+class TestAssessPoolHealth:
+    def test_healthy_pool_is_not_flagged(self):
+        health = assess_pool_health(500, 50)
+        assert health.ratio == 10.0
+        assert not health.depleted
+
+    def test_depleted_pool_is_flagged(self):
+        """The reported case: 127 candidates for a 50-item collection."""
+        health = assess_pool_health(127, 50)
+        assert health.ratio == pytest.approx(2.54)
+        assert health.depleted
+
+    def test_boundary_ratio_is_healthy(self):
+        health = assess_pool_health(int(50 * POOL_DEPLETION_RATIO), 50)
+        assert not health.depleted
+
+    def test_zero_target_does_not_divide_by_zero(self):
+        health = assess_pool_health(10, 0)
+        assert health.ratio == 0.0
+        assert not health.depleted
+
+    def test_empty_pool(self):
+        assert assess_pool_health(0, 50).depleted
+
+    def test_summary_mentions_state(self):
+        assert "DEPLETED" in assess_pool_health(10, 50).summary()
+        assert "healthy" in assess_pool_health(500, 50).summary()
+
+
+class TestFindSupplyGaps:
+    def test_finds_genre_the_library_cannot_supply(self):
+        """Profile wants thriller; the unwatched pool is all comedy."""
+        target = {"thriller": 0.6, "comedy": 0.4}
+        gaps = find_supply_gaps(target, [["comedy"], ["comedy"], ["comedy"]])
+        assert [g.genre for g in gaps] == ["thriller"]
+
+    def test_no_gap_when_supply_matches_demand(self):
+        target = {"thriller": 0.5, "comedy": 0.5}
+        gaps = find_supply_gaps(target, [["thriller"], ["comedy"]])
+        assert gaps == []
+
+    def test_ignores_genres_the_user_barely_watches(self):
+        """A 0.5%-of-profile genre is not a supply problem worth acting on."""
+        target = {"thriller": 0.995, "polka": 0.005}
+        gaps = find_supply_gaps(target, [["thriller"]])
+        assert all(g.genre != "polka" for g in gaps)
+
+    def test_ignores_shortfalls_below_noise_threshold(self):
+        target = {"thriller": 0.50, "comedy": 0.50}
+        gaps = find_supply_gaps(target, [["thriller"], ["thriller"], ["comedy"]], min_shortfall=0.30)
+        assert gaps == []
+
+    def test_sorted_worst_shortfall_first(self):
+        target = {"thriller": 0.5, "scifi": 0.3, "comedy": 0.2}
+        gaps = find_supply_gaps(target, [["comedy"]])
+        assert [g.genre for g in gaps] == ["thriller", "scifi"]
+
+    def test_shortfall_is_demand_minus_supply(self):
+        gaps = find_supply_gaps({"thriller": 0.8, "comedy": 0.2}, [["comedy"]])
+        assert gaps[0].shortfall == pytest.approx(0.8)
+
+    def test_empty_target_yields_no_gaps(self):
+        assert find_supply_gaps({}, [["comedy"]]) == []
+
+    def test_empty_pool_makes_every_wanted_genre_a_gap(self):
+        gaps = find_supply_gaps({"thriller": 0.6, "comedy": 0.4}, [])
+        assert {g.genre for g in gaps} == {"thriller", "comedy"}
+
+
+class TestPrioritizeDiscoveryGenres:
+    def test_gap_genres_lead(self):
+        """
+        The actual fix: acquisition must target what is missing, not
+        fetch more of what the library already holds most of.
+        """
+        gaps = find_supply_gaps({"thriller": 0.7, "comedy": 0.3}, [["comedy"]])
+        ordered = prioritize_discovery_genres(gaps, {"comedy": 100.0, "thriller": 5.0})
+        assert ordered[0] == "thriller"
+
+    def test_profile_genres_follow_as_filler(self):
+        gaps = find_supply_gaps({"thriller": 0.7, "comedy": 0.3}, [["comedy"]])
+        ordered = prioritize_discovery_genres(gaps, {"comedy": 100.0, "thriller": 5.0})
+        assert "comedy" in ordered
+
+    def test_no_gaps_degrades_to_top_genre_order(self):
+        """A healthy library must behave exactly as it did before."""
+        ordered = prioritize_discovery_genres([], {"comedy": 100.0, "thriller": 50.0, "drama": 10.0})
+        assert ordered == ["comedy", "thriller", "drama"]
+
+    def test_no_duplicates(self):
+        gaps = find_supply_gaps({"thriller": 0.7, "comedy": 0.3}, [["comedy"]])
+        ordered = prioritize_discovery_genres(gaps, {"thriller": 100.0, "comedy": 50.0})
+        assert len(ordered) == len(set(ordered))
+
+    def test_respects_limit(self):
+        profile = {f"g{i}": float(i) for i in range(30)}
+        assert len(prioritize_discovery_genres([], profile, limit=5)) == 5
+
+
+class TestFormatHealthReport:
+    def test_healthy_report_omits_the_warning(self):
+        lines = format_health_report(assess_pool_health(500, 50), [])
+        assert not any("exhausted" in ln for ln in lines)
+
+    def test_depleted_report_says_new_content_is_the_fix(self):
+        lines = format_health_report(assess_pool_health(60, 50), [])
+        assert any("new content is the fix" in ln for ln in lines)
+
+    def test_gaps_are_listed(self):
+        gaps = find_supply_gaps({"thriller": 0.8, "comedy": 0.2}, [["comedy"]])
+        lines = format_health_report(assess_pool_health(60, 50), gaps)
+        assert any("thriller" in ln for ln in lines)
+
+
+class TestGapsToDict:
+    def test_serializes_expected_fields(self):
+        gaps = find_supply_gaps({"thriller": 0.8, "comedy": 0.2}, [["comedy"]])
+        row = gaps_to_dict(gaps)[0]
+        assert set(row) == {"genre", "profile_share", "available_share", "shortfall"}
+        assert row["genre"] == "thriller"
+
+    def test_empty_gaps(self):
+        assert gaps_to_dict([]) == []

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -15,6 +15,16 @@ from .cache import (
     save_watched_cache,
 )
 
+# Calibrated recommendation re-ranking (Steck, RecSys 2018)
+from .calibration import (
+    build_target_distribution,
+    calibrate_recommendations,
+    calibration_report,
+    item_genre_distribution,
+    kl_divergence,
+    list_distribution,
+)
+
 # CLI utilities
 from .cli import (
     get_users_from_config,
@@ -28,20 +38,30 @@ from .cli import (
 )
 from .config import (
     CACHE_VERSION,
+    CALIBRATION_DIVERGENCE_SCALE,
+    CALIBRATION_SMOOTHING_ALPHA,
     CANDIDATE_BUFFER_MULTIPLIER,
     COLLECTION_BONUS_BASE,
     COLLECTION_BONUS_CAP,
     COLLECTION_BONUS_LOG_FACTOR,
+    DEFAULT_CALIBRATION_STRENGTH,
     DEFAULT_LIMIT_RESULTS,
+    DEFAULT_MIN_SIMILARITY,
     DEFAULT_NEGATIVE_MULTIPLIERS,
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_RATING,
     DEFAULT_RATING_MULTIPLIERS,
+    IDF_MIN_CORPUS_SIZE,
+    IDF_MIN_WEIGHT,
+    IGNORED_REC_MAX_PROFILE_FRACTION,
+    IGNORED_REC_MIN_DAYS_SHOWN,
+    IGNORED_REC_PENALTY,
     MEDIA_KEY_MOVIES,
     MEDIA_KEY_SHOWS,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_TV,
     PLEX_REQUEST_TIMEOUT,
+    POOL_DEPLETION_RATIO,
     RADARR_REQUEST_TIMEOUT,
     RATING_MULTIPLIER_2_STAR,
     RATING_MULTIPLIER_3_STAR,
@@ -53,6 +73,8 @@ from .config import (
     RATING_TIER_5_STAR,
     RECOMMEND_FOR_NO_HISTORY_DEFAULT,
     SONARR_REQUEST_TIMEOUT,
+    SUPPLY_GAP_MIN_PROFILE_SHARE,
+    SUPPLY_GAP_MIN_SHORTFALL,
     TIER_DIVERSE_PERCENT,
     TIER_SAFE_PERCENT,
     TIER_WILDCARD_PERCENT,
@@ -78,6 +100,14 @@ from .config import (
     load_config,
     load_resolved_config,
     resolve_media_type_overrides,
+)
+
+# Corpus-level IDF - the missing half of scoring's "TF-IDF"
+from .corpus_idf import (
+    build_corpus_idf,
+    build_document_frequency,
+    describe_least_informative,
+    idf_weight,
 )
 
 # Counter utilities
@@ -129,6 +159,12 @@ from .helpers import (
     normalize_title,
 )
 
+# Negative feedback from declined recommendations
+from .ignored_recs import (
+    apply_ignored_penalties,
+    find_ignored_recommendations,
+)
+
 # Integration-health signal (explicit, structured last-attempt status -
 # see module docstring for why this exists instead of log-string matching)
 from .integration_status import (
@@ -145,6 +181,17 @@ from .labels import (
     categorize_labeled_items,
     remove_labels_from_items,
     render_collection_name,
+)
+
+# Library supply health - is ranking still the constraint?
+from .library_health import (
+    PoolHealth,
+    SupplyGap,
+    assess_pool_health,
+    find_supply_gaps,
+    format_health_report,
+    gaps_to_dict,
+    prioritize_discovery_genres,
 )
 
 # MDBList utilities
@@ -384,7 +431,19 @@ __all__ = [
     "TMDB_RATE_LIMIT_DELAY",
     "DEFAULT_RATING",
     "WEIGHT_SUM_TOLERANCE",
+    "CALIBRATION_DIVERGENCE_SCALE",
+    "IDF_MIN_CORPUS_SIZE",
+    "IDF_MIN_WEIGHT",
+    "IGNORED_REC_MAX_PROFILE_FRACTION",
+    "IGNORED_REC_MIN_DAYS_SHOWN",
+    "IGNORED_REC_PENALTY",
+    "POOL_DEPLETION_RATIO",
+    "SUPPLY_GAP_MIN_PROFILE_SHARE",
+    "SUPPLY_GAP_MIN_SHORTFALL",
+    "CALIBRATION_SMOOTHING_ALPHA",
+    "DEFAULT_CALIBRATION_STRENGTH",
     "DEFAULT_LIMIT_RESULTS",
+    "DEFAULT_MIN_SIMILARITY",
     "CANDIDATE_BUFFER_MULTIPLIER",
     "TOP_POOL_PERCENTAGE",
     "MEDIA_TYPE_MOVIE",
@@ -520,6 +579,29 @@ __all__ = [
     "calculate_rewatch_multiplier",
     "calculate_similarity_score",
     "select_tiered_recommendations",
+    # Corpus IDF
+    "build_corpus_idf",
+    "build_document_frequency",
+    "describe_least_informative",
+    "idf_weight",
+    # Ignored-recommendation negative feedback
+    "apply_ignored_penalties",
+    "find_ignored_recommendations",
+    # Library supply health
+    "PoolHealth",
+    "SupplyGap",
+    "assess_pool_health",
+    "find_supply_gaps",
+    "format_health_report",
+    "gaps_to_dict",
+    "prioritize_discovery_genres",
+    # Calibration
+    "build_target_distribution",
+    "calibrate_recommendations",
+    "calibration_report",
+    "item_genre_distribution",
+    "kl_divergence",
+    "list_distribution",
     # Counters
     "build_profile_from_counters",
     "create_empty_counters",

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -1,0 +1,243 @@
+"""
+Calibrated recommendation re-ranking.
+
+Implements the calibration method from Harald Steck, "Calibrated
+Recommendations" (Netflix, RecSys 2018).
+
+The problem it solves: ranking candidates purely by similarity score does
+NOT preserve the user's taste distribution. Greedy top-N lets whatever
+happens to be abundant in the candidate pool dominate the final list,
+regardless of how much of the user's actual watch history that genre
+represents.
+
+Both failure directions are the same defect - the list's genre mix has
+drifted from the profile's:
+
+  - Steck's example (minority interest erased): a user who watches 70%
+    action / 30% romance gets a list that is 100% action.
+  - The inverse (minority interest amplified): a user whose profile is
+    3.8% family, recommended from a pool that is 38% family because
+    they have already watched most of the non-family library, gets a
+    list that is 38% family.
+
+The fix in both cases is to score a candidate list on two axes at once -
+how well its items match the user, and how closely its genre distribution
+matches the user's - and greedily build the list that maximizes:
+
+    (1 - lambda) * sum(similarity) - lambda * KL(target || list)
+
+`lambda` (calibration_strength) trades relevance against calibration.
+0.0 reproduces plain top-N by score; higher values enforce the taste
+distribution more aggressively.
+
+Note this is deliberately NOT a genre exclusion. A user who genuinely
+watches some family content still gets family content - just at the rate
+they actually watch it, and the highest-scoring examples of it.
+"""
+
+import math
+from typing import Callable, Dict, Iterable, List, Sequence, Tuple, TypeVar
+
+from utils.config import (
+    CALIBRATION_DIVERGENCE_SCALE,
+    CALIBRATION_SMOOTHING_ALPHA,
+    DEFAULT_CALIBRATION_STRENGTH,
+)
+
+T = TypeVar("T")
+
+
+def build_target_distribution(genre_counter: Dict[str, float]) -> Dict[str, float]:
+    """
+    Normalize a user's weighted genre counter into a probability
+    distribution p(g|u) - the share of the user's watch history that
+    each genre represents.
+
+    The counter values are the recency/rating-weighted counts that
+    utils/counters.py already produces, so this deliberately preserves
+    those weights rather than counting raw titles: a genre the user
+    watched heavily last month should carry more target mass than one
+    they watched once in 2019.
+
+    Returns an empty dict for an empty/zero-mass profile, which callers
+    treat as "no calibration possible" (see calibrate_recommendations).
+    """
+    if not genre_counter:
+        return {}
+
+    total = sum(v for v in genre_counter.values() if v > 0)
+    if total <= 0:
+        return {}
+
+    return {g: v / total for g, v in genre_counter.items() if v > 0}
+
+
+def item_genre_distribution(genres: Sequence[str]) -> Dict[str, float]:
+    """
+    p(g|i) for a single item: its genre mass split evenly across the
+    genres it carries.
+
+    Splitting rather than assigning 1.0 per genre matters here - the
+    library's kid-oriented titles carry markedly more genre tags than
+    everything else (5.19 vs 3.25 on the reference library), so counting
+    each tag at full weight would let broadly-tagged items contribute
+    outsized mass to the list distribution and distort the KL term.
+    """
+    if not genres:
+        return {}
+    share = 1.0 / len(genres)
+    return {g: share for g in genres}
+
+
+def list_distribution(genre_lists: Iterable[Sequence[str]]) -> Dict[str, float]:
+    """
+    q(g) for a candidate list: the mean of its items' genre
+    distributions.
+    """
+    dist: Dict[str, float] = {}
+    count = 0
+    for genres in genre_lists:
+        count += 1
+        for g, share in item_genre_distribution(genres).items():
+            dist[g] = dist.get(g, 0.0) + share
+    if count == 0:
+        return {}
+    return {g: v / count for g, v in dist.items()}
+
+
+def kl_divergence(
+    target: Dict[str, float],
+    actual: Dict[str, float],
+    alpha: float = CALIBRATION_SMOOTHING_ALPHA,
+) -> float:
+    """
+    KL(target || actual) with Steck's smoothing.
+
+    KL is undefined where actual(g) == 0 but target(g) > 0, which is
+    exactly the case that matters most (a genre the user likes that the
+    list omits entirely). Steck's fix is to interpolate the actual
+    distribution toward the target:
+
+        actual~(g) = (1 - alpha) * actual(g) + alpha * target(g)
+
+    so a missing genre yields a large but finite penalty rather than an
+    infinity that would make every incomplete list incomparable.
+    """
+    divergence = 0.0
+    for g, p in target.items():
+        if p <= 0:
+            continue
+        q = (1 - alpha) * actual.get(g, 0.0) + alpha * p
+        if q <= 0:
+            continue
+        divergence += p * math.log(p / q)
+    return divergence
+
+
+def calibrate_recommendations(
+    candidates: Sequence[T],
+    limit: int,
+    get_genres: Callable[[T], Sequence[str]],
+    get_score: Callable[[T], float],
+    target_distribution: Dict[str, float],
+    calibration_strength: float = DEFAULT_CALIBRATION_STRENGTH,
+) -> List[T]:
+    """
+    Greedily select up to `limit` items maximizing
+
+        (1 - s) * sum(score) - s * SCALE * KL(target || list)
+
+    Steck shows this greedy construction is a (1 - 1/e) approximation of
+    the optimal calibrated list, because the objective is submodular and
+    monotone. In practice the greedy list is close enough that the
+    optimal version is not worth the combinatorial cost.
+
+    At each step every already-selected item contributes the same
+    sum(score) to all candidates under consideration, so the comparison
+    reduces to the marginal term:
+
+        (1 - s) * score(candidate) - s * SCALE * KL(list + candidate)
+
+    SCALE is CALIBRATION_DIVERGENCE_SCALE; see its comment in
+    utils/config.py for why the raw Steck objective needs it to make
+    `calibration_strength` behave as a plain 0.0-1.0 dial.
+
+    Note this calibrates genre MASS, not title count. An item's genre
+    mass is split across the genres it carries (see
+    item_genre_distribution), so a 6-genre action/adventure/comedy/
+    sci-fi/family title contributes only ~1/6 of its weight to `family`.
+    A collection calibrated to a 2.5% family profile can therefore still
+    contain a noticeable number of titles that carry a family tag among
+    several others - they are being counted as the action/adventure
+    films they also are. Calibration bounds how much of the collection's
+    character is family, not how many titles mention it.
+
+    Falls back to plain score order (i.e. the previous behavior) when
+    calibration cannot apply: no target distribution (cold start / empty
+    profile), a non-positive strength, or a candidate set that already
+    fits within the limit.
+
+    Args:
+        candidates: Items to select from. Order is irrelevant; ties are
+            broken by the caller's own pre-sort via stable iteration.
+        limit: Maximum number of items to return.
+        get_genres: Extract an item's genre list (lowercased by caller).
+        get_score: Extract an item's similarity score.
+        target_distribution: p(g|u) from build_target_distribution().
+        calibration_strength: lambda in [0, 1). 0 disables calibration.
+
+    Returns:
+        The selected items, best-first.
+    """
+    if limit <= 0:
+        return []
+
+    ordered = list(candidates)
+
+    # Nothing to trade off - keep the existing score ordering untouched.
+    if not target_distribution or calibration_strength <= 0 or len(ordered) <= limit:
+        return ordered[:limit]
+
+    selected: List[T] = []
+    selected_genres: List[Sequence[str]] = []
+    remaining = ordered[:]
+
+    while len(selected) < limit and remaining:
+        best_index = 0
+        best_value = -math.inf
+
+        for i, candidate in enumerate(remaining):
+            trial_genres = selected_genres + [get_genres(candidate)]
+            divergence = kl_divergence(target_distribution, list_distribution(trial_genres))
+            value = (1 - calibration_strength) * get_score(candidate) - (
+                calibration_strength * CALIBRATION_DIVERGENCE_SCALE * divergence
+            )
+
+            if value > best_value:
+                best_value = value
+                best_index = i
+
+        chosen = remaining.pop(best_index)
+        selected.append(chosen)
+        selected_genres.append(get_genres(chosen))
+
+    return selected
+
+
+def calibration_report(
+    target_distribution: Dict[str, float],
+    genre_lists: Sequence[Sequence[str]],
+    top_n: int = 5,
+) -> List[Tuple[str, float, float]]:
+    """
+    Compare target vs delivered genre share, for logging what calibration
+    actually did.
+
+    Returns (genre, target_share, delivered_share) for the `top_n` genres
+    with the largest absolute divergence, worst first.
+    """
+    actual = list_distribution(genre_lists)
+    genres = set(target_distribution) | set(actual)
+    rows = [(g, target_distribution.get(g, 0.0), actual.get(g, 0.0)) for g in genres]
+    rows.sort(key=lambda r: abs(r[1] - r[2]), reverse=True)
+    return rows[:top_n]

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,10 +14,18 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.10.90"
+__version__ = "2.11.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
-CACHE_VERSION = 7  # v7: another SCORING change, not a format one - the
+CACHE_VERSION = 8  # v8: SCORING change - corpus IDF (utils/corpus_idf.py)
+# now discounts genre/keyword matches by how ubiquitous the term is across
+# the library. Same reasoning as v7/v6 below: per-item scores are cached
+# against profile_hash, which captures the user's profile but NOT the
+# scoring code, so without this bump every existing install would keep
+# serving scores computed by the pre-IDF algorithm and the change would be
+# invisible until each user's profile happened to shift.
+#
+# v7: another SCORING change, not a format one - the
 # MAX_REDISTRIBUTION_MULTIPLIER cap below (2.10.90). Same reasoning as v6
 # immediately after this: a scoring change that doesn't move this constant
 # is invisible on every existing install.
@@ -62,6 +70,22 @@ DEFAULT_LIMIT_RESULTS = {"movie": 50, "tv": 20}
 # call sites in recommenders/base.py; now derived from limit_results so
 # the buffer scales with it automatically.
 CANDIDATE_BUFFER_MULTIPLIER = 2
+
+# Library supply health (utils/library_health.py). Below this
+# candidates-per-slot ratio the selection stage has effectively no
+# discretion left - at 1:1 "the top N" is just "all of them", and
+# quality floors or calibration downstream have nothing to choose
+# between. Flagged so an exhausted library is reported as such instead
+# of silently producing weak collections. 3:1 is the point at which
+# eviction stops being able to meaningfully improve a collection.
+POOL_DEPLETION_RATIO = 3.0
+# Minimum share of a profile a genre must hold before a shortfall in it
+# is worth reporting - a genre the user barely watches is not a supply
+# problem.
+SUPPLY_GAP_MIN_PROFILE_SHARE = 0.03
+# Minimum profile-vs-available shortfall before it counts as a gap
+# rather than noise.
+SUPPLY_GAP_MIN_SHORTFALL = 0.02
 TOP_POOL_PERCENTAGE = 0.1  # Top 10% for randomization pool
 
 # Media type constants - use these instead of hardcoded strings
@@ -77,6 +101,60 @@ MEDIA_KEY_SHOWS = "shows"
 TIER_SAFE_PERCENT = 0.6  # 60% safe picks from top scores
 TIER_DIVERSE_PERCENT = 0.3  # 30% diverse picks from mid-tier
 TIER_WILDCARD_PERCENT = 0.1  # 10% wildcard picks for discovery
+
+# Minimum similarity score an item must reach to enter a Plex collection
+# (config/tuning.yml movies:/tv: `min_similarity`). The library
+# recommendation path previously had no quality gate at all, so a
+# collection was always padded to limit_results no matter how weak the
+# remaining candidates were - a user who has watched most of their
+# library would get items scoring ~12% presented as recommendations.
+# (The external-recommendation path has always had its own equivalent:
+# external_recommendations.min_relevance_score.) Defaults to 0.0 =
+# disabled, so existing installs keep exactly today's behavior until
+# they opt in.
+DEFAULT_MIN_SIMILARITY = 0.0
+
+# Calibrated recommendations - see utils/calibration.py for the method
+# (Steck, RecSys 2018). `lambda` trades relevance against how closely the
+# collection's genre mix matches the user's actual watch history.
+# Defaults to 0.0 = disabled (plain top-N by score, today's behavior).
+DEFAULT_CALIBRATION_STRENGTH = 0.0
+# Suggested starting value when a user turns calibration on. 0.5 weights
+# relevance and calibration equally; Steck reports the relevance cost of
+# calibrating stays small well past this point.
+SUGGESTED_CALIBRATION_STRENGTH = 0.5
+# Steck's smoothing constant for KL(target || list) - keeps the
+# divergence finite when the list omits a genre the user watches.
+CALIBRATION_SMOOTHING_ALPHA = 0.01
+# Scale factor putting the KL term on the same footing as the similarity
+# term in calibrate_recommendations()'s objective.
+#
+# Adding one item to an already-large list barely moves that list's genre
+# distribution, so a marginal KL change is ~1e-3 while a marginal
+# similarity change is ~1e-1. Unscaled, similarity dominates until
+# lambda is within ~0.01 of 1.0 - Steck's own experiments use 0.99 for
+# exactly this reason. That makes a terrible configuration knob: 0.5
+# would be indistinguishable from off. Scaling the divergence by this
+# factor maps the useful range back onto a plain 0.0-1.0 dial, where
+# 0.25/0.5/0.75 are all meaningfully different. Derived from the
+# unscaled behavior: strength 0.5 here reproduces roughly lambda=0.99.
+CALIBRATION_DIVERGENCE_SCALE = 100.0
+
+# Corpus-level IDF (utils/corpus_idf.py) - the missing half of the
+# "TF-IDF" in utils/scoring.py, which only ever measured rarity within a
+# user's own profile and never across the library. Without it,
+# ubiquitous structural metadata ("sequel" - 28% of the reference
+# library, "aftercreditsstinger" - 14%) scores like genuine taste signal.
+#
+# Smallest corpus worth deriving term distribution from. Below this,
+# document frequency is too noisy to distinguish "ubiquitous" from
+# "happens to appear twice", so no weighting is applied at all.
+IDF_MIN_CORPUS_SIZE = 30
+# Floor for an IDF multiplier. A term in literally every item carries no
+# information, but zeroing it would silently erase a scoring dimension
+# for items whose metadata is entirely common terms - degrade, never
+# silently drop (CLAUDE.md).
+IDF_MIN_WEIGHT = 0.05
 
 # TF-IDF scoring penalties for rare/unseen content attributes
 TFIDF_GENRE_PENALTY = 0.3  # Max 30% penalty per rare genre
@@ -134,6 +212,22 @@ DEFAULT_NEGATIVE_MULTIPLIERS = {
 
 # Default threshold for negative signals (Plex 0-10 scale)
 DEFAULT_NEGATIVE_THRESHOLD = 3  # Ratings 0-3 become negative signals
+
+# Ignored-recommendation negative signal (utils/ignored_recs.py). An item
+# that sat in a user's collection this long without being watched counts
+# as declined - the impression-level feedback every large recommender
+# leans on, which curatarr recorded (label_dates) but never read.
+# Three weeks is long enough to outlast "saving it for the weekend".
+IGNORED_REC_MIN_DAYS_SHOWN = 21
+# Total negative weight one ignored title contributes, split across the
+# terms it carries. Small on purpose: one ignored title is weak evidence,
+# twenty sharing a genre is not.
+IGNORED_REC_PENALTY = 0.5
+# Hard floor on how negative a term may go, as a fraction of the
+# profile's largest positive count. Without it a long run of ignored
+# recommendations could bury a genre permanently, leaving the profile
+# unable to recover if the user's taste swung back.
+IGNORED_REC_MAX_PROFILE_FRACTION = 0.25
 
 # #291: whether a user with zero watch history still gets a
 # Recommended collection built for them. Default True (create - see
@@ -508,6 +602,8 @@ KNOWN_ROOT_CONFIG_KEYS = frozenset(
 KNOWN_MEDIA_SECTION_KEYS = frozenset(
     {
         "limit_results",
+        "min_similarity",
+        "calibration_strength",
         "randomize_recommendations",
         "normalize_counters",
         "show_summary",
@@ -780,16 +876,27 @@ def get_negative_signals_config(config: Optional[dict] = None) -> dict:
                 "max_completion_percent": 25,
                 "penalty_multiplier": -0.4,
             },
+            "ignored_recommendations": {
+                "enabled": True,
+                "min_days_shown": IGNORED_REC_MIN_DAYS_SHOWN,
+                "penalty": IGNORED_REC_PENALTY,
+            },
         }
 
     ns = config.get("negative_signals", {})
 
     # If master switch is off, return disabled config
     if not ns.get("enabled", True):
-        return {"enabled": False, "bad_ratings": {"enabled": False}, "dropped_shows": {"enabled": False}}
+        return {
+            "enabled": False,
+            "bad_ratings": {"enabled": False},
+            "dropped_shows": {"enabled": False},
+            "ignored_recommendations": {"enabled": False},
+        }
 
     bad_ratings = ns.get("bad_ratings", {})
     dropped_shows = ns.get("dropped_shows", {})
+    ignored_recs = ns.get("ignored_recommendations", {})
 
     return {
         "enabled": True,
@@ -803,6 +910,11 @@ def get_negative_signals_config(config: Optional[dict] = None) -> dict:
             "min_episodes_watched": dropped_shows.get("min_episodes_watched", 2),
             "max_completion_percent": dropped_shows.get("max_completion_percent", 25),
             "penalty_multiplier": dropped_shows.get("penalty_multiplier", -0.4),
+        },
+        "ignored_recommendations": {
+            "enabled": ignored_recs.get("enabled", True),
+            "min_days_shown": ignored_recs.get("min_days_shown", IGNORED_REC_MIN_DAYS_SHOWN),
+            "penalty": ignored_recs.get("penalty", IGNORED_REC_PENALTY),
         },
     }
 
@@ -882,6 +994,8 @@ def resolve_media_type_overrides(config: Dict, media_type: str) -> Dict:
     media_config = config.get(media_section, config.get(media_section.upper(), {})) or {}
 
     config["limit_results"] = media_config.get("limit_results", DEFAULT_LIMIT_RESULTS[media_type])
+    config["min_similarity"] = media_config.get("min_similarity", DEFAULT_MIN_SIMILARITY)
+    config["calibration_strength"] = media_config.get("calibration_strength", DEFAULT_CALIBRATION_STRENGTH)
     config["randomize_recommendations"] = media_config.get(
         "randomize_recommendations", general_config.get("randomize_recommendations", True)
     )

--- a/utils/corpus_idf.py
+++ b/utils/corpus_idf.py
@@ -1,0 +1,133 @@
+"""
+Corpus-level inverse document frequency for scoring terms.
+
+Fills in the missing half of what utils/scoring.py calls "TF-IDF".
+
+The existing rarity penalties there are computed entirely against the
+USER's profile: a genre or keyword that is rare *for this user* is
+penalized. That is the TF half. Nothing ever asked the complementary
+question - how common is this term across the whole library? - which is
+what the IDF in TF-IDF actually means (inverse *document* frequency).
+
+The consequence is that structural, non-discriminative metadata reads as
+strong taste signal. On the reference library:
+
+    keyword                 profile weight   share of library
+    aftercreditsstinger              14.48                14%
+    based on novel or book           12.23                15%
+    sequel                           11.88                28%
+    survival                         11.04                 2%
+    nasa                              7.66                 1%
+
+`sequel` outranks `survival` in that profile - but a quarter of the
+library is sequels, so matching on it says almost nothing about whether
+a user will like an item, while `nasa` at 1% is highly informative. The
+observable effect was a recommendation list that was 44% sequels against
+a 28% library baseline, because franchise entries kept collecting credit
+for shared packaging rather than shared substance.
+
+IDF weighting corrects that by scaling each matched term's contribution
+by how much information the match actually carries. Terms present in
+almost every item approach zero weight; genuinely distinctive terms keep
+theirs.
+
+Scores are computed once per run from the media cache and passed into
+calculate_similarity_score(); when no corpus is supplied, scoring behaves
+exactly as it did before.
+"""
+
+import math
+from typing import Dict, Iterable, Mapping, Optional
+
+from utils.config import IDF_MIN_CORPUS_SIZE, IDF_MIN_WEIGHT
+
+
+def build_document_frequency(
+    items: Iterable[Mapping],
+    field: str,
+) -> Dict[str, int]:
+    """
+    Count how many items in the corpus carry each term of `field`.
+
+    Terms are lowercased and de-duplicated per item, so an item listing
+    the same keyword twice still counts once - this is *document*
+    frequency, not term frequency.
+
+    Args:
+        items: The corpus (media cache values).
+        field: The per-item list field to index ("genres", "tmdb_keywords").
+
+    Returns:
+        term -> number of items containing it.
+    """
+    frequency: Dict[str, int] = {}
+    for item in items:
+        terms = item.get(field) or []
+        seen = {t.lower() for t in terms if isinstance(t, str)}
+        for term in seen:
+            frequency[term] = frequency.get(term, 0) + 1
+    return frequency
+
+
+def build_corpus_idf(items: Iterable[Mapping], field: str) -> Dict[str, float]:
+    """
+    Build normalized IDF weights in [IDF_MIN_WEIGHT, 1.0] for `field`.
+
+    Uses the standard smoothed form idf(t) = log(N / (1 + df(t))),
+    rescaled by log(N) so the result is a bounded multiplier rather than
+    an unbounded score - callers multiply an existing normalized
+    contribution by it, so it has to stay on a predictable scale.
+
+    A floor of IDF_MIN_WEIGHT applies rather than 0: a term appearing in
+    every single item is uninformative, but zeroing it outright would
+    silently delete a whole dimension for items whose only metadata is
+    common terms, and this codebase's rule is to degrade rather than
+    silently drop (see CLAUDE.md).
+
+    Returns an empty dict for a corpus too small to say anything
+    meaningful about term distribution, which callers treat as "no IDF
+    weighting" rather than as all-terms-equally-rare.
+    """
+    corpus = list(items)
+    total = len(corpus)
+    if total < IDF_MIN_CORPUS_SIZE:
+        return {}
+
+    frequency = build_document_frequency(corpus, field)
+    if not frequency:
+        return {}
+
+    scale = math.log(total)
+    if scale <= 0:
+        return {}
+
+    weights: Dict[str, float] = {}
+    for term, df in frequency.items():
+        raw = math.log(total / (1 + df))
+        weights[term] = max(IDF_MIN_WEIGHT, min(1.0, raw / scale))
+    return weights
+
+
+def idf_weight(term: str, corpus_idf: Optional[Mapping[str, float]]) -> float:
+    """
+    Look up a term's IDF multiplier.
+
+    Returns 1.0 (no adjustment) when no corpus is available, which is
+    what keeps scoring bit-for-bit unchanged for callers that do not
+    supply one.
+
+    A term absent from the corpus is *more* distinctive than any term in
+    it, not less - an unknown keyword means the library holds nothing
+    else carrying it - so it takes the full 1.0 rather than the floor.
+    """
+    if not corpus_idf:
+        return 1.0
+    return corpus_idf.get(term.lower() if isinstance(term, str) else term, 1.0)
+
+
+def describe_least_informative(corpus_idf: Mapping[str, float], top_n: int = 5):
+    """
+    Return the `top_n` lowest-weighted (most ubiquitous, least useful)
+    terms as (term, weight), for logging what IDF is discounting.
+    """
+    return sorted(corpus_idf.items(), key=lambda kv: kv[1])[:top_n]

--- a/utils/ignored_recs.py
+++ b/utils/ignored_recs.py
@@ -1,0 +1,145 @@
+"""
+Negative feedback from ignored recommendations.
+
+The strongest signal a recommender gets is not what a user watched - it
+is what it put in front of them that they declined to watch. Every large
+streaming service logs impressions for exactly this reason: a title shown
+for weeks and never played is a far more direct statement of "not for me"
+than the absence of a play, because the absence of a play is ambiguous
+(never offered? never noticed?) while a long-lived impression is not.
+
+Curatarr already had the raw material and never used it. `label_dates`
+records when each item first entered a user's collection (see
+utils/labels.py), and utils/scoring.py has always handled negative
+profile counts (`elif genre_count < 0` / `elif count < 0`) - but nothing
+ever wrote one. Items sat in a collection indefinitely, were never
+watched, and were re-recommended with an unchanged score every night.
+
+This module closes that loop: an item labeled for at least
+`min_days_shown` days and still unwatched becomes an anti-preference,
+decrementing the profile counters for its genres and keywords so its
+whole neighborhood scores lower next run.
+
+The penalty is deliberately partial and capped (see
+apply_ignored_penalties): a single ignored title is weak evidence -
+people leave things for later - but twenty ignored titles sharing a genre
+is not.
+"""
+
+import logging
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple
+
+from utils.config import (
+    IGNORED_REC_MAX_PROFILE_FRACTION,
+    IGNORED_REC_MIN_DAYS_SHOWN,
+    IGNORED_REC_PENALTY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def find_ignored_recommendations(
+    label_dates: Mapping[str, str],
+    label_name: str,
+    watched_ids: Set[int],
+    now: Optional[datetime] = None,
+    min_days_shown: int = IGNORED_REC_MIN_DAYS_SHOWN,
+) -> List[Tuple[int, int]]:
+    """
+    Identify recommendations that have been on display long enough,
+    unwatched, to count as declined.
+
+    label_dates is keyed "<ratingKey>_<label_name>" (utils/labels.py), so
+    entries for other users' labels are skipped rather than counted
+    against this profile.
+
+    Args:
+        label_dates: The persisted label -> ISO-timestamp map.
+        label_name: This user's collection label.
+        watched_ids: Rating keys the user has since watched.
+        now: Injectable clock for testing.
+        min_days_shown: Days on display before an item counts as ignored.
+
+    Returns:
+        (rating_key, days_shown) for each ignored item, longest first.
+    """
+    current = now or datetime.now()
+    suffix = f"_{label_name}"
+    ignored: List[Tuple[int, int]] = []
+
+    for key, iso in label_dates.items():
+        if not key.endswith(suffix):
+            continue
+        raw_id = key[: -len(suffix)]
+        try:
+            rating_key = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+
+        # Watching it is the opposite signal - the recommendation worked.
+        if rating_key in watched_ids:
+            continue
+
+        try:
+            shown_since = datetime.fromisoformat(iso)
+        except (TypeError, ValueError):
+            # A malformed timestamp is not evidence of anything; skip it
+            # rather than guess a date and manufacture a penalty.
+            logger.debug(f"Skipping unparseable label date for {key}: {iso!r}")
+            continue
+
+        days = (current - shown_since).days
+        if days >= min_days_shown:
+            ignored.append((rating_key, days))
+
+    ignored.sort(key=lambda pair: pair[1], reverse=True)
+    return ignored
+
+
+def apply_ignored_penalties(
+    counters: Dict[str, Dict[str, float]],
+    ignored_items: Iterable[Mapping],
+    penalty: float = IGNORED_REC_PENALTY,
+    max_fraction: float = IGNORED_REC_MAX_PROFILE_FRACTION,
+) -> Dict[str, int]:
+    """
+    Decrement genre/keyword counters for ignored items, in place.
+
+    Two safeguards, because this signal is inferred rather than stated:
+
+    1. Each item's penalty is divided across the terms it carries, so a
+       7-genre title does not deliver seven times the punishment of a
+       2-genre one for the same single act of being ignored.
+    2. No term may be driven below -max_fraction of the profile's
+       largest positive count. Without a floor, a user who ignores a
+       long run of recommendations could drive a genre so far negative
+       that nothing in it could ever surface again - the profile would
+       be unable to recover even if their taste changed back.
+
+    Note the counters this writes are consumed by scoring's existing
+    negative-count branches; no scoring change was needed to read them.
+
+    Returns a per-dimension count of how many terms were penalized.
+    """
+    applied = {"genres": 0, "tmdb_keywords": 0}
+
+    for dimension, field in (("genres", "genres"), ("tmdb_keywords", "tmdb_keywords")):
+        counter = counters.get(dimension)
+        if counter is None:
+            continue
+
+        positives = [v for v in counter.values() if v > 0]
+        floor = -(max(positives) * max_fraction) if positives else -penalty
+
+        for item in ignored_items:
+            terms = [t.lower() for t in (item.get(field) or []) if isinstance(t, str)]
+            if not terms:
+                continue
+            share = penalty / len(terms)
+            for term in terms:
+                current = counter.get(term, 0.0)
+                counter[term] = max(floor, current - share)
+                applied[dimension] += 1
+
+    return applied

--- a/utils/library_health.py
+++ b/utils/library_health.py
@@ -1,0 +1,167 @@
+"""
+Library supply health - measuring when ranking has run out of material.
+
+A recommender's quality is bounded by its candidate pool long before it
+is bounded by its scoring. A large streaming catalog is effectively
+inexhaustible per user - a subscriber has seen a fraction of a percent of
+it - so ranking is the binding constraint and that is where the
+engineering goes. A personal library is the opposite: a long-standing
+user can have watched most of it, at which point no amount of scoring or
+calibration produces good recommendations, because there is nothing good
+left to recommend.
+
+The reference case: a user with 233 of 334 movies watched, leaving 127
+candidates to fill a 50-item collection. 38% of the survivors were
+family/animation - not because the scorer preferred them (measured bias:
+1.01x, i.e. none) but because they were what remained after fifteen years
+of watching everything else. The collection faithfully reported the
+composition of an exhausted shelf.
+
+This module makes that condition visible and, more usefully,
+actionable:
+
+  - `assess_pool_health` answers "is ranking still the constraint here?"
+  - `find_supply_gaps` answers "which genres does this user want that
+    the library can no longer supply?"
+
+The second is what closes the loop. External/Radarr discovery searches
+by a profile's TOP genres, which fetches more of what the library is
+already thickest in. Feeding it the gap list instead targets acquisition
+at the genres the user demonstrably wants and the shelf cannot serve.
+"""
+
+from typing import Any, Dict, Iterable, List, Mapping, NamedTuple, Sequence
+
+from utils.config import (
+    POOL_DEPLETION_RATIO,
+    SUPPLY_GAP_MIN_PROFILE_SHARE,
+    SUPPLY_GAP_MIN_SHORTFALL,
+)
+
+
+class PoolHealth(NamedTuple):
+    """Candidate supply relative to what the collection needs."""
+
+    candidates: int
+    target: int
+    ratio: float
+    depleted: bool
+
+    def summary(self) -> str:
+        state = "DEPLETED" if self.depleted else "healthy"
+        return f"{self.candidates} candidates for {self.target} slots ({self.ratio:.1f}:1) - {state}"
+
+
+class SupplyGap(NamedTuple):
+    """A genre the profile wants more of than the library can supply."""
+
+    genre: str
+    profile_share: float
+    available_share: float
+
+    @property
+    def shortfall(self) -> float:
+        return self.profile_share - self.available_share
+
+
+def assess_pool_health(candidate_count: int, target_count: int) -> PoolHealth:
+    """
+    Compare available candidates against collection size.
+
+    A pool below POOL_DEPLETION_RATIO times the target leaves the
+    selection stage almost no discretion - at 1:1 the "top N" is simply
+    "all of them", and quality filters or calibration downstream have
+    nothing to choose between.
+    """
+    if target_count <= 0:
+        return PoolHealth(candidate_count, target_count, 0.0, False)
+    ratio = candidate_count / target_count
+    return PoolHealth(candidate_count, target_count, ratio, ratio < POOL_DEPLETION_RATIO)
+
+
+def find_supply_gaps(
+    target_distribution: Mapping[str, float],
+    candidate_genre_lists: Iterable[Sequence[str]],
+    min_profile_share: float = SUPPLY_GAP_MIN_PROFILE_SHARE,
+    min_shortfall: float = SUPPLY_GAP_MIN_SHORTFALL,
+) -> List[SupplyGap]:
+    """
+    Find genres the user watches more of than the unwatched pool offers.
+
+    Both sides are genre-mass distributions (see utils/calibration.py's
+    list_distribution) rather than title counts, so the comparison is
+    like-for-like with how calibration measures the collection.
+
+    Genres below `min_profile_share` are ignored - a genre the user
+    barely watches is not a supply problem worth acting on - as are
+    shortfalls below `min_shortfall`, which are noise.
+
+    Returns gaps worst-first, i.e. the acquisition priority order.
+    """
+    # Local import: utils/__init__ imports both modules, and importing
+    # calibration at module scope here would order-depend on which lands
+    # first during package init.
+    from utils.calibration import list_distribution
+
+    available = list_distribution(candidate_genre_lists)
+
+    gaps = []
+    for genre, wanted in target_distribution.items():
+        if wanted < min_profile_share:
+            continue
+        supplied = available.get(genre, 0.0)
+        if wanted - supplied >= min_shortfall:
+            gaps.append(SupplyGap(genre, wanted, supplied))
+
+    gaps.sort(key=lambda g: g.shortfall, reverse=True)
+    return gaps
+
+
+def prioritize_discovery_genres(
+    gaps: Sequence[SupplyGap],
+    profile_genres: Mapping[str, float],
+    limit: int = 10,
+) -> List[str]:
+    """
+    Build the genre list external discovery should actually search.
+
+    Gap genres lead, in shortfall order - those are the ones worth
+    acquiring. The profile's own top genres follow as filler so a healthy
+    library (no gaps) degrades to exactly the previous behavior rather
+    than to an empty search.
+    """
+    ordered = [gap.genre for gap in gaps]
+    seen = set(ordered)
+    for genre, _count in sorted(profile_genres.items(), key=lambda kv: kv[1], reverse=True):
+        if genre not in seen:
+            ordered.append(genre)
+            seen.add(genre)
+    return ordered[:limit]
+
+
+def format_health_report(health: PoolHealth, gaps: Sequence[SupplyGap], media_key: str = "movies") -> List[str]:
+    """Render the human-readable lines the recommender logs."""
+    lines = [f"Library supply: {health.summary()}"]
+    if health.depleted:
+        lines.append(
+            f"  This profile has watched most of the available {media_key}. Scoring and "
+            f"calibration cannot improve on an exhausted pool - new content is the fix."
+        )
+    if gaps:
+        lines.append("  Under-supplied genres (profile wants / library offers):")
+        for gap in gaps[:5]:
+            lines.append(f"    {gap.genre:<20} {gap.profile_share * 100:5.1f}% / {gap.available_share * 100:5.1f}%")
+    return lines
+
+
+def gaps_to_dict(gaps: Sequence[SupplyGap]) -> List[Dict[str, Any]]:
+    """Serialize gaps for run-status/metrics consumers."""
+    return [
+        {
+            "genre": gap.genre,
+            "profile_share": round(gap.profile_share, 4),
+            "available_share": round(gap.available_share, 4),
+            "shortfall": round(gap.shortfall, 4),
+        }
+        for gap in gaps
+    ]

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -9,7 +9,7 @@ import random
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
 
 from .config import (
     MAX_REDISTRIBUTION_MULTIPLIER,
@@ -20,6 +20,7 @@ from .config import (
     UNSEEN_GENRE_PENALTY,
     UNSEEN_KEYWORD_PENALTY,
 )
+from .corpus_idf import idf_weight
 
 
 def normalize_user_profile(user_prefs: Dict, tfidf_penalty_threshold: float = 0.15) -> Dict:
@@ -344,6 +345,13 @@ class ScoringOptions:
     tfidf_penalty_threshold: float = 0.15
     use_popularity_dampening: bool = True
     popularity_threshold: int = 50000
+    # Corpus IDF weights (utils/corpus_idf.py), term -> multiplier in
+    # [IDF_MIN_WEIGHT, 1.0]. None/empty means no corpus was supplied and
+    # scoring behaves exactly as it did before this existed - which is
+    # what keeps every pre-existing caller and test bit-for-bit
+    # unchanged, since only the recommenders build and pass a corpus.
+    genre_idf: Optional[Mapping[str, float]] = None
+    keyword_idf: Optional[Mapping[str, float]] = None
 
 
 def _tfidf_threshold(user_profile: Dict, key: str, max_count: float, options: ScoringOptions) -> float:
@@ -432,8 +440,15 @@ def _score_genre_component(
                     normalized_score = math.sqrt(genre_count / max_genre_count)
                 else:
                     normalized_score = min(genre_count / max_genre_count, 1.0)
+                # Discount the match by how ubiquitous the genre is across
+                # the library - matching on something 80% of the library
+                # carries says far less than matching on something 3% does.
+                # 1.0 (no change) whenever no corpus was supplied.
+                idf = idf_weight(norm_genre, options.genre_idf)
+                normalized_score *= idf
                 genre_scores.append(normalized_score)
-                details.append(f"{genre} (count: {genre_count:.1f}, norm: {round(normalized_score, 2)})")
+                idf_note = f", idf: {round(idf, 2)}" if idf != 1.0 else ""
+                details.append(f"{genre} (count: {genre_count:.1f}, norm: {round(normalized_score, 2)}{idf_note})")
         elif genre_count < 0:
             # Explicit negative signal: penalize this genre
             penalty = abs(genre_count) / max_genre_count * 0.5  # Cap penalty contribution
@@ -667,8 +682,15 @@ def _score_keyword_component(
                     normalized_score = math.sqrt(count / max_counts["keywords"])
                 else:
                     normalized_score = min(count / max_counts["keywords"], 1.0)
+                # The dimension this matters most for: "sequel",
+                # "aftercreditsstinger" and friends are frequent in almost
+                # any profile precisely because they are frequent
+                # everywhere, and carry nearly no signal about taste.
+                idf = idf_weight(kw_lower, options.keyword_idf)
+                normalized_score *= idf
                 keyword_scores.append(normalized_score)
-                details.append(f"{kw} (count: {int(count)}, norm: {round(normalized_score, 2)})")
+                idf_note = f", idf: {round(idf, 2)}" if idf != 1.0 else ""
+                details.append(f"{kw} (count: {int(count)}, norm: {round(normalized_score, 2)}{idf_note})")
         elif count < 0:
             penalty = abs(count) / max_counts["keywords"] * 0.5
             keyword_penalty += penalty
@@ -832,6 +854,8 @@ def calculate_similarity_score(
     tfidf_penalty_threshold: float = 0.15,
     use_popularity_dampening: bool = True,
     popularity_threshold: int = 50000,
+    genre_idf: Optional[Mapping[str, float]] = None,
+    keyword_idf: Optional[Mapping[str, float]] = None,
     options: Optional[ScoringOptions] = None,
 ) -> Tuple[float, Dict]:
     """
@@ -873,6 +897,8 @@ def calculate_similarity_score(
             tfidf_penalty_threshold=tfidf_penalty_threshold,
             use_popularity_dampening=use_popularity_dampening,
             popularity_threshold=popularity_threshold,
+            genre_idf=genre_idf,
+            keyword_idf=keyword_idf,
         )
 
     # Default weights (specificity-first approach)


### PR DESCRIPTION
Reported as "my Recommended collection is full of children's movies" — on a profile that is **3.8%** family/animation, against a collection that was **38%**.

## The scorer was not the cause

Measured on the real candidate pool:

| | kid-genre share |
|---|---|
| candidate pool (127 eligible) | 37.8% |
| delivered top 50 | 38.0% |
| **selection bias** | **1.01x** |

Ranking by score faithfully reproduced the composition of an exhausted library — 233 of 334 movies watched, and what survives is disproportionately the titles bought for the kids. Two earlier hypotheses (genre tag-count bias, junk keywords) were tested and **disproven** before landing on this.

## Changes

- **Calibrated recommendations** — Steck, *Calibrated Recommendations* (Netflix, RecSys 2018). Greedy top-N does not preserve a taste distribution; this matches the collection's genre mix to the profile's. Kid mass 18.0% → 12.5%, thriller 6.8% → 11.7%, action 3.6% → 12.4%. **Not** an exclusion — a genre you watch still appears, at the rate you watch it.
- **`min_similarity` floor** — the library path had no quality gate and padded to `limit_results` down to 12.2% similarity. Collections may now come in short and say so.
- **Corpus IDF** — the missing half of "TF-IDF". Rarity was only ever measured inside a user's profile, never across the library, so `sequel` (28% of titles) read as taste signal. Now discounted to 0.216 while `nasa` keeps 0.761. `CACHE_VERSION` → 8.
- **Ignored-recommendation feedback** — `label_dates` and scoring's `count < 0` branches both already existed; nothing connected them. A title shown 21 days and never watched now counts against the profile.
- **Library supply health** — reports pool depletion (2.6:1 here) and under-supplied genres, and points external discovery at the *gaps* rather than the profile's top genres, which only deepened the hole.

## Interaction worth knowing

The floor and calibration trade off: calibration works by choosing, the floor shrinks what there is to choose from. Floor `0.20` leaves 52 candidates for 50 slots, at which point calibration silently no-ops. `0.10` + `0.5` is the recommended pair.

## Verification

- 3132 tests pass (81 new), ruff + mypy clean, new modules 97–100% coverage
- Every setting defaults to off / prior behavior — upgrading changes nothing until opted in
- One bug caught and fixed during review: the depletion warning told **zero-history** users they'd "watched most of their library"; now suppressed with no profile, and regression-tested