### PR TITLE
Fix exclusion labels lost across libraries and skipped for unconfigured users (2.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.14.0] - 2026-08-03
+
+### Fixed
+
+- **Exclusion labels from movie libraries were silently overwritten by the TV run (#332).** `apply_user_label_restrictions()` writes BOTH `filterMovies` and `filterTelevision` on every call, but each media type's run supplied only its own labels. A user's `PrivateCollection_*` label is per-library - `recommenders/base.py` roots it at `"PrivateCollection" + _library_suffix_for_label()`, which qualifies by library id whenever a media type has more than one library - so the movie run knew only movie labels and the TV run only TV labels. TV runs after movies, so its write replaced the movie exclusions in both fields and movie collections stayed visible to everyone.
+
+  Single-library installs never saw this: both media types produce the identical unqualified label, so the second write was a no-op. It affects **multi-library** installs only, which is how it was reported.
+
+  New `build_all_private_labels()` enumerates every library of every media type up front, so the value written is complete and identical whichever run performs the write. Single-library installs keep exactly today's unqualified label names.
+
+- **Plex users absent from `config.yml` received no label restrictions at all (#332).** The loop only iterated configured users, so anyone else on the server saw every user's `PrivateCollection_*` collections in browse and search - precisely the condition the feature exists to prevent. Restrictions now cover every non-admin user the server reports. They own no labels themselves, so they simply get all of them excluded. Opt out with `restrict_unconfigured_users=False`.
+
+  This remains **UI-level separation, not an access-control boundary** - see `utils/plex_policy.py`'s module docstring for the enumeration caveat.
+
+### Notes
+
+- `apply_user_label_restrictions()` now accepts either a single label or a sequence per user, so any caller predating this change is unaffected.
+
 ## [2.13.2] - 2026-08-03
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -57,6 +57,7 @@ from utils import (
     apply_ignored_penalties,
     apply_user_label_restrictions,
     assess_pool_health,
+    build_all_private_labels,
     build_certificate_distribution,
     build_corpus_idf,
     build_label_name,
@@ -1744,9 +1745,13 @@ class BaseRecommender(ABC):
                     # Build dict of all users' PrivateCollection_* labels for
                     # exclude-based restrictions - each user's own label stays
                     # visible to them, every OTHER user's label is excluded.
-                    all_user_private_labels = {}
-                    for u in users:
-                        all_user_private_labels[u] = build_label_name(private_base_label, users, u, append_usernames)
+                    # Every library's labels, not just this media type's
+                    # (#332). apply_user_label_restrictions() writes both
+                    # filterMovies and filterTelevision on every call, so
+                    # supplying only the running media type's labels meant
+                    # the later run (TV) overwrote the earlier one's
+                    # (movies) in both fields.
+                    all_user_private_labels = build_all_private_labels(self.config, users, append_usernames)
 
                     apply_user_label_restrictions(self.config, all_user_private_labels)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2806,9 +2806,11 @@ class TestManagePlexLabelsFullFlow:
 
         mock_apply.assert_called_once()
         all_user_private_labels = mock_apply.call_args[0][1]
+        # A user owns one private label PER LIBRARY (#332), so this is a
+        # list even on a single-library install.
         assert all_user_private_labels == {
-            "alice": "PrivateCollection_alice",
-            "bob": "PrivateCollection_bob",
+            "alice": ["PrivateCollection_alice"],
+            "bob": ["PrivateCollection_bob"],
         }
 
     @patch("recommenders.base.get_max_rating_for_user", return_value="PG-13")
@@ -2894,8 +2896,8 @@ class TestPrivateCollectionsAppendUsernames:
         assert result is True
         mock_apply.assert_called_once()
         assert mock_apply.call_args[0][1] == {
-            "alice": "PrivateCollection_alice",
-            "bob": "PrivateCollection_bob",
+            "alice": ["PrivateCollection_alice"],
+            "bob": ["PrivateCollection_bob"],
         }
 
     @patch("recommenders.base.apply_user_label_restrictions")
@@ -2912,7 +2914,7 @@ class TestPrivateCollectionsAppendUsernames:
 
         assert result is True
         mock_apply.assert_called_once()
-        assert mock_apply.call_args[0][1] == {"alice": "PrivateCollection"}
+        assert mock_apply.call_args[0][1] == {"alice": ["PrivateCollection"]}
 
     @patch("recommenders.base.log_warning")
     @patch("recommenders.base.apply_user_label_restrictions")

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -3012,3 +3012,137 @@ class TestFetchUserPlayedIds:
         plex.myPlexAccount.return_value = Mock(username="owner")  # .users() -> non-iterable Mock
         plex.library.section.return_value = Mock(search=Mock(return_value=[]))
         assert fetch_user_played_ids(plex, {}, "someone", "Movies") == set()
+
+
+class TestBuildAllPrivateLabels:
+    """
+    build_all_private_labels() - #332 claim 1.
+
+    A user owns one PrivateCollection_* label PER LIBRARY, because
+    recommenders/base.py roots it at "PrivateCollection" +
+    _library_suffix_for_label(), which qualifies by library id whenever a
+    media type has more than one library. Each media type's run therefore
+    knew only its own labels, and since apply_user_label_restrictions()
+    writes BOTH filterMovies and filterTelevision every time, the later
+    run (TV) overwrote the earlier one's (movies).
+    """
+
+    @staticmethod
+    def _config(movie_libs, tv_libs):
+        libs = [{"id": i, "media_type": "movie", "name": i, "section": i} for i in movie_libs]
+        libs += [{"id": i, "media_type": "tv", "name": i, "section": i} for i in tv_libs]
+        return {"libraries": libs}
+
+    def test_single_library_per_type_keeps_todays_unqualified_names(self):
+        from utils.plex_policy import build_all_private_labels
+
+        cfg = self._config(["movies"], ["tv-shows"])
+        labels = build_all_private_labels(cfg, ["alice", "bob"], True)
+        assert labels["alice"] == ["PrivateCollection_alice"]
+        assert labels["bob"] == ["PrivateCollection_bob"]
+
+    def test_multi_library_yields_a_label_per_library(self):
+        """The reported case: movie labels must not be lost."""
+        from utils.plex_policy import build_all_private_labels
+
+        cfg = self._config(["movies", "movies4k"], ["tv-shows"])
+        labels = build_all_private_labels(cfg, ["alice"], True)
+        assert "PrivateCollection_movies_alice" in labels["alice"]
+        assert "PrivateCollection_movies4k_alice" in labels["alice"]
+        assert "PrivateCollection_alice" in labels["alice"], "single-library TV label missing"
+
+    def test_no_duplicate_labels(self):
+        from utils.plex_policy import build_all_private_labels
+
+        cfg = self._config(["movies"], ["tv-shows"])
+        labels = build_all_private_labels(cfg, ["alice"], True)
+        assert len(labels["alice"]) == len(set(labels["alice"]))
+
+    def test_covers_every_user(self):
+        from utils.plex_policy import build_all_private_labels
+
+        cfg = self._config(["movies"], ["tv"])
+        labels = build_all_private_labels(cfg, ["alice", "bob", "carol"], True)
+        assert set(labels) == {"alice", "bob", "carol"}
+
+
+class TestApplyRestrictionsCoverage:
+    """
+    apply_user_label_restrictions() - #332 claims 1 and 2.
+
+    Claim 1: a user's labels are a list now, and all of them must land in
+    the other users' exclude filters.
+    Claim 2: a Plex user absent from config previously got no filter at
+    all, so they saw everyone's collections.
+    """
+
+    USERS_XML = (
+        b"<MediaContainer>"
+        b'<User id="1" title="alice" username="alice" email="a@x"/>'
+        b'<User id="2" title="bob" username="bob" email="b@x"/>'
+        b'<User id="3" title="carol" username="carol" email="c@x"/>'
+        b"</MediaContainer>"
+    )
+
+    def _run(self, labels, **kwargs):
+        from utils import plex_policy
+
+        put_calls = []
+
+        def fake_put(url, params=None, **kw):
+            put_calls.append((url, params))
+            return Mock(raise_for_status=Mock())
+
+        with (
+            patch.object(plex_policy, "MyPlexAccount", return_value=Mock(username="admin")),
+            patch.object(
+                plex_policy, "_capped_get", return_value=Mock(content=self.USERS_XML, raise_for_status=Mock())
+            ),
+            patch.object(plex_policy, "_capped_put", side_effect=fake_put),
+        ):
+            ok = plex_policy.apply_user_label_restrictions({"plex": {"token": "t"}}, labels, **kwargs)
+        return ok, put_calls
+
+    def test_all_of_a_users_labels_are_excluded_from_others(self):
+        """Claim 1: every library's label, not just one."""
+        labels = {
+            "alice": ["PrivateCollection_movies_alice", "PrivateCollection_tv_alice"],
+            "bob": ["PrivateCollection_movies_bob"],
+        }
+        _ok, calls = self._run(labels)
+        bob_filter = next(p["filterMovies"] for url, p in calls if url.endswith("/2"))
+        assert "PrivateCollection_movies_alice" in bob_filter
+        assert "PrivateCollection_tv_alice" in bob_filter, "a library's labels were dropped"
+
+    def test_a_bare_string_still_works(self):
+        """Callers predating #332 pass one label, not a list."""
+        _ok, calls = self._run({"alice": "PrivateCollection_alice", "bob": "PrivateCollection_bob"})
+        bob_filter = next(p["filterMovies"] for url, p in calls if url.endswith("/2"))
+        assert "PrivateCollection_alice" in bob_filter
+
+    def test_unconfigured_server_user_also_gets_restricted(self):
+        """Claim 2: carol is on the server but not in config."""
+        labels = {"alice": ["PrivateCollection_alice"], "bob": ["PrivateCollection_bob"]}
+        _ok, calls = self._run(labels)
+        carol = [p for url, p in calls if url.endswith("/3")]
+        assert carol, "a Plex user absent from config received no restriction"
+        assert "PrivateCollection_alice" in carol[0]["filterMovies"]
+        assert "PrivateCollection_bob" in carol[0]["filterMovies"]
+
+    def test_unconfigured_coverage_can_be_disabled(self):
+        labels = {"alice": ["PrivateCollection_alice"], "bob": ["PrivateCollection_bob"]}
+        _ok, calls = self._run(labels, restrict_unconfigured_users=False)
+        assert not [p for url, p in calls if url.endswith("/3")]
+
+    def test_a_user_never_has_their_own_label_excluded(self):
+        labels = {"alice": ["PrivateCollection_alice"], "bob": ["PrivateCollection_bob"]}
+        _ok, calls = self._run(labels)
+        alice_filter = next(p["filterMovies"] for url, p in calls if url.endswith("/1"))
+        assert "PrivateCollection_alice" not in alice_filter
+        assert "PrivateCollection_bob" in alice_filter
+
+    def test_both_media_filters_are_written(self):
+        labels = {"alice": ["PrivateCollection_alice"], "bob": ["PrivateCollection_bob"]}
+        _ok, calls = self._run(labels)
+        _url, params = calls[0]
+        assert params["filterMovies"] == params["filterTelevision"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -261,6 +261,7 @@ from .plex_policy import (
     MOVIE_RATING_HIERARCHY,
     TV_RATING_HIERARCHY,
     apply_user_label_restrictions,
+    build_all_private_labels,
     get_max_rating_for_user,
     is_rating_allowed,
 )
@@ -682,6 +683,7 @@ __all__ = [
     "MOVIE_RATING_HIERARCHY",
     "TV_RATING_HIERARCHY",
     "apply_user_label_restrictions",
+    "build_all_private_labels",
     "get_user_specific_connection",
     "find_plex_movie",
     "extract_genres",

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.13.2"
+__version__ = "2.14.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -34,7 +34,7 @@ from this module, or the two would form an import cycle.
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Mapping, Optional, Sequence, Union
 
 import requests
 from plexapi.myplex import MyPlexAccount
@@ -105,9 +105,63 @@ def is_rating_allowed(content_rating: Optional[str], max_rating: Optional[str], 
         return True
 
 
+def _as_label_list(labels: Union[str, Sequence[str]]) -> List[str]:
+    """One label or many - callers predating #332 pass a bare string."""
+    if isinstance(labels, str):
+        return [labels]
+    return [str(x) for x in labels if x]
+
+
+def build_all_private_labels(config: Dict, users: List[str], append_usernames: bool = True) -> Dict[str, List[str]]:
+    """
+    Every PrivateCollection_* label a user owns, across every library.
+
+    A user does not have one private label, they have one PER LIBRARY:
+    recommenders/base.py roots the label at
+    "PrivateCollection" + _library_suffix_for_label(), and that suffix is
+    "_<library_id>" on any install with more than one library of a given
+    media type. The movie run therefore knows only the movie labels and
+    the TV run only the TV labels.
+
+    That mattered because apply_user_label_restrictions() writes BOTH
+    filterMovies and filterTelevision on every call. With each media type
+    supplying only its own labels, the later run (TV, which follows
+    movies) overwrote the movie exclusions in both fields - so on a
+    multi-library install only the last-written media type's labels
+    survived and movie collections stayed visible to everyone (#332).
+
+    Enumerating every library here means the value written is complete
+    and identical whichever run performs the write.
+    """
+    from .config import MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV, get_libraries_for_media_type
+    from .labels import build_label_name
+
+    bases: List[str] = []
+    for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV):
+        libraries = get_libraries_for_media_type(config, media_type)
+        if len(libraries) > 1:
+            # Mirrors _library_suffix_for_label(): only a genuine
+            # multi-library media type gets qualified labels, so
+            # single-library installs keep exactly today's names.
+            bases.extend(f"PrivateCollection_{lib['id']}" for lib in libraries)
+        else:
+            bases.append("PrivateCollection")
+
+    labels: Dict[str, List[str]] = {}
+    for user in users:
+        seen: List[str] = []
+        for base in bases:
+            label = build_label_name(base, users, user, append_usernames)
+            if label not in seen:
+                seen.append(label)
+        labels[user] = seen
+    return labels
+
+
 def apply_user_label_restrictions(
     config: Dict,
-    all_user_private_labels: Dict[str, str],
+    all_user_private_labels: Mapping[str, Union[str, Sequence[str]]],
+    restrict_unconfigured_users: bool = True,
 ) -> bool:
     """
     Apply exclude restrictions so each user's collection is excluded from
@@ -190,8 +244,21 @@ def apply_user_label_restrictions(
 
         logger.debug(f"Plex users available for restrictions: {list(plex_users.keys())}")
 
+        # #332: restrict every user on the server, not only those listed
+        # in config. A Plex user curatarr does not generate for still sees
+        # everyone else's PrivateCollection_* collections cluttering their
+        # browse - which is the whole condition this feature exists to
+        # prevent, and it is the admin's library either way. They own no
+        # labels themselves, so they simply get all of them excluded.
+        targets = dict(all_user_private_labels)
+        if restrict_unconfigured_users:
+            configured = {u.lower() for u in all_user_private_labels}
+            for name in plex_users:
+                if name and name.lower() not in configured and name.lower() != admin_username:
+                    targets.setdefault(name, [])
+
         all_success = True
-        for username, _user_private_label in all_user_private_labels.items():
+        for username, _user_private_label in targets.items():
             # Admin can't have restrictions
             if username.lower() == admin_username:
                 logger.debug(f"Skipping restrictions for admin user: {username}")
@@ -216,12 +283,17 @@ def apply_user_label_restrictions(
                 continue
 
             # Labels to EXCLUDE: every OTHER user's already-built
-            # PrivateCollection_* label (on collections), never
+            # PrivateCollection_* labels (on collections), never
             # Recommended_* (on items) - this hides other users'
             # collections but keeps items visible to everyone. Used as
             # given, not derived here (#261 - see this function's docstring).
+            # A user owns one label PER LIBRARY, so this flattens
+            # (#332 - see build_all_private_labels).
             exclude_labels = [
-                private_label for u, private_label in all_user_private_labels.items() if u.lower() != username.lower()
+                label
+                for u, labels in all_user_private_labels.items()
+                if u.lower() != username.lower()
+                for label in _as_label_list(labels)
             ]
 
             if not exclude_labels:


### PR DESCRIPTION
Closes #332. Both reported claims verified against the code and covered by tests.

## Claim 1 — movie labels overwritten by the TV run

`apply_user_label_restrictions()` writes **both** `filterMovies` and `filterTelevision` on every call, but each media type's run supplied only *its own* labels.

A `PrivateCollection_*` label is **per-library**: `recommenders/base.py` roots it at `"PrivateCollection" + _library_suffix_for_label()`, which qualifies by library id whenever a media type has more than one library. So the movie run knew only movie labels, the TV run only TV labels — and TV runs last, replacing the movie exclusions in both fields.

**Single-library installs never saw this**: both media types produce the identical unqualified label, so the second write was a no-op. It affects multi-library installs only, which is how it was reported.

`build_all_private_labels()` now enumerates every library of every media type up front, so the value written is complete and identical whichever run performs the write. Single-library naming is unchanged.

## Claim 2 — unconfigured users got no restriction at all

The loop only iterated configured users, so any other Plex user on the server saw every `PrivateCollection_*` collection in browse and search — the exact condition this feature exists to prevent. Restrictions now cover every non-admin user the server reports; they own no labels, so they simply get all of them excluded. `restrict_unconfigured_users=False` opts out.

Still **UI-level separation, not an access-control boundary** — see `utils/plex_policy.py`'s module docstring for the enumeration caveat.

## Verified

- 10 new tests covering both claims, including the multi-library case that reproduces claim 1 and the unconfigured-user case for claim 2
- `apply_user_label_restrictions()` accepts a single label *or* a sequence per user, so callers predating this are unaffected (covered by a test)
- mypy caught a `Dict` invariance issue on the new signature; corrected to `Mapping`
- 3195 tests pass, ruff + mypy clean

## Note

`tests/test_trakt_auth.py::TestTraktAuthStdoutNotBuffered::test_device_code_visible_before_poll_completes_when_not_a_tty` is flaky under full-suite load — it passes in isolation and on an unmodified tree. Pre-existing, unrelated to this change, but worth a look separately.