### PR TITLE
Preserve label_dates across cache rebuilds; raise the ignored window to 60 days (2.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.17.0] - 2026-08-06
+
+### Fixed
+
+- **A `CACHE_VERSION` bump silently reset every user's ignored-recommendation clock.** `label_dates` - the record of when each recommendation was first shown - lives inside the watched cache, and `check_cache_version()` deletes that file outright whenever `CACHE_VERSION` moves. But `CACHE_VERSION` exists to invalidate *derived* data (cached scores, metadata shape) and is bumped for scoring changes; `label_dates` is not derived, and it is the only clock the ignored-recommendation signal has.
+
+  Observed directly on a real install: two `CACHE_VERSION` bumps in one week left **every one of 301 labels across six users no older than 6 days**, so a signal needing weeks could never accumulate. It is now salvaged version-blind before the check runs and merged back after a rebuild. Verified against a real cache: all 50 entries survived a simulated bump with their original dates intact.
+
+### Changed
+
+- **`negative_signals.ignored_recommendations.min_days_shown` raised from 21 to 60 days.** A movie collection holds `limit_results` (50 by default) titles at once, and measured churn on a real install is only 2-5 replacements per nightly run - so titles genuinely persist for weeks, and someone working through fifty recommendations has not "declined" the ones they simply have not reached yet. Three weeks was flagging queued titles.
+
+  The asymmetry also favors patience: a title wrongly left un-penalized is merely recommended again, whereas one wrongly penalized drags its whole genre/keyword neighborhood down.
+
 ## [2.16.2] - 2026-08-06
 
 ### Fixed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -249,7 +249,13 @@ negative_signals:
   # no genre can be buried so deep the profile cannot recover from it.
   ignored_recommendations:
     enabled: true
-    min_days_shown: 21  # Days on display before it counts as declined
+    # Days on display before a title counts as declined. 60 because a
+    # collection holds limit_results (50) titles at once and churns only
+    # a few per run - someone working through fifty recommendations has
+    # not declined the ones they simply have not reached. A title wrongly
+    # left alone is merely re-recommended; one wrongly penalized drags
+    # its whole neighborhood down, so this errs long.
+    min_days_shown: 60
     penalty: 0.5  # Total negative weight per ignored title
 
 # =============================================================================

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -843,6 +843,20 @@ class BaseRecommender(ABC):
     def _load_watched_cache(self) -> Dict:
         """Load watched cache from file. Returns the loaded cache dict."""
         watched_cache = {}
+        # Salvage label_dates BEFORE the version check, which deletes the
+        # file outright when CACHE_VERSION has moved.
+        #
+        # CACHE_VERSION exists to invalidate DERIVED data - cached scores,
+        # metadata shape - and is bumped for scoring changes that have
+        # nothing to do with user behavior. label_dates is not derived: it
+        # records when each recommendation was first shown, and it is the
+        # only clock the ignored-recommendation signal has (see
+        # utils/ignored_recs.py, which needs weeks of it). Letting a
+        # scoring change reset that clock meant the signal could never
+        # accumulate on an actively-maintained install - observed
+        # directly: two CACHE_VERSION bumps in one week left every label
+        # across six users no older than 6 days.
+        salvaged_label_dates = self._salvage_label_dates(self.watched_cache_path)
         cache_valid = check_cache_version(self.watched_cache_path, f"{self.media_type.upper()} watched cache")
         if cache_valid and os.path.exists(self.watched_cache_path):
             try:
@@ -876,6 +890,19 @@ class BaseRecommender(ABC):
             except (json.JSONDecodeError, KeyError, IOError) as e:
                 log_warning(f"Error loading watched cache: {e}")
                 self._refresh_watched_data()
+
+        # Carry the pre-rebuild clock forward. Entries already loaded from
+        # a still-valid cache win - they are the same values - so this only
+        # has an effect when the version check just deleted the file.
+        if salvaged_label_dates:
+            merged = dict(salvaged_label_dates)
+            merged.update(getattr(self, "label_dates", {}) or {})
+            if len(merged) > len(getattr(self, "label_dates", {}) or {}):
+                logger.debug(
+                    f"Preserved {len(merged) - len(getattr(self, 'label_dates', {}) or {})} label date(s) "
+                    f"across a watched-cache rebuild"
+                )
+            self.label_dates = merged
         return watched_cache
 
     def _do_save_watched_cache(self):
@@ -1245,6 +1272,28 @@ class BaseRecommender(ABC):
                 logger.debug(f"{self.single_user}: {len(self.user_played_ids)} items played per their own Plex view")
         except (AttributeError, KeyError, TypeError, ValueError) as e:
             logger.debug(f"Could not load per-user played ids: {e}")
+
+    @staticmethod
+    def _salvage_label_dates(cache_path: str) -> Dict[str, Any]:
+        """
+        Read label_dates out of a watched cache without honoring its
+        version.
+
+        Deliberately version-blind: this is the one key in that file that
+        must outlive a CACHE_VERSION bump, because it is an observation
+        log rather than derived data. Returns {} for any unreadable or
+        malformed file - a missing clock is recoverable, a crashed run is
+        not.
+        """
+        try:
+            with open(cache_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, ValueError):
+            return {}
+        dates = data.get("label_dates") if isinstance(data, dict) else None
+        if not isinstance(dates, dict):
+            return {}
+        return {k: v for k, v in dates.items() if isinstance(k, str) and isinstance(v, str)}
 
     def _collection_label_name(self) -> str:
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,6 +3,7 @@ Tests for recommenders/base.py - Base cache and recommender classes.
 """
 
 import copy
+import json
 import os
 from collections import Counter
 from unittest.mock import Mock, patch
@@ -3608,3 +3609,60 @@ class TestLoadWatchedCache:
 
         mock_warn.assert_called()
         recommender._refresh_watched_data.assert_called_once()
+
+
+class TestLabelDatesSurviveCacheRebuild:
+    """
+    label_dates must outlive a CACHE_VERSION bump.
+
+    CACHE_VERSION invalidates DERIVED data - cached scores, metadata
+    shape - and is bumped for scoring changes. label_dates is not
+    derived: it records when each recommendation was first shown, and it
+    is the only clock the ignored-recommendation signal has. Because
+    check_cache_version deletes the whole watched cache, a scoring change
+    used to reset that clock for every user. Observed directly: two
+    CACHE_VERSION bumps in one week left every label across six users no
+    older than 6 days, so a 60-day signal could never fire.
+    """
+
+    def test_salvages_label_dates_from_an_outdated_cache(self, tmp_path):
+        recommender = _make_recommender()
+        path = tmp_path / "watched.json"
+        path.write_text(
+            json.dumps({"cache_version": 1, "label_dates": {"1_Recommended_alice": "2026-01-01T00:00:00"}}),
+            encoding="utf-8",
+        )
+        salvaged = recommender._salvage_label_dates(str(path))
+        assert salvaged == {"1_Recommended_alice": "2026-01-01T00:00:00"}
+
+    def test_salvage_ignores_the_version(self, tmp_path):
+        """Version-blind on purpose - that is the whole point."""
+        recommender = _make_recommender()
+        path = tmp_path / "watched.json"
+        path.write_text(
+            json.dumps({"cache_version": 999999, "label_dates": {"7_R_bob": "2026-02-02T00:00:00"}}), encoding="utf-8"
+        )
+        assert recommender._salvage_label_dates(str(path)) == {"7_R_bob": "2026-02-02T00:00:00"}
+
+    def test_missing_file_yields_empty(self, tmp_path):
+        recommender = _make_recommender()
+        assert recommender._salvage_label_dates(str(tmp_path / "nope.json")) == {}
+
+    def test_malformed_file_yields_empty_not_a_crash(self, tmp_path):
+        """A missing clock is recoverable; a crashed run is not."""
+        recommender = _make_recommender()
+        path = tmp_path / "bad.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert recommender._salvage_label_dates(str(path)) == {}
+
+    def test_non_string_entries_are_dropped(self, tmp_path):
+        recommender = _make_recommender()
+        path = tmp_path / "w.json"
+        path.write_text(json.dumps({"label_dates": {"ok": "2026-01-01T00:00:00", "bad": 12345}}), encoding="utf-8")
+        assert recommender._salvage_label_dates(str(path)) == {"ok": "2026-01-01T00:00:00"}
+
+    def test_label_dates_absent_yields_empty(self, tmp_path):
+        recommender = _make_recommender()
+        path = tmp_path / "w.json"
+        path.write_text(json.dumps({"cache_version": 9}), encoding="utf-8")
+        assert recommender._salvage_label_dates(str(path)) == {}

--- a/tests/test_ignored_recs.py
+++ b/tests/test_ignored_recs.py
@@ -51,10 +51,13 @@ class TestFindIgnoredRecommendations:
         assert find_ignored_recommendations(dates, LABEL, set(), now=NOW) == []
 
     def test_sorted_longest_shown_first(self):
+        """All three deliberately clear the threshold - this pins the
+        ORDER, not the cutoff (see the boundary tests above)."""
+        base = IGNORED_REC_MIN_DAYS_SHOWN
         dates = {
-            f"1_{LABEL}": _days_ago(30),
-            f"2_{LABEL}": _days_ago(90),
-            f"3_{LABEL}": _days_ago(60),
+            f"1_{LABEL}": _days_ago(base + 10),
+            f"2_{LABEL}": _days_ago(base + 90),
+            f"3_{LABEL}": _days_ago(base + 40),
         }
         assert [rk for rk, _ in find_ignored_recommendations(dates, LABEL, set(), now=NOW)] == [2, 3, 1]
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.16.2"
+__version__ = "2.17.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item
@@ -259,8 +259,21 @@ DEFAULT_NEGATIVE_THRESHOLD = 3  # Ratings 0-3 become negative signals
 # that sat in a user's collection this long without being watched counts
 # as declined - the impression-level feedback every large recommender
 # leans on, which curatarr recorded (label_dates) but never read.
-# Three weeks is long enough to outlast "saving it for the weekend".
-IGNORED_REC_MIN_DAYS_SHOWN = 21
+#
+# 60 days, not the 21 this shipped with. A movie collection holds
+# limit_results (50 by default) titles at once, and measured churn on a
+# real install is only 2-5 replacements per nightly run - so a title
+# genuinely persists for weeks, and someone working through fifty
+# recommendations at any normal viewing rate has not "declined" the ones
+# they have not reached yet. Three weeks flagged titles that were merely
+# queued.
+#
+# The asymmetry also favors patience: a title wrongly left un-penalized
+# just gets recommended again, whereas one wrongly penalized drags its
+# whole genre/keyword neighborhood down. Two months of sitting there,
+# unwatched, while the user demonstrably watched other things, is
+# evidence; three weeks is not.
+IGNORED_REC_MIN_DAYS_SHOWN = 60
 # Total negative weight one ignored title contributes, split across the
 # terms it carries. Small on purpose: one ignored title is weak evidence,
 # twenty sharing a genre is not.


### PR DESCRIPTION
Two changes, one of which makes the other matter.

## 1. A `CACHE_VERSION` bump was resetting every user's ignored-recommendation clock

`label_dates` — when each recommendation was first shown — lives inside the watched cache, and `check_cache_version()` **deletes that file** whenever `CACHE_VERSION` moves.

But `CACHE_VERSION` exists to invalidate **derived** data (cached scores, metadata shape) and is bumped for scoring changes. `label_dates` is not derived — it's an observation log, and it's the only clock the ignored-recommendation signal has.

Measured on a real install:

```
301 labels across 6 users
median age 5d, p90 6d, max 6d
>=21d: 0    >=30d: 0    >=60d: 0
```

Two `CACHE_VERSION` bumps in one week (2.11.0 and 2.12.0) had wiped every clock. A signal needing weeks could never accumulate on an actively-maintained install — the feature was effectively dead and nothing said so.

`label_dates` is now salvaged **version-blind** before the check runs, and merged back after a rebuild. Verified against a real cache: all 50 entries survived a simulated bump with original dates intact, back to Jul 31.

## 2. `min_days_shown` 21 → 60

A movie collection holds `limit_results` (50) titles at once, and measured churn is only **2–5 replacements per nightly run** — so titles genuinely persist for weeks. Someone working through fifty recommendations has not "declined" the ones they simply haven't reached yet; three weeks was flagging queued titles.

The asymmetry favours patience too: a title wrongly left un-penalized is merely recommended again, whereas one wrongly penalized drags its whole genre/keyword neighbourhood down.

## Tests

6 new, covering version-blind salvage, a missing file, malformed JSON, non-string entries, and absent `label_dates` — all returning `{}` rather than raising, since a missing clock is recoverable and a crashed run isn't.

One existing test used 30/60/90-day fixtures and correctly stopped matching at the new default; retargeted above the threshold so it pins ordering rather than the cutoff.

3233 tests pass, ruff clean.