### PR TITLE
Collapse progress counters instead of stacking them line by line (2.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.11.1] - 2026-07-31
+
+### Fixed
+
+- **Progress counters stacked up hundreds of lines deep in the web UI instead of overwriting in place.** A 337-item library scan rendered as 337 consecutive `Processing movie N/337 (P%)` lines, burying everything around it.
+
+  The recommender was doing nothing wrong: it writes these with a bare `\r` and no newline, which is exactly right for a terminal, where each update overwrites the last. The subprocess pipe is opened in **text mode**, and Python's universal-newline translation rewrites every `\r` to `\n` before `for line in job.process.stdout` ever sees it - so one in-place counter arrived as one line per tick.
+
+  Only a counter advancing under an unchanged prefix now collapses. A line carrying genuinely new information is never touched, and the final update of a run (the `100%`) is committed permanently once a different line follows it, so completed steps stay in the log. `Processing movie 5/337` collapses onto `Processing movie 4/337`; it does **not** collapse onto `Processing alice's watched 4/233`, which is a different operation.
+
+  Implemented on both sides on purpose: `web/job_runner.py` collapses so the stored log and SSE backlog replay hold one line per progress run, and `web/static/app.js` collapses independently because live subscribers still receive every individual tick - that is what animates the counter. The client keeps the in-flight line in its own trailing node so committed text can be inserted *before* it without rewriting the whole log, preserving 2.10.90's fix for the browser-side quadratic.
+
+  Covered by 8 Python tests plus a 14-check browser suite (`tests/static/test_progress_collapse.js`) that runs the real `app.js` against a stubbed DOM - under Node on CI, or macOS's bundled JavaScriptCore locally, skipping only if neither exists. Two of those checks pin the ordering and post-trim cases that the first attempt at this got wrong.
+
 ## [2.11.0] - 2026-07-31
 
 ### Added

--- a/tests/static/test_progress_collapse.js
+++ b/tests/static/test_progress_collapse.js
@@ -1,0 +1,223 @@
+// Tests for the run page's progress-line collapsing (web/static/app.js).
+//
+// Run with macOS's bundled JavaScriptCore:
+//   /System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc \
+//     tests/static/test_progress_collapse.js
+//
+// tests/test_web_static_assets.py drives this from pytest and skips when
+// no JS engine is available, so CI on Linux stays green.
+//
+// The DOM stub below models only what the renderer touches: a parent
+// whose children are text nodes and at most one trailing <span> for the
+// line currently animating. textContent on the parent concatenates its
+// children, and ASSIGNING it destroys them - which is the exact behavior
+// the trim path depends on and the reason liveNode has to be dropped
+// there.
+
+// Engine compatibility: JavaScriptCore (macOS, bundled) provides
+// print/readFile/quit as globals; Node provides console/fs/process
+// instead. Shim whichever is missing so the same file runs under either -
+// CI is Linux with Node, local dev is macOS with jsc, and a test that
+// only ran in one place would be a test that silently stopped running.
+if (typeof print === 'undefined') {
+  var print = function (s) { console.log(s); };
+}
+if (typeof readFile === 'undefined') {
+  var readFile = function (p) { return require('fs').readFileSync(p, 'utf8'); };
+}
+if (typeof quit === 'undefined') {
+  var quit = function (c) { process.exit(c); };
+}
+
+var failures = 0;
+var checks = 0;
+
+function assertEqual(actual, expected, label) {
+  checks++;
+  if (actual !== expected) {
+    failures++;
+    print('FAIL: ' + label);
+    print('  expected: ' + JSON.stringify(expected));
+    print('  actual:   ' + JSON.stringify(actual));
+  }
+}
+
+function makeNode(text) {
+  return { nodeValue: text, children: null };
+}
+
+function makeElement() {
+  var el = {
+    childNodes: [],
+    scrollTop: 0,
+    clientHeight: 100,
+    appendChild: function (n) { el.childNodes.push(n); return n; },
+    removeChild: function (n) {
+      var i = el.childNodes.indexOf(n);
+      if (i >= 0) { el.childNodes.splice(i, 1); }
+      return n;
+    },
+    insertBefore: function (n, ref) {
+      var i = el.childNodes.indexOf(ref);
+      if (i < 0) { el.childNodes.push(n); } else { el.childNodes.splice(i, 0, n); }
+      return n;
+    }
+  };
+  Object.defineProperty(el, 'textContent', {
+    get: function () {
+      return el.childNodes.map(function (n) { return n.nodeValue; }).join('');
+    },
+    set: function (v) {
+      el.childNodes = v === '' ? [] : [makeNode(v)];
+    }
+  });
+  Object.defineProperty(el, 'scrollHeight', {
+    get: function () { return el.textContent.split('\n').length * 10; }
+  });
+  return el;
+}
+
+// Harness: load app.js's renderer by evaluating the file with stubs in
+// place. Simpler and less brittle than duplicating the logic here, which
+// would let the test pass while the shipped file was broken.
+var frameQueue = [];
+var output = makeElement();
+var window = {
+  requestAnimationFrame: function (fn) { frameQueue.push(fn); },
+  CURATARR_JOB_RUNNING: false
+};
+var document = {
+  createTextNode: function (t) { return makeNode(t); },
+  createElement: function () {
+    var span = makeNode('');
+    Object.defineProperty(span, 'textContent', {
+      get: function () { return span.nodeValue; },
+      set: function (v) { span.nodeValue = v; }
+    });
+    return span;
+  },
+  getElementById: function () { return null; },
+  querySelector: function () { return null; },
+  querySelectorAll: function () { return []; },
+  addEventListener: function () {}
+};
+function setTimeout(fn) { frameQueue.push(fn); }
+
+function runFrames() {
+  while (frameQueue.length) { frameQueue.shift()(); }
+}
+
+// --- the code under test, extracted from web/static/app.js -------------
+// Pulled out by marker rather than re-implemented, so a change to the
+// shipped renderer that breaks these rules fails here.
+var src = readFile('web/static/app.js');
+var start = src.indexOf('  var MAX_LINES = 5000;');
+var end = src.indexOf('  function appendLine(text) {');
+end = src.indexOf('\n  }', end) + 4;
+if (start < 0 || end < 4) {
+  print('FAIL: could not locate renderer block in web/static/app.js');
+  quit(1);
+}
+eval(src.slice(start, end));
+// ----------------------------------------------------------------------
+
+function reset() {
+  output.childNodes = [];
+  pending.length = 0;
+  lineCount = 0;
+  flushScheduled = false;
+  liveFamily = null;
+  liveText = null;
+  liveNode = null;
+  frameQueue.length = 0;
+}
+
+// progressFamily ---------------------------------------------------------
+assertEqual(progressFamily('Processing movie 321/337 (95%)'), 'Processing movie', 'family: plain');
+assertEqual(progressFamily('\x1b[96mProcessing movie 5/9 (55%)\x1b[0m'), 'Processing movie', 'family: ansi-wrapped');
+assertEqual(progressFamily('Processing 1/127 (0%)'), 'Processing', 'family: bare prefix');
+assertEqual(progressFamily("Processing alice's watched 4/233 (1%)"), "Processing alice's watched", 'family: apostrophe');
+assertEqual(progressFamily('Found 7 new movies to analyze'), null, 'family: not a progress line');
+assertEqual(progressFamily('Adding 1 new high-scoring recommendations'), null, 'family: informational line');
+assertEqual(progressFamily(''), null, 'family: empty');
+
+// A same-family run collapses to a single line -----------------------------
+reset();
+for (var i = 1; i <= 337; i++) {
+  appendLine('Processing movie ' + i + '/337 (' + Math.floor(i / 337 * 100) + '%)');
+}
+runFrames();
+assertEqual(output.textContent, 'Processing movie 337/337 (100%)\n', 'collapse: 337 updates render as one line');
+
+// The finished line is kept when different information follows ------------
+appendLine('Movies cache updated');
+runFrames();
+assertEqual(
+  output.textContent,
+  'Processing movie 337/337 (100%)\nMovies cache updated\n',
+  'commit: completed progress line survives the next real line'
+);
+
+// A different family starts a new line rather than overwriting ------------
+reset();
+appendLine('Processing movie 1/2 (50%)');
+appendLine('Processing movie 2/2 (100%)');
+appendLine("Processing alice's watched 1/2 (50%)");
+appendLine("Processing alice's watched 2/2 (100%)");
+appendLine('done');
+runFrames();
+assertEqual(
+  output.textContent,
+  "Processing movie 2/2 (100%)\nProcessing alice's watched 2/2 (100%)\ndone\n",
+  'families: distinct prefixes each keep their own line'
+);
+
+// Interleaved informational lines are never collapsed ---------------------
+reset();
+appendLine('Connecting to Plex server...');
+appendLine('Processing movie 1/3 (33%)');
+appendLine('Processing movie 2/3 (66%)');
+appendLine('Processing movie 3/3 (100%)');
+appendLine('Analyzing library movies...');
+runFrames();
+assertEqual(
+  output.textContent,
+  'Connecting to Plex server...\nProcessing movie 3/3 (100%)\nAnalyzing library movies...\n',
+  'ordering: informational lines keep their positions around a collapsed run'
+);
+
+// Committed lines land BEFORE the animating line, not after ---------------
+reset();
+appendLine('Processing movie 1/9 (11%)');
+runFrames(); // live line now rendered as trailing node
+appendLine('a real line');
+appendLine('Processing movie 2/9 (22%)');
+runFrames();
+assertEqual(
+  output.textContent,
+  'Processing movie 1/9 (11%)\na real line\nProcessing movie 2/9 (22%)\n',
+  'ordering: committed text is inserted before the live node'
+);
+
+// The live line survives a trim (which destroys all children) -------------
+reset();
+for (var j = 0; j < 5200; j++) { appendLine('line ' + j); runFrames(); }
+appendLine('Processing movie 1/2 (50%)');
+runFrames();
+appendLine('Processing movie 2/2 (100%)');
+runFrames();
+var tail = output.textContent.split('\n');
+assertEqual(tail[tail.length - 2], 'Processing movie 2/2 (100%)', 'trim: live line still renders after a trim');
+
+// Progress updates must not grow the DOM without bound --------------------
+reset();
+for (var k = 1; k <= 1000; k++) {
+  appendLine('Processing movie ' + k + '/1000 (' + Math.floor(k / 10) + '%)');
+  runFrames();
+}
+assertEqual(output.textContent.split('\n').length - 1, 1, 'bounded: 1000 updates never exceed one rendered line');
+
+print(failures === 0
+  ? 'ok - ' + checks + ' checks passed'
+  : 'FAILED - ' + failures + ' of ' + checks + ' checks failed');
+quit(failures === 0 ? 0 : 1);

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -12,6 +12,9 @@ from flask.testing import FlaskClient
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import queue
+import threading
+
 import pytest
 
 import web.app as app_module
@@ -742,3 +745,90 @@ class TestConcurrentRun:
         assert len(launched) == 1
         assert len(busy) == 5
         _wait_until_idle(app)
+
+
+class TestProgressLineCollapsing:
+    """
+    web/job_runner.py's progress_family() / Job._append_line().
+
+    The recommender writes progress with a bare \r and no newline, which
+    a terminal renders in place. The subprocess pipe is opened in text
+    mode, so universal-newline translation turns each \r into its own
+    line - a 337-item scan reached the web UI as 337 stacked lines.
+    """
+
+    def test_identifies_a_progress_line_and_its_family(self):
+        from web.job_runner import progress_family
+
+        assert progress_family("Processing movie 321/337 (95%)") == "Processing movie"
+
+    def test_strips_ansi_before_matching(self):
+        """The recommender wraps these in CYAN/RESET."""
+        from web.job_runner import progress_family
+
+        assert progress_family("\x1b[96mProcessing movie 5/9 (55%)\x1b[0m") == "Processing movie"
+
+    def test_informational_lines_are_not_progress(self):
+        from web.job_runner import progress_family
+
+        assert progress_family("Found 7 new movies to analyze") is None
+        assert progress_family("Adding 1 new high-scoring recommendations") is None
+        assert progress_family("Final collection size: 50 movies") is None
+
+    def test_distinct_prefixes_are_distinct_families(self):
+        from web.job_runner import progress_family
+
+        assert progress_family("Processing movie 4/9 (44%)") != progress_family("Processing alice 4/9 (44%)")
+
+    def test_same_family_updates_collapse_to_one_line(self):
+        from web.job_runner import Job
+
+        job = Job.__new__(Job)
+        job.lines = []
+        job._subscribers = []
+        job._data_lock = threading.Lock()
+        for i in range(1, 338):
+            job._append_line(f"Processing movie {i}/337 ({i * 100 // 337}%)")
+        assert job.lines == ["Processing movie 337/337 (100%)"]
+
+    def test_completed_progress_line_survives_a_following_line(self):
+        from web.job_runner import Job
+
+        job = Job.__new__(Job)
+        job.lines = []
+        job._subscribers = []
+        job._data_lock = threading.Lock()
+        job._append_line("Processing movie 1/2 (50%)")
+        job._append_line("Processing movie 2/2 (100%)")
+        job._append_line("Movies cache updated")
+        assert job.lines == ["Processing movie 2/2 (100%)", "Movies cache updated"]
+
+    def test_different_families_each_keep_a_line(self):
+        from web.job_runner import Job
+
+        job = Job.__new__(Job)
+        job.lines = []
+        job._subscribers = []
+        job._data_lock = threading.Lock()
+        job._append_line("Processing movie 1/2 (50%)")
+        job._append_line("Processing movie 2/2 (100%)")
+        job._append_line("Processing alice 1/2 (50%)")
+        job._append_line("Processing alice 2/2 (100%)")
+        assert job.lines == ["Processing movie 2/2 (100%)", "Processing alice 2/2 (100%)"]
+
+    def test_subscribers_still_receive_every_update(self):
+        """
+        Collapsing is for the stored log. Live subscribers must still get
+        each tick, or the counter would stop animating in the browser -
+        the client does its own collapsing for the DOM.
+        """
+        from web.job_runner import Job
+
+        job = Job.__new__(Job)
+        job.lines = []
+        q: queue.Queue = queue.Queue(maxsize=100)
+        job._subscribers = [q]
+        job._data_lock = threading.Lock()
+        for i in range(1, 6):
+            job._append_line(f"Processing movie {i}/5 ({i * 20}%)")
+        assert q.qsize() == 5

--- a/tests/test_web_static_assets.py
+++ b/tests/test_web_static_assets.py
@@ -1,0 +1,88 @@
+"""
+Drives the browser-side tests in tests/static/ from pytest.
+
+web/static/app.js has real logic in it (the run page's output renderer),
+and a bug there is as user-visible as a bug in the recommender - the
+2.10.90 quadratic that froze the page for minutes lived in this file. It
+needs tests that actually execute it, not just assertions about the
+Python that serves it.
+
+There is no Node dependency in this project and adding one for a single
+test file would be a poor trade, so this runs under whatever JS engine
+the machine already has: Node on CI's Linux runners, JavaScriptCore
+(bundled with macOS, no install) for local development.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# macOS ships JavaScriptCore inside the framework; it is not on PATH.
+JSC_PATH = "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc"
+
+
+def _find_js_engine():
+    """Return argv prefix for an available JS engine, or None."""
+    for name in ("node", "deno", "bun"):
+        found = shutil.which(name)
+        if found:
+            return [found, "run"] if name == "deno" else [found]
+    if os.path.exists(JSC_PATH):
+        return [JSC_PATH]
+    return None
+
+
+JS_ENGINE = _find_js_engine()
+
+
+@pytest.mark.skipif(JS_ENGINE is None, reason="no JavaScript engine available (node/deno/bun/jsc)")
+class TestRunPageProgressCollapsing:
+    """tests/static/test_progress_collapse.js - see that file for cases."""
+
+    def test_progress_collapse_suite_passes(self):
+        script = os.path.join("tests", "static", "test_progress_collapse.js")
+        result = subprocess.run(
+            JS_ENGINE + [script],
+            cwd=REPO_ROOT,  # the script reads web/static/app.js by relative path
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, f"browser-side progress-collapse tests failed:\n{result.stdout}\n{result.stderr}"
+        assert "ok - " in result.stdout, result.stdout
+
+
+class TestStaticAssetIntegrity:
+    """Cheap guards that run everywhere, engine or not."""
+
+    def test_app_js_renderer_block_markers_exist(self):
+        """
+        The JS suite extracts the renderer by these two markers. If a
+        refactor renames them the suite would silently test nothing, so
+        assert their presence separately - this failing is the signal to
+        update the extraction, not to delete the check.
+        """
+        with open(os.path.join(REPO_ROOT, "web", "static", "app.js"), encoding="utf-8") as f:
+            src = f.read()
+        assert "  var MAX_LINES = 5000;" in src
+        assert "  function appendLine(text) {" in src
+
+    def test_progress_rule_is_mirrored_in_both_languages(self):
+        """
+        web/job_runner.py and web/static/app.js implement the same
+        collapsing rule independently (server: clean stored log + backlog
+        replay; client: clean live DOM). They can drift. This does not
+        compare the regexes character by character - they are written in
+        different dialects - but it does assert neither side quietly lost
+        its half.
+        """
+        with open(os.path.join(REPO_ROOT, "web", "static", "app.js"), encoding="utf-8") as f:
+            js = f.read()
+        with open(os.path.join(REPO_ROOT, "web", "job_runner.py"), encoding="utf-8") as f:
+            py = f.read()
+        assert "progressFamily" in js, "client lost its progress-collapsing rule"
+        assert "def progress_family" in py, "server lost its progress-collapsing rule"

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.11.0"
+__version__ = "2.11.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 8  # v8: SCORING change - corpus IDF (utils/corpus_idf.py)

--- a/web/job_runner.py
+++ b/web/job_runner.py
@@ -190,6 +190,31 @@ def _build_docker_full_script(py: str, movie_script: str, tv_script: str, extern
     )
 
 
+# A progress update: some stable prefix followed by "<n>/<total> (<pct>%)".
+# The prefix is the "family" - two updates belong to the same run of
+# progress only if their prefixes match, so "Processing movie 5/337 (1%)"
+# collapses onto "Processing movie 4/337 (1%)" but NOT onto
+# "Processing alice's watched 4/233 (1%)". A line carrying genuinely new
+# information is never collapsed, only a counter advancing in place.
+_PROGRESS_LINE_RE = re.compile(r"^(?P<prefix>.*?)\s*\d+\s*/\s*\d+\s*\(\s*\d+\s*%\s*\)\s*$")
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def progress_family(line: str) -> Optional[str]:
+    """
+    Return a progress line's stable prefix, or None if it isn't one.
+
+    Color codes are stripped before matching - the recommender wraps
+    these in CYAN/RESET, and the escape sequences would otherwise sit
+    between the prefix and the counter and defeat the match.
+    """
+    plain = _ANSI_RE.sub("", line).strip()
+    match = _PROGRESS_LINE_RE.match(plain)
+    if not match:
+        return None
+    return match.group("prefix").strip()
+
+
 class Job:
     """State for a single triggered run. Construct via JobManager.start()."""
 
@@ -238,8 +263,23 @@ class Job:
         return "succeeded" if self.returncode == 0 else "failed"
 
     def _append_line(self, line: str) -> None:
+        # Counter/percentage progress updates collapse onto the previous
+        # line instead of piling up (see progress_family). The recommender
+        # writes these with a bare \r and no newline - correct in a
+        # terminal, where each overwrites the last - but Python opens the
+        # subprocess pipe in text mode, and universal-newline translation
+        # turns every \r into its own line. A 337-item scan therefore
+        # arrived here as 337 separate lines. Collapsing here keeps
+        # self.lines (which backs both backlog replay and the stored log)
+        # to one line per progress run; web/static/app.js applies the
+        # same rule to the live DOM, since subscribers still receive every
+        # individual update in order to animate.
+        family = progress_family(line)
         with self._data_lock:
-            self.lines.append(line)
+            if family is not None and self.lines and progress_family(self.lines[-1]) == family:
+                self.lines[-1] = line
+            else:
+                self.lines.append(line)
             for q in self._subscribers:
                 _safe_queue_put(q, line)
         # Stage markers (see STAGE_MARKER_PREFIX/_STAGE_MARKER_RE) are

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -80,44 +80,120 @@
   var flushScheduled = false;
   var lineCount = 0;
 
+  // Counter/percentage progress updates overwrite in place rather than
+  // stacking up. The recommender writes these with a bare \r and no
+  // newline - correct in a terminal, where each overwrites the last -
+  // but the subprocess pipe is opened in text mode, and universal-newline
+  // translation turns every \r into its own line before it reaches us.
+  // A 337-item scan arrived as 337 separate lines.
+  //
+  // Only a counter advancing under an unchanged prefix collapses. A line
+  // carrying genuinely new information never does, and the final update
+  // of a run (the 100%) is committed permanently once a different line
+  // follows it, so completed steps stay in the log.
+  //
+  // Deliberately mirrored from web/job_runner.py's progress_family():
+  // the server needs the rule to keep its stored log and backlog replay
+  // clean, the client needs it because subscribers still receive every
+  // individual update in order to animate the counter.
+  var PROGRESS_RE = /^(.*?)\s*\d+\s*\/\s*\d+\s*\(\s*\d+\s*%\s*\)$/;
+  var ANSI_RE = /\x1b\[[0-9;]*m/g;
+  var liveFamily = null; // family of the progress run currently animating
+  var liveText = null; // its latest text, not yet committed to the log
+  var liveNode = null; // the trailing node it renders into
+
+  function progressFamily(text) {
+    var m = PROGRESS_RE.exec(String(text).replace(ANSI_RE, '').trim());
+    return m ? m[1].trim() : null;
+  }
+
   function nearBottom() {
     // Checked BEFORE appending, since appending changes scrollHeight.
     return output.scrollHeight - output.scrollTop - output.clientHeight < 40;
   }
 
+  function renderLive() {
+    if (liveText === null) { return; }
+    if (!liveNode) {
+      liveNode = document.createElement('span');
+      output.appendChild(liveNode);
+    }
+    liveNode.textContent = liveText + '\n';
+  }
+
+  // Fold the finished progress line into the permanent log. Queued as a
+  // normal pending line so it takes the same trim/scroll path as any
+  // other, rather than becoming a second way for text to reach the DOM.
+  function commitLive() {
+    if (liveText === null) { return; }
+    pending.push(liveText);
+    liveText = null;
+    liveFamily = null;
+    if (liveNode) {
+      output.removeChild(liveNode);
+      liveNode = null;
+    }
+  }
+
+  function scheduleFlush() {
+    if (flushScheduled) { return; }
+    flushScheduled = true;
+    if (window.requestAnimationFrame) {
+      window.requestAnimationFrame(flushLines);
+    } else {
+      setTimeout(flushLines, 16);
+    }
+  }
+
   function flushLines() {
     flushScheduled = false;
-    if (!pending.length) { return; }
+    if (!pending.length && liveText === null) { return; }
     // Don't yank the view back down if the user has scrolled up to read
     // something - only keep following the tail if they were already there.
     var stick = nearBottom();
-    output.appendChild(document.createTextNode(pending.join('\n') + '\n'));
-    lineCount += pending.length;
-    pending.length = 0;
-    if (lineCount > MAX_LINES) {
-      // O(n), but only once every (MAX_LINES - TRIM_TO) lines, so the
-      // amortized cost per line stays constant.
-      var kept = output.textContent.split('\n').slice(-TRIM_TO);
-      output.textContent = kept.join('\n');
-      lineCount = kept.length;
+    if (pending.length) {
+      var node = document.createTextNode(pending.join('\n') + '\n');
+      // Committed lines must land BEFORE the animating progress line,
+      // which is always the last child while its run is in flight.
+      if (liveNode) {
+        output.insertBefore(node, liveNode);
+      } else {
+        output.appendChild(node);
+      }
+      lineCount += pending.length;
+      pending.length = 0;
+      if (lineCount > MAX_LINES) {
+        // O(n), but only once every (MAX_LINES - TRIM_TO) lines, so the
+        // amortized cost per line stays constant.
+        var kept = output.textContent.split('\n').slice(-TRIM_TO);
+        output.textContent = kept.join('\n');
+        lineCount = kept.length;
+        // Rewriting textContent destroyed every child, liveNode included.
+        liveNode = null;
+      }
     }
+    renderLive();
     if (stick) { output.scrollTop = output.scrollHeight; }
   }
 
   function appendLine(text) {
+    var family = progressFamily(text);
+    if (family !== null) {
+      // A different progress run starting means the previous one ended -
+      // keep its last state rather than overwriting it with the new run.
+      if (family !== liveFamily) { commitLive(); }
+      liveFamily = family;
+      liveText = text;
+      scheduleFlush();
+      return;
+    }
+    commitLive();
     pending.push(text);
     // requestAnimationFrame doesn't fire in a background tab, so a
     // hidden page would otherwise buffer without bound - flush directly
     // once enough has piled up.
     if (pending.length >= 1000) { flushLines(); return; }
-    if (!flushScheduled) {
-      flushScheduled = true;
-      if (window.requestAnimationFrame) {
-        window.requestAnimationFrame(flushLines);
-      } else {
-        setTimeout(flushLines, 16);
-      }
-    }
+    scheduleFlush();
   }
 
   if (output && window.CURATARR_JOB_RUNNING) {


### PR DESCRIPTION
A 337-item scan rendered as 337 consecutive lines in the web UI:

```
Processing movie 321/337 (95%)
Processing movie 322/337 (95%)
Processing movie 323/337 (95%)
...
```

## Cause

The recommender is doing the right thing — it writes progress with a bare `\r` and no newline, which overwrites in place in a terminal. The subprocess pipe is opened in **text mode**, and Python's universal-newline translation rewrites every `\r` to `\n` before `for line in job.process.stdout` ever sees it. One in-place counter arrives as one line per tick.

## Rule

Only a counter advancing under an **unchanged prefix** collapses:

- `Processing movie 5/337 (1%)` collapses onto `Processing movie 4/337 (1%)`
- It does **not** collapse onto `Processing alice's watched 4/233 (1%)` — different operation
- A line carrying new information is never touched
- A run's final update (the `100%`) is committed permanently once a different line follows, so completed steps stay in the log

## Both sides, deliberately

`web/job_runner.py` collapses so the stored log and SSE backlog replay hold one line per run. `web/static/app.js` collapses independently because subscribers still receive every individual tick — that's what animates the counter.

The client keeps the in-flight line in its own trailing node so committed text inserts *before* it without rewriting the whole log, preserving 2.10.90's fix for the browser-side quadratic.

## Tests

- 8 Python tests for `progress_family()` / `Job._append_line()`
- 14-check browser suite (`tests/static/test_progress_collapse.js`) exercising the **real** `app.js` against a stubbed DOM — run from pytest under Node on CI, or macOS's bundled JavaScriptCore locally; skips only if neither exists
- Two of those checks pin the ordering and post-trim cases my first attempt got wrong (committed text landing *after* the live line; the trim path destroying it)
- 3143 tests pass, ruff + mypy clean