### PR TITLE
Add a read-only live-Plex verification skill

### DIFF
--- a/.claude/skills/verify-recommendations/SKILL.md
+++ b/.claude/skills/verify-recommendations/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: verify-recommendations
+description: Verify Curatarr's recommendations against the LIVE Plex server - what is actually in each user's collection, not what a run log claims. Use after a nightly run, after changing scoring/filtering/franchise logic, or whenever you need to answer "did that actually work?" Covers reaching Plex from a machine that is not the Plex host, the read-only audit script, and the traps that make log-based verification wrong.
+---
+
+# Verifying Curatarr recommendations against live Plex
+
+## Why this exists
+
+`CLAUDE.md` says it plainly: **the Plex collection is the artifact, not
+the log.** The log prints `plex_recs` (up to `general.limit_plex_results`,
+2x the target); the collection holds the smaller `final_items` set. One
+real run printed 50 titles with 19 kid films while the collection held 44
+with 7. Anything concluded from the log alone about *what a user got* is a
+guess.
+
+Measuring the real thing means `section.search(label="Recommended_<user>")`
+against a live server — and the catch is that a Curatarr checkout is often
+not on the machine Plex runs on.
+
+## Run it
+
+```bash
+.claude/skills/verify-recommendations/run_remote.sh [--user NAME] [--media movie|tv]
+```
+
+It probes whether Plex is reachable from here and either runs locally or
+delegates over SSH. Exit code is 1 if any check fails, so it also works as
+a post-run gate.
+
+When Plex is on another machine, set these once in your shell profile
+(same convention as `CURATARR_GH_SSH_HOST` in `RELEASING.md`):
+
+| Variable | Meaning |
+|---|---|
+| `CURATARR_PLEX_SSH_HOST` | SSH alias/host running Plex, with a checkout of this repo. No default. |
+| `CURATARR_PLEX_SSH_REPO_DIR` | Absolute path to that checkout. Defaults to `~/dev/curatarr`. |
+
+Reachability is **probed, not inferred from config** — `plex.url` is
+commonly a `127-0-0-1.<hash>.plex.direct` hostname, which resolves to
+`127.0.0.1` on every machine and therefore tells you nothing about where
+Plex actually is. Same reasoning that rewrote `scripts/release.sh`'s
+origin check in 2.19.1.
+
+## If the repo lives on a network share
+
+A common setup here: the checkout is an SMB/NFS mount of the Plex host's
+own directory, so both machines see one set of files. Two consequences:
+
+- **Editing the script locally is enough** — the remote runs the same
+  file. Nothing to copy or sync.
+- **`.venv` belongs to whichever machine built it.** Architectures differ
+  (arm64 host, x86_64 laptop), so the shared venv only runs on its
+  creator. `run_remote.sh` uses the remote's own `.venv` when delegating,
+  and falls back to `python3` if there isn't one.
+
+## Fallback: SSH tunnel
+
+Only when you want *local* tooling (a scratch venv, an interactive
+session) pointed at the real server:
+
+```bash
+ssh -f -N -o ExitOnForwardFailure=yes -L 32400:127.0.0.1:32400 "$CURATARR_PLEX_SSH_HOST"
+# ... read-only work ...
+pkill -f "ssh -f -N -o ExitOnForwardFailure=yes -L 32400"
+```
+
+**Forward to `127.0.0.1`, not the host's LAN IP.** The plex.direct
+certificate is issued for 127.0.0.1, so the loopback forward is what keeps
+the hostname both resolving *and* passing TLS verification, letting
+`config/config.yml` work untouched. Always tear the tunnel down.
+
+Building a local venv on x86_64 macOS needs one pin relaxed:
+`requirements.lock` pins `cryptography==50.0.0`, which ships no x86_64
+macOS wheel. `cryptography<49` installs; everything else is as written.
+
+## Read-only discipline
+
+This audits a live server other people use. The script only ever calls
+`section.search`, per-user played-id reads, and local JSON reads.
+
+**Never construct a recommender to inspect state.**
+`PlexMovieRecommender.__init__` connects as the admin and calls
+`MovieCache.update_cache()`, which rewrites `cache/all_movies_cache.json`;
+`manage_plex_labels()` adds and removes real labels. If you want a real
+run, run the app properly (`./run.sh`) — don't half-invoke it from a REPL.
+
+## What it checks
+
+Per configured user, against their live collection:
+
+1. **Size** vs `movies.limit_results` / `tv.limit_results`, flagging a short collection.
+2. **Watched items still labeled** — split into a real failure vs expected lag, see below.
+3. **Excluded genres** (`general.exclude_genre` + per-user `exclude_genres`).
+4. **`max_rating`** against each item's live `contentRating`.
+5. **The franchise invariant** — every collection item belonging to a
+   multi-entry TMDB collection must *be* the canonical
+   earliest-eligible-unwatched entry for that user
+   (`utils/franchise.find_next_unwatched`). One check covers both halves of
+   franchise ordering: promotion on a started series and suppression on an
+   unstarted one both converge on "the canonical entry, or the series is
+   absent entirely".
+
+## Traps that make verification wrong
+
+- **`watched_cache_*.json` alone under-reports what a user has seen.** It's
+  the shared history; each user's own Plex view knows about plays it
+  doesn't. The recommender unions both (`_franchise_watched_ids()`), and so
+  must any check — otherwise a started series looks unstarted and the
+  franchise invariant appears to fail.
+- **But the two must stay distinguishable for the watched-item check.** An
+  item the last run *already knew* was watched, still labeled, is a real
+  failure. An item watched *since* that run is lag the next run clears in
+  `_remove_outdated_labels()`. Collapsing them makes this tool cry wolf
+  every time somebody watches a film — which is exactly what the first
+  draft of this script did, on its first run.
+- **`cached_score` is not per-user.** `all_movies_cache.json` is shared and
+  has been observed holding 6 distinct `profile_hash` values at once; each
+  movie's score belongs to whichever user's run last touched it. Per-user
+  *rankings* are not reconstructible offline — only score-independent facts
+  (which entry of a series, genre/rating compliance) are.
+- **Movie and TV logs are named identically** (`recommendations_<user>_<ts>.log`).
+  The movie run comes first and its file is roughly 3x larger; sorting by
+  mtime gets you the TV one.
+- **`log_warning()` never reaches `logs/recommendations_<user>_*.log`.**
+  That file captures stdout only; warnings go to the console / aggregate log.
+
+## Reference output
+
+A healthy movie run:
+
+```
+Connected to <server> (Plex 1.43.x) - READ ONLY
+
+  alice          Recommended_alice     50 items | series 19 (11 started) | OK
+       i watched since the last run, clears tonight: Some Film (2018)
+  bob            Recommended_bob       50 items | series 12 (4 started)  | OK
+  carol          Recommended_carol     50 items | series  8 (5 started)  | OK
+
+All checks passed
+```
+
+Franchise items sitting at roughly 8–19 of 50 is the one-slot-per-series
+cap doing its job. If that share climbs toward the whole collection,
+franchise ordering has started promoting rather than suppressing — the
+regression 2.21.0 exists to prevent.
+
+On the TV library expect **0 series items**: TMDB collections are a
+movie-side concept, no `collection_id` is cached for shows, and franchise
+ordering is inert there by design.

--- a/.claude/skills/verify-recommendations/run_remote.sh
+++ b/.claude/skills/verify-recommendations/run_remote.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Runs verify_collections.py wherever Plex is actually reachable.
+#
+# Usage: ./run_remote.sh [--user NAME] [--media movie|tv]
+#
+# Environment (only needed when Plex is NOT reachable from here):
+#   CURATARR_PLEX_SSH_HOST     - SSH alias/host of the machine running
+#                                Plex, which also has a checkout of this
+#                                repo. No default; set it in your shell
+#                                profile.
+#   CURATARR_PLEX_SSH_REPO_DIR - absolute path to that checkout. Defaults
+#                                to ~/dev/curatarr on that host.
+#
+# Probe-then-delegate rather than pattern-matching a hostname, mirroring
+# scripts/release.sh's own origin-reachability check - and for the same
+# reason it was rewritten that way (see CHANGELOG 2.19.1): guessing from
+# config values gets it wrong on exactly the shared-checkout setups this
+# is for. `plex.url` is commonly a 127-0-0-1.<hash>.plex.direct hostname,
+# which resolves to 127.0.0.1 everywhere and therefore says nothing about
+# WHERE Plex is.
+#
+# Read-only: verify_collections.py never writes to Plex or to the cache.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+REL_PATH=".claude/skills/verify-recommendations/verify_collections.py"
+
+plex_port_open() {
+  # `plex.url`'s host, whatever it is, on its port - a 3s TCP probe.
+  local host port
+  host=$(python3 -c "
+import sys, yaml, urllib.parse
+u = yaml.safe_load(open('$REPO_DIR/config/config.yml'))['plex']['url']
+p = urllib.parse.urlparse(u)
+print(p.hostname or '', p.port or (443 if p.scheme == 'https' else 80))
+" 2>/dev/null) || return 1
+  port=${host##* }
+  host=${host%% *}
+  [ -n "$host" ] || return 1
+  nc -z -G 3 "$host" "$port" >/dev/null 2>&1
+}
+
+if plex_port_open; then
+  echo "==> Plex reachable from here - running locally"
+  PY="$REPO_DIR/.venv/bin/python"
+  [ -x "$PY" ] || PY=python3
+  exec "$PY" "$REPO_DIR/$REL_PATH" "$@"
+fi
+
+if [ -z "${CURATARR_PLEX_SSH_HOST:-}" ]; then
+  echo "ERROR: Plex isn't reachable from here and CURATARR_PLEX_SSH_HOST is unset." >&2
+  echo "       Set it to the SSH alias/host of the machine running Plex (which also" >&2
+  echo "       has a checkout of this repo), e.g. in ~/.zshrc:" >&2
+  echo "         export CURATARR_PLEX_SSH_HOST=my-plex-box" >&2
+  exit 1
+fi
+
+REMOTE_DIR="${CURATARR_PLEX_SSH_REPO_DIR:-~/dev/curatarr}"
+echo "==> Plex not reachable from here - delegating to $CURATARR_PLEX_SSH_HOST"
+
+# Args are re-quoted individually rather than pasted in as $*, so a value
+# containing a space can't split into two arguments on the remote side.
+REMOTE_ARGS=""
+for arg in "$@"; do
+  REMOTE_ARGS="$REMOTE_ARGS $(printf '%q' "$arg")"
+done
+
+# The interpreter is chosen into a variable on the REMOTE side, not
+# selected here: the remote venv is the one built on that machine and so
+# matches its architecture, whereas a venv on a shared mount belongs to
+# whichever machine created it and will not run on the other. $PY is
+# escaped so it expands there, not here. The remote login shell may be
+# zsh, so this stays POSIX - no bashisms, no brace groups as commands.
+exec ssh "$CURATARR_PLEX_SSH_HOST" \
+  "cd $REMOTE_DIR && PY=./.venv/bin/python; [ -x \"\$PY\" ] || PY=python3; \"\$PY\" $REL_PATH$REMOTE_ARGS"

--- a/.claude/skills/verify-recommendations/verify_collections.py
+++ b/.claude/skills/verify-recommendations/verify_collections.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# curatarr
+# Copyright (C) 2026 OrchestratedChaos
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+READ-ONLY audit of what is actually in each user's Plex recommendation
+collection.
+
+Measures `section.search(label=...)` - the real artifact - rather than
+parsing a run log. CLAUDE.md is explicit about why: the log prints
+`plex_recs` (up to `general.limit_plex_results`, 2x the target), while
+the collection holds the smaller `final_items` set. One observed run
+printed 50 titles with 19 kid films while the collection held 44 with 7.
+
+Never writes. No label is added or removed, no collection is created or
+touched, and the recommender itself is never constructed - importing it
+would connect as the admin and (via MovieCache.update_cache) rewrite the
+media cache. Only `section.search`, per-user played-id reads, and local
+JSON reads happen here.
+
+Exit code is 1 if any check fails, so this is usable as a post-run gate.
+
+Usage:
+    python3 verify_collections.py [--user USERNAME] [--media movie|tv]
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# .claude/skills/verify-recommendations/<this file> -> four levels up.
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+sys.path.insert(0, REPO)
+
+import yaml  # noqa: E402
+from plexapi.server import PlexServer  # noqa: E402
+
+from utils.franchise import build_franchise_index, find_next_unwatched  # noqa: E402
+from utils.labels import build_label_name  # noqa: E402
+from utils.plex import fetch_user_played_ids, get_excluded_genres_for_user  # noqa: E402
+from utils.plex_policy import get_franchise_order_for_user, get_max_rating_for_user, is_rating_allowed  # noqa: E402
+
+GREEN, YELLOW, RED, RESET = "\033[92m", "\033[93m", "\033[91m", "\033[0m"
+
+
+def load_config():
+    with open(os.path.join(REPO, "config", "config.yml"), "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def load_tuning():
+    path = os.path.join(REPO, "config", "tuning.yml")
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def user_list(config):
+    users = (config.get("plex_users") or {}).get("list") or (config.get("users") or {}).get("list") or []
+    if isinstance(users, str):
+        users = [u.strip() for u in users.split(",") if u.strip()]
+    return users
+
+
+def watched_ids_for(plex, config, user, library, media_key):
+    """
+    Returns (as_of_last_run, live).
+
+    Kept apart on purpose. The union of the two is what the recommender
+    reasons with (BaseRecommender._franchise_watched_ids - the shared
+    watched cache alone misses plays only that user's own Plex view knows
+    about). But for auditing, the DIFFERENCE is the interesting part: a
+    still-labeled item the last run already knew was watched is a real
+    failure, while one watched since that run is just lag the next run
+    clears via _remove_outdated_labels(). Collapsing them into one set
+    makes this tool cry wolf every time somebody watches a film.
+    """
+    prefix = "watched_cache" if media_key == "movies" else "tv_watched_cache"
+    path = os.path.join(REPO, "cache", f"{prefix}_plex_{user}.json")
+    as_of_last_run = set()
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        key = "watched_movie_ids" if media_key == "movies" else "watched_show_ids"
+        as_of_last_run = {int(i) for i in data.get(key, []) or [] if str(i).isdigit()}
+    live = set(as_of_last_run)
+    try:
+        live |= fetch_user_played_ids(plex, config, user, library)
+    except Exception as e:  # noqa: BLE001 - reporting tool; a partial answer beats none
+        print(f"    {YELLOW}note: per-user played ids unavailable ({e}); using the shared cache only{RESET}")
+    return as_of_last_run, live
+
+
+def check_user(plex, config, tuning, user, media):
+    media_key = "movies" if media == "movie" else "shows"
+    library = config["plex"]["movie_library" if media == "movie" else "tv_library"]
+    section = plex.library.section(library)
+
+    coll_cfg = config.get("collections") or {}
+    label = build_label_name(
+        coll_cfg.get("label_name", "Recommended"),
+        user_list(config),
+        user,
+        coll_cfg.get("append_usernames", True),
+    )
+    items = section.search(label=label)
+
+    cache_file = "all_movies_cache.json" if media == "movie" else "all_shows_cache.json"
+    with open(os.path.join(REPO, "cache", cache_file), "r", encoding="utf-8") as fh:
+        cached = json.load(fh)[media_key]
+
+    prefs = (config.get("users") or {}).get("preferences") or {}
+    general = config.get("general") or {}
+    global_excludes = [g.strip().lower() for g in (general.get("exclude_genre") or "").split(",") if g.strip()]
+    excluded = {g.lower() for g in get_excluded_genres_for_user(global_excludes, prefs, user)}
+    max_rating = get_max_rating_for_user(prefs, user)
+    media_tuning = tuning.get("movies" if media == "movie" else "tv") or {}
+    target = media_tuning.get("limit_results", 50 if media == "movie" else 20)
+
+    watched_then, watched = watched_ids_for(plex, config, user, library, media_key)
+    index = build_franchise_index(cached)
+    franchise_on = get_franchise_order_for_user(prefs, user, bool(media_tuning.get("franchise_order", True)))
+
+    problems = []
+    notes = []
+    series_items = started_items = 0
+
+    if not items:
+        # Not a silent pass. Either the collection was never built, it was
+        # removed, or the label drifted - all worth shouting about. The one
+        # legitimate case is an explicit movies.recommend_for_no_history:
+        # false user, which the message names so it can be dismissed.
+        problems.append(
+            f"no items carry label {label!r} - collection missing, or this user is recommend_for_no_history: false"
+        )
+
+    for item in items:
+        key = int(item.ratingKey)
+        info = cached.get(str(key)) or {}
+        title = f"{item.title} ({getattr(item, 'year', '?')})"
+
+        if key in watched_then:
+            problems.append(f"watched before the last run but still labeled: {title}")
+        elif key in watched:
+            # Watched since the run that built this collection; the next
+            # run strips the label in _remove_outdated_labels().
+            notes.append(f"watched since the last run, clears tonight: {title}")
+
+        genres = [g.lower() for g in (info.get("genres") or [])]
+        hit = excluded.intersection(genres)
+        if hit:
+            problems.append(f"excluded genre {sorted(hit)}: {title}")
+
+        if max_rating and not is_rating_allowed(getattr(item, "contentRating", None), max_rating, media):
+            problems.append(f"exceeds max_rating {max_rating} ({getattr(item, 'contentRating', None)}): {title}")
+
+        entries = index.get(info.get("collection_id")) if info.get("collection_id") else None
+        if entries and len(entries) > 1:
+            series_items += 1
+            if any(e.rating_key in watched for e in entries):
+                started_items += 1
+            if franchise_on:
+                canonical = find_next_unwatched(
+                    entries, watched, excluded_genres=excluded, max_rating=max_rating, media_type=media
+                )
+                if canonical is None or canonical.rating_key != key:
+                    want = canonical.label() if canonical else "nothing (series exhausted)"
+                    problems.append(
+                        f"mid-series entry: {title} - franchise order wants {want} [{info.get('collection_name')}]"
+                    )
+
+    status = f"{GREEN}OK{RESET}" if not problems else f"{RED}{len(problems)} problem(s){RESET}"
+    short = f" {YELLOW}({target - len(items)} short of {target}){RESET}" if len(items) < target else ""
+    print(
+        f"  {user:<18} {label:<28} {len(items):>3} items{short} | "
+        f"series {series_items:>2} ({started_items} started) | {status}"
+    )
+    for p in problems[:8]:
+        print(f"       {RED}!{RESET} {p}")
+    if len(problems) > 8:
+        print(f"       ... and {len(problems) - 8} more")
+    for n in notes[:4]:
+        print(f"       {YELLOW}i{RESET} {n}")
+    if len(notes) > 4:
+        print(f"       ... and {len(notes) - 4} more watched since the run")
+    return problems
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--user", help="Only this user (default: every configured user)")
+    ap.add_argument("--media", choices=["movie", "tv"], default="movie")
+    args = ap.parse_args()
+
+    config = load_config()
+    tuning = load_tuning()
+    plex = PlexServer(config["plex"]["url"], config["plex"]["token"], timeout=30)
+    print(f"{GREEN}Connected to {plex.friendlyName} (Plex {plex.version}){RESET} - READ ONLY\n")
+
+    configured = user_list(config)
+    if not configured:
+        print(f"{RED}No users configured{RESET}")
+        return 1
+    if args.user and args.user not in configured:
+        # Otherwise a typo searches for a label nothing carries, finds
+        # nothing, and reports success.
+        print(f"{RED}Unknown user {args.user!r}. Configured: {', '.join(configured)}{RESET}")
+        return 1
+    users = [args.user] if args.user else configured
+
+    total = 0
+    for user in users:
+        total += len(check_user(plex, config, tuning, user, args.media))
+
+    print()
+    if total:
+        print(f"{RED}{total} problem(s) found{RESET}")
+        return 1
+    print(f"{GREEN}All checks passed{RESET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,12 @@ __pycache__/
 # IDE
 .idea/
 .vscode/
-.claude/
+# .claude/* (not .claude/) so the negation below can take effect - git
+# cannot re-include anything inside an excluded DIRECTORY, only inside an
+# excluded set of paths. Keeps settings.local.json (machine-local
+# permissions) ignored while letting shared skills be committed.
+.claude/*
+!.claude/skills/
 *.xml
 CLAUDE.md
 TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.21.2] - 2026-08-17
+
+### Added
+
+- **`.claude/skills/verify-recommendations/`** - a read-only audit of what is actually in each user's Plex recommendation collection, plus the machine-access knowledge needed to run it. `CLAUDE.md` already warned that the collection is the artifact and the run log is not (the log prints `plex_recs`, up to 2x the target; the collection holds the smaller `final_items`), but nothing in the repo made measuring the real thing straightforward from a machine that isn't the Plex host - which is the normal case when the checkout is a network mount of the Plex machine's own directory.
+
+  `run_remote.sh` probes whether Plex is reachable and either runs locally or delegates over SSH via `CURATARR_PLEX_SSH_HOST` / `CURATARR_PLEX_SSH_REPO_DIR` (same convention as `CURATARR_GH_SSH_HOST` in `RELEASING.md`, and probe-then-delegate for the same reason `scripts/release.sh` was rewritten that way in `2.19.1` - `plex.url` is typically a `127-0-0-1.<hash>.plex.direct` hostname that resolves to `127.0.0.1` everywhere and so says nothing about where Plex is). `verify_collections.py` then checks, per user: collection size against `limit_results`, watched items still labeled, excluded genres, `max_rating`, and the franchise invariant - that every collection item belonging to a multi-entry TMDB collection IS the canonical earliest-eligible-unwatched entry for that user, which covers both halves of franchise ordering in one assertion.
+
+  Two distinctions the tool would be useless without, both found by running it: an item the last run *already knew* was watched is a real failure, while one watched *since* that run is lag `_remove_outdated_labels()` clears tonight - conflating them makes it cry wolf every time somebody watches a film; and an unknown username or an empty collection is now a failure rather than a silent pass.
+
+  `.gitignore` narrows `.claude/` to `.claude/*` with a `!.claude/skills/` negation, so shared skills are versioned while machine-local `settings.local.json` stays ignored (git cannot re-include a path inside an excluded *directory*, only inside an excluded set of paths).
+
 ## [2.21.1] - 2026-08-17
 
 ### Fixed

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.21.1"
+__version__ = "2.21.2"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item


### PR DESCRIPTION
Follow-up to #366. `CLAUDE.md` already warns that **the collection is the artifact and the run log is not** — the log prints `plex_recs` (up to 2x the target) while the collection holds the smaller `final_items` set. But nothing in the repo made measuring the real thing straightforward from a machine that isn't the Plex host, which is the normal case when the checkout is a network mount of the Plex machine's own directory. Verifying the last three releases meant rediscovering that access path each time.

## What's here

`.claude/skills/verify-recommendations/`

- **`run_remote.sh`** — probes whether Plex is reachable and either runs locally or delegates over SSH via `CURATARR_PLEX_SSH_HOST` / `CURATARR_PLEX_SSH_REPO_DIR`. Same convention as `RELEASING.md`'s `CURATARR_GH_SSH_HOST`, and probe-then-delegate for the same reason `scripts/release.sh` was rewritten that way in `2.19.1`: `plex.url` is typically a `127-0-0-1.<hash>.plex.direct` hostname that resolves to `127.0.0.1` on *every* machine, so it says nothing about where Plex actually runs.
- **`verify_collections.py`** — per user: collection size vs `limit_results`, watched items still labeled, excluded genres, `max_rating`, and the franchise invariant.
- **`SKILL.md`** — the access routes, the read-only discipline, and the traps that make log-based verification wrong.

The franchise invariant is the useful one: *every collection item belonging to a multi-entry TMDB collection must **be** the canonical earliest-eligible-unwatched entry for that user.* That single assertion covers both halves of franchise ordering — promotion on a started series and suppression on an unstarted one both converge on it.

## Read-only

Only `section.search`, per-user played-id reads, and local JSON reads. `SKILL.md` spells out why constructing a recommender to inspect state isn't an option: `__init__` connects as admin and rewrites `cache/all_movies_cache.json` via `MovieCache.update_cache()`, and `manage_plex_labels()` mutates real labels.

## Three things that only came out of running it

Writing this would have shipped a broken tool three times over:

1. **The watched check cried wolf.** The first draft unioned "watched as of the last run" with "watched now" — which is exactly what the recommender itself correctly does (`_franchise_watched_ids()`) — and immediately flagged a film watched *hours after* the cron as a failure. An item the last run already knew about is a real defect; one watched since is lag `_remove_outdated_labels()` clears tonight. The two must stay distinguishable for auditing even though the recommender must merge them.
2. **Silent passes.** An unknown `--user` searched for a label nothing carries, found nothing, and reported success. Same for a configured user whose collection is empty. Both are failures now.
3. **The delegated command was invalid shell** — a brace group used as a command name. The interpreter is now chosen into a variable on the remote side, POSIX-only since the remote login shell may be zsh.

## `.gitignore`

Narrowed `.claude/` to `.claude/*` with a `!.claude/skills/` negation, so shared skills are versioned while machine-local `settings.local.json` stays ignored. Git cannot re-include a path inside an excluded *directory*, only inside an excluded set of paths — hence `.claude/*` rather than `.claude/`. Verified both ways with `git check-ignore`.

## Privacy

No host, IP, or account name from any particular install appears in these files, and the sample output is anonymised — this repo is public and the collections belong to several people. Confirmed with a grep over the staged diff.

Suite unchanged at 3438 passed. Bumped to 2.21.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)