### PR TITLE
Recommend the first unwatched entry of a series, not the best-scoring one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.20.0] - 2026-08-16
+
+### Added
+
+- **Franchise-ordered recommendations** (`movies.franchise_order`, default `true` — see `utils/franchise.py`). A recommendation belonging to a TMDB collection is now replaced by the earliest entry of that collection the user has not watched: nothing watched gets you *Rocky*, *Rocky* watched gets you *Rocky II*. Ranking purely by similarity treats every candidate as independently watchable, so it routinely surfaced *Rocky IV*, *The Godfather Part III* or *Cult of Chucky* as somebody's first contact with a series — and the existing collection bonus (`COLLECTION_BONUS_*`) made that *more* likely rather than less, because it boosts a title for belonging to a collection the user has started without ever saying which entry comes next. Costs no additional TMDB calls: `collection_id`/`collection_name`/`year` are already cached per movie by `MovieCache`/`_backfill_collection_data`.
+
+  Four behaviors are deliberate. **Promotion is library-only** — the artifact is a Plex collection, so a promoted entry must be playable; when the true first entry is missing from the library entirely, the earliest *owned* entry is promoted instead and the gap is reported from Sequel Huntarr's already-cached TMDB member lists (read-only, version-blind, silent when that cache is absent), which is exactly the input Sequel Huntarr already turns into a Radarr request. **Hard filters are respected, sizing filters are not** — an entry is never promoted past an excluded genre, a per-user `max_rating`, or a recommendation the user was shown and visibly declined (`utils/ignored_recs.py`), but it *is* promoted past `quality_filters` and `min_similarity`, which size the collection rather than state a preference (a 1976 original with a thin TMDB vote count should not be withheld while its own sequel is recommended). **Order comes from the library's own `year`**, with unknown years sorted last so a missing year can never take position one. **Each series takes one collection slot** rather than several; because the collapse runs before the candidate buffer is truncated, the freed slots refill from the tail instead of shrinking the collection.
+
+  Applied at two points, because one is not enough: `get_recommendations()` re-points the freshly scored pool, and `manage_plex_labels()` additionally suppresses already-labeled later entries once their series' earliest unwatched entry is a candidate — without that second hook a sequel labeled on a previous run would outlive the promotion indefinitely, sitting in the collection beside the original. The suppression only fires when that earliest entry is itself in the pool, so a series whose first entry the `max_rating` filter just removed keeps the entry the user *may* watch rather than vanishing from the collection.
+
+  Movies only — TMDB collections are a movie-side concept and no collection data is cached for shows, so the index is empty for TV and the whole path is inert there. Set `movies.franchise_order: false` in `tuning.yml` to rank franchise entries purely by score, exactly as before.
+
 ## [2.19.3] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Binaries self-update: the app notifies you (CLI and web UI banner) when a newer 
 - **Per-user recommendations** — Each user gets their own curated collection
 - **Per-user by default** — Each user's library Browse/Search only shows their own recommendation collection, not others' (UI-level separation, not access control — see FAQ)
 - **Smart scoring** — Weights keywords, genres, cast, and directors
+- **Franchise order** — Recommends the first movie of a series you haven't seen, not whichever sequel happened to score highest: nothing watched gets you *Rocky*, *Rocky* watched gets you *Rocky II* (`movies.franchise_order` in tuning.yml)
 - **Recency bias** — Recent watches influence recommendations more
 - **Rewatch detection** — Content you love gets weighted higher
 - **Genre exclusions** — Skip horror for the kids, documentaries for movie night
@@ -495,6 +496,9 @@ movies:
   limit_results: 50           # Recommendations per user (the final
                               # collection count - see general.limit_plex_results
                               # below for the internal scoring buffer)
+  franchise_order: true       # Recommend the earliest UNWATCHED entry of a
+                              # series instead of whichever sequel scored
+                              # highest; each series takes one slot
   quality_filters:
     min_rating: 5.0           # TMDB rating threshold
     min_vote_count: 50        # Minimum votes

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -86,6 +86,40 @@ movies:
   # watch history; a user with ANY history is never touched).
   recommend_for_no_history: true
 
+  # Start people at the beginning of a series.
+  #
+  # Scoring alone treats every candidate as independently watchable, so
+  # it will happily recommend Rocky IV, The Godfather Part III or Cult of
+  # Chucky to somebody who has seen none of them - and the collection
+  # bonus makes that MORE likely, because it boosts a film for belonging
+  # to a series you have started without saying which entry comes next.
+  #
+  # With this on, a recommendation that belongs to a TMDB collection is
+  # replaced by the earliest entry of that collection you have not
+  # watched: nothing watched gets you Rocky, Rocky watched gets you
+  # Rocky II, and so on. Each series then takes ONE slot rather than
+  # several, and the slots this frees refill with other films rather
+  # than shrinking the collection.
+  #
+  # What it will not do:
+  #   - recommend a film you don't own (the promoted entry always comes
+  #     from your library; when the true first entry is missing entirely
+  #     you get the earliest one you DO own, and the run logs the gap for
+  #     Sequel Huntarr to request)
+  #   - override an excluded genre, a user's max_rating, or a
+  #     recommendation you were shown and visibly ignored
+  #
+  # It DOES override quality_filters and min_similarity above - those
+  # size the collection rather than state a preference, and a 1976
+  # original with a thin TMDB vote count should not be withheld while
+  # its own sequel is recommended.
+  #
+  # Set to false to rank franchise entries purely by score (what every
+  # release before this setting existed did). Movies only - TMDB
+  # collections are a movie-side concept and no collection data is
+  # cached for TV.
+  franchise_order: true
+
   # Scoring weights - must sum to 1.0
   weights:
     genre: 0.25

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -32,7 +32,7 @@ import time
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import plexapi.exceptions
 import requests
@@ -48,6 +48,9 @@ from utils import (
     DEFAULT_MOVIE_NAME_TEMPLATE,
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_TV_NAME_TEMPLATE,
+    FRANCHISE_GAP_REPORT_LIMIT,
+    FRANCHISE_GAP_TITLES_PER_SERIES,
+    FRANCHISE_ORDER_DEFAULT,
     GREEN,
     IGNORED_REC_MIN_DAYS_SHOWN,
     IGNORED_REC_PENALTY,
@@ -70,12 +73,14 @@ from utils import (
     YELLOW,
     CalibrationDimension,
     add_labels_to_items,
+    apply_franchise_ordering,
     apply_ignored_penalties,
     apply_user_label_restrictions,
     assess_pool_health,
     build_all_private_labels,
     build_certificate_distribution,
     build_corpus_idf,
+    build_franchise_index,
     build_label_name,
     build_target_distribution,
     calculate_recency_multiplier,
@@ -86,6 +91,8 @@ from utils import (
     check_cache_version,
     cleanup_legacy_unnamed_collection,
     cleanup_old_collections,
+    coerce_year,
+    collect_library_tmdb_ids,
     create_empty_counters,
     describe_least_informative,
     enhance_profile_with_trakt,
@@ -93,6 +100,8 @@ from utils import (
     fetch_tmdb_with_retry,
     fetch_user_played_ids,
     find_ignored_recommendations,
+    find_library_gaps,
+    find_next_unwatched,
     find_supply_gaps,
     format_health_report,
     get_configured_users,
@@ -110,11 +119,13 @@ from utils import (
     init_plex,
     is_rating_allowed,
     is_sufficiently_sampled,
+    load_collection_details,
     load_config,
     load_media_cache,
     log_error,
     log_warning,
     migrate_legacy_cache_dir,
+    normalize_collection_id,
     print_similarity_breakdown,
     process_counters_from_cache,
     remove_labels_from_items,
@@ -125,6 +136,7 @@ from utils import (
     save_watched_cache,
     select_tiered_recommendations,
     show_progress,
+    summarize_substitutions,
     update_plex_collection,
     user_select_recommendations,
 )
@@ -560,6 +572,17 @@ class BaseRecommender(ABC):
         # Set for tracking watched item IDs
         self.watched_ids: Set[int] = set()
 
+        # Rating keys this user was shown and visibly declined - populated
+        # by _apply_ignored_recommendation_feedback() from the same
+        # find_ignored_recommendations() call that computes the profile
+        # penalties. Kept as an explicit set (rather than re-derived
+        # later) because franchise ordering must not promote a title the
+        # user has already left sitting in their collection unwatched -
+        # see utils/franchise.is_promotable. Stays empty whenever the
+        # negative-signals feature is off, which correctly means "no
+        # declines are being tracked", not "nothing was declined".
+        self.declined_rating_keys: Set[int] = set()
+
         print("Initializing recommendation system...")
         print("Connecting to Plex server...")
         self.plex = init_plex(self.config)
@@ -640,6 +663,15 @@ class BaseRecommender(ABC):
         # unchanged. See utils/calibration.py for what calibration does.
         self.min_similarity = self.config["min_similarity"]
         self.calibration_strength = self.config["calibration_strength"]
+
+        # Franchise ordering (config/tuning.yml movies.franchise_order) -
+        # hand out the earliest UNWATCHED entry of a series rather than
+        # whichever entry happened to score highest. Read straight off
+        # self.media_config (like recommend_for_no_history and
+        # quality_filters, and unlike the keys resolve_media_type_overrides()
+        # promotes to the root) because it is consumed only here, by name,
+        # and never through self.config. See utils/franchise.py.
+        self.franchise_order = bool(self.media_config.get("franchise_order", FRANCHISE_ORDER_DEFAULT))
 
         self.randomize_recommendations = self.config["randomize_recommendations"]
         self.normalize_counters = self.config["normalize_counters"]
@@ -1134,6 +1166,16 @@ class BaseRecommender(ABC):
                     )
                 scored_items = above_floor
 
+            # Franchise ordering, deliberately AFTER the score floor and
+            # the quality filters above: a promoted first entry inherits
+            # the slot (and the score) its own sequel earned, so those
+            # collection-sizing gates must not be able to withhold it.
+            # Also deliberately BEFORE the buffer truncation below - one
+            # slot per franchise means duplicates collapse, and doing it
+            # here lets the freed slots refill from the tail instead of
+            # shrinking the collection.
+            scored_items = self._apply_franchise_ordering(scored_items, excluded_genres)
+
             if self.randomize_recommendations:
                 plex_recs = select_tiered_recommendations(
                     scored_items,
@@ -1145,6 +1187,10 @@ class BaseRecommender(ABC):
             else:
                 plex_recs = scored_items[: self.limit_plex_results]
 
+            # Reported on the truncated buffer, not the whole pool: this
+            # is about the titles actually being recommended.
+            self._report_franchise_gaps(plex_recs, all_items)
+
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("=== Similarity Score Breakdowns for Recommendations ===")
                 for item in plex_recs:
@@ -1152,6 +1198,222 @@ class BaseRecommender(ABC):
 
         print("\nRecommendation process completed!")
         return {"plex_recommendations": plex_recs}
+
+    # ------------------------------------------------------------------------
+    # FRANCHISE ORDERING (utils/franchise.py)
+    # ------------------------------------------------------------------------
+    def _primary_username(self) -> Optional[str]:
+        """
+        The user whose per-user preferences apply to this run.
+
+        Same derivation manage_plex_labels() has always used to look up
+        max_rating - factored out so franchise ordering applies the
+        identical content-rating ceiling when choosing what to promote,
+        instead of the two drifting apart.
+        """
+        users = self.users["plex_users"] or self.users["managed_users"]
+        return self.single_user or (users[0] if users else None)
+
+    def _franchise_watched_ids(self) -> Set[int]:
+        """
+        Rating keys to treat as already seen when walking a series.
+
+        The union, not self.watched_ids alone: user_played_ids is that
+        user's OWN Plex view (utils.plex.fetch_user_played_ids), and a
+        part wrongly believed unwatched doesn't just add one redundant
+        recommendation here - it sends the entire franchise back to an
+        entry the user already finished.
+        """
+        return self.watched_ids | self.user_played_ids
+
+    def _franchise_rules(self, excluded_genres: Optional[Iterable[str]] = None) -> Dict[str, Any]:
+        """Eligibility inputs for utils/franchise.py (see is_promotable)."""
+        if excluded_genres is None:
+            excluded_genres = get_excluded_genres_for_user(self.exclude_genres, self.user_preferences, self.single_user)
+        return {
+            "declined_ids": set(self.declined_rating_keys),
+            "excluded_genres": {g.lower() for g in (excluded_genres or ()) if isinstance(g, str)},
+            "max_rating": get_max_rating_for_user(self.user_preferences, self._primary_username()),
+            "media_type": self.media_type,
+        }
+
+    def _apply_franchise_ordering(self, scored_items: List[Dict], excluded_genres: Iterable[str]) -> List[Dict]:
+        """
+        Re-point franchise recommendations at their earliest unwatched entry.
+
+        A no-op for TV (no `collection_id` is ever cached for shows, so
+        the index comes back empty) and for any library whose movies have
+        no TMDB collection data yet.
+        """
+        if not scored_items or not self.franchise_order:
+            return scored_items
+
+        try:
+            all_items = self._get_media_cache().cache.get(self.media_key, {})
+            franchise_index = build_franchise_index(all_items)
+            if not franchise_index:
+                return scored_items
+
+            ordered, substitutions = apply_franchise_ordering(
+                scored_items,
+                franchise_index,
+                self._franchise_watched_ids(),
+                **self._franchise_rules(excluded_genres),
+            )
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            # Ordering is an improvement on top of a complete
+            # recommendation list, never a precondition for one - a
+            # malformed cache entry must not cost the user their
+            # collection.
+            logger.debug(f"Franchise ordering skipped: {e}")
+            return scored_items
+
+        if substitutions:
+            print(
+                f"{CYAN}Franchise order: {len(substitutions)} recommendation(s) moved to an "
+                f"earlier unwatched entry{RESET}"
+            )
+            for line in summarize_substitutions(substitutions):
+                print(f"  - {line}")
+
+        collapsed = len(scored_items) - len(ordered)
+        if collapsed > 0:
+            print(f"{CYAN}Franchise order: collapsed {collapsed} later entries into the series they belong to{RESET}")
+
+        return ordered
+
+    def _report_franchise_gaps(self, recommendations: List[Dict], all_items: Dict) -> None:
+        """
+        Report series whose earlier entries this library doesn't hold.
+
+        Free when Sequel Huntarr has run (it already caches the full TMDB
+        member list of every collection in the library - see
+        utils.franchise.load_collection_details), silent when it hasn't.
+        Purely informational: the recommendation itself is already the
+        earliest entry the user can actually play, and Sequel Huntarr is
+        what turns these into Radarr requests.
+        """
+        if not recommendations or not self.franchise_order:
+            return
+
+        try:
+            collection_details = load_collection_details(self.cache_dir)
+            if not collection_details:
+                return
+
+            library_tmdb_ids = collect_library_tmdb_ids(all_items)
+            gapped: Dict[Any, Tuple[Dict, Dict, List[Dict]]] = {}
+
+            for rec in recommendations:
+                collection_id = normalize_collection_id(rec.get("collection_id"))
+                if collection_id is None or collection_id in gapped:
+                    continue
+                detail = collection_details.get(collection_id)
+                if not detail:
+                    continue
+                gaps = find_library_gaps(detail, coerce_year(rec.get("year")), library_tmdb_ids)
+                if gaps:
+                    gapped[collection_id] = (rec, detail, gaps)
+        except (AttributeError, KeyError, OSError, TypeError, ValueError) as e:
+            logger.debug(f"Franchise gap reporting skipped: {e}")
+            return
+
+        if not gapped:
+            return
+
+        total = sum(len(gaps) for _rec, _detail, gaps in gapped.values())
+        noun = "entry" if total == 1 else "entries"
+        print(
+            f"{YELLOW}Franchise gaps: {total} earlier {noun} across {len(gapped)} series "
+            f"missing from this library - Sequel Huntarr can request them{RESET}"
+        )
+        for rec, detail, gaps in list(gapped.values())[:FRANCHISE_GAP_REPORT_LIMIT]:
+            shown = gaps[:FRANCHISE_GAP_TITLES_PER_SERIES]
+            missing = ", ".join(f"{g['title']} ({g['year']})" for g in shown)
+            if len(gaps) > len(shown):
+                missing += f", +{len(gaps) - len(shown)} more"
+            print(
+                f"  - {rec.get('title')} is the earliest owned entry of "
+                f"{detail.get('collection_name', 'this series')}; missing: {missing}"
+            )
+        if len(gapped) > FRANCHISE_GAP_REPORT_LIMIT:
+            print(f"  ... and {len(gapped) - FRANCHISE_GAP_REPORT_LIMIT} more series")
+
+    def _suppress_superseded_franchise_candidates(self, all_candidates: Dict) -> Dict:
+        """
+        Drop already-labeled later entries once their series' earliest
+        unwatched entry is a candidate too.
+
+        get_recommendations()'s ordering alone does not reach the
+        collection: every item still carrying this user's label from a
+        previous run is re-added to the pool by
+        _build_scored_candidates() at its own raw score, so a Rocky IV
+        labeled last week would sit in the collection indefinitely
+        alongside the Rocky this run just promoted.
+
+        Only ever fires when the earliest unwatched entry is ALSO in the
+        pool. Otherwise a franchise would vanish from the collection
+        entirely rather than move to its start - which is exactly what
+        would happen when that earliest entry was just removed by the
+        max_rating filter, or was never found in Plex.
+
+        The survivor keeps the best score any member of its series
+        earned, so franchise ordering changes WHICH entry is recommended
+        without changing how highly the series ranks.
+        """
+        if not all_candidates or not self.franchise_order:
+            return all_candidates
+
+        try:
+            media_items = self._get_media_cache().cache.get(self.media_key, {})
+            franchise_index = build_franchise_index(media_items)
+            if not franchise_index:
+                return all_candidates
+
+            rules = self._franchise_rules()
+            watched_ids = self._franchise_watched_ids()
+
+            by_collection: Dict[Any, List[int]] = {}
+            for item_id in all_candidates:
+                info = media_items.get(str(item_id)) or {}
+                collection_id = normalize_collection_id(info.get("collection_id"))
+                if collection_id is not None:
+                    by_collection.setdefault(collection_id, []).append(item_id)
+
+            remaining = dict(all_candidates)
+            suppressed: List[str] = []
+
+            for collection_id, item_ids in by_collection.items():
+                if len(item_ids) < 2:
+                    continue
+                canonical = find_next_unwatched(franchise_index.get(collection_id) or [], watched_ids, **rules)
+                if canonical is None or canonical.rating_key not in remaining:
+                    continue
+
+                # Non-empty by construction: item_ids holds at least two
+                # distinct candidate ids (dict keys) and at most one of
+                # them is the canonical entry.
+                losers = [item_id for item_id in item_ids if item_id != canonical.rating_key]
+                best_score = max(remaining[item_id][1] for item_id in item_ids)
+                remaining[canonical.rating_key] = (remaining[canonical.rating_key][0], best_score)
+                for item_id in losers:
+                    plex_item, _score = remaining.pop(item_id)
+                    suppressed.append(f"{getattr(plex_item, 'title', item_id)} -> {canonical.label()}")
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            logger.debug(f"Franchise candidate suppression skipped: {e}")
+            return all_candidates
+
+        if suppressed:
+            print(
+                f"{YELLOW}Franchise order: holding back {len(suppressed)} later "
+                f"{self.media_key} until earlier entries are watched{RESET}"
+            )
+            for line in suppressed[:FRANCHISE_GAP_REPORT_LIMIT]:
+                print(f"  - {line}")
+            if len(suppressed) > FRANCHISE_GAP_REPORT_LIMIT:
+                print(f"  ... and {len(suppressed) - FRANCHISE_GAP_REPORT_LIMIT} more")
+
+        return remaining
 
     def _find_plex_items_for_recs(self, section, selected_items: List[Dict]) -> Tuple[List, List[str]]:
         """Find Plex items matching recommendations."""
@@ -1385,6 +1647,11 @@ class BaseRecommender(ABC):
             )
             if not ignored:
                 return
+
+            # Recorded before the early-return below: an item can be a
+            # declined recommendation whether or not it is still in the
+            # media cache, and franchise ordering needs the full set.
+            self.declined_rating_keys = {rating_key for rating_key, _days in ignored}
 
             media_items = self._get_media_cache().cache.get(self.media_key, {})
             ignored_items = [media_items[str(rk)] for rk, _days in ignored if str(rk) in media_items]
@@ -1824,6 +2091,11 @@ class BaseRecommender(ABC):
             max_rating = get_max_rating_for_user(self.user_preferences, username)
             if max_rating:
                 all_candidates = self._filter_candidates_by_rating(all_candidates, max_rating)
+
+            # Franchise ordering, applied AFTER the rating filter so a
+            # series whose first entry this user may not watch keeps the
+            # entry they may - see the method's own docstring.
+            all_candidates = self._suppress_superseded_franchise_candidates(all_candidates)
 
             # Update labels to keep top items
             final_items = self._update_labels_by_rank(all_candidates, unwatched_labeled, label_name, target_count)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3761,3 +3761,340 @@ class TestLabelDatesSurviveCacheRebuild:
         path = tmp_path / "w.json"
         path.write_text(json.dumps({"cache_version": 9}), encoding="utf-8")
         assert recommender._salvage_label_dates(str(path)) == {}
+
+
+# ---------------------------------------------------------------------------
+# Franchise ordering (utils/franchise.py) - see its module docstring
+# ---------------------------------------------------------------------------
+ROCKY_COLLECTION_ID = 1575
+
+ROCKY_CACHE = {
+    "1": {"title": "Rocky", "year": 1976, "collection_id": ROCKY_COLLECTION_ID, "collection_name": "Rocky Collection"},
+    "2": {
+        "title": "Rocky II",
+        "year": 1979,
+        "collection_id": ROCKY_COLLECTION_ID,
+        "collection_name": "Rocky Collection",
+    },
+    "4": {
+        "title": "Rocky IV",
+        "year": 1985,
+        "collection_id": ROCKY_COLLECTION_ID,
+        "collection_name": "Rocky Collection",
+    },
+}
+
+
+def _franchise_recommender(cache=None):
+    """A recommender whose media cache holds a real multi-entry series."""
+    recommender = _make_recommender()
+    media_cache = Mock()
+    media_cache.cache = {"movies": copy.deepcopy(ROCKY_CACHE if cache is None else cache)}
+    recommender._get_media_cache = Mock(return_value=media_cache)
+    return recommender
+
+
+def _scored_from(recommender, rating_key, score):
+    info = recommender._get_media_cache().cache["movies"][str(rating_key)]
+    info["plex_rating_key"] = int(rating_key)
+    info["similarity_score"] = score
+    return info
+
+
+class TestApplyFranchiseOrderingIntegration:
+    """BaseRecommender._apply_franchise_ordering - the get_recommendations() hook."""
+
+    def test_sequel_recommendation_becomes_the_first_entry(self):
+        recommender = _franchise_recommender()
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky"]
+
+    def test_disabled_flag_leaves_recommendations_untouched(self):
+        recommender = _franchise_recommender()
+        recommender.franchise_order = False
+        scored = [_scored_from(recommender, 4, 0.8)]
+        assert recommender._apply_franchise_ordering(scored, []) is scored
+
+    def test_watched_first_entry_promotes_the_next(self):
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1}
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_the_users_own_plex_view_counts_as_watched(self):
+        """user_played_ids is that user's own state; a part wrongly
+        believed unwatched sends the whole series back to the start."""
+        recommender = _franchise_recommender()
+        recommender.user_played_ids = {1, 2}
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky IV"]
+
+    def test_declined_entry_is_not_promoted(self):
+        recommender = _franchise_recommender()
+        recommender.declined_rating_keys = {1}
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_excluded_genre_entry_is_not_promoted(self):
+        recommender = _franchise_recommender()
+        recommender._get_media_cache().cache["movies"]["1"]["genres"] = ["horror"]
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], ["horror"])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_max_rating_preference_is_honored(self):
+        recommender = _franchise_recommender()
+        recommender.single_user = "kid"
+        recommender.user_preferences = {"kid": {"max_rating": "PG"}}
+        recommender._get_media_cache().cache["movies"]["1"]["content_rating"] = "R"
+        recommender._get_media_cache().cache["movies"]["2"]["content_rating"] = "PG"
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_empty_input_is_a_no_op(self):
+        recommender = _franchise_recommender()
+        assert recommender._apply_franchise_ordering([], []) == []
+
+    def test_library_without_collection_data_is_a_no_op(self):
+        recommender = _franchise_recommender(cache={"1": {"title": "Heat", "year": 1995}})
+        scored = [_scored_from(recommender, 1, 0.8)]
+        assert recommender._apply_franchise_ordering(scored, []) is scored
+
+    def test_a_broken_cache_never_costs_the_user_their_recommendations(self):
+        recommender = _franchise_recommender()
+        scored = [_scored_from(recommender, 4, 0.8)]
+        recommender._get_media_cache = Mock(side_effect=AttributeError("boom"))
+        assert recommender._apply_franchise_ordering(scored, []) is scored
+
+    def test_collapsing_a_series_is_reported(self, capsys):
+        recommender = _franchise_recommender()
+        scored = [_scored_from(recommender, 4, 0.9), _scored_from(recommender, 2, 0.8)]
+        capsys.readouterr()  # drop construction chatter
+        recommender._apply_franchise_ordering(scored, [])
+        out = capsys.readouterr().out
+        assert "moved to an earlier unwatched entry" in out
+        assert "collapsed 1 later entries" in out
+
+
+class TestSuppressSupersededFranchiseCandidates:
+    """BaseRecommender._suppress_superseded_franchise_candidates - the
+    manage_plex_labels() hook that stops a previously-labeled sequel
+    outliving the promotion."""
+
+    def _candidates(self, *pairs):
+        return {rating_key: (Mock(title=f"item-{rating_key}"), score) for rating_key, score in pairs}
+
+    def test_labeled_sequel_is_dropped_when_the_first_entry_is_a_candidate(self):
+        recommender = _franchise_recommender()
+        result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (1, 0.3)))
+        assert set(result) == {1}
+
+    def test_survivor_keeps_the_best_score_in_the_series(self):
+        """Franchise ordering changes WHICH entry is recommended, not how
+        highly the series ranks."""
+        recommender = _franchise_recommender()
+        result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (1, 0.3)))
+        assert result[1][1] == 0.9
+
+    def test_sequel_survives_when_the_first_entry_is_not_a_candidate(self):
+        """Otherwise the series vanishes from the collection rather than
+        moving to its start - e.g. when max_rating just removed the
+        first entry."""
+        recommender = _franchise_recommender()
+        candidates = self._candidates((4, 0.9))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) == candidates
+
+    def test_watched_first_entry_hands_the_slot_to_the_next(self):
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1}
+        result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (2, 0.3)))
+        assert set(result) == {2}
+
+    def test_unrelated_candidates_are_untouched(self):
+        recommender = _franchise_recommender()
+        candidates = self._candidates((4, 0.9), (1, 0.3), (99, 0.5))
+        result = recommender._suppress_superseded_franchise_candidates(candidates)
+        assert set(result) == {1, 99}
+
+    def test_disabled_flag_is_a_no_op(self):
+        recommender = _franchise_recommender()
+        recommender.franchise_order = False
+        candidates = self._candidates((4, 0.9), (1, 0.3))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) is candidates
+
+    def test_empty_pool(self):
+        recommender = _franchise_recommender()
+        assert recommender._suppress_superseded_franchise_candidates({}) == {}
+
+    def test_a_broken_cache_never_costs_the_user_their_collection(self):
+        recommender = _franchise_recommender()
+        candidates = self._candidates((4, 0.9), (1, 0.3))
+        recommender._get_media_cache = Mock(side_effect=AttributeError("boom"))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) is candidates
+
+    def test_library_without_collection_data_is_a_no_op(self):
+        recommender = _franchise_recommender(cache={"1": {"title": "Heat", "year": 1995}})
+        candidates = self._candidates((1, 0.3))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) is candidates
+
+    def test_fully_watched_series_suppresses_nothing(self):
+        """find_next_unwatched() returning None must leave the pool
+        alone, not empty the series out of it."""
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1, 2, 4}
+        candidates = self._candidates((4, 0.9), (1, 0.3))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) == candidates
+
+    def test_suppression_is_reported_with_explicit_truncation(self, capsys):
+        cache = {
+            str(i): {
+                "title": f"Part {i}",
+                "year": 1970 + i,
+                "collection_id": ROCKY_COLLECTION_ID,
+                "collection_name": "Rocky Collection",
+            }
+            for i in range(1, 10)
+        }
+        recommender = _franchise_recommender(cache=cache)
+        candidates = self._candidates(*[(i, 0.5) for i in range(1, 10)])
+        capsys.readouterr()  # drop construction chatter
+        result = recommender._suppress_superseded_franchise_candidates(candidates)
+        out = capsys.readouterr().out
+        assert set(result) == {1}
+        assert "holding back 8 later movies" in out
+        assert "... and 3 more" in out
+
+
+class TestReportFranchiseGaps:
+    """BaseRecommender._report_franchise_gaps - "you got Rocky II because
+    you don't own Rocky"."""
+
+    HUNTARR = {
+        "collection_details": {
+            str(ROCKY_COLLECTION_ID): {
+                "collection_id": ROCKY_COLLECTION_ID,
+                "collection_name": "Rocky Collection",
+                "movies": [
+                    {"tmdb_id": 1366, "title": "Rocky", "year": "1976"},
+                    {"tmdb_id": 1367, "title": "Rocky II", "year": "1979"},
+                ],
+            }
+        }
+    }
+
+    def _recommender_with_huntarr_cache(self, tmp_path, payload=None):
+        recommender = _franchise_recommender()
+        recommender.cache_dir = str(tmp_path)
+        if payload is not None:
+            (tmp_path / "huntarr_cache.json").write_text(json.dumps(payload), encoding="utf-8")
+        return recommender
+
+    def test_missing_earlier_entry_is_reported(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}]
+        recommender._report_franchise_gaps(recs, {"2": {"tmdb_id": 1367}})
+        out = capsys.readouterr().out
+        assert "Franchise gaps" in out
+        assert "Rocky (1976)" in out
+
+    def test_owned_earlier_entry_is_not_reported(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}]
+        recommender._report_franchise_gaps(recs, {"1": {"tmdb_id": 1366}, "2": {"tmdb_id": 1367}})
+        assert "Franchise gaps" not in capsys.readouterr().out
+
+    def test_silent_without_a_huntarr_cache(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path)
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}]
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps(recs, {})
+        assert capsys.readouterr().out == ""
+
+    def test_disabled_flag_is_silent(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recommender.franchise_order = False
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}]
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps(recs, {})
+        assert capsys.readouterr().out == ""
+
+    def test_no_recommendations_is_silent(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps([], {})
+        assert capsys.readouterr().out == ""
+
+    def test_a_broken_cache_is_never_fatal(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}]
+        capsys.readouterr()  # drop construction chatter
+        with patch("recommenders.base.load_collection_details", side_effect=OSError("boom")):
+            recommender._report_franchise_gaps(recs, {})
+        assert capsys.readouterr().out == ""
+
+    def test_standalone_and_unknown_collections_are_skipped(self, tmp_path, capsys):
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recs = [
+            {"title": "Heat", "year": 1995, "collection_id": None},
+            {"title": "Some Sequel", "year": 2000, "collection_id": 999999},
+        ]
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps(recs, {})
+        assert capsys.readouterr().out == ""
+
+    def test_each_series_is_reported_once(self, tmp_path, capsys):
+        """Three Rocky candidates are one gap report, not three."""
+        recommender = self._recommender_with_huntarr_cache(tmp_path, self.HUNTARR)
+        recs = [{"title": "Rocky II", "year": 1979, "collection_id": ROCKY_COLLECTION_ID}] * 3
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps(recs, {})
+        assert capsys.readouterr().out.count("earliest owned entry") == 1
+
+    def test_long_gap_lists_are_truncated_explicitly(self, tmp_path, capsys):
+        payload = {
+            "collection_details": {
+                str(cid): {
+                    "collection_id": cid,
+                    "collection_name": f"Series {cid}",
+                    "movies": [
+                        {"tmdb_id": cid * 100 + n, "title": f"Series {cid} Part {n}", "year": str(1960 + n)}
+                        for n in range(5)
+                    ],
+                }
+                for cid in range(1, 8)
+            }
+        }
+        recommender = self._recommender_with_huntarr_cache(tmp_path, payload)
+        recs = [{"title": f"Series {cid} Part 5", "year": 1990, "collection_id": cid} for cid in range(1, 8)]
+        capsys.readouterr()  # drop construction chatter
+        recommender._report_franchise_gaps(recs, {})
+        out = capsys.readouterr().out
+        assert "across 7 series" in out
+        assert "+2 more" in out  # per-series gap list
+        assert "... and 2 more series" in out  # series list itself
+
+
+class TestDeclinedRatingKeys:
+    """The declined set franchise ordering refuses to promote into."""
+
+    def test_starts_empty(self):
+        assert _make_recommender().declined_rating_keys == set()
+
+    def test_populated_from_ignored_recommendations(self):
+        recommender = _make_recommender()
+        recommender.label_dates = {"7_Recommended": "2020-01-01T00:00:00"}
+        recommender.watched_data_counters = {"genres": Counter()}
+        media_cache = Mock()
+        media_cache.cache = {"movies": {"7": {"title": "Rocky", "genres": ["drama"], "tmdb_keywords": []}}}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+        recommender._collection_label_name = Mock(return_value="Recommended")
+
+        recommender._apply_ignored_recommendation_feedback()
+
+        assert recommender.declined_rating_keys == {7}
+
+    def test_stays_empty_when_negative_signals_are_off(self):
+        recommender = _make_recommender()
+        recommender.config["negative_signals"] = {"enabled": False}
+        recommender.label_dates = {"7_Recommended": "2020-01-01T00:00:00"}
+        recommender._apply_ignored_recommendation_feedback()
+        assert recommender.declined_rating_keys == set()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -497,6 +497,10 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
         # directly (as get_recommendations() does) sees it.
         assert result["movies"]["quality_filters"] == movies["quality_filters"]
         assert result["movies"]["recommend_for_no_history"] == movies["recommend_for_no_history"]
+        # franchise_order is read the same way (straight off
+        # self.media_config in BaseRecommender.__init__), not promoted to
+        # the root by this function - see utils/franchise.py.
+        assert result["movies"]["franchise_order"] == movies["franchise_order"]
 
     def test_every_documented_tv_key_resolves(self):
         tuning = self._load_example_tuning()
@@ -537,6 +541,7 @@ class TestResolveMediaTypeOverridesKeyEnumeration:
             "show_imdb_link",
             "quality_filters",
             "recommend_for_no_history",
+            "franchise_order",
             "weights",
         }
         covered_tv_keys = {
@@ -698,6 +703,20 @@ class TestTuningExampleTopLevelSectionsMatchCodeDefaults:
         tuning = self._load_example_tuning()
         assert tuning["movies"]["recommend_for_no_history"] == RECOMMEND_FOR_NO_HISTORY_DEFAULT
         assert tuning["tv"]["recommend_for_no_history"] == RECOMMEND_FOR_NO_HISTORY_DEFAULT
+
+    def test_franchise_order_default_matches(self):
+        """BaseRecommender.__init__ reads movies.franchise_order with this
+        exact fallback default when the key is absent (see
+        utils/franchise.py) - same #261-class drift guard as
+        recommend_for_no_history above."""
+        from recommenders.base import FRANCHISE_ORDER_DEFAULT
+
+        tuning = self._load_example_tuning()
+        assert tuning["movies"]["franchise_order"] == FRANCHISE_ORDER_DEFAULT
+        # Movies only: TMDB collections are a movie-side concept and no
+        # collection_id is ever cached for shows, so documenting the key
+        # under tv: would advertise a setting that cannot do anything.
+        assert "franchise_order" not in tuning["tv"]
 
     def test_top_level_sections_are_all_covered_by_this_class(self):
         """Belt-and-braces, mirroring

--- a/tests/test_franchise.py
+++ b/tests/test_franchise.py
@@ -1,0 +1,503 @@
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for utils/franchise.py - starting people at the beginning of a
+series instead of wherever the similarity score happened to land.
+"""
+
+import json
+import os
+import tempfile
+
+from utils.franchise import (
+    UNKNOWN_YEAR_SORT,
+    apply_franchise_ordering,
+    build_franchise_index,
+    coerce_year,
+    collect_library_tmdb_ids,
+    find_library_gaps,
+    find_next_unwatched,
+    is_promotable,
+    load_collection_details,
+    normalize_collection_id,
+    summarize_substitutions,
+)
+
+ROCKY = 1575
+CHUCKY = 10455
+
+
+def _movie(rating_key, title, year, collection_id=ROCKY, collection_name="Rocky Collection", **extra):
+    """One media-cache entry, in the shape recommenders/base.py caches."""
+    info = {
+        "title": title,
+        "year": year,
+        "collection_id": collection_id,
+        "collection_name": collection_name,
+        "genres": [],
+        "content_rating": "PG",
+    }
+    info.update(extra)
+    return str(rating_key), info
+
+
+def _library(*pairs):
+    return dict(pairs)
+
+
+ROCKY_LIBRARY = _library(
+    _movie(1, "Rocky", 1976),
+    _movie(2, "Rocky II", 1979),
+    _movie(3, "Rocky III", 1982),
+    _movie(4, "Rocky IV", 1985),
+)
+
+
+def _scored(library, rating_key, score):
+    """
+    Mimic get_recommendations(): the scored candidates ARE the cached
+    dicts, with plex_rating_key/similarity_score written onto them.
+    """
+    info = library[str(rating_key)]
+    info["plex_rating_key"] = rating_key
+    info["similarity_score"] = score
+    return info
+
+
+class TestCoerceYear:
+    def test_int_year(self):
+        assert coerce_year(1976) == 1976
+
+    def test_string_year(self):
+        assert coerce_year("1976") == 1976
+
+    def test_release_date_string(self):
+        assert coerce_year("1976-11-21") == 1976
+
+    def test_none(self):
+        assert coerce_year(None) is None
+
+    def test_garbage(self):
+        assert coerce_year("unknown") is None
+
+    def test_empty_string(self):
+        assert coerce_year("") is None
+
+    def test_bool_is_not_a_year(self):
+        """True is an int in Python; a year it is not."""
+        assert coerce_year(True) is None
+
+    def test_implausible_year_rejected(self):
+        assert coerce_year(12) is None
+        assert coerce_year(99999) is None
+
+
+class TestNormalizeCollectionId:
+    def test_int_passes_through(self):
+        assert normalize_collection_id(1575) == 1575
+
+    def test_numeric_string_becomes_int(self):
+        """The movie cache holds the int, the Huntarr cache keys by the
+        string - a franchise splitting in two over that would be
+        invisible, because each half would look like a single-entry
+        collection and simply never reorder."""
+        assert normalize_collection_id("1575") == 1575
+
+    def test_non_numeric_string_kept(self):
+        assert normalize_collection_id("abc") == "abc"
+
+    def test_none_and_blank(self):
+        assert normalize_collection_id(None) is None
+        assert normalize_collection_id("   ") is None
+
+    def test_bool_rejected(self):
+        assert normalize_collection_id(True) is None
+
+    def test_unexpected_types_rejected(self):
+        assert normalize_collection_id(15.75) is None
+        assert normalize_collection_id(["1575"]) is None
+
+
+class TestBuildFranchiseIndex:
+    def test_groups_by_collection_in_release_order(self):
+        index = build_franchise_index(ROCKY_LIBRARY)
+        assert [e.title for e in index[ROCKY]] == ["Rocky", "Rocky II", "Rocky III", "Rocky IV"]
+
+    def test_out_of_order_input_is_sorted(self):
+        library = _library(_movie(4, "Rocky IV", 1985), _movie(1, "Rocky", 1976), _movie(2, "Rocky II", 1979))
+        index = build_franchise_index(library)
+        assert [e.year for e in index[ROCKY]] == [1976, 1979, 1985]
+
+    def test_unknown_year_sorts_last(self):
+        """A single missing year must never take over position one - that
+        is the exact outcome this module exists to prevent."""
+        library = _library(_movie(9, "Rocky Mystery", None), _movie(1, "Rocky", 1976))
+        index = build_franchise_index(library)
+        assert [e.title for e in index[ROCKY]] == ["Rocky", "Rocky Mystery"]
+        assert index[ROCKY][-1].sort_key[0] == UNKNOWN_YEAR_SORT
+
+    def test_string_and_int_collection_ids_land_in_one_group(self):
+        library = _library(
+            _movie(1, "Rocky", 1976, collection_id=ROCKY), _movie(2, "Rocky II", 1979, collection_id="1575")
+        )
+        index = build_franchise_index(library)
+        assert len(index) == 1
+        assert len(index[ROCKY]) == 2
+
+    def test_items_without_collection_are_skipped(self):
+        library = _library(_movie(1, "Heat", 1995, collection_id=None))
+        assert build_franchise_index(library) == {}
+
+    def test_separate_collections_stay_separate(self):
+        library = _library(
+            _movie(1, "Rocky", 1976),
+            _movie(5, "Child's Play", 1988, collection_id=CHUCKY, collection_name="Chucky Collection"),
+        )
+        index = build_franchise_index(library)
+        assert set(index) == {ROCKY, CHUCKY}
+
+    def test_non_numeric_rating_key_skipped(self):
+        library = {"not-a-key": dict(_movie(1, "Rocky", 1976)[1])}
+        assert build_franchise_index(library) == {}
+
+    def test_non_mapping_values_skipped(self):
+        assert build_franchise_index({"1": "junk"}) == {}
+
+    def test_empty_input(self):
+        assert build_franchise_index({}) == {}
+        assert build_franchise_index(None) == {}
+
+    def test_single_entry_collections_are_kept(self):
+        """They can never produce a substitution, but gap reporting still
+        has something to say about them."""
+        index = build_franchise_index(_library(_movie(1, "Rocky", 1976)))
+        assert len(index[ROCKY]) == 1
+
+
+class TestIsPromotable:
+    def test_plain_entry_is_promotable(self):
+        _key, info = _movie(1, "Rocky", 1976)
+        assert is_promotable(info, 1) is True
+
+    def test_declined_entry_is_not(self):
+        _key, info = _movie(1, "Rocky", 1976)
+        assert is_promotable(info, 1, declined_ids={1}) is False
+
+    def test_excluded_genre_is_not(self):
+        _key, info = _movie(1, "Rocky", 1976, genres=["drama", "horror"])
+        assert is_promotable(info, 1, excluded_genres={"horror"}) is False
+
+    def test_excluded_genre_matching_is_case_insensitive(self):
+        _key, info = _movie(1, "Rocky", 1976, genres=["Horror"])
+        assert is_promotable(info, 1, excluded_genres={"horror"}) is False
+
+    def test_over_max_rating_is_not(self):
+        _key, info = _movie(1, "Rocky", 1976, content_rating="R")
+        assert is_promotable(info, 1, max_rating="PG") is False
+
+    def test_within_max_rating_is(self):
+        _key, info = _movie(1, "Rocky", 1976, content_rating="PG")
+        assert is_promotable(info, 1, max_rating="PG-13") is True
+
+    def test_quality_fields_are_not_consulted(self):
+        """Thin vote counts and low ratings size a collection; they do
+        not state a preference, so they never block a promotion."""
+        _key, info = _movie(1, "Rocky", 1976, rating=1.0, vote_count=0)
+        assert is_promotable(info, 1) is True
+
+
+class TestFindNextUnwatched:
+    def _entries(self, library=None):
+        return build_franchise_index(library or ROCKY_LIBRARY)[ROCKY]
+
+    def test_nothing_watched_returns_the_first(self):
+        assert find_next_unwatched(self._entries(), set()).title == "Rocky"
+
+    def test_first_watched_returns_the_second(self):
+        assert find_next_unwatched(self._entries(), {1}).title == "Rocky II"
+
+    def test_first_two_watched_returns_the_third(self):
+        assert find_next_unwatched(self._entries(), {1, 2}).title == "Rocky III"
+
+    def test_watching_a_later_entry_does_not_skip_the_first(self):
+        """Somebody who saw Rocky IV but not Rocky is still owed Rocky."""
+        assert find_next_unwatched(self._entries(), {4}).title == "Rocky"
+
+    def test_all_watched_returns_none(self):
+        assert find_next_unwatched(self._entries(), {1, 2, 3, 4}) is None
+
+    def test_disqualified_entry_is_skipped(self):
+        assert find_next_unwatched(self._entries(), set(), declined_ids={1}).title == "Rocky II"
+
+    def test_all_disqualified_returns_none(self):
+        assert find_next_unwatched(self._entries(), set(), declined_ids={1, 2, 3, 4}) is None
+
+    def test_excluded_genre_entry_is_skipped(self):
+        library = _library(_movie(1, "Rocky", 1976, genres=["horror"]), _movie(2, "Rocky II", 1979))
+        entries = self._entries(library)
+        assert find_next_unwatched(entries, set(), excluded_genres={"horror"}).title == "Rocky II"
+
+    def test_empty_entries(self):
+        assert find_next_unwatched([], set()) is None
+
+
+class TestApplyFranchiseOrdering:
+    def _order(self, library, scored, watched=frozenset(), **kwargs):
+        return apply_franchise_ordering(scored, build_franchise_index(library), set(watched), **kwargs)
+
+    def test_sequel_is_replaced_by_the_first_entry(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, subs = self._order(library, [_scored(library, 4, 0.7)])
+        assert [i["title"] for i in ordered] == ["Rocky"]
+        assert len(subs) == 1
+        assert subs[0].original_title == "Rocky IV"
+        assert subs[0].promoted_title == "Rocky"
+
+    def test_watched_first_entry_promotes_the_next_one(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.7)], watched={1})
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_first_entry_is_left_alone(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, subs = self._order(library, [_scored(library, 1, 0.7)])
+        assert [i["title"] for i in ordered] == ["Rocky"]
+        assert subs == []
+
+    def test_promoted_entry_inherits_the_score_and_the_rank(self):
+        """The slot is the sequel's; the title in it is the original's."""
+        library = dict(ROCKY_LIBRARY)
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.73)])
+        assert ordered[0]["similarity_score"] == 0.73
+        assert ordered[0]["plex_rating_key"] == 1
+
+    def test_whole_franchise_collapses_to_one_slot(self):
+        """Rocky III and Rocky IV both resolving to Rocky is one
+        recommendation, not three."""
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.9), _scored(library, 3, 0.8), _scored(library, 2, 0.7)]
+        ordered, subs = self._order(library, scored)
+        assert [i["title"] for i in ordered] == ["Rocky"]
+        assert len(subs) == 3
+
+    def test_franchise_keeps_the_best_rank_any_member_earned(self):
+        library = dict(ROCKY_LIBRARY)
+        other = {"title": "Heat", "year": 1995, "collection_id": None, "plex_rating_key": 99, "similarity_score": 0.85}
+        scored = [_scored(library, 4, 0.9), other, _scored(library, 3, 0.8)]
+        ordered, _subs = self._order(library, scored)
+        assert [i["title"] for i in ordered] == ["Rocky", "Heat"]
+
+    def test_first_entry_already_in_the_pool_is_not_duplicated(self):
+        """Rocky IV at rank 1 promoting to Rocky, and Rocky itself at
+        rank 2, must yield one Rocky."""
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.9), _scored(library, 1, 0.2)]
+        ordered, _subs = self._order(library, scored)
+        assert [i["plex_rating_key"] for i in ordered] == [1]
+        assert ordered[0]["similarity_score"] == 0.9
+
+    def test_promotion_target_need_not_be_in_the_scored_pool(self):
+        """The whole point of running after the quality/score gates: an
+        original those gates dropped is still promotable."""
+        library = dict(ROCKY_LIBRARY)
+        ordered, _subs = self._order(library, [_scored(library, 2, 0.5)])
+        assert ordered[0]["title"] == "Rocky"
+
+    def test_never_moves_to_a_later_entry(self):
+        """With the first entry declined, the second must stay put rather
+        than be displaced by a third."""
+        library = dict(ROCKY_LIBRARY)
+        ordered, subs = self._order(library, [_scored(library, 2, 0.5)], declined_ids={1})
+        assert ordered[0]["title"] == "Rocky II"
+        assert subs == []
+
+    def test_declined_first_entry_is_skipped_for_a_sequel(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.5)], declined_ids={1})
+        assert ordered[0]["title"] == "Rocky II"
+
+    def test_max_rating_blocks_the_original(self):
+        library = _library(
+            _movie(1, "Rocky", 1976, content_rating="R"),
+            _movie(2, "Rocky II", 1979, content_rating="PG"),
+            _movie(3, "Rocky III", 1982, content_rating="PG"),
+        )
+        ordered, _subs = self._order(library, [_scored(library, 3, 0.5)], max_rating="PG")
+        assert ordered[0]["title"] == "Rocky II"
+
+    def test_standalone_movies_pass_through_untouched(self):
+        heat = {"title": "Heat", "year": 1995, "collection_id": None, "plex_rating_key": 99, "similarity_score": 0.8}
+        ordered, subs = self._order(ROCKY_LIBRARY, [heat])
+        assert ordered == [heat]
+        assert subs == []
+
+    def test_single_entry_collection_is_a_no_op(self):
+        library = _library(_movie(7, "Highlander", 1986, collection_id=999))
+        ordered, subs = self._order(library, [_scored(library, 7, 0.8)])
+        assert [i["title"] for i in ordered] == ["Highlander"]
+        assert subs == []
+
+    def test_fully_watched_franchise_leaves_the_candidate_alone(self):
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.7)]
+        ordered, subs = self._order(library, scored, watched={1, 2, 3, 4})
+        assert [i["title"] for i in ordered] == ["Rocky IV"]
+        assert subs == []
+
+    def test_cached_dict_is_never_mutated(self):
+        """The media cache's own dicts are what get_recommendations()
+        persists - writing a borrowed score onto one would poison the
+        score cache for every later run."""
+        library = dict(ROCKY_LIBRARY)
+        library["1"]["cached_score"] = 0.11
+        library["1"]["profile_hash"] = "old-profile"
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
+        assert library["1"]["cached_score"] == 0.11
+        assert "similarity_score" not in library["1"] or library["1"]["similarity_score"] != 0.9
+
+    def test_promoted_copy_drops_stale_score_cache_keys(self):
+        library = dict(ROCKY_LIBRARY)
+        library["1"]["cached_score"] = 0.11
+        library["1"]["profile_hash"] = "old-profile"
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
+        assert "cached_score" not in ordered[0]
+        assert "profile_hash" not in ordered[0]
+
+    def test_promoted_copy_records_where_the_slot_came_from(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
+        assert ordered[0]["franchise_promoted_from"]["title"] == "Rocky IV"
+        assert "franchise" in ordered[0]["score_breakdown"]["details"]
+
+    def test_missing_rating_key_is_left_alone(self):
+        item = {"title": "Rocky IV", "year": 1985, "collection_id": ROCKY, "similarity_score": 0.5}
+        ordered, subs = self._order(ROCKY_LIBRARY, [item])
+        assert ordered == [item]
+        assert subs == []
+
+    def test_empty_input(self):
+        assert self._order(ROCKY_LIBRARY, []) == ([], [])
+
+
+class TestFindLibraryGaps:
+    DETAIL = {
+        "collection_id": ROCKY,
+        "collection_name": "Rocky Collection",
+        "movies": [
+            {"tmdb_id": 1366, "title": "Rocky", "year": "1976", "release_date": "1976-11-21"},
+            {"tmdb_id": 1367, "title": "Rocky II", "year": "1979", "release_date": "1979-06-15"},
+            {"tmdb_id": 1371, "title": "Rocky III", "year": "1982", "release_date": "1982-05-28"},
+        ],
+    }
+
+    def test_reports_earlier_entries_the_library_lacks(self):
+        gaps = find_library_gaps(self.DETAIL, 1982, {1371})
+        assert [g["title"] for g in gaps] == ["Rocky", "Rocky II"]
+
+    def test_owned_entries_are_not_gaps(self):
+        gaps = find_library_gaps(self.DETAIL, 1982, {1366, 1371})
+        assert [g["title"] for g in gaps] == ["Rocky II"]
+
+    def test_later_entries_are_not_gaps(self):
+        assert find_library_gaps(self.DETAIL, 1976, {1366}) == []
+
+    def test_unknown_reference_year_reports_nothing(self):
+        assert find_library_gaps(self.DETAIL, None, set()) == []
+
+    def test_undated_members_are_skipped(self):
+        detail = {"movies": [{"tmdb_id": 5, "title": "Untitled Rocky", "year": None, "release_date": None}]}
+        assert find_library_gaps(detail, 1982, set()) == []
+
+    def test_release_date_is_used_when_year_is_absent(self):
+        detail = {"movies": [{"tmdb_id": 1366, "title": "Rocky", "release_date": "1976-11-21"}]}
+        assert [g["year"] for g in find_library_gaps(detail, 1982, set())] == [1976]
+
+    def test_gaps_are_sorted_oldest_first(self):
+        gaps = find_library_gaps(self.DETAIL, 1982, set())
+        assert [g["year"] for g in gaps] == [1976, 1979]
+
+    def test_malformed_detail(self):
+        assert find_library_gaps({}, 1982, set()) == []
+        assert find_library_gaps({"movies": ["junk"]}, 1982, set()) == []
+
+
+class TestLoadCollectionDetails:
+    def _write(self, payload):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, "huntarr_cache.json"), "w", encoding="utf-8") as fh:
+            if isinstance(payload, str):
+                fh.write(payload)
+            else:
+                json.dump(payload, fh)
+        return tmpdir
+
+    def test_missing_file_is_not_an_error(self):
+        assert load_collection_details(tempfile.mkdtemp()) == {}
+
+    def test_corrupt_file_is_not_an_error(self):
+        assert load_collection_details(self._write("{not json")) == {}
+
+    def test_string_keys_are_normalized_to_ints(self):
+        details = load_collection_details(self._write({"collection_details": {"1575": {"movies": []}}}))
+        assert set(details) == {1575}
+
+    def test_missing_section(self):
+        assert load_collection_details(self._write({"version": 4})) == {}
+
+    def test_non_dict_entries_skipped(self):
+        details = load_collection_details(self._write({"collection_details": {"1575": "junk"}}))
+        assert details == {}
+
+    def test_version_is_not_enforced(self):
+        """Gap reporting is informational - tolerating an older file
+        beats refusing to report anything."""
+        details = load_collection_details(self._write({"version": 1, "collection_details": {"1575": {"movies": []}}}))
+        assert set(details) == {1575}
+
+
+class TestCollectLibraryTmdbIds:
+    def test_collects_int_ids_only(self):
+        library = _library(
+            _movie(1, "Rocky", 1976, tmdb_id=1366),
+            _movie(2, "Rocky II", 1979, tmdb_id=None),
+            _movie(3, "Rocky III", 1982, tmdb_id="1371"),
+        )
+        assert collect_library_tmdb_ids(library) == {1366}
+
+    def test_empty(self):
+        assert collect_library_tmdb_ids({}) == set()
+
+
+class TestSummarizeSubstitutions:
+    def _subs(self, n):
+        library = _library(*[_movie(i, f"Part {i}", 1970 + i) for i in range(1, n + 2)])
+        scored = [_scored(library, i, 0.5) for i in range(2, n + 2)]
+        _ordered, subs = apply_franchise_ordering(scored, build_franchise_index(library), set())
+        return subs
+
+    def test_describes_each_substitution(self):
+        lines = summarize_substitutions(self._subs(1))
+        assert "Part 2 (1972) -> Part 1 (1971)" in lines[0]
+
+    def test_truncation_is_explicit(self):
+        lines = summarize_substitutions(self._subs(12), limit=10)
+        assert len(lines) == 11
+        assert lines[-1] == "... and 2 more"
+
+    def test_no_truncation_marker_when_under_limit(self):
+        lines = summarize_substitutions(self._subs(3), limit=10)
+        assert len(lines) == 3

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -74,6 +74,9 @@ from .config import (
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_RATING,
     DEFAULT_RATING_MULTIPLIERS,
+    FRANCHISE_GAP_REPORT_LIMIT,
+    FRANCHISE_GAP_TITLES_PER_SERIES,
+    FRANCHISE_ORDER_DEFAULT,
     IDF_MIN_CORPUS_SIZE,
     IDF_MIN_WEIGHT,
     IGNORED_REC_MAX_PROFILE_FRACTION,
@@ -168,6 +171,21 @@ from .display import (
     show_progress,
     smart_open_html,
     user_select_recommendations,
+)
+
+# Franchise ordering - start people at the beginning of a series
+from .franchise import (
+    FranchiseEntry,
+    FranchiseSubstitution,
+    apply_franchise_ordering,
+    build_franchise_index,
+    coerce_year,
+    collect_library_tmdb_ids,
+    find_library_gaps,
+    find_next_unwatched,
+    load_collection_details,
+    normalize_collection_id,
+    summarize_substitutions,
 )
 
 # Helper utilities
@@ -510,6 +528,9 @@ __all__ = [
     "DEFAULT_NEGATIVE_MULTIPLIERS",
     "DEFAULT_NEGATIVE_THRESHOLD",
     "RECOMMEND_FOR_NO_HISTORY_DEFAULT",
+    "FRANCHISE_ORDER_DEFAULT",
+    "FRANCHISE_GAP_REPORT_LIMIT",
+    "FRANCHISE_GAP_TITLES_PER_SERIES",
     "COLLECTION_BONUS_BASE",
     "COLLECTION_BONUS_CAP",
     "COLLECTION_BONUS_LOG_FACTOR",
@@ -620,6 +641,18 @@ __all__ = [
     # Ignored-recommendation negative feedback
     "apply_ignored_penalties",
     "find_ignored_recommendations",
+    # Franchise ordering
+    "FranchiseEntry",
+    "FranchiseSubstitution",
+    "apply_franchise_ordering",
+    "build_franchise_index",
+    "coerce_year",
+    "collect_library_tmdb_ids",
+    "find_library_gaps",
+    "find_next_unwatched",
+    "load_collection_details",
+    "normalize_collection_id",
+    "summarize_substitutions",
     # Library supply health
     "PoolHealth",
     "SupplyGap",

--- a/utils/config.py
+++ b/utils/config.py
@@ -327,6 +327,36 @@ IGNORED_REC_MAX_PROFILE_FRACTION = 0.25
 # code default).
 RECOMMEND_FOR_NO_HISTORY_DEFAULT = True
 
+# Whether a recommendation belonging to a TMDB collection is replaced by
+# the earliest entry of that collection the user has not watched (see
+# utils/franchise.py). Default True: scoring alone routinely surfaces
+# Rocky IV or The Godfather Part III as somebody's first contact with a
+# series, and the existing collection bonus (COLLECTION_BONUS_* below)
+# actively makes that MORE likely - it boosts a title for belonging to a
+# collection the user has started without saying which entry comes next.
+#
+# Set to False (movies.franchise_order in tuning.yml) to rank franchise
+# entries purely by score, which is what every release before this flag
+# existed did.
+#
+# Documented in config/tuning.example.yml's movies.franchise_order -
+# tests/test_config.py's guardrail class enforces the two stay identical
+# (#261 precedent: a documented example silently drifting from the real
+# code default).
+FRANCHISE_ORDER_DEFAULT = True
+
+# How many franchise lines a run prints before collapsing the rest into
+# an explicit "... and N more". A library with 73 multi-entry collections
+# (measured on the reference library) would otherwise bury the rest of
+# the run's output; the count is always reported, so nothing is silently
+# truncated.
+FRANCHISE_GAP_REPORT_LIMIT = 5
+
+# How many missing titles are named per series inside one of those lines
+# before the rest become "+N more". Naming the first few is what makes
+# the report actionable; naming all seven Amityville films is not.
+FRANCHISE_GAP_TITLES_PER_SERIES = 3
+
 # Rating tier thresholds (Plex uses 0-10 scale, Plex UI shows 0-5 stars)
 RATING_TIER_5_STAR = 9.0  # 5 stars: ratings 9-10
 RATING_TIER_4_STAR = 7.0  # 4 stars: ratings 7-8
@@ -666,10 +696,11 @@ KNOWN_ROOT_CONFIG_KEYS = frozenset(
 )
 
 # Keys meaningful inside a `movies:`/`tv:` section of tuning.yml. Split
-# because `show_director` is movies-only: TV has no director-equivalent
-# display option, so resolve_media_type_overrides() never reads it for
-# TV and setting it there is silently inert - precisely the shape of bug
-# this whole section exists to surface.
+# because `show_director` and `franchise_order` are movies-only: TV has
+# no director-equivalent display option, and TMDB collections are a
+# movie-side concept with no collection data cached for shows at all, so
+# neither is ever read for TV and setting either there is silently inert
+# - precisely the shape of bug this whole section exists to surface.
 KNOWN_MEDIA_SECTION_KEYS = frozenset(
     {
         "limit_results",
@@ -688,7 +719,7 @@ KNOWN_MEDIA_SECTION_KEYS = frozenset(
         "recommend_for_no_history",
     }
 )
-MOVIES_ONLY_MEDIA_SECTION_KEYS = frozenset({"show_director"})
+MOVIES_ONLY_MEDIA_SECTION_KEYS = frozenset({"show_director", "franchise_order"})
 
 
 def _suggest_similar_key(unknown: str, known) -> str:

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.19.3"
+__version__ = "2.20.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/franchise.py
+++ b/utils/franchise.py
@@ -1,0 +1,504 @@
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Franchise-ordered recommendations - start people at the beginning.
+
+Ranking purely by similarity happily hands someone Rocky IV, The Godfather
+Part III or Cult of Chucky as their first contact with a series. The score
+is not wrong - those really are the closest match to the profile - but the
+recommendation is, because scoring treats every candidate as independently
+watchable and a franchise entry is not. Curatarr made this MORE likely
+rather than less: the existing collection bonus (COLLECTION_BONUS_* in
+utils/config.py) deliberately boosts a title when the user has watched
+others in its collection, which is right in principle but says nothing
+about which entry to serve next.
+
+This module supplies that missing half. When a candidate belongs to a TMDB
+collection, the recommendation slot goes to the earliest entry of that
+collection the user has not already watched:
+
+    watched nothing        -> Rocky (1976)
+    watched Rocky          -> Rocky II (1979)
+    watched Rocky I and II -> Rocky III (1982)
+
+Four things are deliberate, and each one is a decision that could
+reasonably have gone the other way:
+
+1. **Library-only.** A promoted entry must already be in the Plex library,
+   because the artifact is a Plex collection - a recommendation the user
+   cannot press play on is not a recommendation. When the true first entry
+   is missing entirely, the earliest one they DO own is promoted instead
+   and the gap is reported (see find_library_gaps), which is precisely the
+   input Sequel Huntarr already turns into a Radarr request.
+
+2. **Release order, from the library's own `year`.** Costs no API calls -
+   `collection_id`/`collection_name`/`year` are already cached per movie
+   (recommenders/base.py's MovieCache/_backfill_collection_data). Release
+   order is not always narrative order (prequels exist), but it is the
+   order the films were made to be seen in, and it is the only order the
+   cache can answer for free. Unknown years sort last rather than first,
+   so a missing year can never hijack position one.
+
+3. **Hard filters are respected; sizing filters are not.** An entry is
+   never promoted past an excluded genre, a per-user max content rating,
+   or a recommendation the user has already visibly declined
+   (utils/ignored_recs.py) - those are direct statements of intent. It IS
+   promoted past `quality_filters` and `min_similarity`, which exist to
+   size the collection rather than to express a preference: a 1976
+   original with a thin TMDB vote count should not be withheld while its
+   own sequel is recommended.
+
+4. **One slot per franchise.** Rocky III and Rocky IV both resolving to
+   Rocky is not three recommendations, it is one - so the duplicates
+   collapse and the franchise keeps the best rank any of its members
+   earned. Because this runs before the candidate buffer is truncated,
+   the freed slots refill from the tail rather than shrinking the
+   collection.
+"""
+
+import json
+import logging
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import AbstractSet, Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+from utils.plex_policy import is_rating_allowed
+
+logger = logging.getLogger(__name__)
+
+# Sorts an entry with no usable year to the END of its collection. The
+# alternative (treating unknown as 0) would make a single missing year
+# silently take over position one for the whole franchise, which is the
+# one outcome this module exists to prevent.
+UNKNOWN_YEAR_SORT = 9999
+
+# Written by recommenders/huntarr.py. Read here strictly opportunistically
+# and read-only: it is the one place the FULL TMDB member list of a
+# collection is already on disk, which is what makes "you own Rocky II-V
+# but not Rocky" answerable without a single extra API call. Absent,
+# stale or unreadable simply means no gap reporting.
+HUNTARR_CACHE_FILENAME = "huntarr_cache.json"
+
+
+@dataclass(frozen=True, eq=False)
+class FranchiseEntry:
+    """One library movie, positioned within its TMDB collection."""
+
+    rating_key: int
+    collection_id: Any
+    collection_name: str
+    title: str
+    year: Optional[int]
+    info: Mapping = field(repr=False)
+
+    @property
+    def sort_key(self) -> Tuple[int, str]:
+        """Release order, with unknown years last (see UNKNOWN_YEAR_SORT)."""
+        return (self.year if self.year is not None else UNKNOWN_YEAR_SORT, self.title.lower())
+
+    def label(self) -> str:
+        return f"{self.title} ({self.year if self.year is not None else 'N/A'})"
+
+
+@dataclass(frozen=True, eq=False)
+class FranchiseSubstitution:
+    """A recommendation slot handed from a later entry to an earlier one."""
+
+    collection_id: Any
+    collection_name: str
+    original_title: str
+    original_year: Optional[int]
+    original_rating_key: Optional[int]
+    promoted_title: str
+    promoted_year: Optional[int]
+    promoted_rating_key: int
+
+    def describe(self) -> str:
+        original_year = self.original_year if self.original_year is not None else "N/A"
+        promoted_year = self.promoted_year if self.promoted_year is not None else "N/A"
+        return (
+            f"{self.original_title} ({original_year}) -> "
+            f"{self.promoted_title} ({promoted_year})  [{self.collection_name}]"
+        )
+
+
+def coerce_year(value: Any) -> Optional[int]:
+    """
+    Best-effort year from the several shapes the caches actually hold.
+
+    The movie cache stores an int, the Huntarr cache stores a string, and
+    both store None for items TMDB has no release date for. Anything that
+    isn't a plausible 4-digit year becomes None (sorted last) rather than
+    a guess.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 1000 <= value <= 2999 else None
+    if isinstance(value, str):
+        digits = value.strip()[:4]
+        if digits.isdigit():
+            year = int(digits)
+            return year if 1000 <= year <= 2999 else None
+    return None
+
+
+def normalize_collection_id(value: Any) -> Optional[Any]:
+    """
+    Collection ids compare as ints wherever they can.
+
+    JSON round-trips have left these as both `10455` and `"10455"` in
+    different caches (the movie cache holds the int, the Huntarr cache
+    keys its dict by the string), and a franchise silently splitting in
+    two because of that would be invisible - each half would look like a
+    single-entry collection and simply never reorder.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        return int(text) if text.isdigit() else text
+    return None
+
+
+def build_franchise_index(all_items: Mapping[str, Mapping]) -> Dict[Any, List[FranchiseEntry]]:
+    """
+    Group the media cache into collection_id -> entries in release order.
+
+    Args:
+        all_items: The media cache's item dict (ratingKey -> info), i.e.
+            recommenders/base.py's `media_cache.cache[self.media_key]`.
+            Deliberately the WHOLE cache including watched and
+            filtered-out items - "which entries has the user already
+            seen" is unanswerable from the unwatched candidate pool
+            alone.
+
+    Returns:
+        collection_id -> entries sorted by (year, title). Collections
+        with no `collection_id` (TV, or a standalone film) never appear;
+        single-entry collections do, because gap reporting still has
+        something to say about them.
+    """
+    groups: Dict[Any, List[FranchiseEntry]] = defaultdict(list)
+
+    for raw_key, info in (all_items or {}).items():
+        if not isinstance(info, Mapping):
+            continue
+        collection_id = normalize_collection_id(info.get("collection_id"))
+        if collection_id is None:
+            continue
+        try:
+            rating_key = int(str(raw_key))
+        except (TypeError, ValueError):
+            continue
+
+        groups[collection_id].append(
+            FranchiseEntry(
+                rating_key=rating_key,
+                collection_id=collection_id,
+                collection_name=info.get("collection_name") or "Unknown Collection",
+                title=info.get("title") or str(raw_key),
+                year=coerce_year(info.get("year")),
+                info=info,
+            )
+        )
+
+    return {cid: sorted(entries, key=lambda e: e.sort_key) for cid, entries in groups.items()}
+
+
+def is_promotable(
+    info: Mapping,
+    rating_key: int,
+    *,
+    declined_ids: AbstractSet[int] = frozenset(),
+    excluded_genres: AbstractSet[str] = frozenset(),
+    max_rating: Optional[str] = None,
+    media_type: str = "movie",
+) -> bool:
+    """
+    May this entry be handed a recommendation slot?
+
+    The three disqualifiers are the ones that express what a user WANTS,
+    as opposed to how large their collection should be:
+
+    - an excluded genre (general.exclude_genre / per-user preferences),
+    - a per-user max content rating (users.preferences.max_rating),
+    - a recommendation they were shown and visibly declined
+      (utils/ignored_recs.py).
+
+    Quality thresholds and `min_similarity` are intentionally absent -
+    see this module's docstring for why a promoted original is allowed
+    past them.
+    """
+    if rating_key in declined_ids:
+        return False
+
+    if excluded_genres:
+        genres = info.get("genres") or []
+        if any(isinstance(g, str) and g.lower() in excluded_genres for g in genres):
+            return False
+
+    if max_rating and not is_rating_allowed(info.get("content_rating"), max_rating, media_type):
+        return False
+
+    return True
+
+
+def find_next_unwatched(
+    entries: Sequence[FranchiseEntry],
+    watched_ids: Set[int],
+    *,
+    declined_ids: AbstractSet[int] = frozenset(),
+    excluded_genres: AbstractSet[str] = frozenset(),
+    max_rating: Optional[str] = None,
+    media_type: str = "movie",
+) -> Optional[FranchiseEntry]:
+    """
+    The earliest entry of this collection the user hasn't watched.
+
+    Walks release order and returns the first entry that is neither
+    already watched nor disqualified (see is_promotable). Watched entries
+    LATER in the run do not stop the walk - somebody who saw Rocky IV but
+    not Rocky is still owed Rocky.
+
+    Returns None when every entry is watched or disqualified.
+    """
+    for entry in entries:
+        if entry.rating_key in watched_ids:
+            continue
+        if not is_promotable(
+            entry.info,
+            entry.rating_key,
+            declined_ids=declined_ids,
+            excluded_genres=excluded_genres,
+            max_rating=max_rating,
+            media_type=media_type,
+        ):
+            continue
+        return entry
+    return None
+
+
+def _promote(entry: FranchiseEntry, original: Mapping) -> Dict:
+    """
+    Build the recommendation dict for a promoted entry.
+
+    A COPY, never the cached dict itself: the media cache's own item
+    dicts are the same objects `get_recommendations()` writes
+    `cached_score`/`profile_hash` into and then persists, so writing a
+    borrowed score onto one would poison the score cache for every later
+    run. `cached_score`/`profile_hash` are dropped from the copy for the
+    same reason in reverse - they describe a score this dict no longer
+    carries, and leaving them would invite a future reader to trust them.
+    """
+    promoted = dict(entry.info)
+    promoted.pop("cached_score", None)
+    promoted.pop("profile_hash", None)
+    promoted["plex_rating_key"] = entry.rating_key
+    promoted["similarity_score"] = original.get("similarity_score", 0.0)
+
+    # The slot's score is inherited, so the breakdown shown for it is the
+    # inheriting one, annotated. Using the promoted entry's OWN cached
+    # breakdown would be worse than useless: it may have been computed
+    # against a different profile_hash entirely (see CLAUDE.md).
+    breakdown = dict(original.get("score_breakdown") or {})
+    details = dict(breakdown.get("details") or {})
+    original_year = original.get("year") if original.get("year") is not None else "N/A"
+    details["franchise"] = (
+        f"earliest unwatched entry in {entry.collection_name}; "
+        f"score inherited from {original.get('title', 'unknown')} ({original_year})"
+    )
+    breakdown["details"] = details
+    promoted["score_breakdown"] = breakdown
+
+    promoted["franchise_promoted_from"] = {
+        "title": original.get("title"),
+        "year": original.get("year"),
+        "plex_rating_key": original.get("plex_rating_key"),
+    }
+    return promoted
+
+
+def apply_franchise_ordering(
+    scored_items: Sequence[Mapping],
+    franchise_index: Mapping[Any, List[FranchiseEntry]],
+    watched_ids: Set[int],
+    *,
+    declined_ids: AbstractSet[int] = frozenset(),
+    excluded_genres: AbstractSet[str] = frozenset(),
+    max_rating: Optional[str] = None,
+    media_type: str = "movie",
+) -> Tuple[List[Dict], List[FranchiseSubstitution]]:
+    """
+    Re-point every franchise recommendation at its earliest unwatched entry.
+
+    Args:
+        scored_items: Scored candidates in rank order (highest first).
+        franchise_index: Output of build_franchise_index().
+        watched_ids: Rating keys this user has watched. Pass the union of
+            `watched_ids` and `user_played_ids` - the per-user Plex view
+            knows about plays the shared admin history does not, and a
+            part wrongly believed unwatched sends the whole franchise
+            back to the start.
+        declined_ids / excluded_genres / max_rating / media_type: the
+            promotion eligibility rules - see is_promotable().
+
+    Returns:
+        (reordered items, substitutions made). The reordered list holds
+        the same ranks as the input with promoted entries swapped in, and
+        with any franchise appearing exactly once - so it can be SHORTER
+        than the input. Call this before truncating to the candidate
+        buffer, so the freed slots refill from the tail.
+    """
+    ordered: List[Dict] = []
+    substitutions: List[FranchiseSubstitution] = []
+    seen: Set[int] = set()
+
+    for item in scored_items:
+        target: Dict = item if isinstance(item, dict) else dict(item)
+        rating_key = item.get("plex_rating_key")
+        collection_id = normalize_collection_id(item.get("collection_id"))
+        entries = franchise_index.get(collection_id) if collection_id is not None else None
+
+        if entries and len(entries) > 1 and rating_key is not None:
+            nxt = find_next_unwatched(
+                entries,
+                watched_ids,
+                declined_ids=declined_ids,
+                excluded_genres=excluded_genres,
+                max_rating=max_rating,
+                media_type=media_type,
+            )
+            current = next((e for e in entries if e.rating_key == rating_key), None)
+            # Only ever move EARLIER. Without this an entry the user is
+            # already correctly being offered could be displaced by a
+            # later one whenever eligibility rules skipped it.
+            if (
+                nxt is not None
+                and nxt.rating_key != rating_key
+                and (current is None or nxt.sort_key < current.sort_key)
+            ):
+                target = _promote(nxt, item)
+                substitutions.append(
+                    FranchiseSubstitution(
+                        collection_id=collection_id,
+                        collection_name=nxt.collection_name,
+                        original_title=item.get("title", "unknown"),
+                        original_year=item.get("year"),
+                        original_rating_key=rating_key,
+                        promoted_title=nxt.title,
+                        promoted_year=nxt.year,
+                        promoted_rating_key=nxt.rating_key,
+                    )
+                )
+
+        target_key = target.get("plex_rating_key")
+        if target_key is not None:
+            if target_key in seen:
+                # Same franchise, lower-ranked member - already served.
+                continue
+            seen.add(target_key)
+        ordered.append(target)
+
+    return ordered, substitutions
+
+
+def load_collection_details(cache_dir: str) -> Dict[Any, Dict]:
+    """
+    Read Sequel Huntarr's cached TMDB collection member lists, if any.
+
+    Read-only and version-blind on purpose: this feeds reporting, never a
+    recommendation, so tolerating an older/staler file beats refusing to
+    report anything. Every failure mode - no file, unreadable file,
+    unexpected shape - returns {} and the caller silently skips gap
+    reporting.
+    """
+    path = os.path.join(cache_dir, HUNTARR_CACHE_FILENAME)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as e:
+        logger.debug(f"No Huntarr collection details available for franchise gap reporting: {e}")
+        return {}
+
+    raw = data.get("collection_details") if isinstance(data, dict) else None
+    if not isinstance(raw, dict):
+        return {}
+
+    details: Dict[Any, Dict] = {}
+    for cid, detail in raw.items():
+        collection_id = normalize_collection_id(cid)
+        if collection_id is not None and isinstance(detail, dict):
+            details[collection_id] = detail
+    return details
+
+
+def find_library_gaps(
+    collection_detail: Mapping,
+    before_year: Optional[int],
+    library_tmdb_ids: Set[int],
+) -> List[Dict]:
+    """
+    Entries of this collection released before `before_year` that the
+    library doesn't hold.
+
+    This is the "you are being handed Rocky II because you don't own
+    Rocky" case. Purely informational - Sequel Huntarr is what actually
+    requests these - and it is why option (a) of the missing-part
+    decision is safe: the user still gets the earliest entry they can
+    actually play, plus a note about the one they can't.
+    """
+    if before_year is None:
+        return []
+
+    gaps: List[Dict] = []
+    for movie in collection_detail.get("movies") or []:
+        if not isinstance(movie, Mapping):
+            continue
+        year = coerce_year(movie.get("year")) or coerce_year(movie.get("release_date"))
+        if year is None or year >= before_year:
+            continue
+        tmdb_id = movie.get("tmdb_id")
+        if tmdb_id in library_tmdb_ids:
+            continue
+        gaps.append({"tmdb_id": tmdb_id, "title": movie.get("title") or "Unknown", "year": year})
+
+    return sorted(gaps, key=lambda g: (g["year"], g["title"]))
+
+
+def collect_library_tmdb_ids(all_items: Mapping[str, Mapping]) -> Set[int]:
+    """TMDB ids present in the media cache - the 'do we own it' lookup."""
+    ids: Set[int] = set()
+    for info in (all_items or {}).values():
+        if isinstance(info, Mapping) and isinstance(info.get("tmdb_id"), int):
+            ids.add(info["tmdb_id"])
+    return ids
+
+
+def summarize_substitutions(substitutions: Iterable[FranchiseSubstitution], limit: int = 10) -> List[str]:
+    """Human-readable lines for the run log, capped, with an explicit
+    "... and N more" rather than a silent truncation."""
+    lines = [s.describe() for s in substitutions]
+    if len(lines) > limit:
+        remaining = len(lines) - limit
+        lines = lines[:limit] + [f"... and {remaining} more"]
+    return lines


### PR DESCRIPTION
## The problem

Ranking purely by similarity treats every candidate as independently watchable, so it happily hands somebody **Rocky IV**, **The Godfather Part III** or **Cult of Chucky** as their first contact with a series. The score isn't wrong — those really are the closest match to the profile — but the recommendation is.

The existing collection bonus (`COLLECTION_BONUS_*`) made this *more* likely rather than less: it boosts a title for belonging to a collection the user has started, without ever saying which entry comes next.

## What this does

`utils/franchise.py` supplies that missing half. A recommendation belonging to a TMDB collection is replaced by the earliest entry of that collection the user hasn't watched:

```
watched nothing        -> Rocky (1976)
watched Rocky          -> Rocky II (1979)
watched Rocky I and II -> Rocky III (1982)
```

Costs no API calls — `collection_id` / `collection_name` / `year` are already cached per movie by `MovieCache` / `_backfill_collection_data`.

## Deliberate choices

- **Library-only promotion.** The artifact is a Plex collection, so a promoted entry must be playable. When the true first entry is missing entirely, the earliest *owned* one is promoted and the gap is reported from Sequel Huntarr's already-cached TMDB member lists (read-only, version-blind, silent when absent) — which is exactly the input Sequel Huntarr already turns into a Radarr request.
- **Hard filters respected, sizing filters not.** Never promoted past an excluded genre, a per-user `max_rating`, or a visibly declined recommendation. Deliberately promoted *past* `quality_filters` and `min_similarity`, which size the collection rather than state a preference — a 1976 original with a thin TMDB vote count shouldn't be withheld while its own sequel is recommended.
- **Release order** from the library's own `year`, with unknown years sorted last so a missing year can never take position one.
- **One slot per franchise.** Applied before the candidate buffer is truncated, so collapsed duplicates refill from the tail instead of shrinking the collection.

## Two hooks, because one isn't enough

`get_recommendations()` re-points the fresh pool. `manage_plex_labels()` *also* suppresses already-labeled later entries once their series' earliest unwatched entry is a candidate — without that, a sequel labeled on a previous run would outlive the promotion indefinitely, sitting in the collection next to the original.

That suppression only fires when the earliest entry is itself in the pool, so a series whose first entry the `max_rating` filter just removed keeps the entry the user *may* watch rather than vanishing from the collection entirely.

`declined_rating_keys` is new state, populated from the same `find_ignored_recommendations()` call that already computes the profile penalties, so franchise ordering can refuse to promote a title the user has left sitting unwatched.

## Scope and config

Movies only — TMDB collections are a movie-side concept and no collection data is cached for TV, so the index comes back empty there. Toggle is `movies.franchise_order` (`FRANCHISE_ORDER_DEFAULT`, default `true`); documented in `config/tuning.example.yml` and guarded by the usual `#261`-class drift tests.

## Verification

Dry-run against the reference library (486 movies, 157 collections, 73 with 2+ entries) and each configured user's real watch history:

```
homehouse165 (76 watched):  Rocky Balboa (2006)  -> Rocky (1976)
jasonsmith523 (300 watched): Rocky Balboa (2006) -> Rocky II (1979)   <- had watched Rocky
                             Venom: Let There Be Carnage -> Venom
                             The Karate Kid Part II -> The Karate Kid
                             22 Jump Street -> 21 Jump Street
GAP: Herbie Goes to Monte Carlo is earliest owned of Herbie Collection;
     missing The Love Bug (1968), Herbie Rides Again (1974)
```

`utils/franchise.py` at 100% coverage. 113 new tests; suite goes 3303 -> 3416 passed, ruff and mypy clean.

## Release

Bumped to **2.20.0** with its `CHANGELOG.md` entry, in this PR — matching what every recent change on `main` does (`#358`, `#361`, `#362` each carry their own bump). Minor rather than patch because franchise ordering is on by default, so it changes what existing installs' collections contain rather than only what a newly-set flag can opt into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
