### PR TITLE
Refuse to sign a SHA256SUMS.txt that is not the final aggregate (2.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.16.2] - 2026-08-06
+
+### Fixed
+
+- **`sign-release-checksums.sh` could sign a `SHA256SUMS.txt` that the release no longer serves, producing a signature no client can verify.** `release.yml` publishes a source-archive-only `SHA256SUMS.txt` from the `release` job, then `finalize-checksums` re-uploads the full aggregate with `--clobber` once every binary has built. Signing between those two points signs superseded bytes: the `.sig` uploads without complaint and *self-verifies* (it does match what was signed), and is then silently invalid against the file the release actually serves.
+
+  v2.16.1 shipped exactly that. It was caught only because the post-release smoke test's client-real verification failed - `ssh-keygen -Y verify` against the published pair returned `incorrect signature` - and it was fixed by re-signing the final aggregate.
+
+  The script's header already told the operator to wait for `finalize-checksums`; depending on them to remember is what failed. It now lists the release's assets and refuses to sign unless every published binary appears in the checksums file, naming what is missing and pointing at `gh run list --workflow=release.yml`. `RELEASING.md` carries the same warning.
+
 ## [2.16.1] - 2026-08-05
 
 ### Changed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -177,6 +177,17 @@ works (web UI "Update now" button, or `curatarr --self-update`).
 
 ## Signing a release's checksums (binary self-update trust anchor)
 
+> **Wait for `finalize-checksums` before signing.** `release.yml` publishes a
+> source-archive-only `SHA256SUMS.txt` first, then re-uploads the full
+> aggregate with `--clobber` once every binary has built. Signing in between
+> produces a signature over superseded bytes - it uploads fine and
+> self-verifies fine (it matches what was signed), then is silently invalid
+> against the file the release actually serves, so no client can self-update.
+> This happened on v2.16.1. `sign-release-checksums.sh` now refuses to sign a
+> `SHA256SUMS.txt` that doesn't list every published binary, so the mistake
+> aborts loudly instead of shipping.
+
+
 CI publishes `SHA256SUMS.txt` (step 8 above) but never signs it - the
 release-signing **private** key stays off CI entirely, same as tag
 signing. Signing `SHA256SUMS.txt` is therefore a separate, manual,

--- a/scripts/sign-release-checksums.sh
+++ b/scripts/sign-release-checksums.sh
@@ -166,6 +166,16 @@ gh_release_download_to() {
   fi
 }
 
+# $1=tag - prints the release's asset names, one per line.
+gh_release_asset_names() {
+  local tag="$1"
+  if [ "$GH_DELEGATE" -eq 1 ]; then
+    ssh "$CURATARR_GH_SSH_HOST" "gh release view '$tag' -R '$GITHUB_REPO' --json assets -q '.assets[].name'"
+  else
+    gh release view "$tag" -R "$GITHUB_REPO" --json assets -q '.assets[].name'
+  fi
+}
+
 # $1=tag $2=local file path - uploads $2 to the release. When delegated,
 # `gh release upload` has no stdin/stdout form (unlike download), so the
 # file is scp'd to a throwaway remote temp dir, uploaded from there, and
@@ -273,6 +283,42 @@ if ! gh_release_download_to "$TAG" "$SUMS_FILENAME" "$SUMS_FILENAME"; then
 fi
 echo "==> Downloaded (contents):"
 cat "$SUMS_FILENAME"
+
+# Confirm this is the FINAL aggregate, not the source-archive-only file
+# the `release` job publishes first.
+#
+# release.yml's finalize-checksums job re-uploads SHA256SUMS.txt with
+# --clobber once every binary has built. Signing before that produces a
+# signature over superseded bytes: the .sig uploads fine, self-verifies
+# fine (it matches what was signed), and is then silently invalid against
+# the file the release actually serves - which is how v2.16.1 shipped a
+# SHA256SUMS.txt.sig that no client could verify. The header tells the
+# operator to wait for that job; relying on them to remember is what
+# failed, so check it here instead.
+echo "==> Verifying this is the final aggregate (every published binary is listed)"
+MISSING=""
+while IFS= read -r asset; do
+  case "$asset" in
+    "$SUMS_FILENAME"|"$SIG_FILENAME"|*.sha256) continue ;;
+  esac
+  if ! grep -qF "  ${asset}" "$SUMS_FILENAME"; then
+    MISSING="${MISSING}         ${asset}\n"
+  fi
+done <<EOF
+$(gh_release_asset_names "$TAG")
+EOF
+
+if [ -n "$MISSING" ]; then
+  echo "ERROR: ${SUMS_FILENAME} does not cover every published asset - this is the" >&2
+  echo "       pre-finalize file, and signing it would produce a signature that no" >&2
+  echo "       client can verify against what the release serves." >&2
+  echo "       Missing:" >&2
+  printf "%b" "$MISSING" >&2
+  echo "       Wait for release.yml's finalize-checksums job, then re-run:" >&2
+  echo "         gh run list --workflow=release.yml" >&2
+  exit 1
+fi
+echo "==> Aggregate is complete"
 
 echo "==> Signing ${SUMS_FILENAME} (namespace: file)"
 ssh-keygen -Y sign -f "$SIGNING_KEY" -n file "$SUMS_FILENAME"

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.16.1"
+__version__ = "2.16.2"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item


### PR DESCRIPTION
Closes #345.

`release.yml` publishes a **source-archive-only** `SHA256SUMS.txt` from the `release` job, then `finalize-checksums` re-uploads the **full aggregate** with `--clobber` once every binary has built.

Signing between those two points signs superseded bytes. The failure is quiet in the worst way:

- the `.sig` uploads without complaint
- it **self-verifies**, because it genuinely matches what was signed
- it is silently invalid against the file the release actually serves — so no client can self-update

**v2.16.1 shipped exactly that.** It surfaced only because the post-release smoke test's client-real check failed. Confirmed by hand against the published pair:

```
$ ssh-keygen -Y verify ... -s SHA256SUMS.txt.sig < SHA256SUMS.txt
Signature verification failed: incorrect signature
```

Fixed at the time by re-signing the final aggregate; this stops it recurring.

## Change

The script's header *already* said to wait for `finalize-checksums`. Depending on the operator to remember is precisely what failed. It now lists the release's assets and refuses to sign unless every published binary appears in the checksums file:

```
ERROR: SHA256SUMS.txt does not cover every published asset - this is the
       pre-finalize file, and signing it would produce a signature that no
       client can verify against what the release serves.
       Missing:
         curatarr-linux-x86_64
         curatarr-macos-arm64
       Wait for release.yml's finalize-checksums job, then re-run:
         gh run list --workflow=release.yml
```

`RELEASING.md` gets the same warning above the signing section.

## Verified both directions

- **Rejects** a source-archive-only file, naming the binaries it lacks — the exact v2.16.1 shape
- **Accepts** a complete aggregate: re-signed the real v2.16.1 through the new code path, `Aggregate is complete` → `Self-verification OK` → `Done`
- Delegation-safe: the asset listing honours `CURATARR_GH_SSH_HOST` like every other `gh` call in the script
- `bash -n` clean, 3227 tests pass, ruff clean