### PR TITLE
Expose Sonarr/Radarr global defaults in the web UI (2.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.15.0] - 2026-08-04
+
+### Added
+
+- **Sonarr and Radarr global defaults are now editable in the web UI (#339).** The Connections screen exposed only connection and sync-policy fields (`enabled`/`url`/`api_key`/`auto_sync`/`user_mode`/`plex_users`), so `root_folder`, `quality_profile`, `tag`, `monitor` and the rest could only be set by hand-editing `sonarr.yml`/`radarr.yml`. Those are the values every library inherits unless it overrides them individually - and per-library `arr` overrides were already editable on the Libraries screen - so the global layer was the one piece of the *arr integration with no UI at all.
+
+  Sonarr gains root folder, quality profile, tag, append-usernames, series type, season folders, monitor, monitor option and search-missing. Radarr gains root folder, quality profile, tag, append-usernames, minimum availability, monitor and search-for-movie.
+
+  `series_type`, `monitor_option` and `minimum_availability` are validated as choice sets rather than free text, so an invalid value is rejected at the form instead of being written and then failing mid-sync against a real Sonarr/Radarr.
+
+  **Writes are gated on the field actually being present in the submission.** A form that never rendered these fields - an older template, a scripted POST - leaves the stored values alone rather than writing `""` over a real root folder. An explicitly emptied box still clears the value. This was not hypothetical: the first implementation blanked a stored `root_folder`, which the existing YAML round-trip test caught before it could ship.
+
 ## [2.14.2] - 2026-08-03
 
 ### Fixed

--- a/tests/test_web_config_connections.py
+++ b/tests/test_web_config_connections.py
@@ -443,3 +443,122 @@ class TestConnectionsTestEndpoint:
         # absent (empty) after a failed one.
         sonarr = _read_yaml(root, "sonarr")
         assert sonarr == {}
+
+
+class TestArrGlobalDefaults:
+    """
+    #339: sonarr.yml/radarr.yml global defaults (root_folder,
+    quality_profile, tag, monitor...) were only editable by hand - the
+    Connections screen exposed connection and sync-policy fields only.
+    These are the values every library that does not override them
+    inherits, so being unable to set them made the *arr integration
+    unusable from the UI.
+    """
+
+    def test_saves_sonarr_defaults(self, client):
+        c, _app, root = client
+        form = dict(VALID_FORM)
+        form.update(
+            {
+                "sonarr_root_folder": "/data/tv",
+                "sonarr_quality_profile": "HD-1080p",
+                "sonarr_tag": "Curatarr",
+                "sonarr_series_type": "anime",
+                "sonarr_season_folder": "on",
+                "sonarr_monitor": "on",
+                "sonarr_monitor_option": "future",
+                "sonarr_search_missing": "on",
+            }
+        )
+        assert c.post("/config/connections", data=form).status_code == 303
+
+        sonarr = _read_yaml(root, "sonarr")
+        assert sonarr["root_folder"] == "/data/tv"
+        assert sonarr["quality_profile"] == "HD-1080p"
+        assert sonarr["tag"] == "Curatarr"
+        assert sonarr["series_type"] == "anime"
+        assert sonarr["season_folder"] is True
+        assert sonarr["monitor"] is True
+        assert sonarr["monitor_option"] == "future"
+        assert sonarr["search_missing"] is True
+
+    def test_saves_radarr_defaults(self, client):
+        c, _app, root = client
+        form = dict(VALID_FORM)
+        form.update(
+            {
+                "radarr_root_folder": "/data/movies",
+                "radarr_quality_profile": "Ultra-HD",
+                "radarr_tag": "Curatarr",
+                "radarr_minimum_availability": "inCinemas",
+                "radarr_monitor": "on",
+            }
+        )
+        assert c.post("/config/connections", data=form).status_code == 303
+
+        radarr = _read_yaml(root, "radarr")
+        assert radarr["root_folder"] == "/data/movies"
+        assert radarr["quality_profile"] == "Ultra-HD"
+        assert radarr["minimum_availability"] == "inCinemas"
+        assert radarr["monitor"] is True
+        assert radarr["search_for_movie"] is False  # unchecked box
+
+    def test_a_form_without_these_fields_does_not_blank_stored_values(self, client):
+        """
+        The data-loss case, caught by the round-trip test while building
+        this. An older template or a scripted POST that omits the
+        defaults must leave them alone rather than writing "" over a real
+        root_folder.
+        """
+        c, _app, root = client
+        seeded = dict(VALID_FORM)
+        seeded.update({"sonarr_root_folder": "/data/tv", "sonarr_quality_profile": "HD-1080p"})
+        c.post("/config/connections", data=seeded)
+        assert _read_yaml(root, "sonarr")["root_folder"] == "/data/tv"
+
+        # VALID_FORM carries no *_root_folder key at all.
+        c.post("/config/connections", data=VALID_FORM)
+        assert _read_yaml(root, "sonarr")["root_folder"] == "/data/tv", "stored root_folder was blanked"
+
+    def test_blank_submitted_value_does_clear_it(self, client):
+        """Presence gates the write; an explicitly emptied box still clears."""
+        c, _app, root = client
+        seeded = dict(VALID_FORM)
+        seeded.update({"sonarr_root_folder": "/data/tv"})
+        c.post("/config/connections", data=seeded)
+
+        cleared = dict(VALID_FORM)
+        cleared.update({"sonarr_root_folder": ""})
+        c.post("/config/connections", data=cleared)
+        assert _read_yaml(root, "sonarr")["root_folder"] == ""
+
+    def test_invalid_choice_is_rejected_not_written(self, client):
+        """An invalid series_type would fail mid-sync against a real
+        Sonarr; reject it at the form instead."""
+        c, _app, root = client
+        form = dict(VALID_FORM)
+        form.update({"sonarr_root_folder": "/data/tv", "sonarr_series_type": "not-a-type"})
+        resp = c.post("/config/connections", data=form)
+        # 400 + re-render, matching this screen's existing convention for
+        # an invalid choice (see test_invalid_user_mode_rejected).
+        assert resp.status_code == 400
+        assert _read_yaml(root, "sonarr").get("series_type") != "not-a-type"
+
+    def test_invalid_minimum_availability_is_rejected(self, client):
+        c, _app, root = client
+        form = dict(VALID_FORM)
+        form.update({"radarr_root_folder": "/data/movies", "radarr_minimum_availability": "whenever"})
+        assert c.post("/config/connections", data=form).status_code == 400
+        assert _read_yaml(root, "radarr").get("minimum_availability") != "whenever"
+
+    def test_defaults_are_rendered_on_the_page(self, client):
+        c, _app, _root = client
+        body = c.get("/config/connections").get_data(as_text=True)
+        for field in (
+            "sonarr_root_folder",
+            "sonarr_quality_profile",
+            "sonarr_monitor_option",
+            "radarr_root_folder",
+            "radarr_minimum_availability",
+        ):
+            assert field in body, f"{field} missing from the Connections page"

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.14.2"
+__version__ = "2.15.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/web/config_connections.py
+++ b/web/config_connections.py
@@ -25,6 +25,9 @@ from flask import jsonify, redirect, render_template, request, url_for
 from ruamel.yaml.comments import CommentedMap
 
 from .config_io import (
+    MINIMUM_AVAILABILITY_CHOICES,
+    MONITOR_OPTION_CHOICES,
+    SERIES_TYPE_CHOICES,
     USER_MODE_CHOICES,
     commit_modules,
     ensure_section,
@@ -236,6 +239,17 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
             "auto_sync": pick("sonarr", "auto_sync", bool(sonarr.get("auto_sync", False))),
             "user_mode": pick("sonarr", "user_mode", sonarr.get("user_mode", "mapping")),
             "plex_users": pick("sonarr", "plex_users", format_csv_list(sonarr.get("plex_users"))),
+            # Global defaults (#339) - a library's own arr: block overrides
+            # these per field; anything it omits falls back to here.
+            "root_folder": pick("sonarr", "root_folder", sonarr.get("root_folder", "")),
+            "quality_profile": pick("sonarr", "quality_profile", sonarr.get("quality_profile", "")),
+            "tag": pick("sonarr", "tag", sonarr.get("tag", "")),
+            "append_usernames": pick("sonarr", "append_usernames", bool(sonarr.get("append_usernames", False))),
+            "series_type": pick("sonarr", "series_type", sonarr.get("series_type", "standard")),
+            "season_folder": pick("sonarr", "season_folder", bool(sonarr.get("season_folder", True))),
+            "monitor": pick("sonarr", "monitor", bool(sonarr.get("monitor", False))),
+            "monitor_option": pick("sonarr", "monitor_option", sonarr.get("monitor_option", "none")),
+            "search_missing": pick("sonarr", "search_missing", bool(sonarr.get("search_missing", False))),
         },
         "radarr": {
             "enabled": pick("radarr", "enabled", bool(radarr.get("enabled", False))),
@@ -250,6 +264,16 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
             "auto_sync": pick("radarr", "auto_sync", bool(radarr.get("auto_sync", False))),
             "user_mode": pick("radarr", "user_mode", radarr.get("user_mode", "mapping")),
             "plex_users": pick("radarr", "plex_users", format_csv_list(radarr.get("plex_users"))),
+            # Global defaults (#339) - see the sonarr block above.
+            "root_folder": pick("radarr", "root_folder", radarr.get("root_folder", "")),
+            "quality_profile": pick("radarr", "quality_profile", radarr.get("quality_profile", "")),
+            "tag": pick("radarr", "tag", radarr.get("tag", "")),
+            "append_usernames": pick("radarr", "append_usernames", bool(radarr.get("append_usernames", False))),
+            "minimum_availability": pick(
+                "radarr", "minimum_availability", radarr.get("minimum_availability", "released")
+            ),
+            "monitor": pick("radarr", "monitor", bool(radarr.get("monitor", False))),
+            "search_for_movie": pick("radarr", "search_for_movie", bool(radarr.get("search_for_movie", False))),
         },
         "trakt": {
             "enabled": pick("trakt", "enabled", bool(trakt.get("enabled", False))),
@@ -281,6 +305,9 @@ def _connections_view(data: Dict[str, CommentedMap], overrides: Optional[Dict] =
             "frozen": getattr(sys, "frozen", False),
         },
         "user_mode_choices": USER_MODE_CHOICES,
+        "series_type_choices": SERIES_TYPE_CHOICES,
+        "monitor_option_choices": MONITOR_OPTION_CHOICES,
+        "minimum_availability_choices": MINIMUM_AVAILABILITY_CHOICES,
     }
 
 
@@ -314,6 +341,25 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
     radarr_user_mode = form.get("radarr_user_mode", "mapping")
     validate_choice(radarr_user_mode, "radarr_user_mode", errors, USER_MODE_CHOICES)
 
+    # Global *arr defaults (#339). Validated as choices rather than free
+    # text so an invalid value is rejected here instead of being written
+    # and then failing mid-sync against a real Sonarr/Radarr.
+    # Presence, not value. A form that never rendered these fields (an
+    # older template, a scripted POST) must not blank a stored
+    # root_folder/quality_profile - writing "" over a real path is silent
+    # data loss, which the round-trip test caught.
+    sonarr_has_defaults = "sonarr_root_folder" in form
+    radarr_has_defaults = "radarr_root_folder" in form
+
+    sonarr_series_type = form.get("sonarr_series_type", "standard")
+    validate_choice(sonarr_series_type, "sonarr_series_type", errors, SERIES_TYPE_CHOICES)
+    sonarr_monitor_option = form.get("sonarr_monitor_option", "none")
+    validate_choice(sonarr_monitor_option, "sonarr_monitor_option", errors, MONITOR_OPTION_CHOICES)
+    radarr_minimum_availability = form.get("radarr_minimum_availability", "released")
+    validate_choice(
+        radarr_minimum_availability, "radarr_minimum_availability", errors, MINIMUM_AVAILABILITY_CHOICES
+    )
+
     trakt_enabled = flag("trakt_enabled")
     trakt_client_id = form.get("trakt_client_id", "").strip()
     if trakt_enabled:
@@ -341,6 +387,16 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
             "auto_sync": flag("sonarr_auto_sync"),
             "user_mode": sonarr_user_mode,
             "plex_users": format_csv_list(parse_csv_list(form.get("sonarr_plex_users", ""))),
+            "has_defaults": sonarr_has_defaults,
+            "root_folder": form.get("sonarr_root_folder", "").strip(),
+            "quality_profile": form.get("sonarr_quality_profile", "").strip(),
+            "tag": form.get("sonarr_tag", "").strip(),
+            "append_usernames": flag("sonarr_append_usernames"),
+            "series_type": sonarr_series_type,
+            "season_folder": flag("sonarr_season_folder"),
+            "monitor": flag("sonarr_monitor"),
+            "monitor_option": sonarr_monitor_option,
+            "search_missing": flag("sonarr_search_missing"),
         },
         "radarr": {
             "enabled": radarr_enabled,
@@ -349,6 +405,14 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
             "auto_sync": flag("radarr_auto_sync"),
             "user_mode": radarr_user_mode,
             "plex_users": format_csv_list(parse_csv_list(form.get("radarr_plex_users", ""))),
+            "has_defaults": radarr_has_defaults,
+            "root_folder": form.get("radarr_root_folder", "").strip(),
+            "quality_profile": form.get("radarr_quality_profile", "").strip(),
+            "tag": form.get("radarr_tag", "").strip(),
+            "append_usernames": flag("radarr_append_usernames"),
+            "minimum_availability": radarr_minimum_availability,
+            "monitor": flag("radarr_monitor"),
+            "search_for_movie": flag("radarr_search_for_movie"),
         },
         "trakt": {
             "enabled": trakt_enabled,
@@ -389,6 +453,19 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
     sonarr["auto_sync"] = parsed["sonarr"]["auto_sync"]
     sonarr["user_mode"] = parsed["sonarr"]["user_mode"]
     sonarr["plex_users"] = parse_csv_list(parsed["sonarr"]["plex_users"])
+    if parsed["sonarr"].get("has_defaults"):
+        for key in (
+            "root_folder",
+            "quality_profile",
+            "tag",
+            "append_usernames",
+            "series_type",
+            "season_folder",
+            "monitor",
+            "monitor_option",
+            "search_missing",
+        ):
+            sonarr[key] = parsed["sonarr"][key]
 
     radarr = data["radarr"]
     radarr["enabled"] = parsed["radarr"]["enabled"]
@@ -397,6 +474,17 @@ def _apply_connections(project_root: str, data: Dict[str, CommentedMap], parsed:
     radarr["auto_sync"] = parsed["radarr"]["auto_sync"]
     radarr["user_mode"] = parsed["radarr"]["user_mode"]
     radarr["plex_users"] = parse_csv_list(parsed["radarr"]["plex_users"])
+    if parsed["radarr"].get("has_defaults"):
+        for key in (
+            "root_folder",
+            "quality_profile",
+            "tag",
+            "append_usernames",
+            "minimum_availability",
+            "monitor",
+            "search_for_movie",
+        ):
+            radarr[key] = parsed["radarr"][key]
 
     trakt = data["trakt"]
     trakt["enabled"] = parsed["trakt"]["enabled"]

--- a/web/config_connections.py
+++ b/web/config_connections.py
@@ -356,9 +356,7 @@ def _parse_connections_form(form, errors: Dict[str, str]) -> Dict:
     sonarr_monitor_option = form.get("sonarr_monitor_option", "none")
     validate_choice(sonarr_monitor_option, "sonarr_monitor_option", errors, MONITOR_OPTION_CHOICES)
     radarr_minimum_availability = form.get("radarr_minimum_availability", "released")
-    validate_choice(
-        radarr_minimum_availability, "radarr_minimum_availability", errors, MINIMUM_AVAILABILITY_CHOICES
-    )
+    validate_choice(radarr_minimum_availability, "radarr_minimum_availability", errors, MINIMUM_AVAILABILITY_CHOICES)
 
     trakt_enabled = flag("trakt_enabled")
     trakt_client_id = form.get("trakt_client_id", "").strip()

--- a/web/config_io.py
+++ b/web/config_io.py
@@ -40,6 +40,26 @@ logger = logging.getLogger("curatarr")
 # calls read from.
 USER_MODE_CHOICES = ("mapping", "per_user", "combined")
 
+# Global *arr defaults (#339). These live in sonarr.yml/radarr.yml and are
+# what a library's own `arr:` block overrides field by field - so the
+# global value is what applies to every library that does not override it,
+# which until now could only be edited by hand. Choice sets mirror what
+# Sonarr/Radarr themselves accept; anything outside them is rejected at
+# validation rather than written and later failing mid-sync.
+SERIES_TYPE_CHOICES = ("standard", "daily", "anime")
+MONITOR_OPTION_CHOICES = (
+    "none",
+    "all",
+    "future",
+    "missing",
+    "existing",
+    "pilot",
+    "firstSeason",
+    "lastSeason",
+    "latestSeason",
+)
+MINIMUM_AVAILABILITY_CHOICES = ("announced", "inCinemas", "released", "preDB")
+
 # Matches the plain-yaml.dump() formatting the rest of the codebase
 # already produces (utils/migrate_config.py, config.example.yml, etc.):
 # list items at the same column as their parent key, not indented an

--- a/web/templates/config_connections.html
+++ b/web/templates/config_connections.html
@@ -86,6 +86,42 @@
     <label>Plex users to sync (comma-separated)
       <input type="text" name="sonarr_plex_users" value="{{ sonarr.plex_users }}">
     </label>
+
+    <p class="muted">Defaults for added shows. A library with its own <code>arr</code> block on the
+      Libraries screen overrides these field by field; anything it leaves blank falls back here.</p>
+    <label>Root folder
+      <input type="text" name="sonarr_root_folder" value="{{ sonarr.root_folder }}" placeholder="/path/to/tv">
+    </label>
+    <label>Quality profile
+      <input type="text" name="sonarr_quality_profile" value="{{ sonarr.quality_profile }}" placeholder="HD-1080p">
+    </label>
+    <label>Tag
+      <input type="text" name="sonarr_tag" value="{{ sonarr.tag }}" placeholder="Curatarr">
+    </label>
+    <label><input type="checkbox" name="sonarr_append_usernames" {% if sonarr.append_usernames %}checked{% endif %}>
+      Append username to tag (e.g. Curatarr-Jason)</label>
+    <label>Series type
+      <select name="sonarr_series_type">
+        {% for choice in series_type_choices %}
+        <option value="{{ choice }}" {% if sonarr.series_type == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {{ field_error(errors, 'sonarr_series_type') }}
+    <label><input type="checkbox" name="sonarr_season_folder" {% if sonarr.season_folder %}checked{% endif %}>
+      Use season folders</label>
+    <label><input type="checkbox" name="sonarr_monitor" {% if sonarr.monitor %}checked{% endif %}>
+      Monitor added shows</label>
+    <label>Monitor option
+      <select name="sonarr_monitor_option">
+        {% for choice in monitor_option_choices %}
+        <option value="{{ choice }}" {% if sonarr.monitor_option == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {{ field_error(errors, 'sonarr_monitor_option') }}
+    <label><input type="checkbox" name="sonarr_search_missing" {% if sonarr.search_missing %}checked{% endif %}>
+      Search for missing episodes immediately</label>
   </fieldset>
 
   <fieldset>
@@ -115,6 +151,32 @@
     <label>Plex users to sync (comma-separated)
       <input type="text" name="radarr_plex_users" value="{{ radarr.plex_users }}">
     </label>
+
+    <p class="muted">Defaults for added movies. A library with its own <code>arr</code> block on the
+      Libraries screen overrides these field by field; anything it leaves blank falls back here.</p>
+    <label>Root folder
+      <input type="text" name="radarr_root_folder" value="{{ radarr.root_folder }}" placeholder="/path/to/movies">
+    </label>
+    <label>Quality profile
+      <input type="text" name="radarr_quality_profile" value="{{ radarr.quality_profile }}" placeholder="HD-1080p">
+    </label>
+    <label>Tag
+      <input type="text" name="radarr_tag" value="{{ radarr.tag }}" placeholder="Curatarr">
+    </label>
+    <label><input type="checkbox" name="radarr_append_usernames" {% if radarr.append_usernames %}checked{% endif %}>
+      Append username to tag (e.g. Curatarr-Jason)</label>
+    <label>Minimum availability
+      <select name="radarr_minimum_availability">
+        {% for choice in minimum_availability_choices %}
+        <option value="{{ choice }}" {% if radarr.minimum_availability == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {{ field_error(errors, 'radarr_minimum_availability') }}
+    <label><input type="checkbox" name="radarr_monitor" {% if radarr.monitor %}checked{% endif %}>
+      Monitor added movies</label>
+    <label><input type="checkbox" name="radarr_search_for_movie" {% if radarr.search_for_movie %}checked{% endif %}>
+      Search for movie immediately</label>
   </fieldset>
 
   <fieldset>


### PR DESCRIPTION
Closes #339.

The Connections screen exposed only connection and sync-policy fields (`enabled`, `url`, `api_key`, `auto_sync`, `user_mode`, `plex_users`). `root_folder`, `quality_profile`, `tag`, `monitor` and the rest could only be set by hand-editing `sonarr.yml`/`radarr.yml`.

Those are the values **every library inherits** unless it overrides them individually — and per-library `arr` overrides were already editable on the Libraries screen. So the global layer was the one part of the *arr integration with no UI at all.

## Added

**Sonarr** — root folder, quality profile, tag, append-usernames, series type, season folders, monitor, monitor option, search-missing

**Radarr** — root folder, quality profile, tag, append-usernames, minimum availability, monitor, search-for-movie

`series_type`, `monitor_option` and `minimum_availability` are validated as choice sets rather than free text, so an invalid value is rejected at the form (400 + re-render, matching this screen's existing convention) instead of being written and then failing mid-sync against a real instance.

## The part worth reviewing

**Writes are gated on the field being present in the submission.** A form that never rendered these fields — an older template, a scripted POST — leaves stored values alone rather than writing `""` over a real root folder. An explicitly emptied box still clears the value.

This was not hypothetical. The first implementation blanked a stored `root_folder`, and the existing YAML round-trip test caught it before it could ship. There's now a dedicated regression test for it.

## Verified

- 7 new tests: both services' round trips, the blanking case, explicit clearing, both invalid-choice rejections, and that the fields render
- Confirmed live against the running UI — all 16 inputs render and populate from the real `sonarr.yml`
- 3204 tests pass, ruff clean