### PR TITLE
Stop hiding users' own collections from themselves (2.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.15.1] - 2026-08-04
+
+### Fixed
+
+- **A user's own collection was being hidden from them (#340).** Regression introduced by 2.14.0's fix for #332, confirmed on a live server: every configured user's exclusion filter contained their OWN `PrivateCollection_*` label, so nobody could see their own recommendations.
+
+  Plex lists each user under up to three names - title, username and email - and the unconfigured-user coverage added in 2.14.0 iterated those name keys directly. Only one of the three matched the config key, so the other two were treated as separate, unconfigured users and had *every* label excluded, including that person's own. Whichever alias was written last won. Targets are now resolved to Plex user IDs first, so each user is exactly one target and their own label is always exempt.
+
+- **The same user was written up to three times per run**, for the same reason. One PUT per user now.
+
+- **Movie and TV labels were merged into both filters.** 2.14.0 fixed #332 by building the union of every library's labels and writing it to both `filterMovies` and `filterTelevision`. That was cruder than needed: Plex applies `filterMovies` to movie libraries and `filterTelevision` to television ones, so a label from the other kind can never match there. The two sets are now kept separate, and `build_all_private_labels()` returns `{user: {"movie": [...], "tv": [...]}}`.
+
+- **Restrictions are only written when they actually change.** Every run re-PUT an identical filter for every user. The current filters are already present in the `/api/users` response used to resolve IDs, so they are compared first and an unchanged user is skipped.
+
+- **A single configured user no longer short-circuits the whole path.** The `len(...) <= 1` guard predated #332's unconfigured-user coverage and silently disabled it for single-user installs - one configured user still has a collection that every other Plex user on the server should not see. The short-circuit now applies only when `restrict_unconfigured_users` is off.
+
+### Notes
+
+- `apply_user_label_restrictions()` still accepts a bare string or a flat sequence per user; neither is media-type aware, so both apply to both filters.
+
 ## [2.15.0] - 2026-08-04
 
 ### Added

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2810,9 +2810,11 @@ class TestManagePlexLabelsFullFlow:
         all_user_private_labels = mock_apply.call_args[0][1]
         # A user owns one private label PER LIBRARY (#332), so this is a
         # list even on a single-library install.
+        # Per media type (#340): filterMovies and filterTelevision are
+        # separate Plex filters and must not receive each other's labels.
         assert all_user_private_labels == {
-            "alice": ["PrivateCollection_alice"],
-            "bob": ["PrivateCollection_bob"],
+            "alice": {"movie": ["PrivateCollection_alice"], "tv": ["PrivateCollection_alice"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
         }
 
     @patch("recommenders.base.get_max_rating_for_user", return_value="PG-13")
@@ -2898,8 +2900,8 @@ class TestPrivateCollectionsAppendUsernames:
         assert result is True
         mock_apply.assert_called_once()
         assert mock_apply.call_args[0][1] == {
-            "alice": ["PrivateCollection_alice"],
-            "bob": ["PrivateCollection_bob"],
+            "alice": {"movie": ["PrivateCollection_alice"], "tv": ["PrivateCollection_alice"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
         }
 
     @patch("recommenders.base.apply_user_label_restrictions")
@@ -2916,7 +2918,7 @@ class TestPrivateCollectionsAppendUsernames:
 
         assert result is True
         mock_apply.assert_called_once()
-        assert mock_apply.call_args[0][1] == {"alice": ["PrivateCollection"]}
+        assert mock_apply.call_args[0][1] == {"alice": {"movie": ["PrivateCollection"], "tv": ["PrivateCollection"]}}
 
     @patch("recommenders.base.log_warning")
     @patch("recommenders.base.apply_user_label_restrictions")

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -2688,19 +2688,33 @@ class TestApplyUserLabelRestrictions:
         assert result is False
 
     @patch("utils.plex_policy.MyPlexAccount")
-    def test_returns_true_for_single_user(self, mock_account_class):
-        """Test that single user returns True (nothing to hide)."""
-
+    def test_single_user_short_circuits_when_not_covering_the_server(self, mock_account_class):
+        """With unconfigured-user coverage off, one user hides from nobody."""
         config = {"plex": {"token": "test_token"}}
-
-        # Only one user - no restrictions needed
         all_user_labels = {"Jason": "Recommended_Jason"}
 
-        result = apply_user_label_restrictions(config, all_user_labels)
+        result = apply_user_label_restrictions(config, all_user_labels, restrict_unconfigured_users=False)
 
         assert result is True
-        # MyPlexAccount should not even be instantiated
+        # No work to do, so no network at all.
         mock_account_class.assert_not_called()
+
+    @patch("utils.plex_policy._capped_get")
+    @patch("utils.plex_policy.MyPlexAccount")
+    def test_single_user_still_proceeds_when_covering_the_server(self, mock_account_class, mock_get):
+        """
+        #332/#340: a lone CONFIGURED user still has a collection that
+        every OTHER Plex user on the server should not see, so the old
+        unconditional single-user short-circuit silently disabled that
+        coverage entirely.
+        """
+        config = {"plex": {"token": "test_token"}}
+        mock_account_class.return_value = Mock(username="admin")
+        mock_get.return_value = Mock(content=b"<MediaContainer/>", raise_for_status=Mock())
+
+        apply_user_label_restrictions(config, {"Jason": "Recommended_Jason"})
+
+        mock_account_class.assert_called()
 
     @patch("utils.plex_policy.MyPlexAccount")
     def test_returns_true_for_empty_labels(self, mock_account_class):
@@ -3038,8 +3052,10 @@ class TestBuildAllPrivateLabels:
 
         cfg = self._config(["movies"], ["tv-shows"])
         labels = build_all_private_labels(cfg, ["alice", "bob"], True)
-        assert labels["alice"] == ["PrivateCollection_alice"]
-        assert labels["bob"] == ["PrivateCollection_bob"]
+        # Per media type (#340) - filterMovies and filterTelevision are
+        # separate filters and must not receive each other's labels.
+        assert labels["alice"] == {"movie": ["PrivateCollection_alice"], "tv": ["PrivateCollection_alice"]}
+        assert labels["bob"]["movie"] == ["PrivateCollection_bob"]
 
     def test_multi_library_yields_a_label_per_library(self):
         """The reported case: movie labels must not be lost."""
@@ -3047,16 +3063,19 @@ class TestBuildAllPrivateLabels:
 
         cfg = self._config(["movies", "movies4k"], ["tv-shows"])
         labels = build_all_private_labels(cfg, ["alice"], True)
-        assert "PrivateCollection_movies_alice" in labels["alice"]
-        assert "PrivateCollection_movies4k_alice" in labels["alice"]
-        assert "PrivateCollection_alice" in labels["alice"], "single-library TV label missing"
+        assert "PrivateCollection_movies_alice" in labels["alice"]["movie"]
+        assert "PrivateCollection_movies4k_alice" in labels["alice"]["movie"]
+        assert labels["alice"]["tv"] == ["PrivateCollection_alice"], "single-library TV label missing"
+        # #340: movie labels must NOT leak into the television filter.
+        assert "PrivateCollection_movies_alice" not in labels["alice"]["tv"]
 
     def test_no_duplicate_labels(self):
         from utils.plex_policy import build_all_private_labels
 
         cfg = self._config(["movies"], ["tv-shows"])
         labels = build_all_private_labels(cfg, ["alice"], True)
-        assert len(labels["alice"]) == len(set(labels["alice"]))
+        for media_labels in labels["alice"].values():
+            assert len(media_labels) == len(set(media_labels))
 
     def test_covers_every_user(self):
         from utils.plex_policy import build_all_private_labels
@@ -3146,3 +3165,108 @@ class TestApplyRestrictionsCoverage:
         _ok, calls = self._run(labels)
         _url, params = calls[0]
         assert params["filterMovies"] == params["filterTelevision"]
+
+
+class TestExclusionLabelRegressions:
+    """
+    #340 - three defects introduced by the #332 fix, all confirmed on a
+    live server before being fixed here.
+    """
+
+    # Deliberately gives one user three aliases, which is what Plex
+    # actually returns and what the #332 fix mishandled.
+    USERS_XML = (
+        b"<MediaContainer>"
+        b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+        b' filterMovies="" filterTelevision=""/>'
+        b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+        b"</MediaContainer>"
+    )
+
+    def _run(self, labels, users_xml=None, **kwargs):
+        from utils import plex_policy
+
+        puts = []
+
+        def fake_put(url, params=None, **kw):
+            puts.append((url, params))
+            return Mock(raise_for_status=Mock())
+
+        with (
+            patch.object(plex_policy, "MyPlexAccount", return_value=Mock(username="admin")),
+            patch.object(
+                plex_policy,
+                "_capped_get",
+                return_value=Mock(content=users_xml or self.USERS_XML, raise_for_status=Mock()),
+            ),
+            patch.object(plex_policy, "_capped_put", side_effect=fake_put),
+        ):
+            ok = plex_policy.apply_user_label_restrictions({"plex": {"token": "t"}}, labels, **kwargs)
+        return ok, puts
+
+    def test_a_users_own_label_is_never_excluded_from_themselves(self):
+        """
+        The regression: Plex lists each user under title AND username AND
+        email. Iterating those name keys treated the aliases of a
+        configured user as separate unconfigured users, so that person's
+        OWN collection was excluded from their own library.
+        """
+        labels = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+        }
+        _ok, puts = self._run(labels)
+        home = [p for url, p in puts if url.endswith("/1")]
+        assert home, "configured user received no restriction"
+        assert "PrivateCollection_homehouse165" not in home[0]["filterMovies"]
+        assert "PrivateCollection_bob" in home[0]["filterMovies"]
+
+    def test_each_user_is_written_once_despite_three_aliases(self):
+        """Same defect, other symptom: one PUT per alias, per run."""
+        labels = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+        }
+        _ok, puts = self._run(labels)
+        assert len([u for u, _ in puts if u.endswith("/1")]) == 1
+
+    def test_movie_and_tv_labels_are_not_merged(self):
+        """
+        filterMovies governs movie libraries and filterTelevision
+        television ones; a label from the other kind can never match
+        there and does not belong in it.
+        """
+        labels = {
+            "homehouse165": {"movie": ["PC_movies_home"], "tv": ["PC_tv_home"]},
+            "bob": {"movie": ["PC_movies_bob"], "tv": ["PC_tv_bob"]},
+        }
+        _ok, puts = self._run(labels)
+        home = next(p for url, p in puts if url.endswith("/1"))
+        assert "PC_movies_bob" in home["filterMovies"]
+        assert "PC_tv_bob" not in home["filterMovies"], "tv labels leaked into filterMovies"
+        assert "PC_tv_bob" in home["filterTelevision"]
+        assert "PC_movies_bob" not in home["filterTelevision"], "movie labels leaked into filterTelevision"
+
+    def test_unchanged_filters_are_not_rewritten(self):
+        """Every run re-PUT an identical filter for every user."""
+        already = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="label!=PrivateCollection_bob" filterTelevision="label!=PrivateCollection_bob"/>'
+            b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        labels = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+        }
+        _ok, puts = self._run(labels, users_xml=already)
+        assert not [u for u, _ in puts if u.endswith("/1")], "rewrote an already-correct filter"
+        assert [u for u, _ in puts if u.endswith("/2")], "bob's filter did need writing"
+
+    def test_unconfigured_user_still_covered_and_gets_everything(self):
+        """#332's second claim must keep working."""
+        labels = {"bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]}}
+        _ok, puts = self._run(labels)
+        home = next(p for url, p in puts if url.endswith("/1"))
+        assert "PrivateCollection_bob" in home["filterMovies"]

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.15.0"
+__version__ = "2.15.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -180,7 +180,7 @@ def build_all_private_labels(
 
 def apply_user_label_restrictions(
     config: Dict,
-    all_user_private_labels: Mapping[str, Union[str, Sequence[str]]],
+    all_user_private_labels: Mapping[str, Union[str, Sequence[str], Mapping[str, Sequence[str]]]],
     restrict_unconfigured_users: bool = True,
 ) -> bool:
     """

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -34,12 +34,12 @@ from this module, or the two would form an import cycle.
 """
 
 import logging
-from typing import Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import requests
 from plexapi.myplex import MyPlexAccount
 
-from .config import PLEX_REQUEST_TIMEOUT
+from .config import MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV, PLEX_REQUEST_TIMEOUT
 from .display import GREEN, RESET, log_warning
 from .plex import _capped_get, _capped_put
 
@@ -105,14 +105,25 @@ def is_rating_allowed(content_rating: Optional[str], max_rating: Optional[str], 
         return True
 
 
-def _as_label_list(labels: Union[str, Sequence[str]]) -> List[str]:
-    """One label or many - callers predating #332 pass a bare string."""
+def _labels_for(labels: Union[str, Sequence[str], Mapping[str, Sequence[str]]], media_type: str) -> List[str]:
+    """
+    This user's labels for one media type.
+
+    Accepts every shape callers have used: a bare string (pre-#332), a
+    flat sequence (#332), or the per-media-type mapping (#340). The first
+    two are not media-type aware, so they apply to both - that is the
+    only meaning they can have.
+    """
     if isinstance(labels, str):
         return [labels]
+    if isinstance(labels, Mapping):
+        return [str(x) for x in labels.get(media_type, []) if x]
     return [str(x) for x in labels if x]
 
 
-def build_all_private_labels(config: Dict, users: List[str], append_usernames: bool = True) -> Dict[str, List[str]]:
+def build_all_private_labels(
+    config: Dict, users: List[str], append_usernames: bool = True
+) -> Dict[str, Dict[str, List[str]]]:
     """
     Every PrivateCollection_* label a user owns, across every library.
 
@@ -131,30 +142,39 @@ def build_all_private_labels(config: Dict, users: List[str], append_usernames: b
     survived and movie collections stayed visible to everyone (#332).
 
     Enumerating every library here means the value written is complete
-    and identical whichever run performs the write.
+    whichever run performs the write.
+
+    Returns {username: {"movie": [...], "tv": [...]}}. Kept SEPARATE per
+    media type (#340): Plex applies filterMovies to movie libraries and
+    filterTelevision to television ones, so writing the union to both
+    puts labels in a filter that can never match anything there. An
+    earlier fix for #332 merged them, which was cruder than needed.
     """
-    from .config import MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV, get_libraries_for_media_type
+    from .config import get_libraries_for_media_type
     from .labels import build_label_name
 
-    bases: List[str] = []
+    bases: Dict[str, List[str]] = {}
     for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV):
         libraries = get_libraries_for_media_type(config, media_type)
         if len(libraries) > 1:
             # Mirrors _library_suffix_for_label(): only a genuine
             # multi-library media type gets qualified labels, so
             # single-library installs keep exactly today's names.
-            bases.extend(f"PrivateCollection_{lib['id']}" for lib in libraries)
+            bases[media_type] = [f"PrivateCollection_{lib['id']}" for lib in libraries]
         else:
-            bases.append("PrivateCollection")
+            bases[media_type] = ["PrivateCollection"]
 
-    labels: Dict[str, List[str]] = {}
+    labels: Dict[str, Dict[str, List[str]]] = {}
     for user in users:
-        seen: List[str] = []
-        for base in bases:
-            label = build_label_name(base, users, user, append_usernames)
-            if label not in seen:
-                seen.append(label)
-        labels[user] = seen
+        per_type: Dict[str, List[str]] = {}
+        for media_type, media_bases in bases.items():
+            seen: List[str] = []
+            for base in media_bases:
+                label = build_label_name(base, users, user, append_usernames)
+                if label not in seen:
+                    seen.append(label)
+            per_type[media_type] = seen
+        labels[user] = per_type
     return labels
 
 
@@ -206,11 +226,16 @@ def apply_user_label_restrictions(
     if not all_user_private_labels:
         return True
 
-    # Only one user - nothing to hide from anyone
-    if len(all_user_private_labels) <= 1:
+    # One configured user hides their collection from nobody - UNLESS
+    # unconfigured server users are also covered (#332), in which case
+    # that single user's collection still needs hiding from everyone
+    # else on the server. The old unconditional short-circuit silently
+    # disabled that whole path for single-user installs.
+    if len(all_user_private_labels) <= 1 and not restrict_unconfigured_users:
         return True
 
     plex_token = config["plex"]["token"]
+    all_success = True
 
     try:
         # Get admin username to skip
@@ -227,86 +252,112 @@ def apply_user_label_restrictions(
 
         root = ET.fromstring(response.content)
 
-        # Build user lookup: username -> user_id
-        plex_users = {}
+        # user_id -> {aliases, current filters}. Keyed by ID, never by
+        # name: Plex exposes each user under up to THREE names (title,
+        # username, email), and an earlier version iterated those name
+        # keys directly. That wrote the same person up to three times per
+        # run, and because only one of those names matched the config
+        # key, the other two were treated as unconfigured users - which
+        # excluded that person's OWN collection from their own library
+        # (#340). Resolving to IDs first makes each user exactly one
+        # target.
+        by_id: Dict[str, Dict[str, Any]] = {}
+        alias_to_id: Dict[str, str] = {}
         for user_elem in root.findall(".//User"):
             user_id = user_elem.get("id")
-            title = user_elem.get("title", "")
-            username_attr = user_elem.get("username", "")
-            email = user_elem.get("email", "")
-
-            if title:
-                plex_users[title.lower()] = user_id
-            if username_attr:
-                plex_users[username_attr.lower()] = user_id
-            if email:
-                plex_users[email.lower()] = user_id
-
-        logger.debug(f"Plex users available for restrictions: {list(plex_users.keys())}")
-
-        # #332: restrict every user on the server, not only those listed
-        # in config. A Plex user curatarr does not generate for still sees
-        # everyone else's PrivateCollection_* collections cluttering their
-        # browse - which is the whole condition this feature exists to
-        # prevent, and it is the admin's library either way. They own no
-        # labels themselves, so they simply get all of them excluded.
-        targets = dict(all_user_private_labels)
-        if restrict_unconfigured_users:
-            configured = {u.lower() for u in all_user_private_labels}
-            for name in plex_users:
-                if name and name.lower() not in configured and name.lower() != admin_username:
-                    targets.setdefault(name, [])
-
-        all_success = True
-        for username, _user_private_label in targets.items():
-            # Admin can't have restrictions
-            if username.lower() == admin_username:
-                logger.debug(f"Skipping restrictions for admin user: {username}")
-                continue
-
-            # Find the user ID
-            user_id = plex_users.get(username.lower())
-
-            # Try normalized match if exact match fails
             if not user_id:
-                username_normalized = username.lower().replace(" ", "").replace("-", "").replace("_", "")
-                for key, uid in plex_users.items():
-                    key_normalized = key.replace(" ", "").replace("-", "").replace("_", "")
-                    if username_normalized == key_normalized:
-                        user_id = uid
-                        logger.debug(f"Matched '{username}' to user ID {uid} via normalized match")
-                        break
-
-            if not user_id:
-                log_warning(f"User '{username}' not found for label restrictions. Available: {list(plex_users.keys())}")
-                all_success = False
                 continue
-
-            # Labels to EXCLUDE: every OTHER user's already-built
-            # PrivateCollection_* labels (on collections), never
-            # Recommended_* (on items) - this hides other users'
-            # collections but keeps items visible to everyone. Used as
-            # given, not derived here (#261 - see this function's docstring).
-            # A user owns one label PER LIBRARY, so this flattens
-            # (#332 - see build_all_private_labels).
-            exclude_labels = [
-                label
-                for u, labels in all_user_private_labels.items()
-                if u.lower() != username.lower()
-                for label in _as_label_list(labels)
+            aliases = [
+                user_elem.get("title", ""),
+                user_elem.get("username", ""),
+                user_elem.get("email", ""),
             ]
+            by_id[user_id] = {
+                "aliases": [a for a in aliases if a],
+                "filterMovies": user_elem.get("filterMovies", "") or "",
+                "filterTelevision": user_elem.get("filterTelevision", "") or "",
+            }
+            for alias in aliases:
+                if alias:
+                    alias_to_id[alias.lower()] = user_id
 
-            if not exclude_labels:
-                continue  # Nothing to exclude
+        logger.debug(f"Plex users available for restrictions: {sorted(alias_to_id)}")
 
-            # Build filter string: label!=Label1,Label2,Label3
-            labels_str = ",".join(exclude_labels)
-            filter_value = f"label!={labels_str}"
+        def _resolve(name: str) -> Optional[str]:
+            """A configured username -> Plex user id, tolerating the
+            punctuation/spacing differences between a config key and a
+            Plex display name."""
+            found = alias_to_id.get(name.lower())
+            if found:
+                return found
+            wanted = name.lower().replace(" ", "").replace("-", "").replace("_", "")
+            for alias, uid in alias_to_id.items():
+                if alias.replace(" ", "").replace("-", "").replace("_", "") == wanted:
+                    return uid
+            return None
 
-            # Apply restrictions via direct PUT to Plex API
+        # Map each configured user onto their Plex id, so an id can be
+        # recognized as configured no matter which alias config used.
+        id_to_configured: Dict[str, str] = {}
+        for configured_name in all_user_private_labels:
+            # The admin is the server OWNER and is absent from
+            # /api/users, so resolving them always fails. Plex does not
+            # allow restrictions on them anyway - skip before resolving,
+            # rather than reporting a lookup failure for a user who is
+            # not supposed to be found.
+            if configured_name.lower() == admin_username:
+                logger.debug(f"Skipping restrictions for admin user: {configured_name}")
+                continue
+            resolved = _resolve(configured_name)
+            if resolved:
+                id_to_configured[resolved] = configured_name
+            else:
+                log_warning(
+                    f"User '{configured_name}' not found for label restrictions. Available: {sorted(alias_to_id)}"
+                )
+                all_success = False
+
+        admin_id = alias_to_id.get(admin_username)
+
+        # #332: cover every user on the server, not only configured ones -
+        # an unmanaged user still sees everyone's PrivateCollection_*
+        # collections otherwise, which is the condition this prevents.
+        target_ids = list(id_to_configured) if not restrict_unconfigured_users else list(by_id)
+
+        for user_id in target_ids:
+            if user_id == admin_id:
+                logger.debug("Skipping restrictions for the admin user (Plex does not allow them)")
+                continue
+
+            owner = id_to_configured.get(user_id)  # None => not configured, owns no labels
+            display = owner or (by_id.get(user_id, {}).get("aliases") or [user_id])[0]
+
+            # Per media type (#340): filterMovies governs movie libraries
+            # and filterTelevision television ones, so a label from the
+            # other kind can never match there and does not belong in it.
+            params: Dict[str, str] = {}
+            for field, media_type in (("filterMovies", MEDIA_TYPE_MOVIE), ("filterTelevision", MEDIA_TYPE_TV)):
+                exclude = [
+                    label
+                    for name, labels in all_user_private_labels.items()
+                    if name != owner
+                    for label in _labels_for(labels, media_type)
+                ]
+                params[field] = f"label!={','.join(exclude)}" if exclude else ""
+
+            if not any(params.values()):
+                continue
+
+            # #340: only write when something actually changed. Every run
+            # re-PUT an identical filter for every user, which is pure
+            # noise against plex.tv and made the label state look like it
+            # was churning when it was not.
+            current = by_id.get(user_id, {})
+            if all(current.get(field, "") == value for field, value in params.items()):
+                logger.debug(f"Restrictions for {display} already correct - not rewriting")
+                continue
+
             update_url = f"https://plex.tv/api/users/{user_id}"
-            params = {"filterMovies": filter_value, "filterTelevision": filter_value}
-
             try:
                 put_response = _capped_put(
                     update_url,
@@ -315,9 +366,9 @@ def apply_user_label_restrictions(
                     timeout=PLEX_REQUEST_TIMEOUT,
                 )
                 put_response.raise_for_status()
-                print(f"{GREEN}Applied exclusions for {username}: hiding labels {exclude_labels}{RESET}")
+                print(f"{GREEN}Applied exclusions for {display}{RESET}")
             except requests.RequestException as e:
-                log_warning(f"Failed to apply restrictions for {username}: {e}")
+                log_warning(f"Failed to apply restrictions for {display}: {e}")
                 all_success = False
 
         return all_success


### PR DESCRIPTION
Closes #340. All four defects were introduced or exposed by 2.14.0's fix for #332, and all were confirmed on a live server before being fixed.

## 1. A user's own collection was hidden from them

Every configured user's filter contained their **own** `PrivateCollection_*` label:

```
homehouse165  movies: label!=...,PrivateCollection_homehouse165,...
```

Plex lists each user under up to **three** names — title, username, email. The unconfigured-user coverage added in 2.14.0 iterated those name keys directly. Only one matched the config key, so the other two were treated as separate *unconfigured* users and had every label excluded, including that person's own. Whichever alias was written last won.

Targets now resolve to Plex **user IDs** first, so each user is exactly one target and their own label is always exempt.

## 2. Each user was written up to 3× per run

Same cause. One PUT per user now.

## 3. Movie and TV labels were merged into both filters

2.14.0 fixed #332 by building the union of every library's labels and writing it to both `filterMovies` and `filterTelevision`. Cruder than needed — `filterMovies` governs movie libraries and `filterTelevision` television ones, so a label from the other kind can never match there. `build_all_private_labels()` now returns `{user: {"movie": [...], "tv": [...]}}` and each filter gets only its own.

## 4. Restrictions were rewritten every run

Identical filters were re-PUT for every user on every run. The current filters are already in the `/api/users` response used to resolve IDs, so they're compared first and unchanged users skipped.

## Bonus: a stale guard

`if len(all_user_private_labels) <= 1: return True` predated #332 and silently disabled unconfigured-user coverage for single-user installs — one configured user still has a collection every *other* Plex user should not see. The short-circuit now applies only when `restrict_unconfigured_users` is off. Caught by a new test, not by inspection.

## Verified on the live server

```
before: label!=...,PrivateCollection_homehouse165,...   ← own label
after:  label!=PrivateCollection_jasonsmith523,...      ← own label gone
second run: nothing rewritten
```

5 new regression tests covering each claim plus idempotency. 3210 tests pass, ruff clean.