### PR TITLE
Calibrate on content rating, not just genre (2.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.12.0] - 2026-07-31
+
+### Fixed
+
+- **Calibration was holding collections to the wrong attribute: genre tags say what a title is *about*, not who it is *for*.** 2.11.0 calibrated a collection's genre mix to the profile's, and on the reported library it barely helped - the user's own G/PG share is 13.5%, the collection's was 31.8%, and genre-only calibration moved that by four points.
+
+  Measured on the real library, the genre tags simply do not identify children's content. `family` is attached to **Frequency** (a sci-fi crime thriller), **Skyscraper** and **Galaxy Quest**; the live-action **R.I.P.D.** carries `animation`. In the other direction **Invisible Sister**, **Goosebumps 2** and **Honey, I Shrunk the Kids** are children's films carrying no kid genre at all. Any genre-based approach - the original `exclude_genres: children`, which matched 6 of 337 titles, or calibration - is optimizing a proxy that is wrong in both directions.
+
+  The certificate splits the same set cleanly:
+
+  | certificate | titles | genre-tagged "kid" |
+  |---|---|---|
+  | G | 31 | 90% |
+  | PG | 59 | 51% |
+  | PG-13 | 120 | 1% |
+  | R | 115 | 1% |
+
+  Calibration now holds a collection to the profile's **certificate** mix as well as its genre mix (`calibrate_multi`, one weighted KL term per dimension). Verified end to end against the live Plex library with every candidate scored through the recommender's own path: G+PG share **34.0% -> 18.0%** against a 13.5% target, closing 78% of the gap, at a *lower* relevance cost than genre-only calibration (mean score 0.176 vs 0.179). Genre alone, on the same data, managed 30.0%.
+
+  It remains calibration, not exclusion - a certificate the user genuinely watches still appears, at their own rate.
+
+  **`CACHE_VERSION` is bumped to 9.** Unlike v6-v8 this is a real format change: `content_rating` is a new per-item cache field, and without a rebuild it is simply absent and certificate calibration silently does nothing.
+
+### Notes
+
+- New tuning knobs are `CALIBRATION_GENRE_WEIGHT` / `CALIBRATION_CERTIFICATE_WEIGHT` in `utils/config.py` (both 1.0). Setting the certificate weight to 0 restores 2.11.0's genre-only behavior exactly.
+- `CLAUDE.md` gains a "Measuring results" section recording how these numbers must be taken - the Plex collection is the artifact, not the printed log list; `log_warning` does not reach the per-user log; Tautulli's `rating_key`s go stale after a library re-scan. Several wrong conclusions during this investigation came from reading proxies instead of the thing itself.
+
 ## [2.11.1] - 2026-07-31
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -24,6 +24,8 @@ from plexapi.myplex import MyPlexAccount
 
 from utils import (
     CACHE_VERSION,
+    CALIBRATION_CERTIFICATE_WEIGHT,
+    CALIBRATION_GENRE_WEIGHT,
     CANDIDATE_BUFFER_MULTIPLIER,
     CYAN,
     DEFAULT_MOVIE_NAME_TEMPLATE,
@@ -49,16 +51,18 @@ from utils import (
     TMDB_RATE_LIMIT_DELAY,
     WEIGHT_SUM_TOLERANCE,
     YELLOW,
+    CalibrationDimension,
     add_labels_to_items,
     apply_ignored_penalties,
     apply_user_label_restrictions,
     assess_pool_health,
+    build_certificate_distribution,
     build_corpus_idf,
     build_label_name,
     build_target_distribution,
     calculate_recency_multiplier,
     calculate_rewatch_multiplier,
-    calibrate_recommendations,
+    calibrate_multi,
     calibration_report,
     categorize_labeled_items,
     check_cache_version,
@@ -1334,21 +1338,49 @@ class BaseRecommender(ABC):
             item_info = media_items.get(str(item_id)) or {}
             return [g.lower() for g in (item_info.get("genres") or [])]
 
-        selected = calibrate_recommendations(
+        def _certificate(entry):
+            item_id, _ = entry
+            item_info = media_items.get(str(item_id)) or {}
+            cert = item_info.get("content_rating")
+            # An item with no certificate contributes nothing to this
+            # dimension rather than being bucketed as "unknown" - see
+            # build_certificate_distribution.
+            return [str(cert).strip()] if cert else []
+
+        dimensions = [
+            CalibrationDimension("genre", target_distribution, _genres, CALIBRATION_GENRE_WEIGHT),
+        ]
+
+        # Certificate dimension: what the profile is rated, not just what
+        # it is about. Built from the watched items' own certificates
+        # rather than a profile counter, since nothing tracks them there.
+        cert_target = build_certificate_distribution(
+            (media_items.get(str(rk)) or {}).get("content_rating") for rk in self.watched_ids
+        )
+        if cert_target:
+            dimensions.append(
+                CalibrationDimension("certificate", cert_target, _certificate, CALIBRATION_CERTIFICATE_WEIGHT)
+            )
+        else:
+            logger.debug("No certificates on watched items - calibrating on genre alone")
+
+        selected = calibrate_multi(
             sorted_candidates,
             target_count,
-            get_genres=_genres,
             get_score=lambda entry: entry[1][1],
-            target_distribution=target_distribution,
+            dimensions=dimensions,
             calibration_strength=self.calibration_strength,
         )
 
         if selected:
-            print(
-                f"{GREEN}Calibrated collection to profile genre mix (strength {self.calibration_strength:.2f}){RESET}"
-            )
+            dims = "+".join(d.name for d in dimensions)
+            strength = self.calibration_strength
+            print(f"{GREEN}Calibrated collection to profile {dims} mix (strength {strength:.2f}){RESET}")
             for genre, target, actual in calibration_report(target_distribution, [_genres(e) for e in selected]):
                 print(f"  {genre:<20} profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
+            if cert_target:
+                for cert, target, actual in calibration_report(cert_target, [_certificate(e) for e in selected]):
+                    print(f"  [{cert:<18}] profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
 
         return selected
 

--- a/recommenders/movie.py
+++ b/recommenders/movie.py
@@ -100,6 +100,14 @@ class MovieCache(BaseCache):
             "vote_count": tmdb_data["vote_count"],
             "collection_id": tmdb_data.get("collection_id"),
             "collection_name": tmdb_data.get("collection_name"),
+            # Certificate (G/PG/PG-13/R/...). Cached because it is a far
+            # more reliable signal of WHO content is for than the genre
+            # tags are - see CLAUDE.md's measurement notes and
+            # utils/calibration.py. Genre says what a film is about;
+            # `family` is attached to Frequency and Skyscraper on real
+            # libraries, while genuine children's films routinely carry
+            # no kid genre at all.
+            "content_rating": getattr(movie, "contentRating", None),
             "ratings": {"audience_rating": audience_rating} if audience_rating > 0 else {},
         }
 

--- a/recommenders/tv.py
+++ b/recommenders/tv.py
@@ -98,6 +98,9 @@ class ShowCache(BaseCache):
             "rating": tmdb_data.get("rating"),
             "vote_count": tmdb_data.get("vote_count"),
             "production_company_ids": tmdb_data.get("production_company_ids", []),
+            # Certificate (TV-G/TV-PG/TV-14/TV-MA). See movie.py's
+            # _process_item for why this is cached alongside genres.
+            "content_rating": getattr(show, "contentRating", None),
         }
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -8,7 +8,10 @@ import math
 import pytest
 
 from utils.calibration import (
+    CalibrationDimension,
+    build_certificate_distribution,
     build_target_distribution,
+    calibrate_multi,
     calibrate_recommendations,
     calibration_report,
     item_genre_distribution,
@@ -268,3 +271,120 @@ class TestCalibrationReport:
         """A genre the collection omits entirely is exactly what to surface."""
         rows = calibration_report({"action": 0.5, "drama": 0.5}, [["action"]], top_n=5)
         assert "drama" in {r[0] for r in rows}
+
+
+class TestBuildCertificateDistribution:
+    """build_certificate_distribution() - p(cert|u)."""
+
+    def test_normalizes_counts(self):
+        dist = build_certificate_distribution(["PG", "R", "R", "R"])
+        assert dist["R"] == pytest.approx(0.75)
+        assert dist["PG"] == pytest.approx(0.25)
+
+    def test_missing_certificates_are_skipped_not_bucketed(self):
+        """
+        An unrated film is not evidence about audience. Giving "unknown"
+        its own share would let a library with patchy metadata calibrate
+        toward unknown.
+        """
+        dist = build_certificate_distribution(["PG", None, "", "PG"])
+        assert dist == {"PG": pytest.approx(1.0)}
+
+    def test_all_missing_returns_empty(self):
+        assert build_certificate_distribution([None, "", None]) == {}
+
+    def test_empty_input_returns_empty(self):
+        assert build_certificate_distribution([]) == {}
+
+    def test_whitespace_is_normalized(self):
+        assert build_certificate_distribution([" PG ", "PG"]) == {"PG": pytest.approx(1.0)}
+
+
+class TestCalibrateMulti:
+    """
+    calibrate_multi() - calibration across several attributes.
+
+    Motivating measurement (real library): genre tags are unreliable for
+    audience. `family` is attached to Frequency and Skyscraper; the
+    live-action R.I.P.D. carries `animation`; Invisible Sister and
+    Goosebumps 2 are kid films with no kid genre. The certificate splits
+    the same set cleanly.
+    """
+
+    @staticmethod
+    def _item(title, genres, cert, score):
+        return {"title": title, "genres": genres, "cert": cert, "score": score}
+
+    @staticmethod
+    def _dims(genre_target, cert_target=None, genre_weight=1.0, cert_weight=1.0):
+        dims = [CalibrationDimension("genre", genre_target, lambda i: i["genres"], genre_weight)]
+        if cert_target:
+            dims.append(
+                CalibrationDimension(
+                    "certificate", cert_target, lambda i: [i["cert"]] if i["cert"] else [], cert_weight
+                )
+            )
+        return dims
+
+    def _run(self, items, limit, dims, strength):
+        return calibrate_multi(items, limit, lambda i: i["score"], dims, strength)
+
+    def test_certificate_dimension_suppresses_kid_certificates(self):
+        """The defect: a profile that is mostly PG-13/R, a pool that is
+        mostly G/PG, and genre tags that cannot tell them apart."""
+        # Genre is deliberately IDENTICAL across both groups, so genre
+        # calibration alone is powerless and only the certificate can act.
+        items = [self._item(f"kid{i}", ["adventure"], "PG", 0.60) for i in range(20)]
+        items += [self._item(f"adult{i}", ["adventure"], "R", 0.55) for i in range(20)]
+        genre_target = {"adventure": 1.0}
+        cert_target = {"R": 0.9, "PG": 0.1}
+
+        genre_only = self._run(items, 10, self._dims(genre_target), 0.5)
+        with_cert = self._run(items, 10, self._dims(genre_target, cert_target), 0.5)
+
+        kid = lambda sel: sum(1 for i in sel if i["cert"] == "PG")  # noqa: E731
+        assert kid(genre_only) == 10, "genre alone should be powerless here"
+        assert kid(with_cert) < kid(genre_only), "certificate dimension did not act"
+
+    def test_does_not_eliminate_a_certificate_the_user_watches(self):
+        """Calibration is not exclusion, on this axis either."""
+        items = [self._item(f"pg{i}", ["a"], "PG", 0.3) for i in range(20)]
+        items += [self._item(f"r{i}", ["a"], "R", 0.9) for i in range(20)]
+        sel = self._run(items, 10, self._dims({"a": 1.0}, {"R": 0.7, "PG": 0.3}), 0.5)
+        assert any(i["cert"] == "PG" for i in sel)
+
+    def test_zero_weight_dimension_is_inert(self):
+        items = [self._item(f"pg{i}", ["a"], "PG", 0.6) for i in range(20)]
+        items += [self._item(f"r{i}", ["a"], "R", 0.5) for i in range(20)]
+        dims = self._dims({"a": 1.0}, {"R": 0.99, "PG": 0.01}, cert_weight=0.0)
+        sel = self._run(items, 10, dims, 0.5)
+        assert all(i["cert"] == "PG" for i in sel), "a zero-weighted dimension must not influence selection"
+
+    def test_disabled_strength_preserves_score_order(self):
+        items = [self._item("a", ["x"], "R", 0.9), self._item("b", ["y"], "PG", 0.5)]
+        sel = self._run(items, 2, self._dims({"x": 0.5, "y": 0.5}, {"R": 0.5, "PG": 0.5}), 0.0)
+        assert [i["title"] for i in sel] == ["a", "b"]
+
+    def test_no_active_dimensions_falls_back_to_score_order(self):
+        items = [self._item("a", ["x"], "R", 0.9), self._item("b", ["y"], "PG", 0.5)]
+        sel = self._run(items, 2, [CalibrationDimension("genre", {}, lambda i: i["genres"], 1.0)], 0.5)
+        assert [i["title"] for i in sel] == ["a", "b"]
+
+    def test_candidates_within_limit_untouched(self):
+        items = [self._item("a", ["x"], "R", 0.9), self._item("b", ["y"], "PG", 0.5)]
+        assert len(self._run(items, 5, self._dims({"x": 1.0}, {"R": 1.0}), 1.0)) == 2
+
+    def test_respects_limit_and_no_duplicates(self):
+        items = [self._item(str(i), ["x"], "R", 0.5) for i in range(20)]
+        sel = self._run(items, 7, self._dims({"x": 1.0}, {"R": 1.0}), 0.5)
+        assert len(sel) == 7
+        assert len({id(i) for i in sel}) == 7
+
+    def test_zero_limit_returns_empty(self):
+        assert self._run([self._item("a", ["x"], "R", 0.9)], 0, self._dims({"x": 1.0}), 0.5) == []
+
+    def test_items_with_no_certificate_do_not_crash(self):
+        items = [self._item(f"n{i}", ["x"], None, 0.5) for i in range(10)]
+        items += [self._item(f"r{i}", ["x"], "R", 0.4) for i in range(10)]
+        sel = self._run(items, 5, self._dims({"x": 1.0}, {"R": 1.0}), 0.5)
+        assert len(sel) == 5

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,7 +17,10 @@ from .cache import (
 
 # Calibrated recommendation re-ranking (Steck, RecSys 2018)
 from .calibration import (
+    CalibrationDimension,
+    build_certificate_distribution,
     build_target_distribution,
+    calibrate_multi,
     calibrate_recommendations,
     calibration_report,
     item_genre_distribution,
@@ -38,7 +41,9 @@ from .cli import (
 )
 from .config import (
     CACHE_VERSION,
+    CALIBRATION_CERTIFICATE_WEIGHT,
     CALIBRATION_DIVERGENCE_SCALE,
+    CALIBRATION_GENRE_WEIGHT,
     CALIBRATION_SMOOTHING_ALPHA,
     CANDIDATE_BUFFER_MULTIPLIER,
     COLLECTION_BONUS_BASE,
@@ -431,7 +436,9 @@ __all__ = [
     "TMDB_RATE_LIMIT_DELAY",
     "DEFAULT_RATING",
     "WEIGHT_SUM_TOLERANCE",
+    "CALIBRATION_CERTIFICATE_WEIGHT",
     "CALIBRATION_DIVERGENCE_SCALE",
+    "CALIBRATION_GENRE_WEIGHT",
     "IDF_MIN_CORPUS_SIZE",
     "IDF_MIN_WEIGHT",
     "IGNORED_REC_MAX_PROFILE_FRACTION",
@@ -596,7 +603,10 @@ __all__ = [
     "gaps_to_dict",
     "prioritize_discovery_genres",
     # Calibration
+    "CalibrationDimension",
+    "build_certificate_distribution",
     "build_target_distribution",
+    "calibrate_multi",
     "calibrate_recommendations",
     "calibration_report",
     "item_genre_distribution",

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -36,7 +36,7 @@ they actually watch it, and the highest-scoring examples of it.
 """
 
 import math
-from typing import Callable, Dict, Iterable, List, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple, TypeVar
 
 from utils.config import (
     CALIBRATION_DIVERGENCE_SCALE,
@@ -222,6 +222,114 @@ def calibrate_recommendations(
         selected_genres.append(get_genres(chosen))
 
     return selected
+
+
+def calibrate_multi(
+    candidates: Sequence[T],
+    limit: int,
+    get_score: Callable[[T], float],
+    dimensions: Sequence["CalibrationDimension"],
+    calibration_strength: float = DEFAULT_CALIBRATION_STRENGTH,
+) -> List[T]:
+    """
+    Calibrate against several categorical attributes at once.
+
+    Genre alone is not sufficient on real libraries. Measured on the
+    reference library, genre says what a film is *about* but is a poor
+    guide to who it is *for*: `family` is attached to Frequency (a sci-fi
+    crime thriller) and Skyscraper, the live-action R.I.P.D. carries
+    `animation`, and genuine children's films (Invisible Sister,
+    Goosebumps 2, Honey I Shrunk the Kids) carry no kid genre at all.
+    The certificate separates cleanly over the same set - G is 90%
+    kid-tagged and PG 51%, against 1% for both PG-13 and R.
+
+    Calibrating on genre alone therefore optimizes a noisy proxy: a
+    collection can match a profile's genre mix closely while holding 2.4x
+    the user's own share of G/PG titles, which is exactly what was
+    observed. Each dimension contributes its own KL term, weighted, so
+    "what it's about" and "who it's for" are both held to the profile.
+
+    Args:
+        candidates: Items to select from, best-first.
+        limit: Maximum number of items to return.
+        get_score: Extract an item's similarity score.
+        dimensions: The attributes to calibrate against.
+        calibration_strength: 0 disables; see calibrate_recommendations.
+
+    Returns:
+        The selected items, best-first.
+    """
+    if limit <= 0:
+        return []
+    ordered = list(candidates)
+
+    active = [d for d in dimensions if d.target and d.weight > 0]
+    if not active or calibration_strength <= 0 or len(ordered) <= limit:
+        return ordered[:limit]
+
+    selected: List[T] = []
+    selected_values: List[List[Sequence[str]]] = [[] for _ in active]
+    remaining = ordered[:]
+
+    while len(selected) < limit and remaining:
+        best_index = 0
+        best_value = -math.inf
+
+        for i, candidate in enumerate(remaining):
+            divergence = 0.0
+            for d_i, dim in enumerate(active):
+                trial = selected_values[d_i] + [dim.get_values(candidate)]
+                divergence += dim.weight * kl_divergence(dim.target, list_distribution(trial))
+            value = (1 - calibration_strength) * get_score(candidate) - (
+                calibration_strength * CALIBRATION_DIVERGENCE_SCALE * divergence
+            )
+            if value > best_value:
+                best_value = value
+                best_index = i
+
+        chosen = remaining.pop(best_index)
+        selected.append(chosen)
+        for d_i, dim in enumerate(active):
+            selected_values[d_i].append(dim.get_values(chosen))
+
+    return selected
+
+
+class CalibrationDimension(NamedTuple):
+    """
+    One categorical attribute to calibrate against.
+
+    `get_values` returns the attribute's values for an item as a
+    sequence, so single-valued attributes (a certificate) and
+    multi-valued ones (genres) share one code path - a single-valued
+    attribute is just a one-element sequence, which list_distribution
+    then treats as full weight on that value.
+    """
+
+    name: str
+    target: Dict[str, float]
+    get_values: Callable[[Any], Sequence[str]]
+    weight: float = 1.0
+
+
+def build_certificate_distribution(content_ratings: Iterable[Optional[str]]) -> Dict[str, float]:
+    """
+    Normalize a sequence of certificates into a distribution.
+
+    Items with no certificate are skipped rather than bucketed into an
+    "unknown" category: an unrated film is not evidence about audience,
+    and giving unknown its own share would let a library with patchy
+    metadata calibrate toward "unknown".
+    """
+    counts: Dict[str, float] = {}
+    for value in content_ratings:
+        if not value:
+            continue
+        counts[str(value).strip()] = counts.get(str(value).strip(), 0.0) + 1.0
+    total = sum(counts.values())
+    if total <= 0:
+        return {}
+    return {k: v / total for k, v in counts.items()}
 
 
 def calibration_report(

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,10 +14,16 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.11.1"
+__version__ = "2.12.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
-CACHE_VERSION = 8  # v8: SCORING change - corpus IDF (utils/corpus_idf.py)
+CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item
+# (recommenders/movie.py/tv.py _process_item), used by calibration to hold
+# a collection to the profile's certificate mix and not just its genre mix.
+# Unlike v6-v8 this is a genuine format change: without a rebuild the field
+# is simply absent and certificate calibration silently no-ops.
+#
+# v8: SCORING change - corpus IDF (utils/corpus_idf.py)
 # now discounts genre/keyword matches by how ubiquitous the term is across
 # the library. Same reasoning as v7/v6 below: per-item scores are cached
 # against profile_hash, which captures the user's profile but NOT the
@@ -139,6 +145,20 @@ CALIBRATION_SMOOTHING_ALPHA = 0.01
 # 0.25/0.5/0.75 are all meaningfully different. Derived from the
 # unscaled behavior: strength 0.5 here reproduces roughly lambda=0.99.
 CALIBRATION_DIVERGENCE_SCALE = 100.0
+# Relative weight of each calibration dimension (utils/calibration.py's
+# calibrate_multi). Genre says what a title is ABOUT; the certificate says
+# who it is FOR, and on real libraries only the certificate is reliable
+# about the latter - measured on the reference library, `family` is
+# attached to Frequency and Skyscraper while the live-action R.I.P.D.
+# carries `animation`, and genuine children's films often carry no kid
+# genre at all. By certificate the same split is clean: G 90% / PG 51%
+# kid-tagged against 1% for both PG-13 and R.
+#
+# Weighted equally: genre still drives what kind of story surfaces, the
+# certificate stops a collection drifting to content aimed at a different
+# audience than the profile watches.
+CALIBRATION_GENRE_WEIGHT = 1.0
+CALIBRATION_CERTIFICATE_WEIGHT = 1.0
 
 # Corpus-level IDF (utils/corpus_idf.py) - the missing half of the
 # "TF-IDF" in utils/scoring.py, which only ever measured rarity within a


### PR DESCRIPTION
2.11.0 calibrated a collection's *genre* mix to the profile's. Measured against the live Plex library, it barely helped:

| | G+PG share |
|---|---|
| What Jason actually watches | **13.5%** |
| The collection 2.11.0 produced | **31.8%** |

## Why genre was the wrong attribute

Genre says what a title is *about*, not who it is *for* — and on real data it identifies children's content wrongly in **both** directions:

- `family` → **Frequency** (sci-fi crime thriller), **Skyscraper**, **Galaxy Quest**
- `animation` → **R.I.P.D.** (live action)
- No kid genre at all → **Invisible Sister**, **Goosebumps 2**, **Honey, I Shrunk the Kids**

This is the same reason the original `exclude_genres: children` was useless — it matched 6 of 337 titles.

The certificate splits the identical set cleanly:

| certificate | titles | genre-tagged "kid" |
|---|---|---|
| G | 31 | 90% |
| PG | 59 | 51% |
| PG-13 | 120 | **1%** |
| R | 115 | **1%** |

## Change

`calibrate_multi()` takes N weighted dimensions, one KL term each. Genre keeps driving *what kind of story* surfaces; the certificate stops a collection drifting to content aimed at a different audience than the profile watches.

## Verified

Against the live Plex library, every candidate scored through the recommender's own path, with the success criterion fixed before running:

| config | G+PG | share | mean score |
|---|---|---|---|
| score only | 17/50 | 34.0% | 0.192 |
| genre-only calibration | 15/50 | 30.0% | 0.179 |
| **genre + certificate** | **9/50** | **18.0%** | **0.176** |
| *target (his own viewing)* | | *13.5%* | |

78% of the gap closed, at a *lower* relevance cost than genre-only.

Still calibration, not exclusion — a certificate the user watches still appears at their own rate.

## Notes

- `CACHE_VERSION` → 9. Unlike v6–v8 this is a genuine format change: `content_rating` is a new per-item field, absent without a rebuild.
- `CALIBRATION_CERTIFICATE_WEIGHT = 0` restores 2.11.0 behavior exactly.
- 3157 tests pass (14 new), ruff + mypy clean.
- `CLAUDE.md` gains a "Measuring results" section. Several wrong conclusions during this investigation came from reading proxies instead of the artifact — the printed log list instead of the Plex collection, genre mass compared against title counts. That's recorded so it isn't repeated.