### PR TITLE
Tell the user which Trakt auth failure they actually have (2.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.16.0] - 2026-08-04
+
+### Added
+
+- **Trakt auth failures now say which of the two remedies applies.** A deleted Trakt application and an expired token both surface as an authentication failure, but only one is fixable by re-authorizing - against a deleted application there is nothing to authorize against. The raw API body was passed straight through:
+
+  ```
+  Authentication error: Failed to get device code:
+  {"error":"invalid_client","error_description":"client not found"}
+  ```
+
+  which says neither that the application must be recreated, nor where. On a real install that cost an hour to diagnose.
+
+  `TraktClient.application_is_registered()` asks a public endpoint that authenticates on `client_id` alone - no token involved - so the answer is about the application and nothing else. `describe_auth_failure()` turns that into one of three messages: recreate the application (with the URL and the `urn:ietf:wg:oauth:2.0:oob` redirect URI the device flow requires), re-run `--reauth`, or "could not reach Trakt" when the check itself failed. That third case matters: an unreachable network must never be reported as a dead application.
+
+  Appended to both failure paths - the device-code request (`python -m utils.trakt_auth --reauth`) and the token refresh that runs during a normal sync.
+
 ## [2.15.1] - 2026-08-04
 
 ### Fixed

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -307,12 +307,17 @@ class TestTraktClientDeviceAuth:
         assert result["user_code"] == "USER123"
 
     @patch("utils.trakt.requests.post")
-    def test_get_device_code_failure(self, mock_post):
+    @patch("utils.trakt.requests.get")
+    def test_get_device_code_failure(self, mock_get, mock_post):
         """Test device code request failure."""
         mock_response = Mock()
         mock_response.status_code = 400
         mock_response.text = "Bad Request"
         mock_post.return_value = mock_response
+        # The failure path now also probes whether the APPLICATION is
+        # still registered, to say which of the two remedies applies -
+        # see TestTraktApplicationDiagnostics.
+        mock_get.return_value = Mock(status_code=200)
 
         client = TraktClient("id", "secret")
 
@@ -505,22 +510,26 @@ class TestTraktClientTokenRefresh:
 
     @patch("utils.trakt.log_error")
     @patch("utils.trakt.requests.post")
-    def test_refresh_access_token_failure(self, mock_post, mock_log_error):
+    @patch("utils.trakt.requests.get")
+    def test_refresh_access_token_failure(self, mock_get, mock_post, mock_log_error):
         """Test failed token refresh - status + body are logged (#trakt-
         token-refresh-persistence: this used to fail completely silently)."""
         mock_response = Mock()
         mock_response.status_code = 401
         mock_response.text = '{"error": "invalid_grant"}'
         mock_post.return_value = mock_response
+        mock_get.return_value = Mock(status_code=200)  # application still registered
 
         client = TraktClient("id", "secret", refresh_token="old_refresh")
         result = client._refresh_access_token()
 
         assert result is False
-        mock_log_error.assert_called_once()
-        logged_message = mock_log_error.call_args[0][0]
+        # Two lines now: the raw failure, then which remedy applies.
+        assert mock_log_error.call_count == 2
+        logged_message = mock_log_error.call_args_list[0][0][0]
         assert "401" in logged_message
         assert "invalid_grant" in logged_message
+        assert "--reauth" in mock_log_error.call_args_list[1][0][0]
 
     @patch("utils.trakt.log_error")
     @patch("utils.trakt.requests.post")
@@ -1628,3 +1637,88 @@ class TestSaveTraktEnhanceCache:
 
         # Should not raise exception
         save_trakt_enhance_cache("/nonexistent/path", set(), set())
+
+
+class TestTraktApplicationDiagnostics:
+    """
+    application_is_registered() / describe_auth_failure().
+
+    A deleted Trakt application and an expired token both surface as an
+    auth failure, but only one is fixable by re-authorizing - against a
+    deleted application there is nothing to authorize against. The raw
+    API body for the former is {"error":"invalid_client",
+    "error_description":"client not found"}, which says neither that the
+    application must be recreated nor where. This was a real incident:
+    the cause took an hour to establish from that message.
+    """
+
+    @staticmethod
+    def _client():
+        return TraktClient(client_id="dead-id", client_secret="secret")
+
+    @patch("utils.trakt.requests.get")
+    def test_registered_application_reports_true(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        assert self._client().application_is_registered() is True
+
+    @patch("utils.trakt.requests.get")
+    def test_rejected_key_reports_false(self, mock_get):
+        """403 is what Trakt actually returned for the deleted app."""
+        mock_get.return_value = Mock(status_code=403, text="Forbidden")
+        assert self._client().application_is_registered() is False
+
+    @patch("utils.trakt.requests.get")
+    def test_unauthorized_also_reports_false(self, mock_get):
+        mock_get.return_value = Mock(status_code=401, text="Unauthorized")
+        assert self._client().application_is_registered() is False
+
+    @patch("utils.trakt.requests.get")
+    def test_network_failure_is_unknown_not_a_verdict(self, mock_get):
+        """Never claim the app is dead because we could not ask."""
+        mock_get.side_effect = requests.RequestException("no route to host")
+        assert self._client().application_is_registered() is None
+
+    @patch("utils.trakt.requests.get")
+    def test_unexpected_status_is_unknown(self, mock_get):
+        mock_get.return_value = Mock(status_code=500, text="boom")
+        assert self._client().application_is_registered() is None
+
+    @patch("utils.trakt.requests.get")
+    def test_message_for_a_dead_application_names_the_remedy(self, mock_get):
+        mock_get.return_value = Mock(status_code=403, text="Forbidden")
+        msg = self._client().describe_auth_failure()
+        assert "no longer exists" in msg
+        assert "https://trakt.tv/oauth/applications" in msg
+        assert "urn:ietf:wg:oauth:2.0:oob" in msg
+        assert "Re-authorizing cannot fix this" in msg
+
+    @patch("utils.trakt.requests.get")
+    def test_message_for_a_live_application_says_reauthorize_instead(self, mock_get):
+        """The opposite remedy - must not tell the user to recreate a
+        perfectly good application."""
+        mock_get.return_value = Mock(status_code=200)
+        msg = self._client().describe_auth_failure()
+        assert "--reauth" in msg
+        assert "no longer exists" not in msg
+
+    @patch("utils.trakt.requests.get")
+    def test_message_when_unreachable_claims_neither(self, mock_get):
+        mock_get.side_effect = requests.RequestException("down")
+        msg = self._client().describe_auth_failure()
+        assert "Could not reach Trakt" in msg
+        assert "no longer exists" not in msg
+        assert "--reauth" not in msg
+
+    @patch("utils.trakt.requests.get")
+    @patch("utils.trakt.requests.post")
+    def test_device_code_failure_carries_the_diagnosis(self, mock_post, mock_get):
+        """The path the user actually hit: python -m utils.trakt_auth --reauth."""
+        mock_post.return_value = Mock(
+            status_code=401, text='{"error":"invalid_client","error_description":"client not found"}'
+        )
+        mock_get.return_value = Mock(status_code=403, text="Forbidden")
+
+        with pytest.raises(TraktAuthError) as excinfo:
+            self._client().get_device_code()
+
+        assert "https://trakt.tv/oauth/applications" in str(excinfo.value)

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.15.1"
+__version__ = "2.16.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/trakt.py
+++ b/utils/trakt.py
@@ -24,6 +24,11 @@ logger = logging.getLogger("curatarr")
 
 # Trakt API endpoints
 TRAKT_API_URL = "https://api.trakt.tv"
+# Where a user recreates a deleted/disabled application, and the redirect
+# URI the device (PIN) flow requires - named in the failure message so it
+# is actionable without a search (see describe_auth_failure).
+TRAKT_APPLICATIONS_URL = "https://trakt.tv/oauth/applications"
+TRAKT_DEVICE_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 TRAKT_AUTH_URL = "https://trakt.tv"
 
 # Out-of-band redirect_uri for non-web (device-code/PIN) OAuth flows -
@@ -298,6 +303,79 @@ class TraktClient(BaseAPIClient):
             record_api_call("trakt", outcome, time.time() - request_start)
 
     # =========================================================================
+    # Diagnostics
+    # =========================================================================
+
+    def application_is_registered(self) -> Optional[bool]:
+        """
+        Is this client_id still a usable Trakt application?
+
+        Distinguishes the two failures that look identical from the
+        outside but need opposite remedies:
+
+          - the APPLICATION is gone or disabled -> re-register it at
+            trakt.tv; re-authorizing cannot help, because there is
+            nothing to authorize against.
+          - the application is fine and only the TOKEN died -> re-run
+            the device flow.
+
+        Asks a public endpoint that authenticates on client_id alone,
+        with no token involved, so the answer is about the application
+        and nothing else.
+
+        Returns True/False, or None when the check itself could not run
+        (network failure) - which must not be reported as either verdict.
+        """
+        try:
+            response = requests.get(
+                f"{TRAKT_API_URL}/movies/trending",
+                headers={
+                    "Content-Type": "application/json",
+                    "trakt-api-version": "2",
+                    "trakt-api-key": self.client_id,
+                },
+                params={"limit": 1},
+                timeout=TRAKT_REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            logger.debug(f"Could not check whether the Trakt application is registered: {e}")
+            return None
+        if response.status_code == 200:
+            return True
+        if response.status_code in (401, 403):
+            return False
+        logger.debug(f"Unexpected status probing Trakt application registration: {response.status_code}")
+        return None
+
+    def describe_auth_failure(self) -> str:
+        """
+        A message naming the actual cause and the actual fix.
+
+        The raw API body for a dead application is
+        {"error":"invalid_client","error_description":"client not found"},
+        which does not say that the application must be recreated, or
+        where.
+        """
+        registered = self.application_is_registered()
+        if registered is False:
+            return (
+                "Trakt rejected this client_id: the application no longer exists or has been "
+                "disabled. Re-authorizing cannot fix this - there is nothing to authorize "
+                f"against. Recreate the application at {TRAKT_APPLICATIONS_URL} (redirect URI "
+                f"{TRAKT_DEVICE_REDIRECT_URI}, which the device/PIN flow requires), then put the "
+                "new client_id and client_secret in config/trakt.yml."
+            )
+        if registered is True:
+            return (
+                "The Trakt application is valid, so this is an authorization problem rather than "
+                "a registration one. Re-run: python -m utils.trakt_auth --reauth"
+            )
+        return (
+            "Could not reach Trakt to determine whether the application is still registered - "
+            "check network connectivity, then retry."
+        )
+
+    # =========================================================================
     # Device Authentication Flow
     # =========================================================================
 
@@ -317,7 +395,10 @@ class TraktClient(BaseAPIClient):
         )
 
         if response.status_code != 200:
-            raise TraktAuthError(f"Failed to get device code: {response.text}")
+            # Say WHY, not just what the API returned. "client not found"
+            # gives no indication that the application itself must be
+            # recreated, which is the actual remedy when it is gone.
+            raise TraktAuthError(f"Failed to get device code: {response.text}\n{self.describe_auth_failure()}")
 
         return response.json()
 
@@ -460,6 +541,10 @@ class TraktClient(BaseAPIClient):
             # "Failed to refresh Trakt token" TraktAuthError, which
             # previously carried no detail about WHY.
             log_error(f"Trakt token refresh failed: HTTP {response.status_code}: {response.text}")
+            # An expired token and a deleted application both surface
+            # here as a refresh failure; only one is fixable by
+            # re-authorizing.
+            log_error(self.describe_auth_failure())
             return False
 
         except requests.RequestException as e:


### PR DESCRIPTION
A deleted Trakt application and an expired token both surface as an authentication failure — but only one is fixable by re-authorizing. Against a deleted application there is nothing to authorize against.

The raw API body was passed straight through:

```
Authentication error: Failed to get device code:
{"error":"invalid_client","error_description":"client not found"}
```

That says neither that the application must be recreated, nor where. On a real install it cost an hour to establish the cause.

## Change

`TraktClient.application_is_registered()` asks a public endpoint that authenticates on `client_id` **alone** — no token involved — so the answer is about the application and nothing else. `describe_auth_failure()` turns that into one of three messages:

| probe | message |
|---|---|
| 401/403 | recreate the application, with the URL and the `urn:ietf:wg:oauth:2.0:oob` redirect URI the device flow requires |
| 200 | application is fine — re-run `--reauth` |
| unreachable | could not reach Trakt; check connectivity |

That third case matters: a network failure must never be reported as a dead application, so the probe returns `None` rather than guessing, and the message claims neither remedy.

Appended to both failure paths — the device-code request (`python -m utils.trakt_auth --reauth`) and the token refresh during a normal sync, where the same ambiguity appears as `invalid_grant`.

## Verified against the real thing

Same command that previously printed only `invalid_client`:

```
Authentication error: Failed to get device code: {"error":"invalid_client",...}
Trakt rejected this client_id: the application no longer exists or has been
disabled. Re-authorizing cannot fix this - there is nothing to authorize
against. Recreate the application at https://trakt.tv/oauth/applications
(redirect URI urn:ietf:wg:oauth:2.0:oob, which the device/PIN flow requires),
then put the new client_id and client_secret in config/trakt.yml.
```

9 new tests covering all three verdicts and both failure paths, including that an unreachable network claims neither remedy. Two existing tests needed `requests.get` mocked — the socket guard correctly caught the new probe reaching the network. 3219 tests pass, ruff clean, no new mypy errors (trakt.py's 4 pre-existing are unchanged).