### PR TITLE
Word the two collection-side franchise outcomes apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.21.1] - 2026-08-17
+
+### Fixed
+
+- **The collection-side franchise log described a substitution that never happened.** `manage_plex_labels()`'s suppressor kept `2.20.0`'s wording after `2.21.0` split started from unstarted series, so both outcomes were reported as one `holding back N later movies until earlier entries are watched` list with a shared `A -> B` detail line. On an unstarted series neither half is true: nothing is waiting on a future watch, and nothing takes the dropped item's place. Observed on the first real multi-user run - a user with **zero** promotions had five lines that read exactly like promotions, which is the opposite of what the log is for when you are trying to audit the feature.
+
+  The two outcomes are now tracked and worded apart: `moved N already-labeled movies forward to your next entry in the series` (keeping the arrow, where a slot genuinely moves) and `removed N already-labeled mid-series movies from series you haven't started`, whose detail lines carry no arrow at all - `Barbershop 2: Back in Business (series unstarted, begins at Barbershop (2002))`. Log output only; no change to which items are recommended.
+
 ## [2.21.0] - 2026-08-16
 
 ### Changed

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1417,7 +1417,17 @@ class BaseRecommender(ABC):
                     by_collection.setdefault(collection_id, []).append(item_id)
 
             remaining = dict(all_candidates)
-            suppressed: List[str] = []
+            # Tracked apart, and worded apart below. Reporting both as one
+            # "holding back N until earlier entries are watched" list (as
+            # 2.20.0 did, before the started/unstarted split existed) made
+            # the log actively misleading: on an unstarted series nothing
+            # is waiting on a future watch, and nothing takes the dropped
+            # item's place - so a shared `A -> B` line read as a
+            # substitution that never happened. Observed on a real run: a
+            # user with ZERO promotions had five lines that looked exactly
+            # like promotions.
+            advanced: List[str] = []
+            dropped: List[str] = []
 
             for collection_id, item_ids in by_collection.items():
                 entries = franchise_index.get(collection_id) or []
@@ -1440,22 +1450,43 @@ class BaseRecommender(ABC):
                     remaining[canonical.rating_key] = (remaining[canonical.rating_key][0], best_score)
                 for item_id in losers:
                     plex_item, _score = remaining.pop(item_id)
-                    suppressed.append(f"{getattr(plex_item, 'title', item_id)} -> {canonical.label()}")
+                    title = getattr(plex_item, "title", item_id)
+                    if started:
+                        # A real substitution: the collection slot moves.
+                        advanced.append(f"{title} -> {canonical.label()}")
+                    else:
+                        # No arrow. Nothing takes this item's place; the
+                        # earliest entry is only mentioned to say where
+                        # the series actually begins.
+                        dropped.append(f"{title} (series unstarted, begins at {canonical.label()})")
         except (AttributeError, KeyError, TypeError, ValueError) as e:
             logger.debug(f"Franchise candidate suppression skipped: {e}")
             return all_candidates
 
-        if suppressed:
-            print(
-                f"{YELLOW}Franchise order: holding back {len(suppressed)} later "
-                f"{self.media_key} until earlier entries are watched{RESET}"
-            )
-            for line in suppressed[:FRANCHISE_GAP_REPORT_LIMIT]:
-                print(f"  - {line}")
-            if len(suppressed) > FRANCHISE_GAP_REPORT_LIMIT:
-                print(f"  ... and {len(suppressed) - FRANCHISE_GAP_REPORT_LIMIT} more")
-
+        self._print_franchise_label_changes(advanced, dropped)
         return remaining
+
+    def _print_franchise_label_changes(self, advanced: List[str], dropped: List[str]) -> None:
+        """Report the two collection-side outcomes in their own words."""
+        if advanced:
+            print(
+                f"{CYAN}Franchise order: moved {len(advanced)} already-labeled "
+                f"{self.media_key} forward to your next entry in the series{RESET}"
+            )
+            for line in advanced[:FRANCHISE_GAP_REPORT_LIMIT]:
+                print(f"  - {line}")
+            if len(advanced) > FRANCHISE_GAP_REPORT_LIMIT:
+                print(f"  ... and {len(advanced) - FRANCHISE_GAP_REPORT_LIMIT} more")
+
+        if dropped:
+            print(
+                f"{YELLOW}Franchise order: removed {len(dropped)} already-labeled mid-series "
+                f"{self.media_key} from series you haven't started{RESET}"
+            )
+            for line in dropped[:FRANCHISE_GAP_REPORT_LIMIT]:
+                print(f"  - {line}")
+            if len(dropped) > FRANCHISE_GAP_REPORT_LIMIT:
+                print(f"  ... and {len(dropped) - FRANCHISE_GAP_REPORT_LIMIT} more")
 
     def _find_plex_items_for_recs(self, section, selected_items: List[Dict]) -> Tuple[List, List[str]]:
         """Find Plex items matching recommendations."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4003,24 +4003,44 @@ class TestSuppressSupersededFranchiseCandidates:
         candidates = self._candidates((4, 0.9), (1, 0.3))
         assert recommender._suppress_superseded_franchise_candidates(candidates) == candidates
 
-    def test_suppression_is_reported_with_explicit_truncation(self, capsys):
-        cache = {
+    def _long_series_cache(self, n=10):
+        return {
             str(i): {
                 "title": f"Part {i}",
                 "year": 1970 + i,
                 "collection_id": ROCKY_COLLECTION_ID,
                 "collection_name": "Rocky Collection",
             }
-            for i in range(1, 10)
+            for i in range(1, n)
         }
-        recommender = _franchise_recommender(cache=cache)
+
+    def test_unstarted_removals_are_worded_as_removals(self, capsys):
+        """The 2.20.0 wording ("holding back N until earlier entries are
+        watched", plus an `A -> B` line) described a substitution that
+        never happens on an unstarted series - a user with ZERO promotions
+        saw five lines that read exactly like promotions."""
+        recommender = _franchise_recommender(cache=self._long_series_cache())
         candidates = self._candidates(*[(i, 0.5) for i in range(1, 10)])
         capsys.readouterr()  # drop construction chatter
         result = recommender._suppress_superseded_franchise_candidates(candidates)
         out = capsys.readouterr().out
         assert set(result) == {1}
-        assert "holding back 8 later movies" in out
+        assert "removed 8 already-labeled mid-series movies from series you haven't started" in out
+        assert "(series unstarted, begins at Part 1 (1971))" in out
+        assert "->" not in out, "an arrow implies a substitution that did not happen"
         assert "... and 3 more" in out
+
+    def test_started_advances_are_worded_as_a_move(self, capsys):
+        recommender = _franchise_recommender(cache=self._long_series_cache())
+        recommender.watched_ids = {1}
+        candidates = self._candidates(*[(i, 0.5) for i in range(2, 10)])
+        capsys.readouterr()  # drop construction chatter
+        result = recommender._suppress_superseded_franchise_candidates(candidates)
+        out = capsys.readouterr().out
+        assert set(result) == {2}
+        assert "moved 7 already-labeled movies forward to your next entry" in out
+        assert "-> Part 2 (1972)" in out
+        assert "series unstarted" not in out
 
 
 class TestReportFranchiseGaps:

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.21.0"
+__version__ = "2.21.1"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item


### PR DESCRIPTION
Caught reviewing the first real multi-user run of `2.21.0`. Log output only — no change to which items get recommended.

## The problem

`manage_plex_labels()`'s suppressor kept `2.20.0`'s wording after `2.21.0` split started from unstarted series, so both outcomes came out as one list:

```
Franchise order: holding back 13 later movies until earlier entries are watched
  - Barbershop 2: Back in Business -> Barbershop (2002)
```

On an **unstarted** series neither half is true. Nothing is waiting on a future watch — that's the standing rule, not a hold. And nothing takes the dropped item's place, so the arrow describes a substitution that never happened: Barbershop 2 was *removed*, and Barbershop (2002) was already in the collection on its own score.

natasha4967 had **zero** promotions on that run — no `series you've started` line at all — yet her log showed five lines that read exactly like promotions. That's the opposite of what the log is for when you're trying to audit the feature.

## The fix

```
Franchise order: moved 7 already-labeled movies forward to your next entry in the series
  - Part 9 -> Part 2 (1972)

Franchise order: removed 8 already-labeled mid-series movies from series you haven't started
  - Barbershop 2: Back in Business (series unstarted, begins at Barbershop (2002))
```

No arrow on removals, separate headers, separate truncation counters. A test asserts `"->" not in out` for the unstarted path, so the misleading form can't come back.

## Verified against the live server

Read-only, over an SSH tunnel to the Plex host (first time this has been measurable rather than log-inferred — `section.search(label=...)`, as CLAUDE.md insists):

- All six `Recommended_<user>` collections hold **exactly 50** items. Heavy suppression (74–113 per user) did not starve them; buffer refill worked.
- **The core invariant holds: 0 violations.** Every collection item belonging to a multi-entry TMDB series *is* the canonical earliest-eligible-unwatched entry for that user — 78 series items across six users, checked with each user's own watched state including their per-user Plex played IDs, and their own `exclude_genres` / `max_rating`.
- Franchises take 8–19 slots per 50-item collection, so the one-slot-per-series cap is doing its job rather than crowding.

| User | Series items in collection | of which started | Violations |
|---|---|---|---|
| jasonsmith523 | 19 | 11 | 0 |
| ericarutyunov | 18 | 9 | 0 |
| homehouse165 | 12 | 4 | 0 |
| lynnsmith59 | 10 | 7 | 0 |
| nadiamorse | 8 | 5 | 0 |
| natasha4967 | 11 | 1 | 0 |

Suite 3437 → 3438 passed, ruff and mypy clean. Bumped to 2.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)