### PR TITLE
Stop Plex from locking movies out of auto-managed franchise collections (2.21.3)

### DIFF
--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -326,7 +326,7 @@ class TestRemoveLabelsFromItems:
 
         remove_labels_from_items([item], "Recommended", label_dates, "test reason")
 
-        item.removeLabel.assert_called_once_with("Recommended")
+        item.removeLabel.assert_called_once_with("Recommended", locked=False)
         assert "123_Recommended" not in label_dates
 
     @patch("utils.labels.log_info")
@@ -361,7 +361,7 @@ class TestRemoveLabelsFromItems:
         remove_labels_from_items(items, "Recommended", label_dates, "cleanup")
 
         for item in items:
-            item.removeLabel.assert_called_once_with("Recommended")
+            item.removeLabel.assert_called_once_with("Recommended", locked=False)
         assert len(label_dates) == 0
 
 
@@ -378,7 +378,7 @@ class TestAddLabelsToItems:
 
         count = add_labels_to_items([item], "Recommended", label_dates)
 
-        item.addLabel.assert_called_once_with("Recommended")
+        item.addLabel.assert_called_once_with("Recommended", locked=False)
         assert count == 1
         assert "123_Recommended" in label_dates
 
@@ -411,7 +411,7 @@ class TestAddLabelsToItems:
 
         assert count == 3
         for item in items:
-            item.addLabel.assert_called_once_with("Recommended")
+            item.addLabel.assert_called_once_with("Recommended", locked=False)
 
     def test_mixed_existing_and_new_labels(self):
         """Test with mix of items with and without label."""

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -632,7 +632,7 @@ class TestCleanupLegacyUnnamedCollection:
         cleanup_legacy_unnamed_collection(mock_section, "🎬 Alice - Recommendation", "🎬")
 
         mock_legacy_collection.delete.assert_called_once()
-        legacy_item.removeLabel.assert_called_once_with("Recommended")
+        legacy_item.removeLabel.assert_called_once_with("Recommended", locked=False)
 
     def test_leaves_current_collection_alone(self):
         """A real user literally named 'Recommended' would legitimately
@@ -2318,7 +2318,7 @@ class TestUpdatePlexCollectionOldLabelUpgrade:
         existing.addItems.assert_called_once()
 
         # New, normalized label form was added additively...
-        existing.addLabel.assert_called_once_with("PrivateCollection_alexpigot")
+        existing.addLabel.assert_called_once_with("PrivateCollection_alexpigot", locked=False)
         # ...while the old form is still present (never stripped here).
         old_form_labels = [label.tag for label in existing.labels]
         assert "PrivateCollection_Alex_Pigot" in old_form_labels
@@ -2765,6 +2765,163 @@ class TestUpdatePlexCollectionSort:
 
         assert result is True
         mock_logger.warning.assert_called_once()
+
+
+class TestClearCollectionLock:
+    """Tests for _clear_collection_lock() - the collection-field-lock
+    half of the fix (label-lock half is covered by TestRemoveLabelsFromItems/
+    TestAddLabelsToItems in test_labels.py). Plex locks 'collection'
+    server-side on any addItems/removeItems/createCollection call
+    (verified live on PMS 1.43.3.10861, no lock param plexapi can pass
+    to prevent it), so every write path needs an explicit unlock after.
+    """
+
+    def test_calls_multi_edit_with_locked_false(self):
+        """A single batched multiEdit call clears the lock for the
+        whole item list, not one item.edit() per item."""
+        from utils.plex import _clear_collection_lock
+
+        mock_section = Mock()
+        items = [Mock(), Mock(), Mock()]
+
+        _clear_collection_lock(mock_section, items, "added to Test Collection")
+
+        mock_section.multiEdit.assert_called_once_with(items, **{"collection.locked": 0})
+
+    def test_noop_for_empty_items(self):
+        """Nothing to unlock - must not call the API at all."""
+        from utils.plex import _clear_collection_lock
+
+        mock_section = Mock()
+
+        _clear_collection_lock(mock_section, [], "removed from Test Collection")
+
+        mock_section.multiEdit.assert_not_called()
+
+    def test_swallows_plex_api_exception_and_logs(self):
+        """An unlock failure must never raise - it's cleanup of a side
+        effect, not the write curatarr actually cares about."""
+        from utils.plex import _clear_collection_lock
+
+        mock_section = Mock()
+        mock_section.multiEdit.side_effect = plexapi.exceptions.PlexApiException("locked field error")
+        mock_logger = Mock()
+
+        _clear_collection_lock(mock_section, [Mock()], "added to Test Collection", logger=mock_logger)
+
+        mock_logger.warning.assert_called_once()
+
+    def test_swallows_request_exception_and_logs(self):
+        """Network failures against the multiEdit PUT must also be
+        swallowed, not just plexapi's own exception type."""
+        from utils.plex import _clear_collection_lock
+
+        mock_section = Mock()
+        mock_section.multiEdit.side_effect = requests.exceptions.ConnectionError("connection reset")
+        mock_logger = Mock()
+
+        _clear_collection_lock(mock_section, [Mock()], "added to Test Collection", logger=mock_logger)
+
+        mock_logger.warning.assert_called_once()
+
+    def test_falls_back_to_print_without_logger(self, capsys):
+        """Matches every other non-fatal warning in update_plex_collection:
+        print(f"WARNING: ...") when no logger is passed."""
+        from utils.plex import _clear_collection_lock
+
+        mock_section = Mock()
+        mock_section.multiEdit.side_effect = plexapi.exceptions.PlexApiException("locked field error")
+
+        _clear_collection_lock(mock_section, [Mock()], "added to Test Collection")
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+
+
+class TestUpdatePlexCollectionClearsLocks:
+    """Integration coverage: update_plex_collection() must clear the
+    collection lock for every write path that can trigger it - added
+    items, removed items (rotated OUT, #verified 69 locked movies with
+    no label and no collection had exactly this gap), and items passed
+    to createCollection.
+    """
+
+    def test_create_path_unlocks_added_items(self):
+        """New collection: created items must be unlocked."""
+        from utils.plex import update_plex_collection
+
+        items = [Mock(), Mock()]
+        mock_collection = Mock()
+        mock_section = Mock()
+        mock_section.collections.return_value = []
+        mock_section.createCollection.return_value = mock_collection
+
+        result = update_plex_collection(mock_section, "New Collection", items)
+
+        assert result is True
+        mock_section.multiEdit.assert_called_once_with(items, **{"collection.locked": 0})
+
+    def test_update_path_unlocks_both_added_and_removed_items(self):
+        """Existing collection: BOTH the newly added set AND the
+        rotated-out removed set must each get their own unlock call -
+        removeItems goes through the same locking API path as addItems."""
+        from utils.plex import update_plex_collection
+
+        removed_items = [Mock(), Mock()]
+        added_items = [Mock()]
+
+        mock_existing = Mock()
+        mock_existing.title = "Existing Collection"
+        mock_existing.items.return_value = removed_items
+
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_existing]
+
+        result = update_plex_collection(mock_section, "Existing Collection", added_items)
+
+        assert result is True
+        assert mock_section.multiEdit.call_count == 2
+        mock_section.multiEdit.assert_any_call(removed_items, **{"collection.locked": 0})
+        mock_section.multiEdit.assert_any_call(added_items, **{"collection.locked": 0})
+
+    def test_update_path_skips_removed_unlock_when_collection_was_empty(self):
+        """No prior items means no removed set to unlock - only the
+        added-items call should fire."""
+        from utils.plex import update_plex_collection
+
+        added_items = [Mock()]
+
+        mock_existing = Mock()
+        mock_existing.title = "Existing Collection"
+        mock_existing.items.return_value = []
+
+        mock_section = Mock()
+        mock_section.collections.return_value = [mock_existing]
+
+        result = update_plex_collection(mock_section, "Existing Collection", added_items)
+
+        assert result is True
+        mock_section.multiEdit.assert_called_once_with(added_items, **{"collection.locked": 0})
+
+    def test_unlock_failure_does_not_abort_the_collection_update(self):
+        """A multiEdit failure must be logged and swallowed, never
+        propagate out of update_plex_collection and fail the whole
+        nightly collection rebuild."""
+        from utils.plex import update_plex_collection
+
+        added_items = [Mock()]
+        mock_section = Mock()
+        mock_section.collections.return_value = []
+        mock_section.createCollection.return_value = Mock()
+        mock_section.multiEdit.side_effect = plexapi.exceptions.PlexApiException("locked field error")
+
+        mock_logger = Mock()
+        result = update_plex_collection(mock_section, "Test Collection", added_items, logger=mock_logger)
+
+        assert result is True
+        mock_logger.warning.assert_any_call(
+            "Could not clear collection lock on 1 item(s) (created in Test Collection): locked field error"
+        )
 
 
 class TestApplyUserLabelRestrictions:

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.21.2"
+__version__ = "2.21.3"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item

--- a/utils/labels.py
+++ b/utils/labels.py
@@ -229,7 +229,7 @@ def remove_labels_from_items(items: List, label_name: str, label_dates: Dict, re
         reason: Reason for removal (for logging)
     """
     for item in items:
-        item.removeLabel(label_name)
+        item.removeLabel(label_name, locked=False)
         label_key = f"{int(item.ratingKey)}_{label_name}"
         if label_key in label_dates:
             del label_dates[label_key]
@@ -253,7 +253,7 @@ def add_labels_to_items(items: List, label_name: str, label_dates: Dict) -> int:
     for item in items:
         current_labels = [label.tag for label in item.labels]
         if label_name not in current_labels:
-            item.addLabel(label_name)
+            item.addLabel(label_name, locked=False)
             label_key = f"{int(item.ratingKey)}_{label_name}"
             label_dates[label_key] = datetime.now().isoformat()
             print(f"{GREEN}Added: {item.title}{RESET}")

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -854,6 +854,39 @@ def remove_owned_collection(
     return True
 
 
+def _clear_collection_lock(section: Any, items: List[Any], context: str, logger: Any = None) -> None:
+    """Clear the server-side 'collection' field lock PMS sets whenever
+    Collection.addItems/removeItems/LibrarySection.createCollection
+    touches an item - plexapi sends no lock param on those calls, so
+    Plex locks the field itself (verified live on PMS 1.43.3.10861).
+    Once locked, Plex's own agent can never write that item's collection
+    membership again, so items rotated OUT of a collection need this
+    exactly as much as items rotated in - see the removed-set call site
+    below.
+
+    Batches to a single PUT for the whole list via
+    LibrarySection.multiEdit (id=<comma-joined ratingKeys>) instead of
+    one item.edit() call per item, to avoid inflating a 50-item x
+    6-collection nightly run into hundreds of individual requests
+    against a live, resource-constrained Plex server.
+
+    Best-effort only: never allowed to raise. A failed unlock is a
+    missed cleanup of a side effect, not the collection write curatarr
+    actually cares about, so it's logged and swallowed rather than
+    aborting the rest of update_plex_collection.
+    """
+    if not items:
+        return
+    try:
+        section.multiEdit(items, **{"collection.locked": 0})
+    except (plexapi.exceptions.PlexApiException, requests.RequestException) as e:
+        msg = f"Could not clear collection lock on {len(items)} item(s) ({context}): {e}"
+        if logger:
+            logger.warning(msg)
+        else:
+            print(f"WARNING: {msg}")
+
+
 def update_plex_collection(
     section: Any,
     collection_name: str,
@@ -999,13 +1032,16 @@ def update_plex_collection(
             current_items = target_collection.items()
             if current_items:
                 target_collection.removeItems(current_items)
+                _clear_collection_lock(section, current_items, f"removed from {collection_name}", logger)
             target_collection.addItems(items)
+            _clear_collection_lock(section, items, f"added to {collection_name}", logger)
             if logger:
                 logger.info(f"Updated collection: {collection_name} ({len(items)} items)")
             else:
                 print(f"Updated collection: {collection_name} ({len(items)} items)")
         else:
             target_collection = section.createCollection(title=collection_name, items=items)
+            _clear_collection_lock(section, items, f"created in {collection_name}", logger)
             if logger:
                 logger.info(f"Created collection: {collection_name} ({len(items)} items)")
             else:
@@ -1038,7 +1074,7 @@ def update_plex_collection(
             try:
                 current_labels = [label.tag for label in target_collection.labels]
                 if private_label not in current_labels:
-                    target_collection.addLabel(private_label)
+                    target_collection.addLabel(private_label, locked=False)
             except plexapi.exceptions.PlexApiException as e:
                 if logger:
                     logger.warning(f"Could not add label to collection: {e}")


### PR DESCRIPTION
Opens the already-committed 2.21.3 work for merge — it was committed locally but never pushed, so `main` on origin has been sitting a release behind.

## The bug

Two independent write paths were locking the `collection` field:

- plexapi's `Label.addLabel` / `removeLabel` default to `locked=True`.
- Plex Media Server locks the `collection` field **server-side** on any `addItems` / `removeItems` / `createCollection` write, regardless of what the client sends — plexapi exposes no lock parameter on those calls at all (verified live on PMS 1.43.3.10861).

A locked field is one Plex's own metadata agent will never write again, so once a movie's `collection` field was locked this way it silently stopped being eligible for auto-addition to its franchise collection on every subsequent run. **378 of 518 movies** were affected, growing 6–15 per day.

## The fix

- `locked=False` on the label calls in `utils/labels.py` and `utils/plex.py`.
- New `_clear_collection_lock()` wired into all three collection-membership write paths in `update_plex_collection()`. It covers the **removed** set as well as the added set — an item rotated *out* of a collection needs the lock cleared exactly as much as one rotated in.
- Batches via `LibrarySection.multiEdit()` so each call is a single PUT instead of one `item.edit()` per item, keeping a 50-item × 6-collection nightly run to ≤18 requests instead of ~300 against a live, resource-constrained server.
- Best-effort and never raises: a failed unlock is a missed cleanup of a side effect, not the collection write curatarr actually cares about.

## Note

This PR is the base for the 2.22.0 PR that follows it. The CHANGELOG entry for 2.21.3 was missing (the release bumped `utils/config.py` but never documented itself) and is backfilled in that follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)