### PR TITLE
Remove unreachable return after sys.exit in _run_one_recommender

### DIFF
--- a/curatarr_app.py
+++ b/curatarr_app.py
@@ -268,7 +268,6 @@ def _run_one_recommender(engine: str, rest: list) -> None:
     else:
         print(f"curatarr: unknown recommender engine: {engine}", file=sys.stderr)
         sys.exit(2)
-        return
     run()
 
 


### PR DESCRIPTION
## What

Removes one unreachable line in `_run_one_recommender`:

```diff
     else:
         print(f"curatarr: unknown recommender engine: {engine}", file=sys.stderr)
         sys.exit(2)
-        return
     run()
```

`sys.exit(2)` raises `SystemExit`, so the `return` after it can never execute.

## Why it's safe

The line looks like defensive dead code, and there is a case where it would **not** be dead: if any test replaced `sys.exit` with a no-op, execution would continue past it, and this `return` would be the only thing stopping a fall-through into `run()` — where `run` is unbound on that branch, so it would raise `UnboundLocalError` instead of exiting 2.

That isn't what happens. The covering test lets the exit really raise:

```python
def test_unknown_engine_exits_with_error(self):
    with pytest.raises(SystemExit) as exc_info:
        curatarr_app._run_one_recommender("bogus", [])
    assert exc_info.value.code == 2
```

So the line is dead under test and in production alike. No behaviour change.

## Verification

```
ruff   : All checks passed!
mypy   : Success: no issues found in 1 source file
pytest : 34 passed  (tests/test_curatarr_app.py)
```

## Not included

No version bump or CHANGELOG entry — this has no user-visible effect, so it seems better riding along with the next release than claiming one of its own. Happy to add both if you'd rather it follow the usual per-commit versioning.

## Note on the two other "unreachable" reports in this file

A type checker also flags lines 112 and 149 as unreachable. **Those are false positives and are deliberately left alone.** Both sit behind:

```python
if os.name != "nt" or not getattr(sys, "frozen", False):
    return
```

Analysed on macOS/Linux, `os.name` is statically `"posix"`, so the guard always returns and everything after looks dead. On Windows it isn't — that code is the frozen build's crash-dialog suppression (`SEM_NOGPFAULTERRORBOX`) and console attach. Deleting it would regress the self-updater's "fail silently, never surface a modal dialog" behaviour, and no macOS or Linux CI run would catch it.
