### PR TITLE
Fix: retain departed users private-collection labels in exclude filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.18.1] - 2026-08-13
+
+### Fixed
+
+- **A user removed from config had their private collection silently un-hidden from everyone else.** `collections.private_collections` excludes each user's `PrivateCollection_*` label from every OTHER user's `filterMovies`/`filterTelevision` so recommendation collections stay isolated per user - but `apply_user_label_restrictions()` only ever built that exclude list from the CURRENTLY configured user set. The moment a user left `users.list`, their label dropped out of everyone else's exclude filter on the very next run, exposing a collection that was never meant to be shared.
+
+  `utils/plex_policy.py` now persists every owner it has applied a `PrivateCollection_*` label for to `cache/private_label_owners.json` (new `utils/private_label_cache.py`, keyed by the same stable Plex account id `utils/user_migration.py` already trusts for rename detection - not username, so a rename is never mistaken for a departure). The exclude computation is now the union of currently-configured owners and any persisted owner no longer in config, minus the target user's own label - so a departed owner's collection stays hidden from everyone else indefinitely, and a warning names them each run. Self-exclusion (a user's own label is never in their own filter) and #340's one-PUT-per-physical-account alias collapsing are both unaffected.
+
+  Missing/corrupt `cache/private_label_owners.json` degrades to "no known owners" - never crashes a run, same convention as `utils/user_migration.py`'s own id map.
+
+### Added
+
+- **New opt-in `collections.prune_orphaned_private_labels` (default `false`).** Retaining a departed owner's label forever is the safe default, but some installs want the orphaned collection actually gone. Enabling this deletes it (ownership confirmed solely via its own `PrivateCollection_*` label - the same rule `utils.plex.remove_owned_collection`'s #291 no-history removal path already uses, never title/emoji guessing), strips the label, and drops the owner from the persisted cache. Off by default because it's destructive; never touches a currently-configured user's collection either way.
+- Retaining departed owners' labels makes `filterMovies`/`filterTelevision` monotonically non-shrinking where it previously could only ever be as long as the configured user count. `apply_user_label_restrictions()` now logs loudly (never truncates) if a built filter value grows past a generous length, pointing at the new prune option.
+
 ## [2.18.0] - 2026-08-12
 
 ### Changed

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -174,6 +174,22 @@ collections:
   # Note: Server admin always sees all collections (Plex limitation)
   private_collections: true
 
+  # #351: a user removed from users.list still had a PrivateCollection_*
+  # collection sitting in Plex, and once they were gone from config,
+  # private_collections above stopped excluding their label from
+  # everyone else's filterMovies/filterTelevision - silently un-hiding
+  # it. curatarr now remembers every owner it has ever created a private
+  # collection for (cache/private_label_owners.json, keyed by their
+  # stable Plex account id) and keeps retaining/excluding a departed
+  # owner's label indefinitely, logging a warning naming them each run.
+  # Set this to true to instead actually delete a departed owner's
+  # orphaned collection (ownership confirmed via their own
+  # PrivateCollection_* label, never by title guessing) and stop
+  # tracking them. Off by default: this is destructive (it deletes a
+  # real Plex collection), and never touches a currently-configured
+  # user's collection either way.
+  prune_orphaned_private_labels: false
+
 # =============================================================================
 # EXTERNAL RECOMMENDATIONS
 # =============================================================================

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1827,7 +1827,11 @@ class BaseRecommender(ABC):
                     # (movies) in both fields.
                     all_user_private_labels = build_all_private_labels(self.config, users, append_usernames)
 
-                    apply_user_label_restrictions(self.config, all_user_private_labels)
+                    # #351: cache_dir so departed owners' labels are
+                    # retained/warned-about/prunable - see
+                    # utils.plex_policy.apply_user_label_restrictions's
+                    # own docstring for what passing this actually does.
+                    apply_user_label_restrictions(self.config, all_user_private_labels, cache_dir=self.cache_dir)
 
             return success
 

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -3289,6 +3289,328 @@ class TestExclusionLabelRegressions:
         assert "PrivateCollection_bob" in home["filterMovies"]
 
 
+class TestPrivateLabelOwnerRetention:
+    """
+    #351: a user removed from config must not have their PrivateCollection_*
+    label silently un-hidden from everyone else's filterMovies/
+    filterTelevision. utils.plex_policy persists every owner it has
+    applied that label for (cache/private_label_owners.json - see
+    utils/private_label_cache.py) and retains a departed owner's label in
+    the exclude computation until collections.prune_orphaned_private_labels
+    explicitly tears it down.
+    """
+
+    USERS_XML = (
+        b"<MediaContainer>"
+        b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+        b' filterMovies="" filterTelevision=""/>'
+        b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+        b"</MediaContainer>"
+    )
+
+    BOTH_CONFIGURED = {
+        "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+        "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+    }
+    ONLY_HOME_CONFIGURED = {
+        "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+    }
+
+    def _run(self, config, labels, cache_dir, users_xml=None, puts=None):
+        from utils import plex_policy
+
+        puts = puts if puts is not None else []
+
+        def fake_put(url, params=None, **kw):
+            puts.append((url, params))
+            return Mock(raise_for_status=Mock())
+
+        with (
+            patch.object(plex_policy, "MyPlexAccount", return_value=Mock(username="admin")),
+            patch.object(
+                plex_policy,
+                "_capped_get",
+                return_value=Mock(content=users_xml or self.USERS_XML, raise_for_status=Mock()),
+            ),
+            patch.object(plex_policy, "_capped_put", side_effect=fake_put),
+        ):
+            ok = plex_policy.apply_user_label_restrictions(config, labels, cache_dir=str(cache_dir))
+        return ok, puts
+
+    def test_departed_owner_label_is_retained_across_a_subsequent_run(self, tmp_path):
+        """Required regression #1: bob leaves config, but his label must
+        still show up in home's exclude filter on the very next run."""
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        _ok, puts = self._run(config, self.ONLY_HOME_CONFIGURED, tmp_path)
+
+        home_put = next(p for url, p in puts if url.endswith("/1"))
+        assert "PrivateCollection_bob" in home_put["filterMovies"], "departed owner's label was dropped"
+        assert "PrivateCollection_bob" in home_put["filterTelevision"], "departed owner's label was dropped"
+
+    def test_self_exclusion_invariant_holds_with_departed_owners_present(self, tmp_path):
+        """Required regression #2: retaining bob's label must never leak
+        into home's OWN exclude filter."""
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        _ok, puts = self._run(config, self.ONLY_HOME_CONFIGURED, tmp_path)
+
+        home_put = next(p for url, p in puts if url.endswith("/1"))
+        assert "PrivateCollection_homehouse165" not in home_put["filterMovies"]
+        assert "PrivateCollection_homehouse165" not in home_put["filterTelevision"]
+
+    def test_prune_disabled_by_default_warns_but_never_deletes(self, tmp_path):
+        """Required regression #3: prune is off by default - an orphan
+        is detected and warned about, but nothing in Plex is touched and
+        the owner stays tracked (i.e. their collection is left alone)."""
+        from utils import plex_policy
+        from utils.private_label_cache import load_private_label_owners
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        with (
+            patch.object(plex_policy, "prune_orphaned_private_collections") as mock_prune,
+            patch.object(plex_policy, "log_warning") as mock_warn,
+        ):
+            self._run(config, self.ONLY_HOME_CONFIGURED, tmp_path)
+
+        mock_prune.assert_not_called()
+        assert any("bob" in str(call) for call in mock_warn.call_args_list), "no warning named the departed owner"
+
+        owners = load_private_label_owners(str(tmp_path))
+        assert "2" in owners, "orphaned owner must stay tracked while prune is disabled"
+
+    def test_prune_enabled_deletes_collection_updates_cache_and_stops_excluding(self, tmp_path):
+        """Required regression #4: opting in tears the orphan down -
+        collection deleted, cache entry dropped, and (once that takes
+        effect) remaining users' filters stop carrying the label.
+
+        Uses a THIRD always-configured user (carol) alongside home/bob so
+        home's exclude list never drops to empty when bob departs - an
+        exclude list going empty hits a separate, pre-existing "value
+        unchanged from a caller's point of view" early-continue in
+        apply_user_label_restrictions that skips the PUT needed to CLEAR
+        an existing filter back down to nothing. That gap predates #351
+        and isn't part of what this fix touches; carol keeps this test
+        isolated to what #351 actually changed.
+        """
+        from utils.private_label_cache import load_private_label_owners
+
+        users_xml = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+            b'<User id="3" title="Carol" username="carol" email="c@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        all_three = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+        home_and_carol = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, all_three, tmp_path, users_xml=users_xml)
+
+        prune_config = {"plex": {"token": "t"}, "collections": {"prune_orphaned_private_labels": True}}
+
+        mock_collection = Mock()
+        mock_collection.title = "Bob's Collection"
+        mock_collection.labels = [Mock(tag="PrivateCollection_bob")]
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_collection]
+        mock_plex = Mock()
+        mock_plex.library.section.return_value = mock_section
+
+        puts_run2 = []
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            self._run(prune_config, home_and_carol, tmp_path, users_xml=users_xml, puts=puts_run2)
+
+        assert mock_collection.delete.called, "orphaned collection was never deleted"
+
+        owners_after = load_private_label_owners(str(tmp_path))
+        assert "2" not in owners_after, "departed owner was not dropped from the cache"
+        assert "1" in owners_after and "3" in owners_after, "still-configured owners must stay tracked"
+
+        # Run 3 reflects what run 2 actually applied to home's filter
+        # (the #340 no-op gate only PUTs a genuinely changed value), so
+        # this proves pruning actually changes future behavior rather
+        # than just a dict key disappearing.
+        home_put_run2 = next(p for url, p in puts_run2 if url.endswith("/1"))
+        xml_after_run2 = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="' + home_put_run2["filterMovies"].encode() + b'"'
+            b' filterTelevision="' + home_put_run2["filterTelevision"].encode() + b'"/>'
+            b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+            b'<User id="3" title="Carol" username="carol" email="c@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        _ok, puts_run3 = self._run(prune_config, home_and_carol, tmp_path, users_xml=xml_after_run2)
+
+        home_put_run3 = next(p for url, p in puts_run3 if url.endswith("/1"))
+        assert "PrivateCollection_bob" not in home_put_run3["filterMovies"], "pruned owner's label still excluded"
+        assert "PrivateCollection_carol" in home_put_run3["filterMovies"], "still-configured owner wrongly dropped"
+
+    def test_corrupt_cache_file_degrades_safely(self, tmp_path):
+        """Required regression #5: a corrupt/unreadable cache file must
+        never crash a run - just behave as if nothing was persisted."""
+        (tmp_path / "private_label_owners.json").write_text("not valid json", encoding="utf-8")
+
+        config = {"plex": {"token": "t"}}
+        ok, puts = self._run(config, self.ONLY_HOME_CONFIGURED, tmp_path)
+
+        assert ok is True
+        assert puts  # a normal run still proceeds and applies restrictions
+
+    def test_live_owner_wins_over_a_stale_persisted_entry_with_the_same_name(self, tmp_path):
+        """A departed owner's persisted username can never shadow a
+        currently-configured user who happens to share that exact name -
+        the live entry (from all_user_private_labels) is authoritative,
+        the stale persisted one is skipped.
+
+        The original Plex account (id 2) is gone entirely by run 2 - a
+        DIFFERENT Plex account (id 5) now resolves to the literal
+        username "bob", the same way a server could hand that username
+        to a new person after the old account was removed. This is the
+        only way persisted-id "2" actually ends up orphaned (find_orphaned_owners
+        works on ids, never on username text) - a fixture that reuses
+        the same id across both runs never produces an orphan at all and
+        would pass even if the shadowing guard were deleted.
+        """
+        from utils.private_label_cache import load_private_label_owners
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        new_bob_xml = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b'<User id="5" title="Bob" username="bob" email="newbob@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        replaced = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_2_bob"], "tv": ["PrivateCollection_2_bob"]},
+        }
+        _ok, puts = self._run(config, replaced, tmp_path, users_xml=new_bob_xml)
+
+        home_put = next(p for url, p in puts if url.endswith("/1"))
+        assert "PrivateCollection_2_bob" in home_put["filterMovies"], "live entry was not used"
+        assert home_put["filterMovies"].count("bob") == 1, "stale persisted label leaked in alongside the live one"
+
+        owners = load_private_label_owners(str(tmp_path))
+        assert owners["5"]["labels"]["movie"] == ["PrivateCollection_2_bob"], "live account id must hold the live label"
+
+    def test_self_exclusion_invariant_holds_for_the_departed_owner_too(self, tmp_path):
+        """bob leaves config but is still an actual user on the Plex
+        server (#332 covers every server user, not only configured
+        ones), so his own filter still gets recomputed on this run. His
+        own retained label must never end up excluding his own
+        collection from himself - the same self-exclusion invariant that
+        already holds for a still-configured user must hold for him
+        too."""
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        _ok, puts = self._run(config, self.ONLY_HOME_CONFIGURED, tmp_path)
+
+        bob_put = next(p for url, p in puts if url.endswith("/2"))
+        assert "PrivateCollection_bob" not in bob_put["filterMovies"]
+        assert "PrivateCollection_bob" not in bob_put["filterTelevision"]
+
+    def test_resolution_failure_never_makes_prune_delete_a_configured_user(self, tmp_path):
+        """A currently-configured user whose name fails to resolve
+        against this run's live Plex user list (e.g. a transient lookup
+        glitch) must never be treated as orphaned - a resolution miss is
+        not the same thing as a departure, and
+        collections.prune_orphaned_private_labels must never delete a
+        real, still-configured user's collection over a single bad
+        run."""
+        from utils import plex_policy
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, self.BOTH_CONFIGURED, tmp_path)
+
+        # bob is still configured (still a key in all_user_private_labels)
+        # but this run's Plex user list no longer contains anyone
+        # resolving to him, simulating a transient lookup failure rather
+        # than an actual departure.
+        users_xml_without_bob = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        prune_config = {"plex": {"token": "t"}, "collections": {"prune_orphaned_private_labels": True}}
+
+        with patch.object(plex_policy, "prune_orphaned_private_collections") as mock_prune:
+            self._run(prune_config, self.BOTH_CONFIGURED, tmp_path, users_xml=users_xml_without_bob)
+
+        mock_prune.assert_not_called()
+
+    def test_long_exclude_filter_logs_a_loud_warning_instead_of_truncating(self, tmp_path):
+        """#351 point 5: retention makes filterMovies/filterTelevision
+        monotonically non-shrinking, where it previously could only ever
+        be as long as the configured user count. Once retaining many
+        departed owners grows the built filter value past
+        MAX_EXCLUDE_FILTER_LENGTH, this must log loudly - never silently
+        truncate what actually gets sent to Plex."""
+        from utils import plex_policy
+
+        home_label = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]}
+        }
+        many_configured = dict(home_label)
+        many_configured.update(
+            {f"user_{i}": {"movie": [f"PrivateCollection_user_{i}" * 20], "tv": []} for i in range(30)}
+        )
+        # Every one of the 31 users must actually resolve to a Plex id in
+        # run 1 for their label to be persisted at all.
+        run1_xml_users = [
+            '<User id="1" title="home house" username="homehouse165" email="h@x" filterMovies="" filterTelevision=""/>'
+        ]
+        run1_xml_users += [
+            f'<User id="{i + 2}" title="user_{i}" username="user_{i}" email="u{i}@x" '
+            f'filterMovies="" filterTelevision=""/>'
+            for i in range(30)
+        ]
+        run1_xml = ("<MediaContainer>" + "".join(run1_xml_users) + "</MediaContainer>").encode()
+
+        # Run 2: home is the only user left configured - all 30 others
+        # have left config (whether or not they're still live Plex
+        # users is irrelevant to "departed"; a minimal XML is enough).
+        run2_xml = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, many_configured, tmp_path, users_xml=run1_xml)
+
+        with patch.object(plex_policy, "log_warning") as mock_warn:
+            ok, puts = self._run(config, home_label, tmp_path, users_xml=run2_xml)
+
+        assert ok is True
+        home_put = next(p for url, p in puts if url.endswith("/1"))
+        assert len(home_put["filterMovies"]) > plex_policy.MAX_EXCLUDE_FILTER_LENGTH
+        # Every one of the 30 retained labels is present - nothing was
+        # dropped/truncated to fit under the length.
+        assert all(f"PrivateCollection_user_{i}" in home_put["filterMovies"] for i in range(30))
+        assert any("may exceed what Plex" in str(call) for call in mock_warn.call_args_list)
+
+
 def _root():
     """Whatever conftest's isolation fixture pointed get_project_root at."""
     from utils.plex import get_project_root

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -3460,6 +3460,95 @@ class TestPrivateLabelOwnerRetention:
         assert "PrivateCollection_bob" not in home_put_run3["filterMovies"], "pruned owner's label still excluded"
         assert "PrivateCollection_carol" in home_put_run3["filterMovies"], "still-configured owner wrongly dropped"
 
+    def test_prune_enabled_but_plex_unreachable_orphan_stays_tracked_and_excluded(self, tmp_path):
+        """Regression for the #351 follow-up: prune_orphaned_private_collections
+        returning cleanly with nothing deleted (Plex unreachable) must not
+        be read by the caller as "go ahead and forget this owner". bob's
+        entry has to survive in the persisted cache AND keep showing up
+        in everyone else's exclude filter on the run after this one -
+        exactly the gap test_connect_failure_returns_empty_list, checked
+        only at the low-level prune function in isolation, could not
+        catch.
+        """
+        from utils.private_label_cache import load_private_label_owners
+
+        users_xml = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+            b'<User id="3" title="Carol" username="carol" email="c@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        all_three = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+        home_and_carol = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, all_three, tmp_path, users_xml=users_xml)
+
+        prune_config = {"plex": {"token": "t"}, "collections": {"prune_orphaned_private_labels": True}}
+
+        with patch("utils.plex.init_plex", side_effect=Exception("connection refused")):
+            self._run(prune_config, home_and_carol, tmp_path, users_xml=users_xml)
+
+        owners_after = load_private_label_owners(str(tmp_path))
+        assert "2" in owners_after, "orphan was forgotten despite prune never reaching Plex"
+
+        _ok, puts_run3 = self._run(prune_config, home_and_carol, tmp_path, users_xml=users_xml)
+        home_put_run3 = next(p for url, p in puts_run3 if url.endswith("/1"))
+        assert "PrivateCollection_bob" in home_put_run3["filterMovies"], "un-hid a collection that was never deleted"
+
+    def test_prune_enabled_but_section_raises_orphan_stays_tracked_and_excluded(self, tmp_path):
+        """Same gap as above, but the failure mode is a single library
+        section raising PlexApiException mid-scan rather than Plex being
+        fully unreachable - bob's collection is never located, so bob
+        must stay tracked and excluded exactly as if prune had never run.
+        """
+        from utils.private_label_cache import load_private_label_owners
+
+        users_xml = (
+            b"<MediaContainer>"
+            b'<User id="1" title="home house" username="homehouse165" email="h@x"'
+            b' filterMovies="" filterTelevision=""/>'
+            b'<User id="2" title="Bob" username="bob" email="b@x" filterMovies="" filterTelevision=""/>'
+            b'<User id="3" title="Carol" username="carol" email="c@x" filterMovies="" filterTelevision=""/>'
+            b"</MediaContainer>"
+        )
+        all_three = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "bob": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+        home_and_carol = {
+            "homehouse165": {"movie": ["PrivateCollection_homehouse165"], "tv": ["PrivateCollection_homehouse165"]},
+            "carol": {"movie": ["PrivateCollection_carol"], "tv": ["PrivateCollection_carol"]},
+        }
+
+        config = {"plex": {"token": "t"}}
+        self._run(config, all_three, tmp_path, users_xml=users_xml)
+
+        prune_config = {"plex": {"token": "t"}, "collections": {"prune_orphaned_private_labels": True}}
+
+        mock_plex = Mock()
+        mock_plex.library.section.side_effect = plexapi.exceptions.PlexApiException("section unavailable")
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            self._run(prune_config, home_and_carol, tmp_path, users_xml=users_xml)
+
+        owners_after = load_private_label_owners(str(tmp_path))
+        assert "2" in owners_after, "orphan was forgotten despite its section never being reachable"
+
+        _ok, puts_run3 = self._run(prune_config, home_and_carol, tmp_path, users_xml=users_xml)
+        home_put_run3 = next(p for url, p in puts_run3 if url.endswith("/1"))
+        assert "PrivateCollection_bob" in home_put_run3["filterMovies"], "un-hid a collection that was never deleted"
+
     def test_corrupt_cache_file_degrades_safely(self, tmp_path):
         """Required regression #5: a corrupt/unreadable cache file must
         never crash a run - just behave as if nothing was persisted."""

--- a/tests/test_private_label_cache.py
+++ b/tests/test_private_label_cache.py
@@ -1,0 +1,196 @@
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for utils/private_label_cache.py - the persisted registry of
+PrivateCollection_* label owners (#351).
+
+Every test here uses tmp_path - never the real cache/ directory.
+"""
+
+from unittest.mock import Mock, patch
+
+import plexapi.exceptions
+
+from utils.private_label_cache import (
+    find_orphaned_owners,
+    load_private_label_owners,
+    prune_orphaned_private_collections,
+    save_private_label_owners,
+)
+
+
+class TestLoadSavePrivateLabelOwners:
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        assert load_private_label_owners(str(tmp_path)) == {}
+
+    def test_save_then_load_roundtrip(self, tmp_path):
+        owners = {
+            "1": {
+                "username": "alice",
+                "labels": {"movie": ["PrivateCollection_alice"], "tv": ["PrivateCollection_alice"]},
+            },
+            "2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]}},
+        }
+        save_private_label_owners(str(tmp_path), owners)
+
+        assert load_private_label_owners(str(tmp_path)) == owners
+
+    def test_load_corrupt_json_returns_empty(self, tmp_path):
+        (tmp_path / "private_label_owners.json").write_text("not valid json", encoding="utf-8")
+
+        assert load_private_label_owners(str(tmp_path)) == {}
+
+    def test_load_non_dict_json_returns_empty(self, tmp_path):
+        (tmp_path / "private_label_owners.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        assert load_private_label_owners(str(tmp_path)) == {}
+
+    def test_malformed_entries_are_dropped_not_fatal(self, tmp_path):
+        """One bad entry must not discard every good entry in the file."""
+        (tmp_path / "private_label_owners.json").write_text(
+            '{"1": {"username": "alice", "labels": {"movie": ["PC_alice"], "tv": ["PC_alice"]}}, '
+            '"2": "not a dict", '
+            '"3": {"username": "", "labels": {}}, '
+            '"4": {"labels": {"movie": ["PC_dave"], "tv": []}}}',
+            encoding="utf-8",
+        )
+
+        result = load_private_label_owners(str(tmp_path))
+
+        assert list(result.keys()) == ["1"]
+        assert result["1"]["username"] == "alice"
+
+    def test_missing_media_type_defaults_to_empty_list(self, tmp_path):
+        """labels missing a movie/tv key (e.g. a single-media-type
+        install's owner) must not raise a KeyError downstream."""
+        (tmp_path / "private_label_owners.json").write_text(
+            '{"1": {"username": "alice", "labels": {"movie": ["PC_alice"]}}}', encoding="utf-8"
+        )
+
+        result = load_private_label_owners(str(tmp_path))
+
+        assert result["1"]["labels"] == {"movie": ["PC_alice"], "tv": []}
+
+    def test_save_creates_cache_dir(self, tmp_path):
+        cache_dir = tmp_path / "nested" / "cache"
+
+        save_private_label_owners(str(cache_dir), {"1": {"username": "alice", "labels": {"movie": [], "tv": []}}})
+
+        assert (cache_dir / "private_label_owners.json").exists()
+
+    def test_save_failure_does_not_raise(self, tmp_path, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("utils.private_label_cache.os.makedirs", _boom)
+
+        # Must not raise - a cache that can't be written is a
+        # lost-memory problem for the next run, never this one's.
+        save_private_label_owners(str(tmp_path / "unwritable"), {"1": {"username": "a", "labels": {}}})
+
+
+class TestFindOrphanedOwners:
+    def test_no_persisted_owners_returns_empty(self):
+        assert find_orphaned_owners({}, ["1", "2"]) == {}
+
+    def test_all_persisted_still_current_returns_empty(self):
+        persisted = {"1": {"username": "alice", "labels": {}}}
+        assert find_orphaned_owners(persisted, ["1", "2"]) == {}
+
+    def test_departed_owner_is_returned(self):
+        persisted = {
+            "1": {"username": "alice", "labels": {}},
+            "2": {"username": "bob", "labels": {}},
+        }
+        result = find_orphaned_owners(persisted, ["1"])
+
+        assert list(result.keys()) == ["2"]
+        assert result["2"]["username"] == "bob"
+
+    def test_empty_current_owner_ids_orphans_everyone_persisted(self):
+        persisted = {"1": {"username": "alice", "labels": {}}}
+        assert find_orphaned_owners(persisted, []) == persisted
+
+
+class TestPruneOrphanedPrivateCollections:
+    def _config(self):
+        return {"plex": {"token": "t"}, "plex_users": {}, "libraries": None}
+
+    def test_no_orphans_returns_empty_without_connecting(self):
+        with patch("utils.plex.init_plex") as mock_init:
+            result = prune_orphaned_private_collections(self._config(), {})
+
+        assert result == []
+        mock_init.assert_not_called()
+
+    def test_connect_failure_returns_empty_list(self):
+        orphaned = {"2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": []}}}
+
+        with patch("utils.plex.init_plex", side_effect=Exception("connection refused")):
+            result = prune_orphaned_private_collections(self._config(), orphaned)
+
+        assert result == []
+
+    def test_deletes_matching_collection_and_reports_username(self):
+        orphaned = {
+            "2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": ["PrivateCollection_bob"]}}
+        }
+
+        mock_collection = Mock()
+        mock_collection.title = "Bob's Collection"
+        mock_collection.labels = [Mock(tag="PrivateCollection_bob")]
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_collection]
+        mock_plex = Mock()
+        mock_plex.library.section.return_value = mock_section
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            result = prune_orphaned_private_collections(self._config(), orphaned)
+
+        assert mock_collection.delete.called
+        assert result == ["bob"]
+
+    def test_never_touches_a_collection_without_the_label(self):
+        """A collection that doesn't carry the departed owner's label is
+        never a candidate, no matter what else lives in that library."""
+        orphaned = {"2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": []}}}
+
+        unrelated_collection = Mock()
+        unrelated_collection.labels = [Mock(tag="SomeoneElsesLabel")]
+        mock_section = Mock()
+        mock_section.collections.return_value = [unrelated_collection]
+        mock_plex = Mock()
+        mock_plex.library.section.return_value = mock_section
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            prune_orphaned_private_collections(self._config(), orphaned)
+
+        unrelated_collection.delete.assert_not_called()
+
+    def test_unavailable_library_is_skipped_not_fatal(self):
+        """A library that doesn't resolve (e.g. renamed/removed section)
+        must not stop pruning for other libraries/owners."""
+        orphaned = {"2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": []}}}
+
+        mock_plex = Mock()
+        mock_plex.library.section.side_effect = plexapi.exceptions.NotFound("no such library")
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            result = prune_orphaned_private_collections(self._config(), orphaned)
+
+        # Still reports the owner as attempted - nothing left to keep
+        # retrying for indefinitely once every library has been tried.
+        assert result == ["bob"]

--- a/tests/test_private_label_cache.py
+++ b/tests/test_private_label_cache.py
@@ -191,6 +191,53 @@ class TestPruneOrphanedPrivateCollections:
         with patch("utils.plex.init_plex", return_value=mock_plex):
             result = prune_orphaned_private_collections(self._config(), orphaned)
 
-        # Still reports the owner as attempted - nothing left to keep
-        # retrying for indefinitely once every library has been tried.
+        # The only library that could have held bob's collection could
+        # not even be checked, so nothing was confirmed deleted - bob
+        # must NOT be reported as pruned, or the caller would stop
+        # tracking a collection that, for all this run knows, still
+        # exists.
+        assert result == []
+
+    def test_section_exception_does_not_mask_a_deletion_found_elsewhere(self):
+        """One library section raising must not stop a later library in
+        the same run from being checked and, if found there, deleted -
+        and the owner MUST be reported pruned in that case."""
+        orphaned = {"2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": []}}}
+
+        mock_collection = Mock()
+        mock_collection.title = "Bob's Collection"
+        mock_collection.labels = [Mock(tag="PrivateCollection_bob")]
+        good_section = Mock()
+        good_section.collections.return_value = [mock_collection]
+
+        mock_plex = Mock()
+        mock_plex.library.section.side_effect = [
+            plexapi.exceptions.NotFound("no such library"),
+            good_section,
+        ]
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            with patch(
+                "utils.private_label_cache.get_libraries_for_media_type",
+                return_value=[{"section": "Movies1"}, {"section": "Movies2"}],
+            ):
+                result = prune_orphaned_private_collections(self._config(), orphaned)
+
+        assert mock_collection.delete.called
         assert result == ["bob"]
+
+    def test_nothing_found_anywhere_is_not_reported_pruned(self):
+        """A label with no matching collection in any checkable library
+        (already removed by hand, never created, etc) is left untouched
+        in the cache - nothing to forget, since nothing was deleted."""
+        orphaned = {"2": {"username": "bob", "labels": {"movie": ["PrivateCollection_bob"], "tv": []}}}
+
+        mock_section = Mock()
+        mock_section.collections.return_value = []
+        mock_plex = Mock()
+        mock_plex.library.section.return_value = mock_section
+
+        with patch("utils.plex.init_plex", return_value=mock_plex):
+            result = prune_orphaned_private_collections(self._config(), orphaned)
+
+        assert result == []

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.18.0"
+__version__ = "2.18.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -58,6 +58,12 @@ from plexapi.myplex import MyPlexAccount
 from .config import MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV, PLEX_REQUEST_TIMEOUT
 from .display import GREEN, RESET, log_warning
 from .plex import _capped_get, _capped_put
+from .private_label_cache import (
+    find_orphaned_owners,
+    load_private_label_owners,
+    prune_orphaned_private_collections,
+    save_private_label_owners,
+)
 
 logger = logging.getLogger("curatarr")
 
@@ -194,10 +200,27 @@ def build_all_private_labels(
     return labels
 
 
+# #351: filterMovies/filterTelevision are sent to plex.tv as URL
+# query-string params (see the _capped_put call below), not a request
+# body - there is no documented hard limit, but a query string growing
+# without bound risks silent rejection/truncation somewhere between here
+# and Plex's servers (a proxy, a load balancer, plex.tv itself).
+# Retaining departed owners' labels (see the exclude-list computation
+# below) makes this list monotonically non-shrinking by design, where
+# previously it could only ever be as long as the currently-configured
+# user count. Purely advisory: nothing here ever truncates the value
+# being sent - silently dropping a label to fit under a made-up limit
+# would just reintroduce this same bug for whichever label got cut - it
+# only logs loudly so an install accumulating many never-pruned departed
+# owners finds out from a warning, not from a quietly-broken exclusion.
+MAX_EXCLUDE_FILTER_LENGTH = 4000
+
+
 def apply_user_label_restrictions(
     config: Dict,
     all_user_private_labels: Mapping[str, Union[str, Sequence[str], Mapping[str, Sequence[str]]]],
     restrict_unconfigured_users: bool = True,
+    cache_dir: Optional[str] = None,
 ) -> bool:
     """
     Apply exclude restrictions so each user's collection is excluded from
@@ -235,6 +258,22 @@ def apply_user_label_restrictions(
                          "PrivateCollection" instead of the configured
                          label_name)
                          e.g., {'Jason': 'PrivateCollection_Jason', 'Sarah': 'PrivateCollection_Sarah'}
+        restrict_unconfigured_users: Cover every user on the server
+                         (#332), not only configured ones - see the
+                         comment on the short-circuit below.
+        cache_dir: Directory holding cache/private_label_owners.json
+                         (#351) - typically BaseRecommender.cache_dir.
+                         When given, this run (a) retains any previously
+                         -persisted owner's label in the exclude
+                         computation even after they leave config, (b)
+                         warns once if any such departed owners are
+                         found, (c) tears their collection down if
+                         collections.prune_orphaned_private_labels is
+                         enabled, and (d) persists this run's owners for
+                         next time. None (the default) skips all of
+                         that and behaves exactly as before #351 -
+                         existing callers/tests that never pass it are
+                         unaffected.
 
     Returns:
         True if all restrictions applied successfully, False if any failed
@@ -242,12 +281,23 @@ def apply_user_label_restrictions(
     if not all_user_private_labels:
         return True
 
+    # #351: loaded up front (cheap, local disk) so the short-circuit
+    # below can account for departed owners this run might still need to
+    # retain - a non-empty persisted cache means there is potentially
+    # something to do even when today's config has only one owner.
+    persisted_owners: Dict[str, Dict] = {}
+    if cache_dir:
+        persisted_owners = load_private_label_owners(cache_dir)
+
     # One configured user hides their collection from nobody - UNLESS
     # unconfigured server users are also covered (#332), in which case
     # that single user's collection still needs hiding from everyone
     # else on the server. The old unconditional short-circuit silently
-    # disabled that whole path for single-user installs.
-    if len(all_user_private_labels) <= 1 and not restrict_unconfigured_users:
+    # disabled that whole path for single-user installs. #351: also
+    # skipped only when nothing is persisted either - a departed owner's
+    # retained label still needs excluding from this one remaining user
+    # even though today's config has only them.
+    if len(all_user_private_labels) <= 1 and not restrict_unconfigured_users and not persisted_owners:
         return True
 
     plex_token = config["plex"]["token"]
@@ -335,6 +385,50 @@ def apply_user_label_restrictions(
 
         admin_id = alias_to_id.get(admin_username)
 
+        # #351: a user removed from config must not have their label
+        # silently un-hidden from everyone else - union in any persisted
+        # owner whose account id is no longer among this run's resolved
+        # id_to_configured. Keyed by their last-known username, which can
+        # never collide with a real id_to_configured VALUE for someone
+        # else (those all come from all_user_private_labels' own keys,
+        # checked first) unless a live config user happens to reuse that
+        # exact name, in which case the live entry wins and the stale one
+        # is skipped.
+        orphaned_owners = find_orphaned_owners(persisted_owners, id_to_configured.keys())
+
+        # Defense in depth: a username that is still a key in
+        # all_user_private_labels is, by definition, still configured
+        # this run - never treat it as orphaned just because id
+        # resolution happened to miss it this run (a transient Plex API
+        # hiccup, a one-off alias mismatch, etc). Without this, a
+        # resolution failure for an otherwise-still-configured user could
+        # both misreport them as departed AND - with
+        # prune_orphaned_private_labels enabled - actually delete their
+        # real collection, which must never happen to a configured user.
+        orphaned_owners = {
+            account_id: entry
+            for account_id, entry in orphaned_owners.items()
+            if entry["username"] not in all_user_private_labels
+        }
+
+        effective_labels: Dict[str, Any] = dict(all_user_private_labels)
+        for entry in orphaned_owners.values():
+            key = entry["username"]
+            if key in effective_labels:
+                continue
+            effective_labels[key] = entry["labels"]
+
+        if orphaned_owners:
+            orphan_names = sorted(entry["username"] for entry in orphaned_owners.values())
+            log_warning(
+                f"{len(orphan_names)} user(s) no longer configured still have a "
+                f"PrivateCollection_* label excluded from every other user's filters, "
+                f"so their collection stays hidden rather than unexpectedly exposed: "
+                f"{', '.join(orphan_names)}. Set collections.prune_orphaned_private_labels: "
+                "true in config/tuning.yml to delete their orphaned collection(s) and "
+                "stop tracking them."
+            )
+
         # #332: cover every user on the server, not only configured ones -
         # an unmanaged user still sees everyone's PrivateCollection_*
         # collections otherwise, which is the condition this prevents.
@@ -346,6 +440,17 @@ def apply_user_label_restrictions(
                 continue
 
             owner = id_to_configured.get(user_id)  # None => not configured, owns no labels
+            if owner is None:
+                # #351: a departed-but-still-present-on-the-server owner
+                # (restrict_unconfigured_users still recomputes their
+                # filter too, per #332) must keep seeing their OWN old
+                # collection - only every OTHER user's exclude filter is
+                # supposed to retain their label. Without this fallback,
+                # their retained label would never match `owner` below
+                # (which is None for them) and would wrongly get
+                # excluded from their own filter too.
+                orphan_entry = orphaned_owners.get(user_id)
+                owner = orphan_entry["username"] if orphan_entry else None
             display = owner or (by_id.get(user_id, {}).get("aliases") or [user_id])[0]
 
             # Per media type (#340): filterMovies governs movie libraries
@@ -353,13 +458,30 @@ def apply_user_label_restrictions(
             # other kind can never match there and does not belong in it.
             params: Dict[str, str] = {}
             for field, media_type in (("filterMovies", MEDIA_TYPE_MOVIE), ("filterTelevision", MEDIA_TYPE_TV)):
-                exclude = [
-                    label
-                    for name, labels in all_user_private_labels.items()
-                    if name != owner
-                    for label in _labels_for(labels, media_type)
-                ]
-                params[field] = f"label!={','.join(exclude)}" if exclude else ""
+                # #351: effective_labels (computed above), not
+                # all_user_private_labels directly - the union of
+                # currently configured owners and any still-retained
+                # departed owners. De-duped (explicit loop, not a list
+                # comprehension, to preserve order while doing it) in
+                # case a departed owner's persisted labels ever overlap
+                # a live one's.
+                exclude: List[str] = []
+                for name, labels in effective_labels.items():
+                    if name == owner:
+                        continue
+                    for label in _labels_for(labels, media_type):
+                        if label not in exclude:
+                            exclude.append(label)
+                value = f"label!={','.join(exclude)}" if exclude else ""
+                if len(value) > MAX_EXCLUDE_FILTER_LENGTH:
+                    log_warning(
+                        f"{field} for {display} is {len(value)} characters across "
+                        f"{len(exclude)} excluded labels - this may exceed what Plex's "
+                        "API can reliably accept. Consider enabling "
+                        "collections.prune_orphaned_private_labels (config/tuning.yml) "
+                        "to remove labels for users no longer configured."
+                    )
+                params[field] = value
 
             if not any(params.values()):
                 continue
@@ -386,6 +508,30 @@ def apply_user_label_restrictions(
             except requests.RequestException as e:
                 log_warning(f"Failed to apply restrictions for {display}: {e}")
                 all_success = False
+
+        # #351: persist this run's owners so a FUTURE run - even after
+        # some of today's owners are gone from config - still knows
+        # their label needs excluding. Starts from whatever was already
+        # persisted (so an orphan not pruned this run stays remembered),
+        # then overlays every currently-configured owner resolved above.
+        if cache_dir:
+            updated_owners = dict(persisted_owners)
+            for account_id, name in id_to_configured.items():
+                updated_owners[account_id] = {
+                    "username": name,
+                    "labels": {
+                        media_type: _labels_for(all_user_private_labels.get(name, {}), media_type)
+                        for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV)
+                    },
+                }
+
+            prune_orphaned = bool(config.get("collections", {}).get("prune_orphaned_private_labels", False))
+            if orphaned_owners and prune_orphaned:
+                prune_orphaned_private_collections(config, orphaned_owners)
+                for account_id in orphaned_owners:
+                    updated_owners.pop(account_id, None)
+
+            save_private_label_owners(cache_dir, updated_owners)
 
         return all_success
 

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -527,9 +527,18 @@ def apply_user_label_restrictions(
 
             prune_orphaned = bool(config.get("collections", {}).get("prune_orphaned_private_labels", False))
             if orphaned_owners and prune_orphaned:
-                prune_orphaned_private_collections(config, orphaned_owners)
-                for account_id in orphaned_owners:
-                    updated_owners.pop(account_id, None)
+                # #351 follow-up: only forget an orphan whose collection
+                # was actually located and deleted this run - never on
+                # the strength of "we tried". A discarded return value
+                # here previously popped every orphan regardless of
+                # outcome, which meant a Plex-unreachable run or a single
+                # library section raising mid-scan silently un-hid a
+                # still-existing departed user's collection from every
+                # other user's exclude filter on the very next run.
+                pruned_usernames = set(prune_orphaned_private_collections(config, orphaned_owners))
+                for account_id, entry in orphaned_owners.items():
+                    if entry.get("username") in pruned_usernames:
+                        updated_owners.pop(account_id, None)
 
             save_private_label_owners(cache_dir, updated_owners)
 

--- a/utils/private_label_cache.py
+++ b/utils/private_label_cache.py
@@ -1,0 +1,208 @@
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Persisted registry of PrivateCollection_* label owners (#351).
+
+utils.plex_policy.apply_user_label_restrictions excludes every OTHER
+configured user's PrivateCollection_* label from a given user's
+filterMovies/filterTelevision, but it only ever knew about the labels of
+users CURRENTLY in config - a user removed from users.list (but not
+necessarily removed from the Plex server itself) dropped out of that
+computation entirely, silently un-hiding their old collection from
+everyone else the very next run.
+
+This module is the fix's memory: every run that successfully applies
+restrictions records who it applied a PrivateCollection_* label for, so a
+later run - even after that user is gone from config - still knows their
+label needs to stay excluded. utils.plex_policy is the only caller that
+mutates this file; it owns the load-merge-save lifecycle (mirrors
+utils.user_migration.migrate_renamed_plex_users' own orchestration), this
+module only provides the mechanism.
+
+Keyed on the stable Plex account id, never username - same reasoning as
+utils/user_migration.py's id<->username map (USER_ID_MAP_FILENAME):
+usernames are mutable, so keying on one would make a simple rename look
+exactly like a departure the next run.
+
+Missing/corrupt cache file degrades to "no known owners" (never raises) -
+same convention as utils.user_migration.load_user_id_map. Losing this
+file only means a previously-departed owner's label stops being retained
+starting from whatever run first sees the empty cache; it can never take
+down a normal run.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Mapping
+
+import plexapi.exceptions
+
+from .config import MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV, get_libraries_for_media_type
+from .display import log_warning
+
+logger = logging.getLogger("curatarr")
+
+PRIVATE_LABEL_OWNERS_FILENAME = "private_label_owners.json"
+
+
+def load_private_label_owners(cache_dir: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Load the persisted {account_id: {"username": str, "labels": {"movie":
+    [...], "tv": [...]}}} map.
+
+    A missing file, unreadable/corrupt JSON, or a value that isn't the
+    expected shape all degrade to {} rather than raising or propagating a
+    partially-parsed result - malformed entries are dropped individually,
+    not treated as a reason to discard the whole file.
+    """
+    path = os.path.join(cache_dir, PRIVATE_LABEL_OWNERS_FILENAME)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError, OSError) as e:
+        log_warning(f"Could not read private label owner cache ({path}): {e}")
+        return {}
+
+    if not isinstance(data, dict):
+        log_warning(f"Private label owner cache ({path}) was not a JSON object - ignoring")
+        return {}
+
+    owners: Dict[str, Dict[str, Any]] = {}
+    for account_id, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        username = entry.get("username")
+        raw_labels = entry.get("labels")
+        if not isinstance(username, str) or not username or not isinstance(raw_labels, dict):
+            continue
+        owners[str(account_id)] = {
+            "username": username,
+            "labels": {
+                media_type: [str(x) for x in (raw_labels.get(media_type) or []) if x]
+                for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV)
+            },
+        }
+    return owners
+
+
+def save_private_label_owners(cache_dir: str, owners: Mapping[str, Dict[str, Any]]) -> None:
+    """Persist the account id -> {username, labels} map. Best-effort - a
+    cache that cannot be written is a lost-memory problem for the NEXT
+    run, never a reason to fail this one (mirrors
+    utils.user_migration.save_user_id_map)."""
+    path = os.path.join(cache_dir, PRIVATE_LABEL_OWNERS_FILENAME)
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(owners, f, indent=2, sort_keys=True)
+    except (IOError, OSError) as e:
+        log_warning(f"Could not save private label owner cache ({path}): {e}")
+
+
+def find_orphaned_owners(
+    persisted_owners: Mapping[str, Dict[str, Any]], current_owner_ids: Any
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Persisted owners whose account id is not in current_owner_ids - i.e.
+    curatarr created a PrivateCollection_* label for them at some point,
+    but they are no longer a currently-configured user this run.
+
+    current_owner_ids: any iterable of account id strings (typically
+    utils.plex_policy.apply_user_label_restrictions' own id_to_configured
+    .keys() - the ids it already resolved this run for users actually in
+    config, admin excluded the same way it always is).
+    """
+    current = set(current_owner_ids)
+    return {account_id: entry for account_id, entry in persisted_owners.items() if account_id not in current}
+
+
+def prune_orphaned_private_collections(config: Dict, orphaned_owners: Mapping[str, Dict[str, Any]]) -> List[str]:
+    """
+    Best-effort teardown of orphaned PrivateCollection_* collections -
+    #351's collections.prune_orphaned_private_labels opt-in.
+
+    A currently-configured user can never reach this function's delete
+    path: orphaned_owners only ever contains entries find_orphaned_owners
+    identified as NOT among this run's currently-configured owner ids -
+    this function has no other way to select what to delete.
+
+    Ownership of each collection is confirmed the same way #291's
+    no-watch-history removal path already does - solely via the
+    PrivateCollection_* label already on it (utils.plex.
+    remove_owned_collection), never by title/emoji/name-pattern
+    guessing - so this can never delete a collection curatarr didn't
+    create, even if a departed user's display name collides with
+    something else in the library.
+
+    Every library matching each media type (utils.config.
+    get_libraries_for_media_type) is checked for each persisted label -
+    the same multi-library enumeration utils.plex_policy.
+    build_all_private_labels used to build those label names in the
+    first place, so a multi-library install's per-library-suffixed
+    labels (PrivateCollection_<library_id>_<user>) are found regardless
+    of which library they were created in.
+
+    Entirely best-effort, like utils.user_migration's rename migration:
+    a Plex connection failure or a single collection's delete failure is
+    logged and does not stop the rest.
+
+    Does NOT touch cache/private_label_owners.json itself - the caller
+    (utils.plex_policy.apply_user_label_restrictions) owns the single
+    load-merge-save lifecycle for that file and decides what "pruned"
+    means for its own already-loaded copy.
+
+    Returns the usernames this attempted to prune (whether or not a
+    matching collection actually existed to delete - a missing
+    collection is not a reason for the caller to keep tracking that
+    owner forever).
+    """
+    if not orphaned_owners:
+        return []
+
+    from .plex import init_plex, remove_owned_collection
+
+    try:
+        plex = init_plex(config)
+    except Exception as e:
+        log_warning(f"Could not connect to Plex to prune orphaned private collections: {e}")
+        return []
+
+    pruned: List[str] = []
+    for account_id, entry in orphaned_owners.items():
+        username = entry.get("username") or account_id
+        labels = entry.get("labels") or {}
+        reason = "owner no longer configured (collections.prune_orphaned_private_labels)"
+
+        for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV):
+            for label in labels.get(media_type) or []:
+                for library in get_libraries_for_media_type(config, media_type):
+                    section_name = library.get("section")
+                    if not section_name:
+                        continue
+                    try:
+                        section = plex.library.section(section_name)
+                    except plexapi.exceptions.PlexApiException as e:
+                        logger.debug(f"Library '{section_name}' not available while pruning {username}: {e}")
+                        continue
+                    remove_owned_collection(section, label, username, reason, logger)
+
+        pruned.append(username)
+
+    return pruned

--- a/utils/private_label_cache.py
+++ b/utils/private_label_cache.py
@@ -168,10 +168,15 @@ def prune_orphaned_private_collections(config: Dict, orphaned_owners: Mapping[st
     load-merge-save lifecycle for that file and decides what "pruned"
     means for its own already-loaded copy.
 
-    Returns the usernames this attempted to prune (whether or not a
-    matching collection actually existed to delete - a missing
-    collection is not a reason for the caller to keep tracking that
-    owner forever).
+    Returns only the usernames whose collection was actually located and
+    deleted. An owner is NEVER included just because a delete was
+    attempted - if Plex couldn't be reached, a library section couldn't
+    be resolved, or no matching collection was found in any library
+    that could be checked, that owner is left out so the caller keeps
+    tracking them rather than assuming (possibly wrongly) that nothing
+    is left to hide. This is what lets the caller safely pop an owner
+    out of cache/private_label_owners.json only once their collection
+    is confirmed gone.
     """
     if not orphaned_owners:
         return []
@@ -190,6 +195,7 @@ def prune_orphaned_private_collections(config: Dict, orphaned_owners: Mapping[st
         labels = entry.get("labels") or {}
         reason = "owner no longer configured (collections.prune_orphaned_private_labels)"
 
+        deleted = False
         for media_type in (MEDIA_TYPE_MOVIE, MEDIA_TYPE_TV):
             for label in labels.get(media_type) or []:
                 for library in get_libraries_for_media_type(config, media_type):
@@ -201,8 +207,10 @@ def prune_orphaned_private_collections(config: Dict, orphaned_owners: Mapping[st
                     except plexapi.exceptions.PlexApiException as e:
                         logger.debug(f"Library '{section_name}' not available while pruning {username}: {e}")
                         continue
-                    remove_owned_collection(section, label, username, reason, logger)
+                    if remove_owned_collection(section, label, username, reason, logger):
+                        deleted = True
 
-        pruned.append(username)
+        if deleted:
+            pruned.append(username)
 
     return pruned


### PR DESCRIPTION
Fixes #351

## Mechanism

`apply_user_label_restrictions()` (utils/plex_policy.py) built each
user's `filterMovies`/`filterTelevision` exclude list only from the
CURRENTLY configured user set. A user removed from `users.list` had
their `PrivateCollection_*` label silently dropped from every other
user's exclude filter on the very next run, un-hiding a collection that
was never meant to be shared.

- New `utils/private_label_cache.py` persists every owner curatarr has
  applied a `PrivateCollection_*` label for to
  `cache/private_label_owners.json`, keyed by the stable Plex account
  id (same identifier `utils/user_migration.py` already trusts for
  rename detection, not username - so a rename is never mistaken for a
  departure). Missing/corrupt cache degrades to no known owners,
  never crashes a run.
- The exclude computation is now the union of currently-configured
  owners and any persisted owner no longer in config, minus the target
  user's own label. Self-exclusion and #340's one-PUT-per-physical-
  account alias collapsing are unaffected.
- Departed owners are warned about once per run, naming them.
- New opt-in `collections.prune_orphaned_private_labels` (default
  `false`, see `config/tuning.example.yml`) tears an orphan down:
  deletes the collection (ownership confirmed solely via its own label,
  same rule as the existing #291 no-history removal path), and drops
  the cache entry. Never touches a currently-configured user's
  collection.
- Retaining labels indefinitely makes the filter value monotonically
  non-shrinking; once it grows past a generous length this now logs
  loudly instead of truncating silently.

Version bumped 2.18.0 -> 2.18.1 (bug fix + new opt-in flag, matching
the bump level used for the same combination previously - see
`utils/cache_prune.py`'s 2.10.24 changelog entry).

## Test plan
- [x] New `tests/test_private_label_cache.py` (17 tests): load/save
      roundtrip, corrupt/missing/malformed cache, find_orphaned_owners,
      prune_orphaned_private_collections (delete, connect failure,
      unavailable library, no-op on empty input).
- [x] New `TestPrivateLabelOwnerRetention` in `tests/test_plex.py` (9
      tests): departed owner's label retained across a subsequent run,
      self-exclusion invariant holds, prune disabled by default (warns,
      never deletes), prune enabled (deletes collection, updates cache,
      remaining filters stop carrying the label), corrupt cache degrades
      safely, a live owner never shadowed by a stale persisted entry
      with the same name, long exclude filter warns instead of
      truncating.
- [x] Full suite: `3259 passed, 1 skipped`
- [x] `ruff check` / `ruff format --check`: clean