### PR TITLE
Warn when calibration cannot act instead of silently doing nothing (2.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.12.1] - 2026-07-31
+
+### Fixed
+
+- **Calibration could silently do nothing while reporting that it had run.** Calibration works by *choosing*; handed no more candidates than there are slots, it returns them unchanged. From the outside that is indistinguishable from a calibrated collection - the run still prints its calibration report and its profile-vs-collection table.
+
+  This was not hypothetical. `min_similarity: 0.10` cut a real 125-candidate pool to **48** for a 50-item collection. Every run since produced an entirely uncalibrated collection, came in short at 41 items, and said it had calibrated. Two separate fixes (2.11.0's genre calibration, 2.12.0's certificate dimension) were measured as ineffective on a live library when in fact neither had ever executed there.
+
+  A run whose candidate count does not exceed its slot count now warns, names `min_similarity` as the setting to change, and explains why. Verified on the same library: dropping the floor to 0.0 let calibration actually run, taking the over-represented G/PG share from **34.1% to 18.0%** (against a 13.2% target) and filling the collection to 50.
+
+- **`config/tuning.example.yml` recommended a `min_similarity` that causes the above.** It suggested 0.20 as "a reasonable starting point". On the reference library 0.20 leaves 7 candidates for 50 slots. The guidance now states what the gate is actually for - dropping junk, not sizing the collection - and to raise it only while candidates still comfortably outnumber `limit_results`.
+
 ## [2.12.0] - 2026-07-31
 
 ### Fixed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -17,11 +17,21 @@ movies:
   # the bar, you get 31 and a warning telling you the library is running
   # short of unwatched content matching that profile.
   #
+  # This gate exists to drop genuine junk, NOT to size the collection -
+  # calibration_strength below does that. KEEP IT LOW, and raise it only
+  # while candidates still comfortably outnumber limit_results.
+  #
+  # Measured failure worth avoiding: on a library with 125 candidates for
+  # a 50-item collection, min_similarity 0.10 cut the pool to 48. That is
+  # fewer candidates than slots, so calibration had nothing to choose
+  # between and silently returned them all - producing an uncalibrated
+  # collection while reporting success, and a collection that came in
+  # short as well. Dropping the floor back to 0.0 on the same library took
+  # the over-represented share from 34% to 18%.
+  #
   # Default 0.0 (disabled) preserves the historical behavior of always
-  # filling to limit_results regardless of score. 0.20 is a reasonable
-  # starting point; raise it until the tail of the collection stops
-  # looking like filler. This is the library-side counterpart to
-  # external_recommendations.min_relevance_score.
+  # filling to limit_results regardless of score. This is the library-side
+  # counterpart to external_recommendations.min_relevance_score.
   min_similarity: 0.0
 
   # Calibrated recommendations (Steck, "Calibrated Recommendations",

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1364,6 +1364,22 @@ class BaseRecommender(ABC):
         else:
             logger.debug("No certificates on watched items - calibrating on genre alone")
 
+        # Calibration works by CHOOSING. Handed no more candidates than
+        # slots it returns them unchanged, which looks identical to
+        # "calibration is enabled and working" from the outside - the
+        # failure that wasted a full debugging cycle: min_similarity 0.10
+        # cut a 125-candidate pool to 48 for a 50-item collection, so
+        # every run silently produced an uncalibrated collection while
+        # reporting that it had calibrated one.
+        if len(sorted_candidates) <= target_count:
+            log_warning(
+                f"Calibration cannot act: only {len(sorted_candidates)} candidates for "
+                f"{target_count} slots, so every candidate is selected regardless of mix. "
+                f"Lower movies/tv min_similarity (currently {self.min_similarity:.2f}) or "
+                f"raise limit_results' candidate supply - calibration needs more candidates "
+                f"than slots to have anything to choose between."
+            )
+
         selected = calibrate_multi(
             sorted_candidates,
             target_count,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2624,6 +2624,60 @@ class TestSelectCalibrated:
         assert [int(i.ratingKey) for i in result] == [2, 1]
 
 
+class TestCalibrationCannotActGuard:
+    """
+    Calibration works by CHOOSING. Handed no more candidates than slots
+    it returns them unchanged - indistinguishable from working, from the
+    outside.
+
+    This is not hypothetical: min_similarity 0.10 cut a real 125-candidate
+    pool to 48 for a 50-item collection, so every run silently produced an
+    uncalibrated collection while printing that it had calibrated one.
+    Dropping the floor took the over-represented share from 34% to 18% on
+    the same library.
+    """
+
+    @staticmethod
+    def _recommender(n_candidates, target, strength=0.5):
+        recommender = _make_recommender()
+        recommender.calibration_strength = strength
+        recommender.min_similarity = 0.10
+        recommender.watched_data_counters = {"genres": {"thriller": 50.0}}
+        recommender.watched_ids = set()
+        media_cache = Mock()
+        media_cache.cache = {"movies": {str(i): {"genres": ["thriller"]} for i in range(n_candidates)}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        candidates = [(i, (Mock(ratingKey=i), 0.5)) for i in range(n_candidates)]
+        return recommender, candidates, media_cache.cache["movies"]
+
+    @patch("recommenders.base.log_warning")
+    def test_warns_when_candidates_do_not_exceed_slots(self, mock_warn):
+        recommender, candidates, media_items = self._recommender(40, 50)
+        recommender._select_calibrated(candidates, media_items, 50)
+        assert mock_warn.called, "silent no-op: calibration could not act and said nothing"
+        assert "Calibration cannot act" in mock_warn.call_args[0][0]
+
+    @patch("recommenders.base.log_warning")
+    def test_warning_names_the_setting_to_change(self, mock_warn):
+        recommender, candidates, media_items = self._recommender(40, 50)
+        recommender._select_calibrated(candidates, media_items, 50)
+        assert "min_similarity" in mock_warn.call_args[0][0]
+
+    @patch("recommenders.base.log_warning")
+    def test_no_warning_when_calibration_has_room(self, mock_warn):
+        recommender, candidates, media_items = self._recommender(200, 50)
+        recommender._select_calibrated(candidates, media_items, 50)
+        warned = [c for c in mock_warn.call_args_list if "Calibration cannot act" in str(c)]
+        assert not warned
+
+    @patch("recommenders.base.log_warning")
+    def test_exactly_equal_counts_still_warns(self, mock_warn):
+        """50 candidates for 50 slots is still zero choice."""
+        recommender, candidates, media_items = self._recommender(50, 50)
+        recommender._select_calibrated(candidates, media_items, 50)
+        assert mock_warn.called
+
+
 class TestSyncPlexCollectionEmpty:
     """Tests for BaseRecommender._sync_plex_collection with no items."""
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item


### PR DESCRIPTION
Calibration works by **choosing**. Handed no more candidates than slots, it returns them unchanged — and from the outside that is indistinguishable from success, because the run still prints its calibration report and profile-vs-collection table.

## This wasn't hypothetical

`min_similarity: 0.10` cut a real 125-candidate pool to **48** for a 50-item collection:

```
Library supply: 125 candidates for 50 slots (2.5:1) - DEPLETED
Finding 48 recommendations in Plex library...      ← floor cut it here
  Scoring 42 existing labeled items...
Calibrated collection to profile genre+certificate mix (strength 0.50)   ← a lie
Final collection size: 41 movies
```

Every run since 2.11.0 produced an entirely uncalibrated collection, came in short, and reported success. **Both** prior fixes — 2.11.0's genre calibration and 2.12.0's certificate dimension — were measured as ineffective on a live library when in fact neither had ever executed there.

## Verified

Dropping the floor to 0.0 on the same library, measured against the Plex collection itself:

| | before | after |
|---|---|---|
| candidates reaching calibration | 42 | 100+ |
| collection size | 41 (short) | **50** |
| G+PG share | 34.1% | **18.0%** |
| vs the user's own 13.2% | 2.39x | **1.36x** |

Composition changed too, not just the count: Alvin and the Chipmunks, Smurfs 2, Cloudy 2, Diary of a Wimpy Kid all dropped out.

## Changes

- Warn when candidates ≤ slots, naming `min_similarity` and explaining why calibration cannot act
- `tuning.example.yml` previously recommended `min_similarity: 0.20` as "a reasonable starting point". On the reference library that leaves **7** candidates for 50 slots. Guidance now states the gate is for dropping junk, not sizing the collection.
- 3161 tests pass (4 new, covering the equal-counts boundary), ruff + mypy clean