### PR TITLE
Lower the calibration sample threshold and stop reporting unused dimensions (2.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.14.2] - 2026-08-03
+
+### Fixed
+
+- **2.13.2's minimum-sample guard was set too high and regressed a real profile.** The threshold of 25 was derived entirely from TV data (samples of 2 to 17) and never checked against the movie case it would also govern. A user with **21** certificate samples had their certificate dimension silently dropped, leaving only genre calibration - which does not track audience at all - and their collection went from **14% to 22% G/PG against a 9% profile**.
+
+  Lowered to **10**. 21 noisy samples across ~5 certificate buckets is plainly better than calibrating on an attribute that cannot express audience; two samples is not. Re-measured after the change: that user's PG share is **12.0% against a 9.1% profile**, PG-13 62.0% against 63.6%, R 26.0% against 27.3%, with no G at all. All six configured users now sit between 0.95x and 1.32x of their own viewing rate.
+
+- **A degenerate single-category target is now rejected regardless of sample count.** This is the failure the original guard was really aimed at - a user whose two watched shows were both TV-G would have had their entire collection driven to 100% TV-G - and it is ruinous at *any* sample size, so a count threshold was the wrong instrument for it. Checked independently via `CALIBRATION_MIN_TARGET_CATEGORIES`.
+
+- **The calibration report printed dimensions that were never applied.** When the guard dropped the certificate dimension, the run still emitted its profile-vs-collection rows, so a genre-only run was indistinguishable from a genre+certificate one in the logs - the same "looks like success" failure the guard exists to prevent, reintroduced by the guard itself. Only dimensions that actually ran are reported now.
+
 ## [2.14.1] - 2026-08-03
 
 ### Fixed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1452,13 +1452,22 @@ class BaseRecommender(ABC):
             calibration_strength=self.calibration_strength,
         )
 
-        if selected:
-            dims = "+".join(d.name for d in dimensions)
+        # Report ONLY the dimensions that were actually applied. Printing a
+        # dimension that calibrate_multi() dropped made a genre-only run
+        # look like a genre+certificate one - the same "looks like
+        # success" failure this guard exists to prevent, reintroduced by
+        # the guard itself.
+        applied = [d for d in dimensions if is_sufficiently_sampled(d)]
+        applied_names = {d.name for d in applied}
+
+        if selected and applied:
+            dims = "+".join(d.name for d in applied)
             strength = self.calibration_strength
             print(f"{GREEN}Calibrated collection to profile {dims} mix (strength {strength:.2f}){RESET}")
-            for genre, target, actual in calibration_report(target_distribution, [_genres(e) for e in selected]):
-                print(f"  {genre:<20} profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
-            if cert_target:
+            if "genre" in applied_names:
+                for genre, target, actual in calibration_report(target_distribution, [_genres(e) for e in selected]):
+                    print(f"  {genre:<20} profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
+            if "certificate" in applied_names:
                 for cert, target, actual in calibration_report(cert_target, [_certificate(e) for e in selected]):
                     print(f"  [{cert:<18}] profile {target * 100:5.1f}%  ->  collection {actual * 100:5.1f}%")
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2646,9 +2646,11 @@ class TestCalibrationCannotActGuard:
         recommender = _make_recommender()
         recommender.calibration_strength = strength
         recommender.min_similarity = 0.10
-        recommender.watched_data_counters = {"genres": {"thriller": 50.0}}
-        # Well-sampled on purpose: this class tests the candidates-vs-slots
-        # guard, not the profile-sample guard.
+        # Multi-category and well-sampled on purpose: this class tests the
+        # candidates-vs-slots guard, not the profile-sample or
+        # degenerate-target guards, both of which would otherwise skip
+        # calibration before it is reached.
+        recommender.watched_data_counters = {"genres": {"thriller": 50.0, "drama": 30.0}}
         recommender.watched_ids = set(range(9000, 9200))
         media_cache = Mock()
         media_cache.cache = {"movies": {str(i): {"genres": ["thriller"]} for i in range(n_candidates)}}

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -405,11 +405,33 @@ class TestMinimumProfileSample:
 
     @staticmethod
     def _dim(sample):
-        return CalibrationDimension("genre", {"a": 1.0}, lambda i: i["genres"], 1.0, sample)
+        # Multi-category on purpose: a single-category target is rejected
+        # independently of sample size (see test_degenerate_target_*).
+        return CalibrationDimension("genre", {"a": 0.6, "b": 0.4}, lambda i: i["genres"], 1.0, sample)
 
     def test_unstated_sample_is_allowed(self):
         """Callers predating the check must be unaffected."""
-        assert is_sufficiently_sampled(CalibrationDimension("g", {"a": 1.0}, lambda i: []))
+        assert is_sufficiently_sampled(CalibrationDimension("g", {"a": 0.5, "b": 0.5}, lambda i: []))
+
+    def test_degenerate_single_category_target_is_rejected(self):
+        """
+        Ruinous at ANY sample count: calibrating to a one-value target
+        drives the whole collection onto that value. The real case was a
+        user whose two watched shows were both TV-G.
+        """
+        assert not is_sufficiently_sampled(CalibrationDimension("c", {"TV-G": 1.0}, lambda i: [], 1.0, 2))
+        assert not is_sufficiently_sampled(CalibrationDimension("c", {"R": 1.0}, lambda i: [], 1.0, 9999))
+
+    def test_real_world_21_sample_certificate_target_is_allowed(self):
+        """
+        Regression: an earlier threshold of 25 blocked a 21-sample
+        certificate profile, and that user's collection went from 14% to
+        22% G/PG against a 9% profile because only genre calibration ran.
+        21 noisy samples beat calibrating on an attribute that does not
+        track audience at all.
+        """
+        target = {"G": 0.05, "PG": 0.05, "PG-13": 0.6, "R": 0.3}
+        assert is_sufficiently_sampled(CalibrationDimension("certificate", target, lambda i: [], 1.0, 21))
 
     def test_tiny_sample_is_rejected(self):
         assert not is_sufficiently_sampled(self._dim(2))
@@ -428,8 +450,8 @@ class TestMinimumProfileSample:
         """
         items = [{"title": f"kid{i}", "genres": ["family"], "score": 0.4} for i in range(20)]
         items += [{"title": f"adult{i}", "genres": ["thriller"], "score": 0.9} for i in range(20)]
-        # A target insisting the collection be all-family, from 2 samples.
-        thin = CalibrationDimension("genre", {"family": 1.0}, lambda i: i["genres"], 1.0, 2)
+        # A target overwhelmingly favouring family, from 2 samples.
+        thin = CalibrationDimension("genre", {"family": 0.95, "thriller": 0.05}, lambda i: i["genres"], 1.0, 2)
         sel = calibrate_multi(items, 10, lambda i: i["score"], [thin], 0.5)
         assert all(i["genres"] == ["thriller"] for i in sel), "an untrustworthy target steered the collection"
 
@@ -445,8 +467,10 @@ class TestMinimumProfileSample:
     def test_mixed_sampling_keeps_only_the_trustworthy_dimension(self):
         items = [{"g": ["family"], "c": "G", "score": 0.5} for _ in range(20)]
         items += [{"g": ["thriller"], "c": "R", "score": 0.5} for _ in range(20)]
-        good = CalibrationDimension("genre", {"thriller": 1.0}, lambda i: i["g"], 1.0, 200)
-        thin = CalibrationDimension("certificate", {"G": 1.0}, lambda i: [i["c"]], 1.0, 2)
+        # Both multi-category, so only the SAMPLE SIZE differs between
+        # them - otherwise the degenerate-target check would reject both.
+        good = CalibrationDimension("genre", {"thriller": 0.9, "family": 0.1}, lambda i: i["g"], 1.0, 200)
+        thin = CalibrationDimension("certificate", {"G": 0.9, "R": 0.1}, lambda i: [i["c"]], 1.0, 2)
         sel = calibrate_multi(items, 10, lambda i: i["score"], [good, thin], 0.5)
         # Genre (trusted, wants thriller) must win; certificate (2 samples,
         # wants G) must be ignored entirely.

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -41,6 +41,7 @@ from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Se
 from utils.config import (
     CALIBRATION_DIVERGENCE_SCALE,
     CALIBRATION_MIN_PROFILE_SAMPLE,
+    CALIBRATION_MIN_TARGET_CATEGORIES,
     CALIBRATION_SMOOTHING_ALPHA,
     DEFAULT_CALIBRATION_STRENGTH,
 )
@@ -336,9 +337,20 @@ def is_sufficiently_sampled(
     of two watched titles yields a target that would drag an entire
     collection onto those two titles' attributes.
 
-    A dimension that does not state its sample size is assumed fine, so
-    that callers predating this check are unaffected.
+    Two independent rejections:
+      - too few samples behind the target, and
+      - a target spanning a single category, which is ruinous at ANY
+        sample count because calibrating to it drives the collection to
+        100% of that one value.
+
+    A dimension that does not state its sample size is assumed
+    sufficiently sampled, so callers predating this check are unaffected -
+    but the degenerate-target check still applies to them, since it does
+    not depend on knowing the sample size.
     """
+    if len(dimension.target) < CALIBRATION_MIN_TARGET_CATEGORIES:
+        # Degenerate: every candidate would be pushed onto one value.
+        return False
     return dimension.sample_size is None or dimension.sample_size >= minimum
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.14.1"
+__version__ = "2.14.2"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item
@@ -160,19 +160,24 @@ CALIBRATION_DIVERGENCE_SCALE = 100.0
 # Smallest profile a calibration target may be built from.
 #
 # Calibration reproduces whatever distribution it is handed, faithfully.
-# Handed a target derived from two watched titles it will drive a whole
-# collection toward those two. Measured on a real server: four of six
-# users had fewer than seven watched TV shows, one had exactly two (both
-# TV-G) - calibrating that profile would have pushed their collection to
-# ~100% TV-G off a two-item sample. The movie profiles where calibration
-# demonstrably works range from 47 to 239 watched titles.
+# The catastrophic case is a target derived from a couple of titles: one
+# user had two watched shows, both TV-G, and calibrating that would have
+# driven their whole collection to ~100% TV-G.
 #
-# 25 sits above the largest sample we could not read (17) and well below
-# the smallest that works (47). Under-sampled dimensions are skipped, not
-# silently trusted - a wrong target is worse than no target, because
-# ranking by score alone at least degrades to "most similar", whereas a
-# bad target actively pulls the collection somewhere the user never was.
-CALIBRATION_MIN_PROFILE_SAMPLE = 25
+# 10 rather than a larger number, because the cost of blocking a usable
+# target is real and was measured: a user with 21 certificate samples had
+# certificate calibration disabled by an earlier threshold of 25, which
+# regressed their collection from 14% to 22% G/PG against a 9% profile.
+# 21 samples over ~5 certificate buckets is noisy but plainly better than
+# the alternative of calibrating on genre alone, which does not track
+# audience at all. Two samples is not.
+CALIBRATION_MIN_PROFILE_SAMPLE = 10
+
+# A target spanning a single category is degenerate no matter how many
+# samples produced it: calibrating to it drives the collection to 100% of
+# that one value. Checked independently of the sample count, since a
+# small homogeneous profile can clear the count and still be ruinous.
+CALIBRATION_MIN_TARGET_CATEGORIES = 2
 
 CALIBRATION_GENRE_WEIGHT = 1.0
 CALIBRATION_CERTIFICATE_WEIGHT = 1.0


### PR DESCRIPTION
2.13.2's minimum-sample guard was derived **entirely from TV data** (samples of 2–17) and never checked against the movie case it also governs. At 25 it silently dropped the certificate dimension for a user with **21** certificate samples, leaving only genre calibration — which does not track audience at all.

That user's collection regressed **14% → 22% G/PG against a 9% profile**. My guard caused it.

## Three fixes

**1. Threshold 25 → 10.** Twenty-one noisy samples across ~5 certificate buckets beat calibrating on an attribute that cannot express audience. Two samples do not.

Re-measured after the change:

```
[PG]     profile  9.1%  ->  collection 12.0%     (was 18.0%)
[PG-13]  profile 63.6%  ->  collection 62.0%
[R]      profile 27.3%  ->  collection 26.0%
                                    (and no G at all)
```

All six configured users, measured against Plex:

| user | own | pool | delivered | vs own |
|---|---|---|---|---|
| jasonsmith523 | 13.7% | 37.1% | 16.0% | 1.17x |
| ericarutyunov | 41.0% | 25.2% | 42.0% | 1.02x |
| homehouse165 | 9.1% | 28.2% | 12.0% | **1.32x** (was 2.42x) |
| lynnsmith59 | 7.7% | 30.8% | 8.0% | 1.04x |
| nadiamorse | 23.1% | 29.1% | 22.0% | 0.95x |
| natasha4967 | 46.2% | 29.1% | 58.0% | 1.26x |

**2. Degenerate targets rejected at any sample count.** A single-category target is what the guard was really aimed at — two watched shows, both TV-G, would drive a collection to 100% TV-G — and it's ruinous at *any* sample size, so a count threshold was the wrong instrument. Now checked independently via `CALIBRATION_MIN_TARGET_CATEGORIES`.

**3. The report printed dimensions that never ran.** When the guard dropped the certificate dimension, the run still emitted its profile-vs-collection rows — so a genre-only run was indistinguishable from a genre+certificate one in the logs. That's the same "looks like success" failure the guard exists to prevent, reintroduced by the guard itself. Only applied dimensions are reported now.

3197 tests pass, ruff clean. Three test fixtures were using single-category targets and are now correctly rejected — fixed rather than weakened.