### PR TITLE
Rank the collection by score, and stop calibration favoring broad tags (2.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Curatarr will be documented in this file.
 
+## [2.22.0] - 2026-08-21
+
+### Fixed
+
+- **`mypy` was unrunnable from an SMB-mounted checkout, reporting it as its own INTERNAL ERROR.** mypy defaults to a 16-shard sqlite cache and puts each shard in WAL mode, which persists in the `.db` file header - and opening a WAL database requires a `-shm` shared-memory file, which `smbfs` cannot provide. This checkout is commonly an SMB mount of the Plex host's own directory (see `.claude/skills/verify-recommendations`), so the moment mypy ran on the host, where WAL is fine, every later run from a mounted checkout died with `sqlite3.OperationalError: unable to open database file` wrapped in `INTERNAL ERROR -- Please try using mypy master on GitHub`. A *fresh* cache dir worked and a stale one did not, which made it look intermittent and like a mypy bug rather than a filesystem one.
+
+  `mypy.ini` now sets `sqlite_cache = False`. The filesystem cache has no shared-memory requirement and works from both machines; at 153 source files the speed difference is noise. `mypy .` passes clean, warm cache included.
+
+- **The recommendation collection was ordered by calibration's greedy pick order, not by score, under a log line claiming otherwise.** `_select_calibrated()` returns the order in which the greedy loop *constructed* the set - an artifact of `(1 - s) * score - s * SCALE * KL(target || list)`, where an item can be taken early because it patches the collection's genre mix rather than because it matches the user. `_update_labels_by_rank()` handed that order straight to `_sync_plex_collection()`, which pushes it into Plex as the collection's `sort="custom"` order, while `base.py` printed `Final collection size: N movies (sorted by similarity)`.
+
+  Measured on a real run: **Brave** (similarity **7.3%**, 93rd of 100 candidates) sat at collection position **3**, while **Sonic the Hedgehog 2** (**37.2%**, 2nd) sat near the bottom. Across the whole collection, position carried no ranking signal at all - the first ten picks averaged 12.6% similarity against 11.7% for the last ten. `_update_labels_by_rank()` now re-sorts by `_rank_key` (score, then TMDB rating, then vote count - the same tiebreak `get_recommendations()` uses) before returning, so the log line is true. Which items are in the collection is still calibration's call and is unchanged by this half.
+
+- **Calibration's greedy selection systematically favored broadly-tagged titles, which on real metadata means kid films.** Each candidate was scored on `KL(target || list-so-far)`, which conflates two different things: how far the committed picks have drifted from the profile, and how little of the target a short list can cover at all. The second dominates early - one item cannot reproduce a twenty-genre profile - so pick 1 degenerated into *whichever candidate covers the most target mass by itself*, i.e. whichever carries the most genre tags.
+
+  That is the `CLAUDE.md` genre-tags-are-unreliable trap resurfacing inside calibration itself. Measured on this library's own 100-candidate pool: G/PG titles average **4.69** genre tags against **3.25** for PG-13/R, and the greedy filled its first ten slots with 5.00-tag items while its last ten averaged 3.40. Brave earns its way in on eight tags (`family, fantasy, animation, action, adventure, comedy, drama, mystery`) at a 7.3% score; at pick 3 its similarity deficit against Sonic 2 was worth **+0.1495** while its divergence advantage was worth **6.845**, a 46x thumb on the scale.
+
+  New `projected_distribution()` holds the list's unfilled slots at the target, so only the deviation the committed picks actually introduce is measured, scaled by the share of the list they occupy. Early picks are no longer asked to carry the whole distribution alone and the similarity axis survives the top of the list. The final step is unchanged - at `filled == total` the projection *is* the list - so this changes the path greedy takes, not the target it converges on. Measured on the same pool: final genre KL **0.1090** vs 0.1103 before, certificate KL unchanged at 0.0030, mean similarity **15.29%** vs 15.03%, G/PG count 8 vs 7, and **three titles of fifty** changed. Sonic 2 returns to position 2; Brave drops out of the collection entirely, which is where a 93rd-place candidate belongs.
+
+  Note this is deliberately *not* a reduction in family content - the G/PG count barely moves. Calibration still includes family titles at the rate the profile watches them; it now picks the highest-scoring examples instead of the most-tagged ones.
+
+## [2.21.3] - 2026-08-18
+
+### Fixed
+
+- **Plex was locking movies out of their own auto-managed franchise collections, and curatarr was causing it.** Two independent write paths set the lock. plexapi's `Label.addLabel`/`removeLabel` default to `locked=True`; separately, Plex Media Server locks the `collection` field server-side on *any* `addItems` / `removeItems` / `createCollection` write, regardless of what the client sends - plexapi exposes no lock parameter on those calls at all (verified live on PMS 1.43.3.10861). A locked field is one Plex's own metadata agent will never write again, so once a movie's `collection` field was locked this way it silently stopped being eligible for auto-addition to its franchise collection on every subsequent run. **378 of 518 movies** were affected, growing 6-15 per day.
+
+  `utils/labels.py` and `utils/plex.py` now pass `locked=False` on the label calls, and a new `_clear_collection_lock()` is wired into all three collection-membership write paths in `update_plex_collection()`. It covers the **removed** set as well as the added set - an item rotated *out* of a collection needs the lock cleared exactly as much as one rotated in. The helper batches via `LibrarySection.multiEdit()` so each call is a single PUT rather than one `item.edit()` per item, keeping a 50-item x 6-collection nightly run to <=18 requests instead of ~300 against a live, resource-constrained server. It is best-effort and never raises: a failed unlock is a missed cleanup of a side effect, not the collection write curatarr actually cares about.
+
 ## [2.21.2] - 2026-08-17
 
 ### Added

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,16 @@
 # blocking, same as ruff.
 python_version = 3.10
 ignore_missing_imports = True
+# Filesystem cache, not sqlite. mypy defaults to a 16-shard sqlite cache
+# and puts those shards in WAL mode, which persists in each .db header -
+# and opening a WAL database needs a `-shm` shared-memory file, which
+# smbfs cannot provide. This checkout is commonly an SMB mount of the
+# Plex host's own directory (see .claude/skills/verify-recommendations),
+# so the moment mypy runs on the host - where WAL is fine - every later
+# run from a mounted checkout dies with `sqlite3.OperationalError:
+# unable to open database file`, reported as an INTERNAL ERROR that
+# looks like a mypy bug rather than a filesystem one. A fresh cache dir
+# works and a stale one does not, which makes it look intermittent.
+# The filesystem cache has no such requirement and works from both
+# machines; on a project this size the speed difference is noise.
+sqlite_cache = False

--- a/recommenders/base.py
+++ b/recommenders/base.py
@@ -1964,7 +1964,20 @@ class BaseRecommender(ABC):
             add_labels_to_items(items_to_add, label_name, self.label_dates)
 
         print(f"{GREEN}Collection now has top {len(top_candidates)} recommendations by score{RESET}")
-        return [plex_item for item_id, (plex_item, score) in top_candidates]
+
+        # Re-sort by score before returning. _select_calibrated hands back
+        # calibration's greedy PICK order, which is a construction
+        # artifact rather than a ranking, and this list goes straight to
+        # _sync_plex_collection - which pushes it into Plex as the
+        # collection's custom sort order. The two were silently different
+        # things: on a real run Brave (similarity 7.3%, 93rd of 100
+        # candidates) sat at collection position 3 while Sonic the
+        # Hedgehog 2 (37.2%, 2nd) sat near the bottom, under a log line
+        # that claimed the collection was "sorted by similarity".
+        # Sorting here fixes the ORDER only - which items are in the
+        # collection is still calibration's call, unchanged.
+        ranked = sorted(top_candidates, key=_rank_key, reverse=True)
+        return [plex_item for _item_id, (plex_item, _score) in ranked]
 
     def _sync_plex_collection(
         self,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2702,6 +2702,43 @@ class TestCalibrationCannotActGuard:
         recommender._select_calibrated(candidates, media_items, 50)
         assert mock_warn.called
 
+    @patch("recommenders.base.add_labels_to_items")
+    @patch("recommenders.base.remove_labels_from_items")
+    def test_returned_collection_is_ordered_by_score(self, _mock_remove, _mock_add):
+        """
+        Regression: _select_calibrated returns greedy PICK order, and
+        this list is handed to _sync_plex_collection, which pushes it
+        into Plex as the collection's custom sort. Shipping pick order
+        put a 7.3%-similarity title at collection position 3 while a
+        37.2% one sat near the bottom. Membership is calibration's call;
+        the ORDER the user reads must still be the ranking.
+
+        The genres have to VARY across candidates for this to test
+        anything - give every candidate the same genre and the
+        divergence term is equal for all of them, greedy degenerates to
+        picking by score, and pick order matches the ranking by accident.
+        """
+        recommender = _make_recommender()
+        recommender.calibration_strength = 0.5
+        recommender.min_similarity = 0.0
+        recommender.watched_data_counters = {"genres": {"thriller": 50.0, "drama": 30.0, "comedy": 20.0}}
+        recommender.watched_ids = set(range(9000, 9200))
+
+        # Deliberately anti-correlated: the broadly-tagged candidates
+        # calibration reaches for first are the ones scoring worst.
+        genre_sets = [["thriller"], ["drama"], ["comedy"], ["thriller", "drama", "comedy"]]
+        media_items = {str(i): {"genres": genre_sets[i % 4]} for i in range(200)}
+        media_cache = Mock()
+        media_cache.cache = {"movies": media_items}
+        recommender._get_media_cache = Mock(return_value=media_cache)
+
+        candidates = {i: (Mock(ratingKey=i), 1.0 - (i % 4) * 0.25) for i in range(200)}
+
+        result = recommender._update_labels_by_rank(candidates, [], "Recommended_alice", target_count=50)
+
+        scores = [candidates[int(item.ratingKey)][1] for item in result]
+        assert scores == sorted(scores, reverse=True), "collection order is not a ranking"
+
 
 class TestSyncPlexCollectionEmpty:
     """Tests for BaseRecommender._sync_plex_collection with no items."""

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -34,6 +34,7 @@ from utils.calibration import (
     item_genre_distribution,
     kl_divergence,
     list_distribution,
+    projected_distribution,
 )
 from utils.config import CALIBRATION_MIN_PROFILE_SAMPLE, CALIBRATION_SMOOTHING_ALPHA
 
@@ -491,3 +492,79 @@ class TestMinimumProfileSample:
         # Genre (trusted, wants thriller) must win; certificate (2 samples,
         # wants G) must be ignored entirely.
         assert sum(1 for i in sel if i["g"] == ["thriller"]) > 5
+
+
+class TestProjectedDistribution:
+    """projected_distribution() - unfilled slots held at target."""
+
+    def test_full_list_is_returned_unchanged(self):
+        actual = {"action": 0.7, "drama": 0.3}
+        target = {"action": 0.5, "drama": 0.5}
+        assert projected_distribution(actual, target, 4, 4) == actual
+
+    def test_overfull_list_is_returned_unchanged(self):
+        actual = {"action": 1.0}
+        assert projected_distribution(actual, {"drama": 1.0}, 5, 4) == actual
+
+    def test_non_positive_total_is_returned_unchanged(self):
+        actual = {"action": 1.0}
+        assert projected_distribution(actual, {"drama": 1.0}, 0, 0) == actual
+
+    def test_blends_toward_target_by_filled_share(self):
+        actual = {"action": 1.0}
+        target = {"drama": 1.0}
+        projected = projected_distribution(actual, target, 1, 4)
+        assert projected["action"] == pytest.approx(0.25)
+        assert projected["drama"] == pytest.approx(0.75)
+
+    def test_stays_a_distribution(self):
+        actual = {"action": 0.6, "comedy": 0.4}
+        target = {"action": 0.2, "drama": 0.8}
+        projected = projected_distribution(actual, target, 2, 5)
+        assert sum(projected.values()) == pytest.approx(1.0)
+
+    def test_early_pick_barely_moves_the_projection(self):
+        """
+        The whole point: one item out of fifty can only shift the mix by
+        1/50, so its divergence penalty must be small enough that the
+        similarity term still decides. Before this, pick 1 was scored on
+        how well that single item reproduced the entire profile.
+        """
+        target = {"action": 0.5, "drama": 0.3, "comedy": 0.2}
+        one_item = list_distribution([["action"]])
+        projected = projected_distribution(one_item, target, 1, 50)
+        assert kl_divergence(target, projected) < kl_divergence(target, one_item)
+
+
+class TestGreedyDoesNotFavorBroadlyTaggedItems:
+    """
+    Regression: the pre-fix greedy scored each candidate on how much of
+    the profile it covered BY ITSELF, so the most-tagged candidate won
+    the early slots regardless of score. On this library that is a
+    standing bias toward kid films, which carry 4.69 genre tags on
+    average against 3.25 for everything else (see CLAUDE.md on genre
+    tags being unreliable).
+    """
+
+    def test_high_scorer_beats_a_broadly_tagged_low_scorer(self):
+        target = {"action": 0.4, "thriller": 0.3, "science fiction": 0.3}
+        # Carries a tag for nearly every genre in the profile, but is a
+        # poor match; the pre-fix objective picked this first.
+        broad = _item("Broad", ["action", "thriller", "science fiction", "family", "animation"], 0.05)
+        strong = _item("Strong", ["action", "thriller"], 0.90)
+        filler = [_item(f"Filler {i}", ["action"], 0.10) for i in range(10)]
+
+        selected = _calibrate([broad, strong] + filler, 4, target, 0.5)
+
+        assert selected[0]["title"] == "Strong"
+
+    def test_still_selects_for_the_profile_mix(self):
+        """The fix must not turn calibration back into plain top-N."""
+        target = {"action": 0.5, "romance": 0.5}
+        action = [_item(f"Action {i}", ["action"], 0.9 - i * 0.01) for i in range(10)]
+        romance = [_item(f"Romance {i}", ["romance"], 0.2 - i * 0.01) for i in range(10)]
+
+        selected = _calibrate(action + romance, 6, target, 0.5)
+
+        genres = [i["genres"][0] for i in selected]
+        assert genres.count("romance") >= 2, genres

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -43,6 +43,7 @@ from .calibration import (
     item_genre_distribution,
     kl_divergence,
     list_distribution,
+    projected_distribution,
 )
 
 # CLI utilities
@@ -679,6 +680,7 @@ __all__ = [
     "item_genre_distribution",
     "kl_divergence",
     "list_distribution",
+    "projected_distribution",
     # Counters
     "build_profile_from_counters",
     "create_empty_counters",

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -152,6 +152,50 @@ def kl_divergence(
     return divergence
 
 
+def projected_distribution(
+    actual: Dict[str, float],
+    target: Dict[str, float],
+    filled: int,
+    total: int,
+) -> Dict[str, float]:
+    """
+    The distribution the list would have if its remaining slots were
+    filled exactly on target.
+
+    Greedy selection compares candidates by the divergence of the list
+    SO FAR, which conflates two different things: how far the committed
+    picks have drifted, and how little of the target a short list can
+    cover at all. The second dominates early - one item cannot reproduce
+    a twenty-genre profile, so at pick 1 the objective degenerates into
+    "whichever candidate covers the most target mass by itself", which on
+    real metadata means whichever candidate carries the most genre tags.
+
+    That is a systematic bias toward kid films, for the reason CLAUDE.md
+    already records about genre tags: measured on this library's own
+    candidate pool, G/PG titles average 4.69 genre tags against 3.25 for
+    PG-13/R. The pre-fix greedy filled its first ten slots with 5.00-tag
+    items while its last ten averaged 3.40, and put Brave (similarity
+    7.3%, 93rd of 100 candidates) in the collection at all.
+
+    Projecting the unfilled slots onto the target removes that term, so
+    only the deviation the committed picks actually introduce is
+    measured, scaled by the share of the list they occupy. Early picks
+    are no longer asked to carry the whole distribution alone and the
+    similarity axis survives the top of the list. The last step is
+    unchanged - at filled == total the projection IS the list - so this
+    changes the path greedy takes, not the target it converges on.
+    Measured on the same 100-candidate pool: final genre KL 0.1090 vs
+    0.1103 before, mean similarity 15.29% vs 15.03%, G/PG count 8 vs 7,
+    three titles of fifty changed.
+    """
+    if total <= 0 or filled >= total:
+        return actual
+    weight = filled / total
+    return {
+        key: weight * actual.get(key, 0.0) + (1 - weight) * target.get(key, 0.0) for key in set(actual) | set(target)
+    }
+
+
 def calibrate_recommendations(
     candidates: Sequence[T],
     limit: int,
@@ -205,7 +249,12 @@ def calibrate_recommendations(
         calibration_strength: lambda in [0, 1). 0 disables calibration.
 
     Returns:
-        The selected items, best-first.
+        The selected items, in greedy PICK order. That is a construction
+        artifact, not a ranking - the objective trades similarity against
+        distribution fit, so an item can be picked early because it
+        patches the list's mix rather than because it scores well. A
+        caller that shows this list to a user must re-sort it by score
+        (see BaseRecommender._update_labels_by_rank).
     """
     if limit <= 0:
         return []
@@ -226,7 +275,10 @@ def calibrate_recommendations(
 
         for i, candidate in enumerate(remaining):
             trial_genres = selected_genres + [get_genres(candidate)]
-            divergence = kl_divergence(target_distribution, list_distribution(trial_genres))
+            trial_distribution = projected_distribution(
+                list_distribution(trial_genres), target_distribution, len(trial_genres), limit
+            )
+            divergence = kl_divergence(target_distribution, trial_distribution)
             value = (1 - calibration_strength) * get_score(candidate) - (
                 calibration_strength * CALIBRATION_DIVERGENCE_SCALE * divergence
             )
@@ -276,7 +328,12 @@ def calibrate_multi(
         calibration_strength: 0 disables; see calibrate_recommendations.
 
     Returns:
-        The selected items, best-first.
+        The selected items, in greedy PICK order. That is a construction
+        artifact, not a ranking - the objective trades similarity against
+        distribution fit, so an item can be picked early because it
+        patches the list's mix rather than because it scores well. A
+        caller that shows this list to a user must re-sort it by score
+        (see BaseRecommender._update_labels_by_rank).
     """
     if limit <= 0:
         return []
@@ -303,7 +360,8 @@ def calibrate_multi(
             divergence = 0.0
             for d_i, dim in enumerate(active):
                 trial = selected_values[d_i] + [dim.get_values(candidate)]
-                divergence += dim.weight * kl_divergence(dim.target, list_distribution(trial))
+                trial_distribution = projected_distribution(list_distribution(trial), dim.target, len(trial), limit)
+                divergence += dim.weight * kl_divergence(dim.target, trial_distribution)
             value = (1 - calibration_strength) * get_score(candidate) - (
                 calibration_strength * CALIBRATION_DIVERGENCE_SCALE * divergence
             )

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,7 +30,7 @@ import yaml
 from .display import log_error, log_info, log_warning
 
 # Project version - single source of truth
-__version__ = "2.21.3"
+__version__ = "2.22.0"
 
 # Cache version - bump this when cache format changes to auto-invalidate old caches
 CACHE_VERSION = 9  # v9: new cache FIELD - `content_rating` per item


### PR DESCRIPTION
Stacked on #368 (2.21.3) so this PR shows only its own commit. GitHub will retarget it to `main` automatically when #368 merges.

Two defects, both surfaced by asking why **Brave** sat at collection position **3** for a user whose profile scores it **7.3%** — 93rd of 100 candidates — while **Sonic the Hedgehog 2** (**37.2%**, 2nd) sat near the bottom.

## 1. The collection was ordered by calibration's pick order, not by score

`_select_calibrated()` returns the order in which the greedy loop *constructed* the set — an artifact of `(1 - s) * score - s * SCALE * KL(target || list)`, where an item can be taken early because it patches the collection's genre mix rather than because it matches the user. `_update_labels_by_rank()` handed that straight to `_sync_plex_collection()`, which pushes it into Plex as the collection's `sort="custom"` order, while the log printed `Final collection size: N movies (sorted by similarity)`.

Position carried no ranking signal at all: the first ten picks averaged **12.6%** similarity against **11.7%** for the last ten.

Now re-sorted by `_rank_key` (score → TMDB rating → vote count, the same tiebreak `get_recommendations()` uses) before returning, so the log line is true. **Which items are in the collection is unchanged by this half.**

## 2. Calibration systematically favored broadly-tagged titles

Scoring each candidate on `KL(target || list-so-far)` conflates two different things: how far the committed picks have drifted, and how little of the target a short list can cover at all. The second dominates early — one item cannot reproduce a twenty-genre profile — so pick 1 degenerated into *whichever candidate covers the most target mass by itself*, i.e. whichever carries the most genre tags.

That is the `CLAUDE.md` genre-tags-are-unreliable trap resurfacing inside calibration itself. On this library's own candidate pool, G/PG titles average **4.69** genre tags against **3.25** for PG-13/R, and the greedy filled its first ten slots with 5.00-tag items while its last ten averaged 3.40. Brave earns its way in on eight tags (`family, fantasy, animation, action, adventure, comedy, drama, mystery`) at a 7.3% score; at pick 3 its similarity deficit against Sonic 2 was worth **+0.1495** while its divergence advantage was worth **6.845** — a 46× thumb on the scale.

New `projected_distribution()` holds the list's unfilled slots at the target, so only the deviation the committed picks actually introduce is measured, scaled by the share of the list they occupy. At `filled == total` the projection *is* the list, so this changes the **path** greedy takes, not the target it converges on.

| | before | after |
|---|---|---|
| final genre KL | 0.1103 | **0.1090** |
| certificate KL | 0.0030 | 0.0030 |
| mean similarity | 15.03% | **15.29%** |
| G/PG titles | 7/50 | 8/50 |
| titles changed | — | 3 of 50 |

Sonic 2 returns to position 2; Brave drops out of the collection entirely, which is where a 93rd-place candidate belongs.

**This is deliberately not a reduction in family content** — the G/PG count barely moves. Calibration still includes family titles at the rate the profile watches them; it now picks the highest-scoring examples instead of the most-tagged ones.

## Also in this PR

- **`mypy` was unrunnable from an SMB-mounted checkout**, reporting it as its own `INTERNAL ERROR`. mypy defaults to a 16-shard sqlite cache and puts each shard in WAL mode, which persists in the `.db` header — and opening a WAL database needs a `-shm` shared-memory file that `smbfs` cannot provide. Once mypy ran on the Plex host, where WAL is fine, every later run from a mounted checkout died with `sqlite3.OperationalError: unable to open database file`. A *fresh* cache dir worked and a stale one did not, which made it look intermittent and like a mypy bug. `mypy.ini` now sets `sqlite_cache = False`.
- **Backfills the missing CHANGELOG entry for 2.21.3**, which bumped the version but never documented itself.

## Verification

- `pytest tests/` — **3456 passed, 1 skipped**
- `ruff check .` — clean; `ruff format --check .` — 163 files already formatted
- `mypy .` — **Success: no issues found in 153 source files** (cold *and* warm cache)
- `utils/calibration.py` at 98% coverage
- Six new tests. Each new regression test was confirmed to **fail without its fix** — the first draft of the ordering test passed either way, because the shared fixture gives every candidate the same genre, which makes greedy degenerate to score order by accident; rewritten with varying genres and anti-correlated scores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)