### PR TITLE
Promote franchise entries only on a series the user has started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.21.0] - 2026-08-16
+
+### Changed
+
+- **Franchise ordering now distinguishes a series you have STARTED from one you have never touched**, and only promotes on the former. `2.20.0` treated both alike: any mid-series candidate handed its slot *and its score* to the earliest unwatched entry. On a started series that is right — the slot belongs to the franchise. On an unstarted one it let `utils/franchise.py` manufacture a ranking it never earned: *Rocky IV* matching a profile is not evidence that a 1976 boxing drama deserves a top-50 place, and treating it as such displaced better-matched titles wholesale. Measured on the reference library before the fix: a user with 32 watched movies had **68 of 73** multi-entry series pinned to their oldest member, every one of them a series she had never started.
+
+  Now: a **started** series moves to the next unwatched entry and inherits the slot (watched *Rocky*, get *Rocky II*) — the "continue watching" case every major service gives a dedicated shelf, and rare enough that it can never crowd a collection (0–13 series per user across the six real profiles measured). An **unstarted** series has its mid-series entries dropped instead, with the earliest entry left to stand or fall on its **own** score. On an unstarted series this can therefore only ever *remove* a wrong recommendation, never invent a highly-ranked one. The ranker decides which franchise; franchise ordering decides which entry, and it can no longer do the ranker's job.
+
+  `manage_plex_labels()`'s collection-side suppression mirrors the same split, or the two halves would contradict each other on one series: on an unstarted series a mid-series entry still carrying a label from a previous run is now dropped whether or not the earliest entry is a candidate, and the survivor keeps its own score rather than inheriting the best in the series — otherwise a stale label would reintroduce exactly the inheritance this removes.
+
+### Added
+
+- **`users.preferences.<user>.franchise_order`** (`config.yml`) — per-user override of `movies.franchise_order`, resolving narrowest-first: per-user, then `movies.franchise_order` in `tuning.yml`, then `FRANCHISE_ORDER_DEFAULT`. Per-user because the setting describes a *person*, not a library: a completionist who wants walking through Rocky I–VI and a housemate who just wants tonight's best match are both right and they share one server. Mirrors the existing `max_rating`/`exclude_genres` preference shape (`utils.plex_policy.get_franchise_order_for_user`); a non-boolean value is ignored rather than coerced, since `franchise_order: "no"` is truthy in Python.
+
 ## [2.20.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Binaries self-update: the app notifies you (CLI and web UI banner) when a newer 
 - **Per-user recommendations** — Each user gets their own curated collection
 - **Per-user by default** — Each user's library Browse/Search only shows their own recommendation collection, not others' (UI-level separation, not access control — see FAQ)
 - **Smart scoring** — Weights keywords, genres, cast, and directors
-- **Franchise order** — Recommends the first movie of a series you haven't seen, not whichever sequel happened to score highest: nothing watched gets you *Rocky*, *Rocky* watched gets you *Rocky II* (`movies.franchise_order` in tuning.yml)
+- **Franchise order** — Started a series? You get your next unwatched entry: *Rocky* watched gets you *Rocky II*. Never touched it? The mid-series entry is dropped rather than promoted, so the collection never fills with originals for series you've shown no interest in (`movies.franchise_order`, overridable per user)
 - **Recency bias** — Recent watches influence recommendations more
 - **Rewatch detection** — Content you love gets weighted higher
 - **Genre exclusions** — Skip horror for the kids, documentaries for movie night
@@ -355,11 +355,14 @@ users:
     sarah:
       display_name: Sarah
       exclude_genres: [horror]
+      franchise_order: false  # Overrides movies.franchise_order for Sarah only
     kids:
       display_name: Kids
       exclude_genres: [horror, thriller, war]
       max_rating: PG  # Only G and PG content (movies: G < PG < PG-13 < R < NC-17)
 ```
+
+**Franchise Order:** `franchise_order` is per-person because the setting describes a *person*, not a library — a completionist who wants walking through Rocky I–VI and a housemate who just wants tonight's best match are both right, and they share one server. Unset means follow `movies.franchise_order` in tuning.yml.
 
 **Content Rating Filter:**
 - Movies: `G`, `PG`, `PG-13`, `R`, `NC-17` (from least to most restrictive)

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -32,6 +32,13 @@ users:
     user2:
       display_name: User Two
       max_rating: PG-13  # Filter out R and NC-17 movies
+      # Optional: overrides movies.franchise_order (tuning.yml) for this
+      # person only. Franchise ordering walks you through a series in
+      # release order instead of handing you whichever entry scored
+      # highest - some people want that, some want tonight's best match
+      # regardless of where it falls in a series. Unset = follow
+      # tuning.yml.
+      franchise_order: false
     kids:
       display_name: Kids
       exclude_genres:

--- a/config/tuning.example.yml
+++ b/config/tuning.example.yml
@@ -94,12 +94,24 @@ movies:
   # bonus makes that MORE likely, because it boosts a film for belonging
   # to a series you have started without saying which entry comes next.
   #
-  # With this on, a recommendation that belongs to a TMDB collection is
-  # replaced by the earliest entry of that collection you have not
-  # watched: nothing watched gets you Rocky, Rocky watched gets you
-  # Rocky II, and so on. Each series then takes ONE slot rather than
-  # several, and the slots this frees refill with other films rather
-  # than shrinking the collection.
+  # A series you HAVE started moves to your next unwatched entry and
+  # keeps the slot the series earned - watched Rocky, get Rocky II. This
+  # is the "continue watching" case every streaming service has a
+  # dedicated shelf for, and it is rare enough that it can never crowd
+  # out the rest of your collection.
+  #
+  # A series you have NEVER touched works the other way round: the
+  # mid-series entry is simply dropped, and the first film stands or
+  # falls on its OWN score. It is deliberately not promoted into the
+  # sequel's slot - Rocky IV matching your taste is not evidence that a
+  # 1976 boxing drama deserves a top-50 place, and treating it as such
+  # buried light-history users under 1980s originals (measured: 68 of 73
+  # series, for a user who had started none of them).
+  #
+  # So on an unstarted series this can only ever REMOVE a wrong
+  # recommendation, never invent a highly-ranked one. Each series still
+  # takes at most ONE slot, and the slots this frees refill with other
+  # films rather than shrinking the collection.
   #
   # What it will not do:
   #   - recommend a film you don't own (the promoted entry always comes
@@ -109,15 +121,16 @@ movies:
   #   - override an excluded genre, a user's max_rating, or a
   #     recommendation you were shown and visibly ignored
   #
-  # It DOES override quality_filters and min_similarity above - those
-  # size the collection rather than state a preference, and a 1976
-  # original with a thin TMDB vote count should not be withheld while
-  # its own sequel is recommended.
+  # For a series you have started it DOES override quality_filters and
+  # min_similarity above - those size the collection rather than state a
+  # preference, and the next film in a series you're working through
+  # should not be withheld over a thin TMDB vote count.
   #
-  # Set to false to rank franchise entries purely by score (what every
-  # release before this setting existed did). Movies only - TMDB
-  # collections are a movie-side concept and no collection data is
-  # cached for TV.
+  # Per-user override: users.preferences.<user>.franchise_order in
+  # config.yml wins over this. Set false to rank franchise entries purely
+  # by score (what every release before this setting existed did).
+  # Movies only - TMDB collections are a movie-side concept and no
+  # collection data is cached for TV.
   franchise_order: true
 
   # Scoring weights - must sum to 1.0

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -45,6 +45,8 @@ from utils import (
     CALIBRATION_MIN_PROFILE_SAMPLE,
     CANDIDATE_BUFFER_MULTIPLIER,
     CYAN,
+    DECISION_PROMOTED,
+    DECISION_SUPPRESSED,
     DEFAULT_MOVIE_NAME_TEMPLATE,
     DEFAULT_NEGATIVE_THRESHOLD,
     DEFAULT_TV_NAME_TEMPLATE,
@@ -94,6 +96,7 @@ from utils import (
     coerce_year,
     collect_library_tmdb_ids,
     create_empty_counters,
+    decisions_of_kind,
     describe_least_informative,
     enhance_profile_with_trakt,
     extract_ids_from_guids,
@@ -106,6 +109,7 @@ from utils import (
     format_health_report,
     get_configured_users,
     get_excluded_genres_for_user,
+    get_franchise_order_for_user,
     get_full_language_name,
     get_libraries_for_media_type,
     get_library_imdb_ids_from_items,
@@ -136,7 +140,7 @@ from utils import (
     save_watched_cache,
     select_tiered_recommendations,
     show_progress,
-    summarize_substitutions,
+    summarize_decisions,
     update_plex_collection,
     user_select_recommendations,
 )
@@ -1214,6 +1218,19 @@ class BaseRecommender(ABC):
         users = self.users["plex_users"] or self.users["managed_users"]
         return self.single_user or (users[0] if users else None)
 
+    def _franchise_ordering_enabled(self) -> bool:
+        """
+        Does franchise ordering apply to the user this run is for?
+
+        Narrowest wins: users.preferences.<user>.franchise_order overrides
+        movies.franchise_order, which overrides FRANCHISE_ORDER_DEFAULT.
+        The setting describes a PERSON, not a library - a completionist
+        who wants walking through Rocky I-VI and a housemate who just
+        wants tonight's best match are both right, and they share a
+        server. See utils.plex_policy.get_franchise_order_for_user.
+        """
+        return get_franchise_order_for_user(self.user_preferences, self._primary_username(), self.franchise_order)
+
     def _franchise_watched_ids(self) -> Set[int]:
         """
         Rating keys to treat as already seen when walking a series.
@@ -1239,13 +1256,13 @@ class BaseRecommender(ABC):
 
     def _apply_franchise_ordering(self, scored_items: List[Dict], excluded_genres: Iterable[str]) -> List[Dict]:
         """
-        Re-point franchise recommendations at their earliest unwatched entry.
+        Point franchise recommendations at the entry to watch next.
 
         A no-op for TV (no `collection_id` is ever cached for shows, so
         the index comes back empty) and for any library whose movies have
         no TMDB collection data yet.
         """
-        if not scored_items or not self.franchise_order:
+        if not scored_items or not self._franchise_ordering_enabled():
             return scored_items
 
         try:
@@ -1254,7 +1271,7 @@ class BaseRecommender(ABC):
             if not franchise_index:
                 return scored_items
 
-            ordered, substitutions = apply_franchise_ordering(
+            ordered, decisions = apply_franchise_ordering(
                 scored_items,
                 franchise_index,
                 self._franchise_watched_ids(),
@@ -1268,17 +1285,28 @@ class BaseRecommender(ABC):
             logger.debug(f"Franchise ordering skipped: {e}")
             return scored_items
 
-        if substitutions:
-            print(
-                f"{CYAN}Franchise order: {len(substitutions)} recommendation(s) moved to an "
-                f"earlier unwatched entry{RESET}"
-            )
-            for line in summarize_substitutions(substitutions):
+        # Reported separately because they are different statements: one
+        # says "you started this, here's what's next", the other says
+        # "this isn't where that series begins".
+        promoted = decisions_of_kind(decisions, DECISION_PROMOTED)
+        if promoted:
+            print(f"{CYAN}Franchise order: {len(promoted)} series you've started moved to your next entry{RESET}")
+            for line in summarize_decisions(promoted):
                 print(f"  - {line}")
 
-        collapsed = len(scored_items) - len(ordered)
+        suppressed = decisions_of_kind(decisions, DECISION_SUPPRESSED)
+        if suppressed:
+            unstarted = len({d.collection_id for d in suppressed})
+            print(
+                f"{CYAN}Franchise order: held back {len(suppressed)} mid-series {self.media_key} "
+                f"across {unstarted} series you haven't started{RESET}"
+            )
+            for line in summarize_decisions(suppressed, limit=FRANCHISE_GAP_REPORT_LIMIT):
+                print(f"  - {line}")
+
+        collapsed = len(scored_items) - len(ordered) - len(suppressed)
         if collapsed > 0:
-            print(f"{CYAN}Franchise order: collapsed {collapsed} later entries into the series they belong to{RESET}")
+            print(f"{CYAN}Franchise order: collapsed {collapsed} duplicate entries of the same series{RESET}")
 
         return ordered
 
@@ -1351,17 +1379,25 @@ class BaseRecommender(ABC):
         labeled last week would sit in the collection indefinitely
         alongside the Rocky this run just promoted.
 
-        Only ever fires when the earliest unwatched entry is ALSO in the
-        pool. Otherwise a franchise would vanish from the collection
-        entirely rather than move to its start - which is exactly what
-        would happen when that earliest entry was just removed by the
-        max_rating filter, or was never found in Plex.
+        Mirrors apply_franchise_ordering()'s started/unstarted split, or
+        the two halves of the feature would contradict each other on the
+        same series:
 
-        The survivor keeps the best score any member of its series
-        earned, so franchise ordering changes WHICH entry is recommended
-        without changing how highly the series ranks.
+        - **Started series**: only fires when the earliest unwatched
+          entry is ALSO in the pool, and the survivor inherits the best
+          score any member earned. Without that guard the franchise would
+          vanish from the collection rather than move to its start -
+          exactly what would happen when the earliest entry was just
+          removed by the max_rating filter, or was never found in Plex.
+        - **Unstarted series**: every non-earliest member is dropped
+          whether or not the earliest one is a candidate, and the
+          survivor keeps its OWN score. The fresh pool already refuses to
+          offer a mid-series entry here; letting a label from last week
+          keep one alive - or letting it hand over its score - would
+          reintroduce through the back door precisely the inheritance
+          that flooded light-history users with 1980s originals.
         """
-        if not all_candidates or not self.franchise_order:
+        if not all_candidates or not self._franchise_ordering_enabled():
             return all_candidates
 
         try:
@@ -1384,18 +1420,24 @@ class BaseRecommender(ABC):
             suppressed: List[str] = []
 
             for collection_id, item_ids in by_collection.items():
-                if len(item_ids) < 2:
+                entries = franchise_index.get(collection_id) or []
+                if len(entries) < 2:
                     continue
-                canonical = find_next_unwatched(franchise_index.get(collection_id) or [], watched_ids, **rules)
-                if canonical is None or canonical.rating_key not in remaining:
+                canonical = find_next_unwatched(entries, watched_ids, **rules)
+                if canonical is None:
                     continue
 
-                # Non-empty by construction: item_ids holds at least two
-                # distinct candidate ids (dict keys) and at most one of
-                # them is the canonical entry.
+                started = any(e.rating_key in watched_ids for e in entries)
+                if started and canonical.rating_key not in remaining:
+                    continue
+
                 losers = [item_id for item_id in item_ids if item_id != canonical.rating_key]
-                best_score = max(remaining[item_id][1] for item_id in item_ids)
-                remaining[canonical.rating_key] = (remaining[canonical.rating_key][0], best_score)
+                if not losers:
+                    continue
+
+                if started:
+                    best_score = max(remaining[item_id][1] for item_id in item_ids)
+                    remaining[canonical.rating_key] = (remaining[canonical.rating_key][0], best_score)
                 for item_id in losers:
                     plex_item, _score = remaining.pop(item_id)
                     suppressed.append(f"{getattr(plex_item, 'title', item_id)} -> {canonical.label()}")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3776,6 +3776,12 @@ ROCKY_CACHE = {
         "collection_id": ROCKY_COLLECTION_ID,
         "collection_name": "Rocky Collection",
     },
+    "3": {
+        "title": "Rocky III",
+        "year": 1982,
+        "collection_id": ROCKY_COLLECTION_ID,
+        "collection_name": "Rocky Collection",
+    },
     "4": {
         "title": "Rocky IV",
         "year": 1985,
@@ -3804,10 +3810,24 @@ def _scored_from(recommender, rating_key, score):
 class TestApplyFranchiseOrderingIntegration:
     """BaseRecommender._apply_franchise_ordering - the get_recommendations() hook."""
 
-    def test_sequel_recommendation_becomes_the_first_entry(self):
+    def test_started_series_advances_to_the_next_entry(self):
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1}
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_unstarted_series_drops_the_sequel_rather_than_promoting(self):
+        """The measured fix: a series the user never touched must not have
+        its original promoted into the sequel's slot."""
         recommender = _franchise_recommender()
         ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
-        assert [i["title"] for i in ordered] == ["Rocky"]
+        assert ordered == []
+
+    def test_unstarted_first_entry_keeps_its_own_rank(self):
+        recommender = _franchise_recommender()
+        scored = [_scored_from(recommender, 4, 0.9), _scored_from(recommender, 1, 0.2)]
+        ordered = recommender._apply_franchise_ordering(scored, [])
+        assert [(i["title"], i["similarity_score"]) for i in ordered] == [("Rocky", 0.2)]
 
     def test_disabled_flag_leaves_recommendations_untouched(self):
         recommender = _franchise_recommender()
@@ -3815,40 +3835,37 @@ class TestApplyFranchiseOrderingIntegration:
         scored = [_scored_from(recommender, 4, 0.8)]
         assert recommender._apply_franchise_ordering(scored, []) is scored
 
-    def test_watched_first_entry_promotes_the_next(self):
-        recommender = _franchise_recommender()
-        recommender.watched_ids = {1}
-        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
-        assert [i["title"] for i in ordered] == ["Rocky II"]
-
     def test_the_users_own_plex_view_counts_as_watched(self):
-        """user_played_ids is that user's own state; a part wrongly
-        believed unwatched sends the whole series back to the start."""
+        """user_played_ids is that user's own state, and it decides both
+        how far along the series is AND whether it counts as started."""
         recommender = _franchise_recommender()
         recommender.user_played_ids = {1, 2}
         ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
-        assert [i["title"] for i in ordered] == ["Rocky IV"]
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_declined_entry_is_not_promoted(self):
         recommender = _franchise_recommender()
-        recommender.declined_rating_keys = {1}
+        recommender.watched_ids = {1}
+        recommender.declined_rating_keys = {2}
         ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
-        assert [i["title"] for i in ordered] == ["Rocky II"]
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_excluded_genre_entry_is_not_promoted(self):
         recommender = _franchise_recommender()
-        recommender._get_media_cache().cache["movies"]["1"]["genres"] = ["horror"]
+        recommender.watched_ids = {1}
+        recommender._get_media_cache().cache["movies"]["2"]["genres"] = ["horror"]
         ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], ["horror"])
-        assert [i["title"] for i in ordered] == ["Rocky II"]
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_max_rating_preference_is_honored(self):
         recommender = _franchise_recommender()
         recommender.single_user = "kid"
         recommender.user_preferences = {"kid": {"max_rating": "PG"}}
-        recommender._get_media_cache().cache["movies"]["1"]["content_rating"] = "R"
-        recommender._get_media_cache().cache["movies"]["2"]["content_rating"] = "PG"
+        recommender.watched_ids = {1}
+        recommender._get_media_cache().cache["movies"]["2"]["content_rating"] = "R"
+        recommender._get_media_cache().cache["movies"]["3"]["content_rating"] = "PG"
         ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
-        assert [i["title"] for i in ordered] == ["Rocky II"]
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_empty_input_is_a_no_op(self):
         recommender = _franchise_recommender()
@@ -3859,20 +3876,53 @@ class TestApplyFranchiseOrderingIntegration:
         scored = [_scored_from(recommender, 1, 0.8)]
         assert recommender._apply_franchise_ordering(scored, []) is scored
 
+    def test_per_user_preference_can_disable_it(self):
+        recommender = _franchise_recommender()
+        recommender.single_user = "sarah"
+        recommender.user_preferences = {"sarah": {"franchise_order": False}}
+        recommender.watched_ids = {1}
+        scored = [_scored_from(recommender, 4, 0.8)]
+        assert recommender._apply_franchise_ordering(scored, []) is scored
+
+    def test_per_user_preference_can_enable_it_against_the_media_default(self):
+        recommender = _franchise_recommender()
+        recommender.franchise_order = False
+        recommender.single_user = "sarah"
+        recommender.user_preferences = {"sarah": {"franchise_order": True}}
+        recommender.watched_ids = {1}
+        ordered = recommender._apply_franchise_ordering([_scored_from(recommender, 4, 0.8)], [])
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+
+    def test_per_user_preference_also_reaches_the_collection_side(self):
+        recommender = _franchise_recommender()
+        recommender.single_user = "sarah"
+        recommender.user_preferences = {"sarah": {"franchise_order": False}}
+        candidates = {4: (Mock(title="Rocky IV"), 0.9), 1: (Mock(title="Rocky"), 0.3)}
+        assert recommender._suppress_superseded_franchise_candidates(candidates) is candidates
+
     def test_a_broken_cache_never_costs_the_user_their_recommendations(self):
         recommender = _franchise_recommender()
         scored = [_scored_from(recommender, 4, 0.8)]
         recommender._get_media_cache = Mock(side_effect=AttributeError("boom"))
         assert recommender._apply_franchise_ordering(scored, []) is scored
 
-    def test_collapsing_a_series_is_reported(self, capsys):
+    def test_promotions_and_suppressions_are_reported_separately(self, capsys):
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1}
+        scored = [_scored_from(recommender, 4, 0.9), _scored_from(recommender, 3, 0.8)]
+        capsys.readouterr()  # drop construction chatter
+        recommender._apply_franchise_ordering(scored, [])
+        out = capsys.readouterr().out
+        assert "series you've started moved to your next entry" in out
+        assert "collapsed 1 duplicate entries" in out
+
+    def test_suppressions_are_reported_with_the_series_count(self, capsys):
         recommender = _franchise_recommender()
         scored = [_scored_from(recommender, 4, 0.9), _scored_from(recommender, 2, 0.8)]
         capsys.readouterr()  # drop construction chatter
         recommender._apply_franchise_ordering(scored, [])
         out = capsys.readouterr().out
-        assert "moved to an earlier unwatched entry" in out
-        assert "collapsed 1 later entries" in out
+        assert "held back 2 mid-series movies across 1 series you haven't started" in out
 
 
 class TestSuppressSupersededFranchiseCandidates:
@@ -3888,26 +3938,35 @@ class TestSuppressSupersededFranchiseCandidates:
         result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (1, 0.3)))
         assert set(result) == {1}
 
-    def test_survivor_keeps_the_best_score_in_the_series(self):
-        """Franchise ordering changes WHICH entry is recommended, not how
-        highly the series ranks."""
-        recommender = _franchise_recommender()
-        result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (1, 0.3)))
-        assert result[1][1] == 0.9
-
-    def test_sequel_survives_when_the_first_entry_is_not_a_candidate(self):
-        """Otherwise the series vanishes from the collection rather than
-        moving to its start - e.g. when max_rating just removed the
-        first entry."""
-        recommender = _franchise_recommender()
-        candidates = self._candidates((4, 0.9))
-        assert recommender._suppress_superseded_franchise_candidates(candidates) == candidates
-
-    def test_watched_first_entry_hands_the_slot_to_the_next(self):
+    def test_started_series_survivor_keeps_the_best_score(self):
+        """On a series being worked through, franchise ordering changes
+        WHICH entry is recommended, not how highly the series ranks."""
         recommender = _franchise_recommender()
         recommender.watched_ids = {1}
         result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (2, 0.3)))
         assert set(result) == {2}
+        assert result[2][1] == 0.9
+
+    def test_unstarted_survivor_keeps_its_own_score(self):
+        """Transferring here would reintroduce, via a stale label, exactly
+        the inheritance the started/unstarted split removed."""
+        recommender = _franchise_recommender()
+        result = recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9), (1, 0.3)))
+        assert result[1][1] == 0.3
+
+    def test_started_series_survives_when_its_next_entry_is_not_a_candidate(self):
+        """Otherwise the series vanishes from the collection rather than
+        advancing - e.g. when max_rating just removed that next entry."""
+        recommender = _franchise_recommender()
+        recommender.watched_ids = {1}
+        candidates = self._candidates((4, 0.9))
+        assert recommender._suppress_superseded_franchise_candidates(candidates) == candidates
+
+    def test_unstarted_series_is_dropped_even_with_no_replacement(self):
+        """The fresh pool already refuses to offer this; a label left over
+        from a previous run must not keep it alive."""
+        recommender = _franchise_recommender()
+        assert recommender._suppress_superseded_franchise_candidates(self._candidates((4, 0.9))) == {}
 
     def test_unrelated_candidates_are_untouched(self):
         recommender = _franchise_recommender()

--- a/tests/test_franchise.py
+++ b/tests/test_franchise.py
@@ -24,17 +24,20 @@ import os
 import tempfile
 
 from utils.franchise import (
+    DECISION_PROMOTED,
+    DECISION_SUPPRESSED,
     UNKNOWN_YEAR_SORT,
     apply_franchise_ordering,
     build_franchise_index,
     coerce_year,
     collect_library_tmdb_ids,
+    decisions_of_kind,
     find_library_gaps,
     find_next_unwatched,
     is_promotable,
     load_collection_details,
     normalize_collection_id,
-    summarize_substitutions,
+    summarize_decisions,
 )
 
 ROCKY = 1575
@@ -256,141 +259,192 @@ class TestFindNextUnwatched:
 
 
 class TestApplyFranchiseOrdering:
+    """The started/unstarted split is the heart of this module - see
+    apply_franchise_ordering's docstring for why the two cases are not
+    the same recommendation."""
+
     def _order(self, library, scored, watched=frozenset(), **kwargs):
         return apply_franchise_ordering(scored, build_franchise_index(library), set(watched), **kwargs)
 
-    def test_sequel_is_replaced_by_the_first_entry(self):
-        library = dict(ROCKY_LIBRARY)
-        ordered, subs = self._order(library, [_scored(library, 4, 0.7)])
-        assert [i["title"] for i in ordered] == ["Rocky"]
-        assert len(subs) == 1
-        assert subs[0].original_title == "Rocky IV"
-        assert subs[0].promoted_title == "Rocky"
+    # -- Started series: promote and inherit the slot -------------------
 
-    def test_watched_first_entry_promotes_the_next_one(self):
+    def test_started_series_promotes_to_the_next_unwatched_entry(self):
         library = dict(ROCKY_LIBRARY)
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.7)], watched={1})
+        ordered, decisions = self._order(library, [_scored(library, 4, 0.7)], watched={1})
         assert [i["title"] for i in ordered] == ["Rocky II"]
+        assert [d.kind for d in decisions] == [DECISION_PROMOTED]
 
-    def test_first_entry_is_left_alone(self):
+    def test_started_series_walks_forward_as_entries_are_watched(self):
         library = dict(ROCKY_LIBRARY)
-        ordered, subs = self._order(library, [_scored(library, 1, 0.7)])
-        assert [i["title"] for i in ordered] == ["Rocky"]
-        assert subs == []
+        ordered, _d = self._order(library, [_scored(library, 4, 0.7)], watched={1, 2})
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_promoted_entry_inherits_the_score_and_the_rank(self):
-        """The slot is the sequel's; the title in it is the original's."""
+        """The slot is the sequel's; the title in it is the earlier one's."""
         library = dict(ROCKY_LIBRARY)
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.73)])
+        ordered, _d = self._order(library, [_scored(library, 4, 0.73)], watched={1})
         assert ordered[0]["similarity_score"] == 0.73
-        assert ordered[0]["plex_rating_key"] == 1
+        assert ordered[0]["plex_rating_key"] == 2
 
-    def test_whole_franchise_collapses_to_one_slot(self):
-        """Rocky III and Rocky IV both resolving to Rocky is one
-        recommendation, not three."""
+    def test_promotion_target_need_not_be_in_the_scored_pool(self):
+        """The point of running after the quality/score gates: on a series
+        being worked through, an entry those gates dropped is still owed."""
         library = dict(ROCKY_LIBRARY)
-        scored = [_scored(library, 4, 0.9), _scored(library, 3, 0.8), _scored(library, 2, 0.7)]
-        ordered, subs = self._order(library, scored)
-        assert [i["title"] for i in ordered] == ["Rocky"]
-        assert len(subs) == 3
+        library["2"]["rating"], library["2"]["vote_count"] = 1.0, 0
+        ordered, _d = self._order(library, [_scored(library, 4, 0.5)], watched={1})
+        assert ordered[0]["title"] == "Rocky II"
 
-    def test_franchise_keeps_the_best_rank_any_member_earned(self):
+    def test_started_franchise_collapses_to_one_slot(self):
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.9), _scored(library, 3, 0.8)]
+        ordered, decisions = self._order(library, scored, watched={1})
+        assert [i["title"] for i in ordered] == ["Rocky II"]
+        assert len(decisions) == 2
+
+    def test_started_franchise_keeps_the_best_rank_any_member_earned(self):
         library = dict(ROCKY_LIBRARY)
         other = {"title": "Heat", "year": 1995, "collection_id": None, "plex_rating_key": 99, "similarity_score": 0.85}
         scored = [_scored(library, 4, 0.9), other, _scored(library, 3, 0.8)]
-        ordered, _subs = self._order(library, scored)
-        assert [i["title"] for i in ordered] == ["Rocky", "Heat"]
+        ordered, _d = self._order(library, scored, watched={1})
+        assert [i["title"] for i in ordered] == ["Rocky II", "Heat"]
 
-    def test_first_entry_already_in_the_pool_is_not_duplicated(self):
-        """Rocky IV at rank 1 promoting to Rocky, and Rocky itself at
-        rank 2, must yield one Rocky."""
+    def test_target_already_in_the_pool_is_not_duplicated(self):
         library = dict(ROCKY_LIBRARY)
-        scored = [_scored(library, 4, 0.9), _scored(library, 1, 0.2)]
-        ordered, _subs = self._order(library, scored)
-        assert [i["plex_rating_key"] for i in ordered] == [1]
+        scored = [_scored(library, 4, 0.9), _scored(library, 2, 0.2)]
+        ordered, _d = self._order(library, scored, watched={1})
+        assert [i["plex_rating_key"] for i in ordered] == [2]
         assert ordered[0]["similarity_score"] == 0.9
 
-    def test_promotion_target_need_not_be_in_the_scored_pool(self):
-        """The whole point of running after the quality/score gates: an
-        original those gates dropped is still promotable."""
+    # -- Unstarted series: suppress, never promote ----------------------
+
+    def test_unstarted_series_drops_the_sequel_instead_of_promoting(self):
+        """Rocky IV matching the profile is not evidence that a 1976
+        boxing drama deserves its top-50 slot."""
         library = dict(ROCKY_LIBRARY)
-        ordered, _subs = self._order(library, [_scored(library, 2, 0.5)])
-        assert ordered[0]["title"] == "Rocky"
+        ordered, decisions = self._order(library, [_scored(library, 4, 0.7)])
+        assert ordered == []
+        assert [d.kind for d in decisions] == [DECISION_SUPPRESSED]
+        assert decisions[0].target_title == "Rocky"
+
+    def test_unstarted_first_entry_keeps_its_own_rank_and_score(self):
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.9), _scored(library, 1, 0.2)]
+        ordered, _d = self._order(library, scored)
+        assert [i["plex_rating_key"] for i in ordered] == [1]
+        assert ordered[0]["similarity_score"] == 0.2, "no inheritance on an unstarted series"
+
+    def test_unstarted_series_absent_from_the_pool_disappears_entirely(self):
+        library = dict(ROCKY_LIBRARY)
+        scored = [_scored(library, 4, 0.9), _scored(library, 3, 0.8)]
+        ordered, decisions = self._order(library, scored)
+        assert ordered == []
+        assert all(d.kind == DECISION_SUPPRESSED for d in decisions)
+
+    def test_unstarted_first_entry_alone_is_left_alone(self):
+        library = dict(ROCKY_LIBRARY)
+        ordered, decisions = self._order(library, [_scored(library, 1, 0.7)])
+        assert [i["title"] for i in ordered] == ["Rocky"]
+        assert decisions == []
+
+    def test_suppression_never_removes_a_standalone_film(self):
+        heat = {"title": "Heat", "year": 1995, "collection_id": None, "plex_rating_key": 99, "similarity_score": 0.8}
+        ordered, decisions = self._order(ROCKY_LIBRARY, [heat])
+        assert ordered == [heat]
+        assert decisions == []
+
+    # -- Eligibility rules, shared by both cases ------------------------
 
     def test_never_moves_to_a_later_entry(self):
-        """With the first entry declined, the second must stay put rather
-        than be displaced by a third."""
+        """With the first entry declined, the second stays put rather than
+        being displaced by a third."""
         library = dict(ROCKY_LIBRARY)
-        ordered, subs = self._order(library, [_scored(library, 2, 0.5)], declined_ids={1})
+        ordered, decisions = self._order(library, [_scored(library, 2, 0.5)], declined_ids={1})
         assert ordered[0]["title"] == "Rocky II"
-        assert subs == []
+        assert decisions == []
 
-    def test_declined_first_entry_is_skipped_for_a_sequel(self):
+    def test_declined_first_entry_is_skipped(self):
         library = dict(ROCKY_LIBRARY)
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.5)], declined_ids={1})
-        assert ordered[0]["title"] == "Rocky II"
+        ordered, _d = self._order(library, [_scored(library, 4, 0.5)], watched={2}, declined_ids={1})
+        assert ordered[0]["title"] == "Rocky III"
 
     def test_max_rating_blocks_the_original(self):
+        """The R-rated first entry is skipped for a PG-capped user; the
+        series still advances to the earliest entry they may watch."""
         library = _library(
             _movie(1, "Rocky", 1976, content_rating="R"),
             _movie(2, "Rocky II", 1979, content_rating="PG"),
             _movie(3, "Rocky III", 1982, content_rating="PG"),
+            _movie(4, "Rocky IV", 1985, content_rating="PG"),
         )
-        ordered, _subs = self._order(library, [_scored(library, 3, 0.5)], max_rating="PG")
-        assert ordered[0]["title"] == "Rocky II"
-
-    def test_standalone_movies_pass_through_untouched(self):
-        heat = {"title": "Heat", "year": 1995, "collection_id": None, "plex_rating_key": 99, "similarity_score": 0.8}
-        ordered, subs = self._order(ROCKY_LIBRARY, [heat])
-        assert ordered == [heat]
-        assert subs == []
+        ordered, _d = self._order(library, [_scored(library, 4, 0.5)], watched={2}, max_rating="PG")
+        assert [i["title"] for i in ordered] == ["Rocky III"]
 
     def test_single_entry_collection_is_a_no_op(self):
         library = _library(_movie(7, "Highlander", 1986, collection_id=999))
-        ordered, subs = self._order(library, [_scored(library, 7, 0.8)])
+        ordered, decisions = self._order(library, [_scored(library, 7, 0.8)])
         assert [i["title"] for i in ordered] == ["Highlander"]
-        assert subs == []
+        assert decisions == []
 
     def test_fully_watched_franchise_leaves_the_candidate_alone(self):
         library = dict(ROCKY_LIBRARY)
-        scored = [_scored(library, 4, 0.7)]
-        ordered, subs = self._order(library, scored, watched={1, 2, 3, 4})
+        ordered, decisions = self._order(library, [_scored(library, 4, 0.7)], watched={1, 2, 3, 4})
         assert [i["title"] for i in ordered] == ["Rocky IV"]
-        assert subs == []
+        assert decisions == []
+
+    # -- Cache hygiene --------------------------------------------------
 
     def test_cached_dict_is_never_mutated(self):
         """The media cache's own dicts are what get_recommendations()
         persists - writing a borrowed score onto one would poison the
         score cache for every later run."""
         library = dict(ROCKY_LIBRARY)
-        library["1"]["cached_score"] = 0.11
-        library["1"]["profile_hash"] = "old-profile"
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
-        assert library["1"]["cached_score"] == 0.11
-        assert "similarity_score" not in library["1"] or library["1"]["similarity_score"] != 0.9
+        library["2"]["cached_score"] = 0.11
+        library["2"]["profile_hash"] = "old-profile"
+        self._order(library, [_scored(library, 4, 0.9)], watched={1})
+        assert library["2"]["cached_score"] == 0.11
+        assert library["2"].get("similarity_score") != 0.9
 
     def test_promoted_copy_drops_stale_score_cache_keys(self):
         library = dict(ROCKY_LIBRARY)
-        library["1"]["cached_score"] = 0.11
-        library["1"]["profile_hash"] = "old-profile"
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
+        library["2"]["cached_score"] = 0.11
+        library["2"]["profile_hash"] = "old-profile"
+        ordered, _d = self._order(library, [_scored(library, 4, 0.9)], watched={1})
         assert "cached_score" not in ordered[0]
         assert "profile_hash" not in ordered[0]
 
     def test_promoted_copy_records_where_the_slot_came_from(self):
         library = dict(ROCKY_LIBRARY)
-        ordered, _subs = self._order(library, [_scored(library, 4, 0.9)])
+        ordered, _d = self._order(library, [_scored(library, 4, 0.9)], watched={1})
         assert ordered[0]["franchise_promoted_from"]["title"] == "Rocky IV"
         assert "franchise" in ordered[0]["score_breakdown"]["details"]
 
     def test_missing_rating_key_is_left_alone(self):
         item = {"title": "Rocky IV", "year": 1985, "collection_id": ROCKY, "similarity_score": 0.5}
-        ordered, subs = self._order(ROCKY_LIBRARY, [item])
+        ordered, decisions = self._order(ROCKY_LIBRARY, [item])
         assert ordered == [item]
-        assert subs == []
+        assert decisions == []
 
     def test_empty_input(self):
         assert self._order(ROCKY_LIBRARY, []) == ([], [])
+
+
+class TestDecisionsOfKind:
+    def test_splits_by_kind(self):
+        library = _library(
+            _movie(1, "Rocky", 1976),
+            _movie(2, "Rocky II", 1979),
+            _movie(3, "Rocky III", 1982),
+            _movie(5, "Jaws", 1975, collection_id=999, collection_name="Jaws Collection"),
+            _movie(6, "Jaws 2", 1978, collection_id=999, collection_name="Jaws Collection"),
+        )
+        # Rocky started (part 1 watched) -> promote; Jaws untouched -> suppress.
+        scored = [_scored(library, 3, 0.9), _scored(library, 6, 0.8)]
+        _ordered, decisions = apply_franchise_ordering(scored, build_franchise_index(library), {1})
+        assert [d.collection_name for d in decisions_of_kind(decisions, DECISION_PROMOTED)] == ["Rocky Collection"]
+        assert [d.collection_name for d in decisions_of_kind(decisions, DECISION_SUPPRESSED)] == ["Jaws Collection"]
+
+    def test_empty(self):
+        assert decisions_of_kind([], DECISION_PROMOTED) == []
 
 
 class TestFindLibraryGaps:
@@ -482,22 +536,40 @@ class TestCollectLibraryTmdbIds:
         assert collect_library_tmdb_ids({}) == set()
 
 
-class TestSummarizeSubstitutions:
-    def _subs(self, n):
-        library = _library(*[_movie(i, f"Part {i}", 1970 + i) for i in range(1, n + 2)])
-        scored = [_scored(library, i, 0.5) for i in range(2, n + 2)]
-        _ordered, subs = apply_franchise_ordering(scored, build_franchise_index(library), set())
-        return subs
+class TestSummarizeDecisions:
+    def _decisions(self, n):
+        """n sequels of one series the user HAS started (Part 1 watched),
+        so every decision is a promotion."""
+        library = _library(*[_movie(i, f"Part {i}", 1970 + i) for i in range(1, n + 3)])
+        scored = [_scored(library, i, 0.5) for i in range(3, n + 3)]
+        _ordered, decisions = apply_franchise_ordering(scored, build_franchise_index(library), {1})
+        return decisions
 
-    def test_describes_each_substitution(self):
-        lines = summarize_substitutions(self._subs(1))
-        assert "Part 2 (1972) -> Part 1 (1971)" in lines[0]
+    def test_describes_a_promotion(self):
+        lines = summarize_decisions(self._decisions(1))
+        assert "Part 3 (1973) -> Part 2 (1972)" in lines[0]
+
+    def test_describes_a_suppression(self):
+        library = dict(ROCKY_LIBRARY)
+        _ordered, decisions = apply_franchise_ordering(
+            [_scored(library, 4, 0.5)], build_franchise_index(library), set()
+        )
+        line = summarize_decisions(decisions)[0]
+        assert "Rocky IV (1985) held back" in line
+        assert "begins at Rocky (1976)" in line
 
     def test_truncation_is_explicit(self):
-        lines = summarize_substitutions(self._subs(12), limit=10)
+        lines = summarize_decisions(self._decisions(12), limit=10)
         assert len(lines) == 11
         assert lines[-1] == "... and 2 more"
 
     def test_no_truncation_marker_when_under_limit(self):
-        lines = summarize_substitutions(self._subs(3), limit=10)
+        lines = summarize_decisions(self._decisions(3), limit=10)
         assert len(lines) == 3
+
+    def test_unknown_years_render_as_na(self):
+        library = _library(_movie(1, "Part 1", None), _movie(2, "Part 2", None))
+        _ordered, decisions = apply_franchise_ordering(
+            [_scored(library, 2, 0.5)], build_franchise_index(library), set()
+        )
+        assert "(N/A)" in summarize_decisions(decisions)[0]

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -3055,6 +3055,50 @@ class TestApplyUserLabelRestrictions:
         mock_put.assert_called_once()
 
 
+class TestFranchiseOrderPreference:
+    """Tests for get_franchise_order_for_user - the per-user override of
+    movies.franchise_order (see utils/franchise.py)."""
+
+    @staticmethod
+    def _resolve(prefs, username, default=True):
+        from utils.plex_policy import get_franchise_order_for_user
+
+        return get_franchise_order_for_user(prefs, username, default)
+
+    def test_user_preference_wins_over_the_media_default(self):
+        prefs = {"sarah": {"franchise_order": False}}
+        assert self._resolve(prefs, "sarah", default=True) is False
+
+    def test_user_preference_can_enable_against_a_disabled_default(self):
+        prefs = {"john": {"franchise_order": True}}
+        assert self._resolve(prefs, "john", default=False) is True
+
+    def test_unset_falls_back_to_the_media_default(self):
+        prefs = {"john": {"display_name": "John"}}
+        assert self._resolve(prefs, "john", default=True) is True
+        assert self._resolve(prefs, "john", default=False) is False
+
+    def test_unknown_user_falls_back(self):
+        assert self._resolve({"sarah": {"franchise_order": False}}, "nobody", default=True) is True
+
+    def test_no_username_falls_back(self):
+        assert self._resolve({"sarah": {"franchise_order": False}}, None, default=True) is True
+
+    def test_empty_preferences_fall_back(self):
+        assert self._resolve({}, "sarah", default=True) is True
+        assert self._resolve(None, "sarah", default=False) is False
+
+    def test_null_user_entry_falls_back(self):
+        """A `sarah:` key with nothing under it parses as None."""
+        assert self._resolve({"sarah": None}, "sarah", default=True) is True
+
+    def test_non_boolean_value_is_ignored_not_coerced(self):
+        """`franchise_order: "no"` is truthy in Python; silently turning
+        that into True would be the opposite of what was written."""
+        assert self._resolve({"sarah": {"franchise_order": "no"}}, "sarah", default=False) is False
+        assert self._resolve({"sarah": {"franchise_order": 1}}, "sarah", default=False) is False
+
+
 class TestContentRatingFilter:
     """Tests for content rating filter functions."""
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -175,17 +175,20 @@ from .display import (
 
 # Franchise ordering - start people at the beginning of a series
 from .franchise import (
+    DECISION_PROMOTED,
+    DECISION_SUPPRESSED,
+    FranchiseDecision,
     FranchiseEntry,
-    FranchiseSubstitution,
     apply_franchise_ordering,
     build_franchise_index,
     coerce_year,
     collect_library_tmdb_ids,
+    decisions_of_kind,
     find_library_gaps,
     find_next_unwatched,
     load_collection_details,
     normalize_collection_id,
-    summarize_substitutions,
+    summarize_decisions,
 )
 
 # Helper utilities
@@ -297,6 +300,7 @@ from .plex_policy import (
     TV_RATING_HIERARCHY,
     apply_user_label_restrictions,
     build_all_private_labels,
+    get_franchise_order_for_user,
     get_max_rating_for_user,
     is_rating_allowed,
 )
@@ -642,17 +646,20 @@ __all__ = [
     "apply_ignored_penalties",
     "find_ignored_recommendations",
     # Franchise ordering
+    "DECISION_PROMOTED",
+    "DECISION_SUPPRESSED",
+    "FranchiseDecision",
     "FranchiseEntry",
-    "FranchiseSubstitution",
     "apply_franchise_ordering",
     "build_franchise_index",
     "coerce_year",
     "collect_library_tmdb_ids",
+    "decisions_of_kind",
     "find_library_gaps",
     "find_next_unwatched",
     "load_collection_details",
     "normalize_collection_id",
-    "summarize_substitutions",
+    "summarize_decisions",
     # Library supply health
     "PoolHealth",
     "SupplyGap",
@@ -731,6 +738,7 @@ __all__ = [
     "fetch_user_played_ids",
     "resolve_plex_user",
     "get_streaming_services_for_user",
+    "get_franchise_order_for_user",
     "get_max_rating_for_user",
     "is_rating_allowed",
     "MOVIE_RATING_HIERARCHY",

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.20.0"
+__version__ = "2.21.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/franchise.py
+++ b/utils/franchise.py
@@ -28,14 +28,22 @@ others in its collection, which is right in principle but says nothing
 about which entry to serve next.
 
 This module supplies that missing half. When a candidate belongs to a TMDB
-collection, the recommendation slot goes to the earliest entry of that
-collection the user has not already watched:
+collection, the entry offered is the earliest one the user has not watched:
 
-    watched nothing        -> Rocky (1976)
     watched Rocky          -> Rocky II (1979)
     watched Rocky I and II -> Rocky III (1982)
+    watched none of them   -> Rocky IV is dropped; Rocky (1976) stands or
+                              falls on its own score
 
-Four things are deliberate, and each one is a decision that could
+That last line is the important one, and it is the one thing this module
+learned the hard way. Started and unstarted series are not the same
+recommendation (see apply_franchise_ordering): on a started series the
+slot belongs to the franchise and moves with it, but on an unstarted one
+promoting the original would let this module manufacture a ranking it
+never earned. The ranker decides WHICH franchise; this decides WHICH
+ENTRY, and it must not be able to do the ranker's job.
+
+Five things are deliberate, and each one is a decision that could
 reasonably have gone the other way:
 
 1. **Library-only.** A promoted entry must already be in the Plex library,
@@ -68,6 +76,15 @@ reasonably have gone the other way:
    earned. Because this runs before the candidate buffer is truncated,
    the freed slots refill from the tail rather than shrinking the
    collection.
+
+5. **Promotion only on a series the user has started.** The industry
+   pattern this borrows from is the split every major service makes
+   between a dedicated continuation surface (Netflix "Continue
+   Watching", Apple TV "Up Next", Hulu "Keep Watching") and the
+   recommendation rails proper - two mechanisms, two questions. On an
+   unstarted series this module answers only the second question, by
+   removal, and leaves the ranking alone. See apply_franchise_ordering
+   for the measurement that forced this.
 """
 
 import json
@@ -115,26 +132,40 @@ class FranchiseEntry:
         return f"{self.title} ({self.year if self.year is not None else 'N/A'})"
 
 
-@dataclass(frozen=True, eq=False)
-class FranchiseSubstitution:
-    """A recommendation slot handed from a later entry to an earlier one."""
+# A series the user has already started: the slot belongs to the
+# franchise, so it moves to their next unwatched entry and keeps the
+# score. "Continue watching" semantics.
+DECISION_PROMOTED = "promoted"
 
+# A series the user has never touched: the later entry is dropped and
+# nothing is promoted in its place. See apply_franchise_ordering.
+DECISION_SUPPRESSED = "suppressed"
+
+
+@dataclass(frozen=True, eq=False)
+class FranchiseDecision:
+    """What franchise ordering did to one candidate, and why."""
+
+    kind: str
     collection_id: Any
     collection_name: str
     original_title: str
     original_year: Optional[int]
     original_rating_key: Optional[int]
-    promoted_title: str
-    promoted_year: Optional[int]
-    promoted_rating_key: int
+    target_title: str
+    target_year: Optional[int]
+    target_rating_key: int
+
+    @staticmethod
+    def _year(value: Optional[int]) -> str:
+        return str(value) if value is not None else "N/A"
 
     def describe(self) -> str:
-        original_year = self.original_year if self.original_year is not None else "N/A"
-        promoted_year = self.promoted_year if self.promoted_year is not None else "N/A"
-        return (
-            f"{self.original_title} ({original_year}) -> "
-            f"{self.promoted_title} ({promoted_year})  [{self.collection_name}]"
-        )
+        original = f"{self.original_title} ({self._year(self.original_year)})"
+        target = f"{self.target_title} ({self._year(self.target_year)})"
+        if self.kind == DECISION_PROMOTED:
+            return f"{original} -> {target}  [{self.collection_name}]"
+        return f"{original} held back; series unstarted, begins at {target}  [{self.collection_name}]"
 
 
 def coerce_year(value: Any) -> Optional[int]:
@@ -347,9 +378,36 @@ def apply_franchise_ordering(
     excluded_genres: AbstractSet[str] = frozenset(),
     max_rating: Optional[str] = None,
     media_type: str = "movie",
-) -> Tuple[List[Dict], List[FranchiseSubstitution]]:
+) -> Tuple[List[Dict], List[FranchiseDecision]]:
     """
-    Re-point every franchise recommendation at its earliest unwatched entry.
+    Point every franchise recommendation at the entry the user should
+    actually watch next - promoting on a started series, suppressing on
+    an unstarted one.
+
+    The two cases are NOT the same recommendation, and treating them
+    alike is what made the first cut of this feature bury light-history
+    users in 1980s originals (measured: one user with 32 watched movies
+    had 68 of 73 multi-entry series pinned to their oldest member, all
+    of them series she had never touched):
+
+    - **Started the series** (any entry already watched) -> the slot
+      belongs to the franchise, so it moves to the next unwatched entry
+      and INHERITS the score. Watched Rocky, get Rocky II. This is
+      "continue watching", it is high-confidence, and it is rare enough
+      (0-9 series per user on the reference library) that it can never
+      flood a collection.
+
+    - **Never touched the series** -> the later entry is DROPPED and
+      nothing takes its slot. The earliest entry still stands, at its
+      OWN rank, if it earned one in scored_items. Inheriting here would
+      let franchise ordering manufacture a ranking it did not earn:
+      Rocky IV matched the profile, Rocky (1976) is a different film,
+      and handing it a top slot displaces better-matched titles. The
+      ranker decides WHICH franchise; this decides WHICH ENTRY, and it
+      must not be able to do the ranker's job.
+
+    Net effect: on an unstarted series this can only ever REMOVE a
+    mid-franchise recommendation, never invent a top-ranked one.
 
     Args:
         scored_items: Scored candidates in rank order (highest first).
@@ -358,19 +416,20 @@ def apply_franchise_ordering(
             `watched_ids` and `user_played_ids` - the per-user Plex view
             knows about plays the shared admin history does not, and a
             part wrongly believed unwatched sends the whole franchise
-            back to the start.
+            back to the start. This is also what decides started vs
+            unstarted, so its accuracy matters twice.
         declined_ids / excluded_genres / max_rating / media_type: the
             promotion eligibility rules - see is_promotable().
 
     Returns:
-        (reordered items, substitutions made). The reordered list holds
-        the same ranks as the input with promoted entries swapped in, and
-        with any franchise appearing exactly once - so it can be SHORTER
+        (reordered items, decisions made). The reordered list holds the
+        same ranks as the input with promoted entries swapped in, and
+        with any franchise appearing at most once - so it can be SHORTER
         than the input. Call this before truncating to the candidate
         buffer, so the freed slots refill from the tail.
     """
     ordered: List[Dict] = []
-    substitutions: List[FranchiseSubstitution] = []
+    decisions: List[FranchiseDecision] = []
     seen: Set[int] = set()
 
     for item in scored_items:
@@ -397,19 +456,31 @@ def apply_franchise_ordering(
                 and nxt.rating_key != rating_key
                 and (current is None or nxt.sort_key < current.sort_key)
             ):
-                target = _promote(nxt, item)
-                substitutions.append(
-                    FranchiseSubstitution(
+                # Derived from the entries themselves rather than from
+                # watched_data["collections"] (the collection bonus's own
+                # signal): both are built from the same library cache, but
+                # that Counter round-trips through JSON, which turns its
+                # int collection-id keys into strings on reload. Same
+                # answer, no key-type hazard.
+                started = any(e.rating_key in watched_ids for e in entries)
+                decisions.append(
+                    FranchiseDecision(
+                        kind=DECISION_PROMOTED if started else DECISION_SUPPRESSED,
                         collection_id=collection_id,
                         collection_name=nxt.collection_name,
                         original_title=item.get("title", "unknown"),
                         original_year=item.get("year"),
                         original_rating_key=rating_key,
-                        promoted_title=nxt.title,
-                        promoted_year=nxt.year,
-                        promoted_rating_key=nxt.rating_key,
+                        target_title=nxt.title,
+                        target_year=nxt.year,
+                        target_rating_key=nxt.rating_key,
                     )
                 )
+                if not started:
+                    # Dropped outright. The earliest entry keeps whatever
+                    # rank it earned on its own elsewhere in this list.
+                    continue
+                target = _promote(nxt, item)
 
         target_key = target.get("plex_rating_key")
         if target_key is not None:
@@ -419,7 +490,7 @@ def apply_franchise_ordering(
             seen.add(target_key)
         ordered.append(target)
 
-    return ordered, substitutions
+    return ordered, decisions
 
 
 def load_collection_details(cache_dir: str) -> Dict[Any, Dict]:
@@ -494,10 +565,16 @@ def collect_library_tmdb_ids(all_items: Mapping[str, Mapping]) -> Set[int]:
     return ids
 
 
-def summarize_substitutions(substitutions: Iterable[FranchiseSubstitution], limit: int = 10) -> List[str]:
+def decisions_of_kind(decisions: Iterable[FranchiseDecision], kind: str) -> List[FranchiseDecision]:
+    """The promoted-only or suppressed-only slice - the two get reported
+    separately, because they are different statements about the user."""
+    return [d for d in decisions if d.kind == kind]
+
+
+def summarize_decisions(decisions: Iterable[FranchiseDecision], limit: int = 10) -> List[str]:
     """Human-readable lines for the run log, capped, with an explicit
     "... and N more" rather than a silent truncation."""
-    lines = [s.describe() for s in substitutions]
+    lines = [d.describe() for d in decisions]
     if len(lines) > limit:
         remaining = len(lines) - limit
         lines = lines[:limit] + [f"... and {remaining} more"]

--- a/utils/plex_policy.py
+++ b/utils/plex_policy.py
@@ -93,6 +93,32 @@ def get_max_rating_for_user(user_preferences: dict, username: Optional[str] = No
     return user_prefs.get("max_rating")
 
 
+def get_franchise_order_for_user(user_preferences: dict, username: Optional[str] = None, default: bool = True) -> bool:
+    """
+    Whether franchise ordering (utils/franchise.py) applies to this user.
+
+    Resolution order, narrowest first:
+      1. users.preferences.<user>.franchise_order (config.yml)
+      2. movies.franchise_order (tuning.yml)          <- passed in as `default`
+      3. FRANCHISE_ORDER_DEFAULT
+
+    Per-user because the setting is a statement about a PERSON, not about
+    a library: a completionist who wants to be walked through Rocky I-VI
+    and a housemate who just wants the best match tonight are both right,
+    and they share one Plex server. This mirrors max_rating/exclude_genres
+    above - same `preferences` block, same "unset means fall back" rule.
+
+    A non-boolean value is ignored rather than coerced: `franchise_order:
+    "no"` is truthy in Python and silently turning that into True would
+    be the opposite of what was written.
+    """
+    if not username or not user_preferences or username not in user_preferences:
+        return default
+
+    value = (user_preferences[username] or {}).get("franchise_order")
+    return value if isinstance(value, bool) else default
+
+
 def is_rating_allowed(content_rating: Optional[str], max_rating: Optional[str], media_type: str = "movie") -> bool:
     """
     Check if a content rating is allowed given the user's max_rating.


### PR DESCRIPTION
Follow-up to #364. `2.20.0` shipped franchise ordering; running it against the six real profiles showed the default was far more aggressive than intended, and the cause was a case it wasn't distinguishing.

## The problem

`2.20.0` treated *"you're three films into Rocky"* and *"you've never seen a Rocky film"* as the same recommendation. Both handed a mid-series candidate's slot **and its score** to the earliest unwatched entry.

The first case is right — the slot belongs to the franchise. The second let `utils/franchise.py` manufacture a ranking it never earned: *Rocky IV* matching a profile is not evidence that a 1976 boxing drama deserves a top-50 place, and treating it as such displaced better-matched titles wholesale.

Measured on the reference library **before** this change — a user with 32 watched movies had **68 of 73** multi-entry series pinned to their oldest member, every one a series she had never started:

| User | Watched | Series pinned | of which *unstarted* |
|---|---|---|---|
| natasha4967 | 32 | 68 | **68** |
| homehouse165 | 76 | 65 | 63 |
| lynnsmith59 | 59 | 62 | 58 |
| nadiamorse | 91 | 57 | 55 |
| ericarutyunov | 78 | 59 | 50 |
| jasonsmith523 | 300 | 35 | 29 |

## The split

- **Started series** → move to the next unwatched entry and inherit the slot. Unchanged, and rare enough it can never crowd a collection.
- **Unstarted series** → drop the mid-series entry and promote *nothing*. The earliest entry stands or falls on its **own** score.

So on an unstarted series this can now only ever **remove** a wrong recommendation, never invent a highly-ranked one. The ranker decides *which franchise*; franchise ordering decides *which entry*, and it can no longer do the ranker's job.

After, on the same profiles:

| User | Promoted (started) | Suppressed (unstarted) |
|---|---|---|
| natasha4967 | **0** | 124 |
| homehouse165 | 3 | 114 |
| nadiamorse | 3 | 101 |
| lynnsmith59 | 8 | 105 |
| ericarutyunov | 12 | 85 |
| jasonsmith523 | 13 | 54 |

## Two details worth review

**Where the started/unstarted signal comes from.** Derived from the franchise entries + `watched_ids`, *not* from `watched_data["collections"]` (the collection bonus's own signal). Both come from the same library cache, but that Counter round-trips through JSON, which turns its int collection-id keys into strings on reload. Same answer, no key-type hazard.

**The collection side mirrors the split.** Otherwise the two halves contradict each other on one series: on an unstarted series, a mid-series entry still carrying a label from a previous run is now dropped whether or not the earliest entry is a candidate, and the survivor keeps its **own** score rather than inheriting the series best — a stale label would otherwise reintroduce exactly the inheritance this removes.

## Per-user override

Adds `users.preferences.<user>.franchise_order`, resolving narrowest-first: per-user → `movies.franchise_order` → `FRANCHISE_ORDER_DEFAULT`. Per-user because the setting describes a *person*, not a library — a completionist who wants walking through Rocky I–VI and a housemate who just wants tonight's best match are both right, and they share one server. Mirrors the existing `max_rating`/`exclude_genres` shape. A non-boolean value is ignored rather than coerced, since `franchise_order: "no"` is truthy in Python.

## Also

`FranchiseSubstitution` → `FranchiseDecision` with a `kind`, since a suppression is not a substitution. The two are reported separately in the run log — they're different statements about the user.

Suite 3416 → 3437 passed, ruff and mypy clean. Bumped to 2.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)